### PR TITLE
[ESDB-106-15] Always replicate the chunk header

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -2167,7 +2167,7 @@
               },
               {
                 "id": 5,
-                "name": "is_completed_chunk",
+                "name": "is_scavenged_chunk",
                 "type": "bool"
               }
             ]

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -32,10 +32,10 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_from_start() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.AreEqual(1, messages.Length);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.Zero(subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);
@@ -66,15 +66,13 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_from_last_epoch_position() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.IsTrue(messages.Length >= 2);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.AreEqual(_lastEpoch.EpochPosition, subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);
-
-			Assert.IsInstanceOf<ReplicationTrackingMessage.ReplicatedTo>(messages[1]);
 		}
 	}
 
@@ -103,15 +101,13 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_from_requested_position() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.IsTrue(messages.Length >= 2);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.AreEqual(_subscribedPosition, subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);
-
-			Assert.IsInstanceOf<ReplicationTrackingMessage.ReplicatedTo>(messages[1]);
 		}
 	}
 
@@ -147,10 +143,10 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_replica_subscribed_message_for_epoch_after_common_epoch() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.AreEqual(1, messages.Length);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.AreEqual(_replicaEpochs[2].EpochPosition, subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);
@@ -183,10 +179,10 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_replica_subscribed_message_for_epoch_after_common_epoch() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.AreEqual(1, messages.Length);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.AreEqual(_replicaEpochs[0].EpochPosition, subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);
@@ -220,10 +216,10 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_replica_subscribed_message_for_leaders_writer_checkpoint() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.AreEqual(1, messages.Length);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.AreEqual(Writer.Position, subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);
@@ -259,10 +255,10 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_replica_subscribed_message_for_leaders_epoch_after_common_epoch() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.AreEqual(1, messages.Length);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.AreEqual(EpochManager.GetLastEpoch().EpochPosition, subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);
@@ -299,15 +295,13 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_common_epoch() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.IsTrue(messages.Length >= 2);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.AreEqual(_replicaEpochs[0].EpochPosition, subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);
-
-			Assert.IsInstanceOf<ReplicationTrackingMessage.ReplicatedTo>(messages[1]);
 		}
 	}
 
@@ -349,10 +343,10 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_to_epoch_position_after_common_epoch() {
-			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
-			Assert.AreEqual(1, messages.Length);
+			var message = GetTcpSendsFor(_replicaManager).Select(x => x.Message).First();
 
-			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.IsInstanceOf<ReplicationMessage.ReplicaSubscribed>(message);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)message;
 			Assert.AreEqual(EpochManager.GetLastEpochs(5).First(x => x.EpochNumber == 4).EpochPosition, subscribed.SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed.LeaderId);

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -73,9 +73,9 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Service.Handle(new SystemMessage.SystemStart());
 			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
-			ReplicaSubscriptionId = AddSubscription(ReplicaId, ReplicationSubscriptionVersions.V1, true, out ReplicaManager1);
-			ReplicaSubscriptionId2 = AddSubscription(ReplicaId2, ReplicationSubscriptionVersions.V1, true, out ReplicaManager2);
-			ReadOnlyReplicaSubscriptionId = AddSubscription(ReadOnlyReplicaId, ReplicationSubscriptionVersions.V1, false, out ReadOnlyReplicaManager);
+			ReplicaSubscriptionId = AddSubscription(ReplicaId, ReplicationSubscriptionVersions.V_CURRENT, true, out ReplicaManager1);
+			ReplicaSubscriptionId2 = AddSubscription(ReplicaId2, ReplicationSubscriptionVersions.V_CURRENT, true, out ReplicaManager2);
+			ReadOnlyReplicaSubscriptionId = AddSubscription(ReadOnlyReplicaId, ReplicationSubscriptionVersions.V_CURRENT, false, out ReadOnlyReplicaManager);
 			ReplicaSubscriptionIdV0 = AddSubscription(ReplicaIdV0, ReplicationSubscriptionVersions.V0, true, out ReplicaManagerV0);
 
 			When();

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -122,7 +122,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				Guid.NewGuid(),
 				new NoopEnvelope(),
 				manager,
