### PR TITLE
[DB-26-3] Open scavenged chunks quickly. Build midpoints later on demand

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -292,7 +292,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			_readSide = _chunkHeader.IsScavenged
 				? new TFChunkReadSideScavenged(this, optimizeReadSideCache, tracker)
 				: new TFChunkReadSideUnscavenged(this, tracker);
-			_readSide.Cache();
+
+			// do not actually cache now because it is too slow when opening the database
+			_readSide.RequestCaching();
 
 			if (verifyHash)
 				VerifyFileHash();
@@ -696,7 +698,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 					return;
 				if (_cacheStatus == CacheStatus.Cached) {
 					// we won the right to un-cache and chunk was cached
-					_readSide.Cache();
+					// possibly we could use a mem reader work item and do the actual midpoint caching now
+					_readSide.RequestCaching();
 
 					_writerWorkItem?.DisposeMemStream();
 


### PR DESCRIPTION
Changed: Open the database faster by building the midpoints for scavenged chunks later on demand

Otherwise opening a database with thousands scavenged chunks can become too slow