### PR TITLE
Improve error messaging for non-existent projections in GRPC API (Fix…

### DIFF
--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Delete.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Delete.cs
@@ -33,12 +33,17 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			return new DeleteResp();
 
 			void OnMessage(Message message) {
-				if (!(message is ProjectionManagementMessage.Updated)) {
-					deletedSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
-					return;
+				switch (message) {
+					case ProjectionManagementMessage.Updated _:
+						deletedSource.TrySetResult(true);
+						break;
+					case ProjectionManagementMessage.NotFound _:
+						deletedSource.TrySetException(ProjectionManagement.ProjectionNotFound(name));
+						break;
+					default:
+						deletedSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+						break;
 				}
-
-				deletedSource.TrySetResult(true);
 			}
 		}
 	}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
@@ -32,12 +32,17 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			return new DisableResp();
 
 			void OnMessage(Message message) {
-				if (!(message is ProjectionManagementMessage.Updated)) {
-					disableSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
-					return;
+				switch (message) {
+					case ProjectionManagementMessage.Updated _:
+						disableSource.TrySetResult(true);
+						break;
+					case ProjectionManagementMessage.NotFound _:
+						disableSource.TrySetException(ProjectionManagement.ProjectionNotFound(name));
+						break;
+					default:
+						disableSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+						break;
 				}
-
-				disableSource.TrySetResult(true);
 			}
 		}
 	}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Enable.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Enable.cs
@@ -30,12 +30,17 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			return new EnableResp();
 
 			void OnMessage(Message message) {
-				if (!(message is ProjectionManagementMessage.Updated)) {
-					enableSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
-					return;
+				switch (message) {
+					case ProjectionManagementMessage.Updated _:
+						enableSource.TrySetResult(true);
+						break;
+					case ProjectionManagementMessage.NotFound _:
+						enableSource.TrySetException(ProjectionManagement.ProjectionNotFound(name));
+						break;
+					default:
+						enableSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+						break;
 				}
-
-				enableSource.TrySetResult(true);
 			}
 		}
 	}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
@@ -30,13 +30,19 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			return new ResetResp();
 
 			void OnMessage(Message message) {
-				if (!(message is ProjectionManagementMessage.Updated)) {
-					resetSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
-					return;
+				switch (message) {
+					case ProjectionManagementMessage.Updated _:
+						resetSource.TrySetResult(true);
+						break;
+					case ProjectionManagementMessage.NotFound _:
+						resetSource.TrySetException(ProjectionManagement.ProjectionNotFound(name));
+						break;
+					default:
+						resetSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+						break;
 				}
-
-				resetSource.TrySetResult(true);
 			}
+
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Statistics.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Statistics.cs
@@ -58,12 +58,17 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			}
 
 			void OnMessage(Message message) {
-				if (!(message is ProjectionManagementMessage.Statistics statistics)) {
-					statsSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Statistics>(message));
-					return;
+				switch (message) {
+					case ProjectionManagementMessage.Statistics statistics:
+						statsSource.TrySetResult(statistics.Projections);
+						break;
+					case ProjectionManagementMessage.NotFound _:
+						statsSource.TrySetException(ProjectionManagement.ProjectionNotFound(name));
+						break;
+					default:
+						statsSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+						break;
 				}
-
-				statsSource.TrySetResult(statistics.Projections);
 			}
 		}
 	}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Update.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Update.cs
@@ -40,12 +40,17 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			return new UpdateResp();
 
 			void OnMessage(Message message) {
-				if (!(message is ProjectionManagementMessage.Updated)) {
-					updatedSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
-					return;
+				switch (message) {
+					case ProjectionManagementMessage.Updated _:
+						updatedSource.TrySetResult(true);
+						break;
+					case ProjectionManagementMessage.NotFound _:
+						updatedSource.TrySetException(ProjectionManagement.ProjectionNotFound(name));
+						break;
+					default:
+						updatedSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+						break;
 				}
-
-				updatedSource.TrySetResult(true);
 			}
 		}
 	}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.cs
@@ -36,6 +36,9 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				new Status(StatusCode.FailedPrecondition,
 					$"Projection Subsystem cannot be restarted as it is in the wrong state: {state}"));
 
+		private static Exception ProjectionNotFound(string name) =>
+			new RpcException(new Status(StatusCode.NotFound, $"Projection '{name}' not found"));
+
 		private static Value GetProtoValue(JsonElement element) =>
 			element.ValueKind switch {
 				JsonValueKind.Null => new Value {NullValue = NullValue.NullValue},


### PR DESCRIPTION
…es #2732, DB-379)

This commit resolves the issue where querying non-existent projections through the Projection Management GRPC API returned an unclear 'UNKNOWN: Envelope callback expected Statistics, received NotFound instead' error. This fix introduces a clearer not found error message across the projection management operations Delete, Disable, Enable, Reset, Update, and Statistics (Status).

There are currently no GRPC tests for this on the server validation was performed using the node client. Future improvements should include adding server-side GRPC tests for these scenarios.

GitHub Issue: https://github.com/EventStore/EventStore/issues/2732
Linear Issue: https://linear.app/eventstore/issue/DB-379/grpc-listing-a-non-existant-projection-gives-a-poor-quality-error