### PR TITLE
[master] Projections claims fix

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Other/claims_serialization.cs
+++ b/src/EventStore.Projections.Core.Tests/Other/claims_serialization.cs
@@ -1,0 +1,52 @@
+﻿using System.Security.Claims;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Management;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Other;
+
+[TestFixture]
+public class claims_serialization {
+	[Test]
+	public void should_serialize_principal_name() {
+		var principalName = "foo-name";
+		var claimsIdentity = new ClaimsIdentity(new Claim[] {
+			new(ClaimTypes.Name, principalName),
+			new(ClaimTypes.Role, "$admins"),
+		});
+		var runas = new ProjectionManagementMessage.RunAs(new ClaimsPrincipal(claimsIdentity));
+		var sra = SerializedRunAs.SerializePrincipal(runas);
+		Assert.AreEqual(principalName, sra.Name);
+	}
+
+	[Test]
+	public void should_only_serialize_role() {
+		var roleClaim = new Claim(ClaimTypes.Role, "$admins");
+		var claimsIdentity = new ClaimsIdentity(new [] {
+			new(ClaimTypes.Name, "foo-name"),
+			roleClaim,
+			new("uid", "foo-uid"),
+			new("pwd", "foo-pwd")
+		});
+		var runas = new ProjectionManagementMessage.RunAs(new ClaimsPrincipal(claimsIdentity));
+		var sra = SerializedRunAs.SerializePrincipal(runas);
+		Assert.AreEqual(1, sra.Roles.Length);
+		Assert.AreEqual($"{roleClaim.Type}$$${roleClaim.Value}", sra.Roles[0]);
+	}
+
+	[Test]
+	public void should_return_null_for_anonymous() {
+		var runas = new ProjectionManagementMessage.RunAs(SystemAccounts.Anonymous);
+		var sra = SerializedRunAs.SerializePrincipal(runas);
+		Assert.IsNull(sra);
+	}
+
+	[Test]
+	public void should_set_runas_system_for_system_principal() {
+		var runas = new ProjectionManagementMessage.RunAs(SystemAccounts.System);
+		var sra = SerializedRunAs.SerializePrincipal(runas);
+		Assert.AreEqual("$system", sra.Name);
+		Assert.IsNull(sra.Roles);
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -1081,7 +1081,9 @@ namespace EventStore.Projections.Core.Services.Management {
 				return new SerializedRunAs {Name = "$system"};
 
 			var principal = runAs.Principal;
-			var roles = principal.Claims.Where(x => x.Type != ClaimTypes.Name).Select(c => $"{c.Type}$$${c.Value}").ToArray();
+			var roles = principal.Claims
+				.Where(x => x.Type == ClaimTypes.Role)
+				.Select(c => $"{c.Type}$$${c.Value}").ToArray();
 			return new SerializedRunAs {Name = runAs.Principal.Identity.Name, Roles = roles};
 		}
 


### PR DESCRIPTION
Changed: <internal changes>

This PR is the master branch edition of the recent projections fix already present in v20.10, v21.20, v22.10, v23.20 and v24.2. I've moved it over from the internal repo https://github.com/EventStore/EventStore-Internal/pull/20

Changelog entry is not required because it already appears in the changelog for 24.2.0 (It was added to 24.2.0 before the fix was open sourced)