### PR TITLE
Fix docker build after buildkit change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN dotnet restore --runtime=${RUNTIME}
 COPY ./src .
 
 WORKDIR /build/.git
-COPY ./.git .
+COPY ./.git/ .
 
 WORKDIR /build/src
 RUN find /build/src -maxdepth 1 -type d -name "*.Tests" -print0 | xargs -I{} -0 -n1 sh -c \


### PR DESCRIPTION
Updated: dockerfile for newer buildkit

The CI has started reporting

```
17 |
18 | WORKDIR /build/.git
19 | >>> COPY ./.git .
20 |
21 | WORKDIR /build/src

```

e.g. https://github.com/EventStore/EventStore/actions/runs/8295795061/job/22734132242

It may be that this commit https://github.com/moby/buildkit/commit/a8d926a0c718415e4423dfdfce8c386f8ffdedaf is causing the COPY line to be detected as a git ref now (because it ends in .git) but it isn't.

Adding the slash prevents this and doesn't change the behaviour of the COPY line (the commit SHA is still printed correctly in the ES VERSION line).