-				ReplicationSubscriptionVersions.V1,
+				ReplicationSubscriptionVersions.V_CURRENT,
 				logPosition,
 				Guid.NewGuid(),
 				epochs,

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
@@ -32,6 +32,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 					new byte[3]);
 				Assert.IsTrue(Writer.Write(r, out _));
 				Writer.CompleteChunk();
+				Writer.AddNewChunk();
 
 				_scavenged.Add(r);
 			}
@@ -40,16 +41,19 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 			_survivors.Add(r2);
 
 			Writer.CompleteChunk();
+			Writer.AddNewChunk();
 
 			var r3 = WriteDeletePrepare("s1");
 			_survivors.Add(r3);
 
 			Writer.CompleteChunk();
+			Writer.AddNewChunk();
 
 			var r4 = WriteDeleteCommit(r3);
 			_survivors.Add(r4);
 
 			Writer.CompleteChunk();
+			Writer.AddNewChunk();
 
 			Scavenge(completeLast: false, mergeChunks: true);
 

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_deleted_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_deleted_records.cs
@@ -32,6 +32,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 			_event4 = WriteSingleEvent(_eventStreamId, 3, "bla1");
 
 			Writer.CompleteChunk();
+			Writer.AddNewChunk();
 
 			Scavenge(completeLast: false, mergeChunks: true);
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_transactions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_transactions.cs
@@ -46,6 +46,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				t1Commit.GetNextLogPosition(t1Commit.LogPosition, t1Commit.GetSizeWithLengthPrefixAndSuffix() - 2 * sizeof(int));
 
 			Writer.CompleteChunk();
+			Writer.AddNewChunk();
 
 			// Need to have a second chunk as otherwise the checkpoints will be off
 			_random1 = WriteSingleEvent("random-stream", 0, "bla");

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
@@ -40,6 +40,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				3);
 
 			Writer.CompleteChunk();
+			Writer.AddNewChunk();
 
 			Scavenge(completeLast: false, mergeChunks: true);
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
@@ -49,6 +49,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				t1.EventStreamId, 0, out _postCommitPos);
 
 			Writer.CompleteChunk();
+			Writer.AddNewChunk();
 
 			// Need to have a second chunk as otherwise the checkpoints will be off
 			_random1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), "random-stream",

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_data_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_data_chunk_boundary.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Core.Tests.TransactionLog.Validation;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Truncation {
+	[TestFixture]
+	public class when_truncating_to_a_data_chunk_boundary : SpecificationWithDirectoryPerTestFixture {
+		private TFChunkDbConfig _config;
+
+		private const int ChunkSize = 1000;
+		private  const long TruncateChk = ChunkSize * 3;
+
+		[OneTimeSetUp]
+		public override async Task TestFixtureSetUp() {
+			await base.TestFixtureSetUp();
+
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 11111, 5500, 5500, -1, TruncateChk, ChunkSize, -1);
+
+			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
+			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));
+			DbUtil.CreateSingleChunk(_config, 3, GetFilePathFor("chunk-000003.000000"));
+			DbUtil.CreateSingleChunk(_config, 4, GetFilePathFor("chunk-000004.000000"));
+			DbUtil.CreateOngoingChunk(_config, 5, GetFilePathFor("chunk-000005.000000"));
+
+			var truncator = new TFChunkDbTruncator(_config);
+			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		}
+
+		[OneTimeTearDown]
+		public override Task TestFixtureTearDown() {
+			using (var db = new TFChunkDb(_config)) {
+				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
+			}
+
+			Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000002")));
+			Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000003.000000")));
+			Assert.AreEqual(2, Directory.GetFiles(PathName, "*").Length);
+
+			return base.TestFixtureTearDown();
+		}
+
+		[Test]
+		public void chunk_at_boundary_should_be_deleted() {
+			var files = Directory.GetFiles(PathName, "*").Select(Path.GetFileName).Order().ToArray();
+			Assert.AreEqual(new[] { "chunk-000000.000001", "chunk-000000.000002" }, files);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_scavenged_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_scavenged_chunk_boundary.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Core.Tests.TransactionLog.Validation;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Truncation {
+	[TestFixture]
+	public class when_truncating_to_a_scavenged_chunk_boundary : SpecificationWithDirectoryPerTestFixture {
+		private TFChunkDbConfig _config;
+
+		private const int ChunkSize = 1000;
+		private  const long TruncateChk = ChunkSize * 3;
+
+		[OneTimeSetUp]
+		public override async Task TestFixtureSetUp() {
+			await base.TestFixtureSetUp();
+
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 11111, 5500, 5500, -1, TruncateChk, ChunkSize, -1);
+
+			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
+			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));
+			DbUtil.CreateMultiChunk(_config, 3, 3, GetFilePathFor("chunk-000003.000001"));
+			DbUtil.CreateSingleChunk(_config, 4, GetFilePathFor("chunk-000004.000000"));
+			DbUtil.CreateOngoingChunk(_config, 5, GetFilePathFor("chunk-000005.000000"));
+
+			var truncator = new TFChunkDbTruncator(_config);
+			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		}
+
+		[OneTimeTearDown]
+		public override Task TestFixtureTearDown() {
+			using (var db = new TFChunkDb(_config)) {
+				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
+			}
+
+			Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000002")));
+			Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000003.000000")));
+			Assert.AreEqual(2, Directory.GetFiles(PathName, "*").Length);
+
+			return base.TestFixtureTearDown();
+		}
+
+		[Test]
+		public void chunk_at_boundary_should_be_deleted() {
+			var files = Directory.GetFiles(PathName, "*").Select(Path.GetFileName).Order().ToArray();
+			Assert.AreEqual(new[] { "chunk-000000.000001", "chunk-000000.000002" }, files);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -43,8 +43,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 		}
 
 		[Test]
