### PR TITLE
[DB-26-5] Change event type of Persistent Subscription checkpoint to $SubscriptionCheckpoint

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointReader.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointReader.cs
@@ -30,7 +30,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 			public void LoadStateCompleted(ClientMessage.ReadStreamEventsBackwardCompleted msg) {
 				if (msg.Events.Length > 0) {
-					var checkpoint = msg.Events.Where(v => v.Event.EventType == "SubscriptionCheckpoint")
+					var checkpoint = msg.Events.Where(v => v.Event.EventType == "$SubscriptionCheckpoint")
 						.Select(x => x.Event).FirstOrDefault();
 					if (checkpoint != null) {
 						string lastEvent = checkpoint.Data.ParseJson<string>();

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointWriter.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointWriter.cs
@@ -42,7 +42,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		private void PublishCheckpoint(IPersistentSubscriptionStreamPosition state) {
 			_outstandingWrite = true;
-			var evnt = new Event(Guid.NewGuid(), "SubscriptionCheckpoint", true, state.ToString().ToJson(), null);
+			var evnt = new Event(Guid.NewGuid(), "$SubscriptionCheckpoint", true, state.ToString().ToJson(), null);
 			_ioDispatcher.WriteEvent(_subscriptionStateStream, _version, evnt, SystemAccounts.System,
 				WriteStateCompleted);
 		}


### PR DESCRIPTION
Fixed : SubscriptionCheckpoint event type not filtered. https://linear.app/eventstore/issue/DB-543/subscriptioncheckpoint-event-type-not-filtered

Before this fix/change, the Persistent Subscription Checkpoint event was of type "SubscriptionCheckpoint". As a result, it was not filtered out, when reading only non-system events through a subscription to $all stream.

Following discussion has more details : https://discuss.eventstore.com/t/subscription-returning-system-events/5037