-		public void flush_throws_invalid_operation_exception() {
-			Assert.Throws<InvalidOperationException>(() => _testChunk.Flush());
+		public void flush_does_not_throw_any_exception() {
+			Assert.DoesNotThrow(() => _testChunk.Flush());
 		}
 	}
 }

--- a/src/EventStore.Core/Cluster/ReplicationPartials.cs
+++ b/src/EventStore.Core/Cluster/ReplicationPartials.cs
@@ -73,7 +73,7 @@ namespace EventStore.Cluster {
 
 	partial class CreateChunk {
 		public CreateChunk(byte[] leaderId, byte[] subscriptionId, byte[] chunkHeaderBytes, int fileSize,
-			bool isCompletedChunk) {
+			bool isScavengedChunk) {
 			Ensure.NotNull(leaderId, "leaderId");
 			Ensure.NotNull(subscriptionId, "subscriptionId");
 			Ensure.NotNull(chunkHeaderBytes, "chunkHeaderBytes");
@@ -82,7 +82,7 @@ namespace EventStore.Cluster {
 			SubscriptionId = ByteString.CopyFrom(subscriptionId);
 			ChunkHeaderBytes = ByteString.CopyFrom(chunkHeaderBytes);
 			FileSize = fileSize;
-			IsCompletedChunk = isCompletedChunk;
+			IsScavengedChunk = isScavengedChunk;
 		}
 	}
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -594,7 +594,7 @@ namespace EventStore.Core {
 			}
 
 			// DYNAMIC CACHE MANAGER
-			Db.Open(!options.Database.SkipDbVerify, threads: options.Database.InitializationThreads);
+			Db.Open(!options.Database.SkipDbVerify, threads: options.Database.InitializationThreads, createNewChunks: false);
 			var indexPath = options.Database.Index ?? Path.Combine(Db.Config.Path, ESConsts.DefaultIndexDirectoryName);
 
 			var pTableMaxReaderCount = GetPTableMaxReaderCount(readerThreadsCount);

--- a/src/EventStore.Core/Messages/ReplicationMessage.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessage.cs
@@ -314,10 +314,10 @@ namespace EventStore.Core.Messages {
 
 			public readonly ChunkHeader ChunkHeader;
 			public readonly int FileSize;
-			public bool IsCompletedChunk;
+			public bool IsScavengedChunk;
 
 			public CreateChunk(Guid leaderId, Guid subscriptionId, ChunkHeader chunkHeader, int fileSize,
-				bool isCompletedChunk) {
+				bool isScavengedChunk) {
 				Ensure.NotEmptyGuid(leaderId, "leaderId");
 				Ensure.NotEmptyGuid(subscriptionId, "subscriptionId");
 				Ensure.NotNull(chunkHeader, "chunkHeader");
@@ -326,13 +326,13 @@ namespace EventStore.Core.Messages {
 				SubscriptionId = subscriptionId;
 				ChunkHeader = chunkHeader;
 				FileSize = fileSize;
-				IsCompletedChunk = isCompletedChunk;
+				IsScavengedChunk = isScavengedChunk;
 			}
 
 			public override string ToString() {
 				return string.Format(
-					"CreateChunk message: LeaderId: {0}, SubscriptionId: {1}, ChunkHeader: {2}, FileSize: {3}, IsCompletedChunk: {4}",
-					LeaderId, SubscriptionId, ChunkHeader, FileSize, IsCompletedChunk);
+					"CreateChunk message: LeaderId: {0}, SubscriptionId: {1}, ChunkHeader: {2}, FileSize: {3}, IsScavengedChunk: {4}",
+					LeaderId, SubscriptionId, ChunkHeader, FileSize, IsScavengedChunk);
 			}
 		}
 

--- a/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			AddUnwrapper(TcpCommand.DropSubscription, UnwrapDropSubscription, ClientVersion.V2);
 			AddWrapper<ReplicationMessage.DropSubscription>(WrapDropSubscription, ClientVersion.V2);
 		}
-		
+
 
 		private TcpPackage WrapReplicatedTo(ReplicationTrackingMessage.ReplicatedTo msg) {
 			var dto = new ReplicatedTo(msg.LogPosition);
@@ -105,7 +105,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			}
 
 			return new ReplicationMessage.CreateChunk(new Guid(dto.LeaderId.Span), new Guid(dto.SubscriptionId.Span), chunkHeader,
-				dto.FileSize, dto.IsCompletedChunk);
+				dto.FileSize, dto.IsScavengedChunk);
 		}
 
 		private TcpPackage WrapCreateChunk(ReplicationMessage.CreateChunk msg) {
@@ -113,7 +113,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 				msg.SubscriptionId.ToByteArray(),
 				msg.ChunkHeader.AsByteArray(),
 				msg.FileSize,
-				msg.IsCompletedChunk);
+				msg.IsScavengedChunk);
 			return new TcpPackage(TcpCommand.CreateChunk, Guid.NewGuid(), dto.Serialize());
 		}
 

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -215,7 +215,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 					"Unable to connect to Remote EndPoint : {remoteEndPoint}. Connection is potentially blocked. Total bytes sent: {TotalBytesSent}, Total bytes received: {TotalBytesReceived}",
 					RemoteEndPoint, _connection.TotalBytesSent, _connection.TotalBytesReceived);
 			}
-			
+
 			if (_connectionClosed != null)
 				_connectionClosed(this, socketError);
 		}
@@ -294,7 +294,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 						reason = Helper.UTF8NoBom.GetString(package.Data.Array, package.Data.Offset,
 							package.Data.Count));
 					Log.Error(
-						"Bad request received from '{connectionName}{clientConnectionName}' [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}], will stop server. CorrelationId: {correlationId:B}, Error: {e}.",
+						"Bad request received from '{connectionName}{clientConnectionName}' [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]. CorrelationId: {correlationId:B}, Error: {e}.",
 						ConnectionName,
 						ClientConnectionName.IsEmptyString() ? string.Empty : ":" + ClientConnectionName,
 						RemoteEndPoint,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -788,7 +788,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			if (_inMem)
 				return;
 			if (IsReadOnly)
-				throw new InvalidOperationException("Cannot write to a read-only TFChunk.");
+				return;
 			_writerWorkItem.FlushToDisk();
 		}
 

--- a/src/EventStore.Core/TransactionLog/FileNamingStrategy/IVersionedFileNamingStrategy.cs
+++ b/src/EventStore.Core/TransactionLog/FileNamingStrategy/IVersionedFileNamingStrategy.cs
@@ -1,7 +1,7 @@
 namespace EventStore.Core.TransactionLog.FileNamingStrategy {
 	public interface IVersionedFileNamingStrategy {
 		string GetFilenameFor(int index, int version);
-		string DetermineBestVersionFilenameFor(int index);
+		string DetermineBestVersionFilenameFor(int index, int initialVersion);
 		string[] GetAllVersionsFor(int index);
 		string[] GetAllPresentFiles();
 		string GetTempFilename();

--- a/src/EventStore.Core/TransactionLog/FileNamingStrategy/VersionedPatternFileNamingStrategy.cs
+++ b/src/EventStore.Core/TransactionLog/FileNamingStrategy/VersionedPatternFileNamingStrategy.cs
@@ -27,10 +27,10 @@ namespace EventStore.Core.TransactionLog.FileNamingStrategy {
 			return Path.Combine(_path, string.Format("{0}{1:000000}.{2:000000}", _prefix, index, version));
 		}
 
-		public string DetermineBestVersionFilenameFor(int index) {
+		public string DetermineBestVersionFilenameFor(int index, int initialVersion) {
 			var allVersions = GetAllVersionsFor(index);
 			if (allVersions.Length == 0)
-				return GetFilenameFor(index, 0);
+				return GetFilenameFor(index, initialVersion);
 			int lastVersion;
 			if (!int.TryParse(allVersions[0].Substring(allVersions[0].LastIndexOf('.') + 1), out lastVersion))
 				throw new Exception(string.Format("Could not determine version from filename '{0}'.", allVersions[0]));

--- a/src/Protos/Grpc/cluster.proto
+++ b/src/Protos/Grpc/cluster.proto
@@ -9,14 +9,14 @@ service Gossip {
 	rpc Read (event_store.client.Empty) returns (ClusterInfo);
 }
 
-service Elections {	
+service Elections {
 	rpc ViewChange (ViewChangeRequest) returns (event_store.client.Empty);
 	rpc ViewChangeProof (ViewChangeProofRequest) returns (event_store.client.Empty);
 	rpc Prepare (PrepareRequest) returns (event_store.client.Empty);
 	rpc PrepareOk (PrepareOkRequest) returns (event_store.client.Empty);
 	rpc Proposal (ProposalRequest) returns (event_store.client.Empty);
 	rpc Accept (AcceptRequest) returns (event_store.client.Empty);
-	
+
 	rpc LeaderIsResigning (LeaderIsResigningRequest) returns (event_store.client.Empty);
 	rpc LeaderIsResigningOk (LeaderIsResigningOkRequest) returns (event_store.client.Empty);
 }
@@ -132,7 +132,7 @@ message MemberInfo {
 	EndPoint external_tcp = 7;
 	bool internal_tcp_uses_tls = 8;
 	bool external_tcp_uses_tls = 9;
-	
+
     int64 last_commit_position = 10;
     int64 writer_checkpoint = 11;
 	int64 chaser_checkpoint = 12;
@@ -197,7 +197,7 @@ message CreateChunk{
 	bytes subscription_id = 2;
 	bytes chunk_header_bytes = 3;
 	int32 file_size = 4;
-	bool is_completed_chunk = 5;
+	bool is_scavenged_chunk = 5;
 }
 
 message RawChunkBulk{


### PR DESCRIPTION
Changed: Always replicate the chunk header

This PR causes followers to always replicate the chunk header from the leader. It is a pre-requisite for the encryption at rest plugin. Prior to this PR, the chunk header was replicated only for scavenged chunks.

This change has an additional benefit: it's easy for sysadmins to compare files on a leader and a follower by using standard tools like `md5sum`, `sha1sum`, etc. without needing to exclude the first 128 bytes from the comparison (as previously, the chunk IDs were different on the leader and followers)