### PR TITLE
[ESDB-106-5] Refactoring to support chunk data transformation

### DIFF
--- a/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using EventStore.Core.Data.Redaction;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.RedactionService {
@@ -130,9 +132,9 @@ namespace EventStore.Core.Tests.Services.RedactionService {
 			Assert.AreEqual(SwitchChunkResult.ChunkRangeDoesNotMatch, msg.Result);
 
 			newChunk = $"{nameof(cannot_switch_with_chunk_having_mismatched_range)}-chunk-0-2.tmp";
-			var chunkHeader = new ChunkHeader(1, 1024, 0, 2, true, Guid.NewGuid());
+			var chunkHeader = new ChunkHeader(1, 1024, 0, 2, true, Guid.NewGuid(), TransformType.Identity);
 			var chunk = TFChunk.CreateWithHeader(Path.Combine(PathName, newChunk), chunkHeader, 1024, false, false, false, false,
-				new TFChunkTracker.NoOp());
+				new TFChunkTracker.NoOp(), new IdentityChunkTransformFactory(), ReadOnlyMemory<byte>.Empty);
 			chunk.Dispose();
 			msg = await SwitchChunk(GetChunk(0, 0), newChunk);
 			Assert.AreEqual(SwitchChunkResult.ChunkRangeDoesNotMatch, msg.Result);

--- a/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationWithExistingDbFixture.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationWithExistingDbFixture.cs
@@ -5,6 +5,8 @@ using EventStore.Core.LogAbstraction;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 
 namespace EventStore.Core.Tests.Services.Replication.LogReplication;
 
@@ -35,7 +37,8 @@ public abstract class LogReplicationWithExistingDbFixture<TLogFormat, TStreamId>
 			chunkStartNumber: chunkStartNumber,
 			chunkEndNumber: chunkEndNumber,
 			isScavenged: raw,
-			chunkId: Guid.NewGuid());
+			chunkId: Guid.NewGuid(),
+			transformType: TransformType.Identity);
 
 		var chunk = TFChunk.CreateWithHeader(
 			filename: filename,
@@ -45,7 +48,9 @@ public abstract class LogReplicationWithExistingDbFixture<TLogFormat, TStreamId>
 			unbuffered: db.Config.Unbuffered,
 			writethrough: db.Config.WriteThrough,
 			reduceFileCachePressure: db.Config.ReduceFileCachePressure,
-			tracker: new TFChunkTracker.NoOp());
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new IdentityChunkTransformFactory(),
+			transformHeader: ReadOnlyMemory<byte>.Empty);
 
 		var posMaps = new List<PosMap>();
 

--- a/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Optimization {
@@ -90,7 +91,8 @@ namespace EventStore.Core.Tests.TransactionLog.Optimization {
 			var chunk = TFChunk.CreateNew(GetFilePathFor("chunk-" + chunkNumber + "-" + Guid.NewGuid()), 1024 * 1024,
 				chunkNumber, chunkNumber, scavenged, false, false, false,
 				false,
-				new TFChunkTracker.NoOp());
+				new TFChunkTracker.NoOp(),
+				new IdentityChunkTransformFactory());
 			long offset = chunkNumber * 1024 * 1024;
 			long logPos = 0 + offset;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Scavenging {
@@ -13,7 +14,8 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 			var map = new List<PosMap>();
 			var chunk = TFChunk.CreateNew(Filename, 1024 * 1024, 0, 0, true, false, false, false,
 				false,
-				new TFChunkTracker.NoOp());
+				new TFChunkTracker.NoOp(),
+				new IdentityChunkTransformFactory());
 			long logPos = 0;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {
 				map.Add(new PosMap(logPos, (int)logPos));

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -3,6 +3,7 @@ using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Transforms.Identity;
 using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -19,7 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			return CreateDbConfigEx(pathName, writerCheckpointPosition,0,-1,-1,-1,chunkSize,-1);
 		}
 		public static TFChunkDbConfig CreateDbConfigEx(
-			string pathName, 
+			string pathName,
 			long writerCheckpointPosition,
 			long chaserCheckpointPosition,// Default 0
 			long epochCheckpointPosition ,// Default -1
@@ -37,17 +38,17 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(epochCheckpointPosition),
 				new InMemoryCheckpoint(proposalCheckpointPosition),
 				new InMemoryCheckpoint(truncateCheckpoint),
-				new InMemoryCheckpoint(-1), 
+				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				maxTruncation: maxTruncation);
 		}
 
 		public static TFChunkDbConfig CreateDbConfig(
-			string pathName, 
+			string pathName,
 			ICheckpoint writerCheckpoint,
-			ICheckpoint chaserCheckpoint, 
-			int chunkSize = 10000, 
+			ICheckpoint chaserCheckpoint,
+			int chunkSize = 10000,
 			ICheckpoint replicationCheckpoint = null) {
 			if (replicationCheckpoint == null) replicationCheckpoint = new InMemoryCheckpoint(-1);
 			return new TFChunkDbConfig(
@@ -60,7 +61,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
-				replicationCheckpoint, 
+				replicationCheckpoint,
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1));
 		}
@@ -68,7 +69,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public static TFChunk CreateNewChunk(string fileName, int chunkSize = 4096, bool isScavenged = false) {
 			return TFChunk.CreateNew(fileName, chunkSize, 0, 0,
 				isScavenged: isScavenged, inMem: false, unbuffered: false,
-				writethrough: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp());
+				writethrough: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+				transformFactory: new IdentityChunkTransformFactory());
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateScenario.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Services.Storage;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Transforms.Identity;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
 	public abstract class TruncateScenario<TLogFormat, TStreamId> : ReadIndexTestScenario<TLogFormat, TStreamId> {
@@ -30,7 +31,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			Db.Close();
 			Db.Dispose();
 
-			var truncator = new TFChunkDbTruncator(Db.Config);
+			var truncator = new TFChunkDbTruncator(Db.Config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(TruncateCheckpoint);
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -32,7 +33,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		[Test]
 		public void truncate_above_max_throws_exception() {
 			Assert.Throws<Exception>(() => {
-				var truncator = new TFChunkDbTruncator(_config);
+				var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 				truncator.TruncateDb(0);
 			});
 		}
@@ -41,7 +42,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public void truncate_within_max_does_not_throw_exception() {
 
 			Assert.DoesNotThrow(() => {
-				var truncator = new TFChunkDbTruncator(_config);
+				var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 				truncator.TruncateDb(4800);
 			});
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
@@ -6,7 +6,9 @@ using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -33,7 +35,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateSingleChunk(_config, 2, GetFilePathFor("chunk-000002.000000"));
 			DbUtil.CreateSingleChunk(_config, 3, GetFilePathFor("chunk-000003.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 
@@ -94,7 +96,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		[Test]
 		public void ongoing_chunk_should_have_full_size_and_filled_with_zeros_after_writer_checkpoint() {
 			var fileInfo = new FileInfo(GetFilePathFor("chunk-000001.000002"));
-			Assert.AreEqual(ChunkHeader.Size + 1000 + ChunkFooter.Size, fileInfo.Length);
+			Assert.AreEqual(TFChunk.GetAlignedSize(ChunkHeader.Size + 1000 + ChunkFooter.Size), fileInfo.Length);
 
 			using (var fs = File.OpenRead(fileInfo.FullName)) {
 				var leftDataSize = (int)(_config.WriterCheckpoint.Read() % _config.ChunkSize);

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -29,7 +30,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateMultiChunk(_config, 8, 9, GetFilePathFor("chunk-000008.000001"));
 			DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -26,7 +27,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateMultiChunk(_config, 11, 12, GetFilePathFor("chunk-000011.000001"));
 			DbUtil.CreateOngoingChunk(_config, 13, GetFilePathFor("chunk-000013.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_data_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_data_chunk_boundary.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -25,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateSingleChunk(_config, 4, GetFilePathFor("chunk-000004.000000"));
 			DbUtil.CreateOngoingChunk(_config, 5, GetFilePathFor("chunk-000005.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_scavenged_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_scavenged_chunk_boundary.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -25,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateSingleChunk(_config, 4, GetFilePathFor("chunk-000004.000000"));
 			DbUtil.CreateOngoingChunk(_config, 5, GetFilePathFor("chunk-000005.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -25,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateMultiChunk(_config, 7, 8, GetFilePathFor("chunk-000007.000001"));
 			DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/TFChunkDbCreationTestBase.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/TFChunkDbCreationTestBase.cs
@@ -2,13 +2,14 @@ using System;
 using System.IO;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.Transforms;
 
 namespace EventStore.Core.Tests.TransactionLog.Validation {
 	public static class DbUtil {
 		public static void CreateSingleChunk(TFChunkDbConfig config, int chunkNum, string filename,
 			int? actualDataSize = null, bool isScavenged = false, byte[] contents = null) {
 			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, config.ChunkSize, chunkNum, chunkNum,
-				isScavenged, Guid.NewGuid());
+				isScavenged, Guid.NewGuid(), TransformType.Identity);
 			var chunkBytes = chunkHeader.AsByteArray();
 			var dataSize = actualDataSize ?? config.ChunkSize;
 			var buf = new byte[ChunkHeader.Size + dataSize + ChunkFooter.Size];
@@ -31,7 +32,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			if (chunkStartNum > chunkEndNum) throw new ArgumentException("chunkStartNum");
 
 			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, config.ChunkSize, chunkStartNum, chunkEndNum,
-				true, Guid.NewGuid());
+				true, Guid.NewGuid(), TransformType.Identity);
 			var chunkBytes = chunkHeader.AsByteArray();
 			var physicalDataSize = physicalSize ?? config.ChunkSize;
 			var logicalDataSize = logicalSize ?? (chunkEndNum - chunkStartNum + 1) * config.ChunkSize;
@@ -47,7 +48,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		public static void CreateOngoingChunk(TFChunkDbConfig config, int chunkNum, string filename,
 			int? actualSize = null, byte[] contents = null) {
 			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, config.ChunkSize, chunkNum, chunkNum, false,
-				Guid.NewGuid());
+				Guid.NewGuid(), TransformType.Identity);
 			var chunkBytes = chunkHeader.AsByteArray();
 			var dataSize = actualSize ?? config.ChunkSize;
 			var buf = new byte[ChunkHeader.Size + dataSize + ChunkFooter.Size];

--- a/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
@@ -5,6 +5,7 @@ using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -15,7 +16,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		private TFChunkDb _db;
 
 		private static void CreateChunk(string path, int size) {
-			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, size, 0, 0, false, Guid.NewGuid());
+			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, size, 0, 0, false, Guid.NewGuid(), TransformType.Identity);
 			var chunkBytes = chunkHeader.AsByteArray();
 			var buf = new byte[ChunkHeader.Size + ChunkFooter.Size + chunkHeader.ChunkSize];
 			Buffer.BlockCopy(chunkBytes, 0, buf, 0, chunkBytes.Length);
@@ -67,7 +68,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void checkpoints_should_be_flushed_only_when_chunks_are_properly_closed(bool chunksClosed) {
 			if (!chunksClosed) {
 				// acquire a reader to prevent the chunk from being properly closed
-				_db.Manager.GetChunk(0).AcquireReader();
+				_db.Manager.GetChunk(0).AcquireRawReader();
 			}
 
 			var writer = new TFChunkWriter(_db);

--- a/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk = TFChunkHelper.CreateNewChunk(Filename, 1000);
 			_chunk.Complete();
 			_chunk.UnCacheFromMemory();
-			_reader = _chunk.AcquireReader();
+			_reader = _chunk.AcquireRawReader();
 			_chunk.MarkForDeletion();
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public override void SetUp() {
 			base.SetUp();
 			_chunk = TFChunkHelper.CreateNewChunk(Filename, 1000);
-			var reader = _chunk.AcquireReader();
+			var reader = _chunk.AcquireRawReader();
 			_chunk.MarkForDeletion();
 			reader.Release();
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -2,6 +2,7 @@ using System;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -16,7 +17,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk = TFChunkHelper.CreateNewChunk(Filename);
 			_chunk.Complete();
 			_testChunk = TFChunk.FromCompletedFile(Filename, true, false,
-				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp());
+				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+				getTransformFactory: _ => new IdentityChunkTransformFactory());
 		}
 
 		[TearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -1,6 +1,7 @@
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -9,7 +10,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void it_should_throw_a_file_not_found_exception() {
 			Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true,
-				unbufferedRead: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp()));
+				unbufferedRead: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+				getTransformFactory: _ => new IdentityChunkTransformFactory()));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -3,6 +3,7 @@ using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -30,7 +31,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Flush();
 			_chunk.Complete();
 			_cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
-				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp());
+				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+				getTransformFactory: _ => new IdentityChunkTransformFactory());
 			_cachedChunk.CacheInMemory();
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -8,10 +8,10 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void the_file_will_not_be_deleted_until_reader_released() {
 			var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
-			using (var reader = chunk.AcquireReader()) {
+			using (var reader = chunk.AcquireRawReader()) {
 				chunk.MarkForDeletion();
 				var buffer = new byte[1024];
-				var result = reader.ReadNextRawBytes(1024, buffer);
+				var result = reader.ReadNextBytes(1024, buffer);
 				Assert.IsFalse(result.IsEOF);
 				Assert.AreEqual(1024, result.BytesRead);
 			}
@@ -22,9 +22,9 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void a_read_on_new_file_can_be_performed() {
 			var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
-			using (var reader = chunk.AcquireReader()) {
+			using (var reader = chunk.AcquireRawReader()) {
 				var buffer = new byte[1024];
-				var result = reader.ReadNextRawBytes(1024, buffer);
+				var result = reader.ReadNextBytes(1024, buffer);
 				Assert.IsFalse(result.IsEOF);
 				Assert.AreEqual(1024, result.BytesRead);
 			}
@@ -38,10 +38,10 @@ namespace EventStore.Core.Tests.TransactionLog {
         {
             var chunk = TFChunk.CreateNew(GetFilePathFor("afile"), 200, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
             chunk.CompleteScavenge(new [] {new PosMap(0, 0), new PosMap(1,1) }, false);
-            using (var reader = chunk.AcquireReader())
+            using (var reader = chunk.AcquireRawReader())
             {
                 var buffer = new byte[1024];
-                var result = reader.ReadNextRawBytes(1024, buffer);
+                var result = reader.ReadNextBytes(1024, buffer);
                 Assert.IsFalse(result.IsEOF);
                 Assert.AreEqual(ChunkHeader.Size + ChunkHeader.Size + 2 * PosMap.FullSize, result.BytesRead);
             }
@@ -54,10 +54,10 @@ namespace EventStore.Core.Tests.TransactionLog {
         {
             var chunk = TFChunk.CreateNew(GetFilePathFor("File1"), 300, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
             chunk.Complete();
-            using (var reader = chunk.AcquireReader())
+            using (var reader = chunk.AcquireRawReader())
             {
                 var buffer = new byte[1024];
-                var result = reader.ReadNextRawBytes(1024, buffer);
+                var result = reader.ReadNextBytes(1024, buffer);
                 Assert.IsTrue(result.IsEOF);
                 Assert.AreEqual(ChunkHeader.Size + ChunkFooter.Size, result.BytesRead); //just header + footer = 256
             }
@@ -69,9 +69,9 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void if_asked_for_more_than_buffer_size_will_only_read_buffer_size() {
 			var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 3000);
-			using (var reader = chunk.AcquireReader()) {
+			using (var reader = chunk.AcquireRawReader()) {
 				var buffer = new byte[1024];
-				var result = reader.ReadNextRawBytes(3000, buffer);
+				var result = reader.ReadNextBytes(3000, buffer);
 				Assert.IsFalse(result.IsEOF);
 				Assert.AreEqual(1024, result.BytesRead);
 			}
@@ -83,9 +83,9 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void a_read_past_eof_returns_eof_and_no_footer() {
 			var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
-			using (var reader = chunk.AcquireReader()) {
+			using (var reader = chunk.AcquireRawReader()) {
 				var buffer = new byte[8092];
-				var result = reader.ReadNextRawBytes(8092, buffer);
+				var result = reader.ReadNextBytes(8092, buffer);
 				Assert.IsTrue(result.IsEOF);
 				Assert.AreEqual(4096, result.BytesRead); //does not includes header and footer space
 			}

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -3,6 +3,7 @@ using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -30,7 +31,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Flush();
 			_chunk.Complete();
 			_uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
-				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp());
+				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+				getTransformFactory: _ => new IdentityChunkTransformFactory());
 			_uncachedChunk.CacheInMemory();
 			_uncachedChunk.UnCacheFromMemory();
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public override void SetUp() {
 			base.SetUp();
 			_chunk = TFChunkHelper.CreateNewChunk(Filename, 1000);
-			var reader = _chunk.AcquireReader();
+			var reader = _chunk.AcquireRawReader();
 			_chunk.MarkForDeletion();
 			reader.Release();
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
@@ -6,6 +6,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -19,7 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void a_record_can_be_written() {
 			var filename = GetFilePathFor("chunk-000000.000000");
-			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, 10000, 0, 0, false, chunkId: Guid.NewGuid());
+			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, 10000, 0, 0, false, chunkId: Guid.NewGuid(), TransformType.Identity);
 			var chunkBytes = chunkHeader.AsByteArray();
 			var bytes = new byte[ChunkHeader.Size + 10000 + ChunkFooter.Size];
 			Buffer.BlockCopy(chunkBytes, 0, bytes, 0, chunkBytes.Length);

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum_and_data_bigger_than_buffer.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum_and_data_bigger_than_buffer.cs
@@ -6,6 +6,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -21,7 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void a_record_can_be_written() {
 			var filename = GetFilePathFor("chunk-000000.000000");
-			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, 10000, 0, 0, false, Guid.NewGuid());
+			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, 10000, 0, 0, false, Guid.NewGuid(), TransformType.Identity);
 			var chunkBytes = chunkHeader.AsByteArray();
 			var buf = new byte[ChunkHeader.Size + ChunkFooter.Size + chunkHeader.ChunkSize];
 			Buffer.BlockCopy(chunkBytes, 0, buf, 0, chunkBytes.Length);

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_not_enough_space_in_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_not_enough_space_in_chunk.cs
@@ -7,6 +7,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -22,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void a_record_is_not_written_at_first_but_written_on_second_try() {
 			var filename1 = GetFilePathFor("chunk-000000.000000");
 			var filename2 = GetFilePathFor("chunk-000001.000000");
-			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, 10000, 0, 0, false, Guid.NewGuid());
+			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, 10000, 0, 0, false, Guid.NewGuid(), TransformType.Identity);
 			var chunkBytes = chunkHeader.AsByteArray();
 			var bytes = new byte[ChunkHeader.Size + 10000 + ChunkFooter.Size];
 			Buffer.BlockCopy(chunkBytes, 0, bytes, 0, chunkBytes.Length);

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/ChunkHeaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/ChunkHeaderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Transforms;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
@@ -15,7 +16,8 @@ public class ChunkHeaderTests {
 			chunkStartNumber: Random.Shared.Next(500, 600),
 			chunkEndNumber: Random.Shared.Next(700, 800),
 			isScavenged: isScavenged,
-			chunkId: Guid.NewGuid());
+			chunkId: Guid.NewGuid(),
+			transformType: TransformType.Identity);
 
 		var destination = new ChunkHeader(source.AsByteArray());
 
@@ -25,5 +27,6 @@ public class ChunkHeaderTests {
 		Assert.Equal(source.ChunkEndNumber, destination.ChunkEndNumber);
 		Assert.Equal(source.IsScavenged, destination.IsScavenged);
 		Assert.Equal(source.ChunkId, destination.ChunkId);
+		Assert.Equal(source.TransformType, destination.TransformType);
 	}
 }

--- a/src/EventStore.Core/Data/Redaction/SwitchChunkResult.cs
+++ b/src/EventStore.Core/Data/Redaction/SwitchChunkResult.cs
@@ -14,7 +14,8 @@ namespace EventStore.Core.Data.Redaction {
 		NewChunkHashInvalid = 11,
 		NewChunkOpenFailed = 12,
 		ChunkRangeDoesNotMatch = 13,
-		UnexpectedError = 14
+		UnexpectedError = 14,
+		TargetChunkFormatNotSupported = 15,
 	}
 
 	public static class SwitchChunkResultExtensions {
@@ -33,6 +34,7 @@ namespace EventStore.Core.Data.Redaction {
 				SwitchChunkResult.NewChunkOpenFailed => "An error has occurred when opening the new chunk.",
 				SwitchChunkResult.ChunkRangeDoesNotMatch => "The target chunk's range and the new chunk's range do not match.",
 				SwitchChunkResult.UnexpectedError => "An unexpected error has occurred.",
+				SwitchChunkResult.TargetChunkFormatNotSupported => "The target chunk's file format is not supported.",
 				_ => result.ToString()
 			};
 		}

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -17,6 +17,7 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services {
@@ -205,11 +206,19 @@ namespace EventStore.Core.Services {
 
 			_framer.Reset();
 
+			if (!Db.TransformManager.SupportsTransform(message.ChunkHeader.TransformType)) {
+				ReplicationFail(
+					"Unsupported chunk transform: {0}",
+					"Unsupported chunk transform: {transformType}.",
+					message.ChunkHeader.TransformType);
+			}
+
 			if (message.IsScavengedChunk) {
 				_activeChunk = Db.Manager.CreateTempChunk(message.ChunkHeader, message.FileSize);
 			} else {
+				var identityTransformHeader = ReadOnlyMemory<byte>.Empty;
 				if (message.ChunkHeader.ChunkStartNumber == Db.Manager.ChunksCount) {
-					Writer.AddNewChunk(message.ChunkHeader, message.FileSize);
+					Writer.AddNewChunk(message.ChunkHeader, identityTransformHeader, message.FileSize);
 				} else if (message.ChunkHeader.ChunkStartNumber + 1 == Db.Manager.ChunksCount) {
 					// the requested chunk was already created. this is fine, it can happen if the follower created the
 					// chunk in a previous run, was killed and re-subscribed to the leader at the beginning of the chunk.

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -362,8 +362,9 @@ namespace EventStore.Core.Services.Replication {
 				Debug.Assert(chunk != null, string.Format(
 					"Chunk for LogPosition {0} (0x{0:X}) is null in LeaderReplicationService! Replica: [{1},C:{2},S:{3}]",
 					logPosition, sub.ReplicaEndPoint, sub.ConnectionId, sub.SubscriptionId));
-				var bulkReader = chunk.AcquireReader();
-				if (chunk.ChunkHeader.IsScavenged) {
+				var rawSend = chunk.ChunkHeader.IsScavenged;
+				var bulkReader = rawSend ? chunk.AcquireRawReader() : chunk.AcquireDataReader();
+				if (rawSend) {
 					var chunkStartPos = chunk.ChunkHeader.ChunkStartPosition;
 					if (verbose) {
 						Log.Information(
@@ -379,7 +380,7 @@ namespace EventStore.Core.Services.Replication {
 
 					sub.LogPosition = chunkStartPos;
 					sub.RawSend = true;
-					bulkReader.SetRawPosition(ChunkHeader.Size);
+					bulkReader.SetPosition(ChunkHeader.Size);
 					if (replicationStart)
 						sub.SendMessage(new ReplicationMessage.ReplicaSubscribed(_instanceId, sub.SubscriptionId,
 							sub.LogPosition));
@@ -396,7 +397,7 @@ namespace EventStore.Core.Services.Replication {
 
 					sub.LogPosition = logPosition;
 					sub.RawSend = false;
-					bulkReader.SetDataPosition(chunk.ChunkHeader.GetLocalLogPosition(logPosition));
+					bulkReader.SetPosition(chunk.ChunkHeader.GetLocalLogPosition(logPosition));
 					if (replicationStart)
 						sub.SendMessage(new ReplicationMessage.ReplicaSubscribed(_instanceId, sub.SubscriptionId,
 							sub.LogPosition));
@@ -539,11 +540,11 @@ namespace EventStore.Core.Services.Replication {
 
 			BulkReadResult bulkResult;
 			if (subscription.RawSend) {
-				bulkResult = bulkReader.ReadNextRawBytes(subscription.DataBuffer.Length, subscription.DataBuffer);
+				bulkResult = bulkReader.ReadNextBytes(subscription.DataBuffer.Length, subscription.DataBuffer);
 			} else {
 				var bytesToRead = (int)Math.Min(subscription.DataBuffer.Length,
 					leaderCheckpoint - subscription.LogPosition);
-				bulkResult = bulkReader.ReadNextDataBytes(bytesToRead, subscription.DataBuffer);
+				bulkResult = bulkReader.ReadNextBytes(bytesToRead, subscription.DataBuffer);
 			}
 
 			bool dataFound = false;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -13,6 +13,8 @@ using DotNext.IO;
 using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using EventStore.Core.Util;
 using Microsoft.Win32.SafeHandles;
 using ILogger = Serilog.ILogger;
@@ -27,6 +29,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		}
 
 		public const byte CurrentChunkVersion = 3;
+		private const int AlignmentSize = 4096;
 
 		private static readonly ILogger Log = Serilog.Log.ForContext<TFChunk>();
 
@@ -39,12 +42,12 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			get { return _cacheStatus == CacheStatus.Cached; }
 		}
 
-		// the logical size of data (could be > PhysicalDataSize if scavenged chunk)
+		// the logical size of (untransformed) data (could be > PhysicalDataSize if scavenged chunk)
 		public long LogicalDataSize {
 			get { return Interlocked.Read(ref _logicalDataSize); }
 		}
 
-		// the physical size of data size of data
+		// the physical size of (untransformed) data
 		public int PhysicalDataSize {
 			get { return _physicalDataSize; }
 		}
@@ -63,6 +66,10 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 		public ChunkFooter ChunkFooter {
 			get { return _chunkFooter; }
+		}
+
+		public ReadOnlyMemory<byte> TransformHeader {
+			get { return _transformHeader; }
 		}
 
 		public readonly int MidpointsDepth;
@@ -107,6 +114,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		// potentially causing problems.
 		private readonly object _cachedDataLock = new();
 		private volatile nint _cachedData;
+		// When the chunk is Cached/Uncaching, _cachedDataTransformed indicates whether _cachedData has had the transformation applied
+		private bool _cachedDataTransformed;
 		private int _cachedLength;
 		private volatile CacheStatus _cacheStatus;
 
@@ -138,6 +147,10 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 		private IChunkReadSide _readSide;
 
+		private IChunkTransform _transform;
+		private ReadOnlyMemory<byte> _transformHeader;
+		private readonly IdentityChunkReadTransform _identityReadTransform = IdentityChunkReadTransform.Instance;
+
 		private TFChunk(string filename,
 			int midpointsDepth,
 			bool inMem,
@@ -160,11 +173,12 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		}
 
 		public static TFChunk FromCompletedFile(string filename, bool verifyHash, bool unbufferedRead,
-			ITransactionFileTracker tracker, bool optimizeReadSideCache = false, bool reduceFileCachePressure = false) {
+			ITransactionFileTracker tracker, Func<TransformType, IChunkTransformFactory> getTransformFactory,
+			bool optimizeReadSideCache = false, bool reduceFileCachePressure = false) {
 			var chunk = new TFChunk(filename,
 				TFConsts.MidpointsDepth, false, unbufferedRead, false, reduceFileCachePressure);
 			try {
-				chunk.InitCompleted(verifyHash, optimizeReadSideCache, tracker);
+				chunk.InitCompleted(verifyHash, optimizeReadSideCache, tracker, getTransformFactory);
 			} catch {
 				chunk.Dispose();
 				throw;
@@ -173,15 +187,17 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			return chunk;
 		}
 
-		public static TFChunk FromOngoingFile(string filename, int writePosition, bool checkSize, bool unbuffered,
-			bool writethrough, bool reduceFileCachePressure, ITransactionFileTracker tracker) {
+		public static TFChunk FromOngoingFile(string filename, int writePosition, bool unbuffered,
+			bool writethrough, bool reduceFileCachePressure, ITransactionFileTracker tracker,
+			Func<TransformType, IChunkTransformFactory> getTransformFactory) {
 			var chunk = new TFChunk(filename,
 				TFConsts.MidpointsDepth,
 				false,
 				unbuffered,
-				writethrough, reduceFileCachePressure);
+				writethrough,
+				reduceFileCachePressure);
 			try {
-				chunk.InitOngoing(writePosition, checkSize, tracker);
+				chunk.InitOngoing(writePosition, tracker, getTransformFactory);
 			} catch {
 				chunk.Dispose();
 				throw;
@@ -191,7 +207,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		}
 
 		public static TFChunk CreateNew(string filename,
-			int chunkSize,
+			int chunkDataSize,
 			int chunkStartNumber,
 			int chunkEndNumber,
 			bool isScavenged,
@@ -199,12 +215,14 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			bool unbuffered,
 			bool writethrough,
 			bool reduceFileCachePressure,
-			ITransactionFileTracker tracker) {
-			var size = GetAlignedSize(chunkSize + ChunkHeader.Size + ChunkFooter.Size);
-			var chunkHeader = new ChunkHeader(CurrentChunkVersion, chunkSize, chunkStartNumber, chunkEndNumber,
-				isScavenged, Guid.NewGuid());
-			return CreateWithHeader(filename, chunkHeader, size, inMem, unbuffered, writethrough,
-				reduceFileCachePressure, tracker);
+			ITransactionFileTracker tracker,
+			IChunkTransformFactory transformFactory) {
+			var chunkHeader = new ChunkHeader(CurrentChunkVersion, chunkDataSize, chunkStartNumber, chunkEndNumber,
+				isScavenged, Guid.NewGuid(), transformFactory.Type);
+			var fileSize = GetAlignedSize(transformFactory.TransformDataPosition(chunkDataSize) + ChunkHeader.Size + ChunkFooter.Size);
+
+			return CreateWithHeader(filename, chunkHeader, fileSize, inMem, unbuffered, writethrough,
+				reduceFileCachePressure, tracker, transformFactory, transformFactory.CreateTransformHeader());
 		}
 
 		public static TFChunk CreateWithHeader(string filename,
@@ -214,7 +232,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			bool unbuffered,
 			bool writethrough,
 			bool reduceFileCachePressure,
-			ITransactionFileTracker tracker) {
+			ITransactionFileTracker tracker,
+			IChunkTransformFactory transformFactory,
+			ReadOnlyMemory<byte> transformHeader) {
 			var chunk = new TFChunk(filename,
 				TFConsts.MidpointsDepth,
 				inMem,
@@ -222,7 +242,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				writethrough,
 				reduceFileCachePressure);
 			try {
-				chunk.InitNew(header, fileSize, tracker);
+				chunk.InitNew(header, fileSize, tracker, transformFactory, transformHeader);
 			} catch {
 				chunk.Dispose();
 				throw;
@@ -231,7 +251,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			return chunk;
 		}
 
-		private void InitCompleted(bool verifyHash, bool optimizeReadSideCache, ITransactionFileTracker tracker) {
+		private void InitCompleted(bool verifyHash, bool optimizeReadSideCache, ITransactionFileTracker tracker,
+			Func<TransformType, IChunkTransformFactory> getTransformFactory) {
 			var fileInfo = new FileInfo(_filename);
 			if (!fileInfo.Exists)
 				throw new CorruptDatabaseException(new ChunkNotFoundException(_filename));
@@ -247,18 +268,20 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 			IsReadOnly = true;
 			SetAttributes(_filename, true);
-			CreateReaderStreams();
 
-			var reader = GetReaderWorkItem();
-			try {
-				_chunkHeader = ReadHeader(reader.BaseStream);
+			using (var stream = _handle.AsUnbufferedStream(FileAccess.Read)) {
+				_chunkHeader = ReadHeader(stream);
 				Log.Debug("Opened completed {chunk} as version {version}", _filename, _chunkHeader.Version);
 				if (_chunkHeader.Version != (byte)ChunkVersions.Unaligned &&
 				    _chunkHeader.Version != (byte)ChunkVersions.Aligned)
 					throw new CorruptDatabaseException(new WrongFileVersionException(_filename, _chunkHeader.Version,
 						CurrentChunkVersion));
 
-				_chunkFooter = ReadFooter(reader.BaseStream);
+				var transformFactory = getTransformFactory(_chunkHeader.TransformType);
+				_transformHeader = transformFactory.ReadTransformHeader(stream);
+				_transform = transformFactory.CreateTransform(_transformHeader);
+
+				_chunkFooter = ReadFooter(stream);
 				if (!_chunkFooter.IsCompleted) {
 					throw new CorruptDatabaseException(new BadChunkInDatabaseException(
 						string.Format("Chunk file '{0}' should be completed, but is not.", _filename)));
@@ -266,19 +289,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 				_logicalDataSize = _chunkFooter.LogicalDataSize;
 				_physicalDataSize = _chunkFooter.PhysicalDataSize;
-				var expectedFileSize = _chunkFooter.PhysicalDataSize + _chunkFooter.MapSize + ChunkHeader.Size +
-				                       ChunkFooter.Size;
-				if (_chunkHeader.Version == (byte)ChunkVersions.Unaligned && reader.BaseStream.Length != expectedFileSize) {
-					throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-						string.Format(
-							"Chunk file '{0}' should have a file size of {1} bytes, but it has a size of {2} bytes.",
-							_filename,
-							expectedFileSize,
-							reader.BaseStream.Length)));
-				}
-			} finally {
-				ReturnReaderWorkItem(reader);
 			}
+
+			CreateReaderStreams();
 
 			_readSide = _chunkHeader.IsScavenged
 				? new TFChunkReadSideScavenged(this, optimizeReadSideCache, tracker)
@@ -291,7 +304,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				VerifyFileHash();
 		}
 
-		private void InitNew(ChunkHeader chunkHeader, int fileSize, ITransactionFileTracker tracker) {
+		private void InitNew(ChunkHeader chunkHeader, int fileSize, ITransactionFileTracker tracker,
+			IChunkTransformFactory transformFactory, ReadOnlyMemory<byte> transformHeader) {
 			Ensure.NotNull(chunkHeader, "chunkHeader");
 			Ensure.Positive(fileSize, "fileSize");
 
@@ -300,11 +314,13 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			_chunkHeader = chunkHeader;
 			_physicalDataSize = 0;
 			_logicalDataSize = 0;
+			_transformHeader = transformHeader;
+			_transform = transformFactory.CreateTransform(_transformHeader);
 
 			if (_inMem)
-				CreateInMemChunk(chunkHeader, fileSize);
+				CreateInMemChunk(chunkHeader, fileSize, transformHeader);
 			else {
-				CreateWriterWorkItemForNewChunk(chunkHeader, fileSize);
+				CreateWriterWorkItemForNewChunk(chunkHeader, fileSize, transformHeader);
 				SetAttributes(_filename, false);
 			}
 
@@ -319,7 +335,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			}
 		}
 
-		private void InitOngoing(int writePosition, bool checkSize, ITransactionFileTracker tracker) {
+		private void InitOngoing(int writePosition, ITransactionFileTracker tracker,
+			Func<TransformType, IChunkTransformFactory> getTransformFactory) {
 			Ensure.Nonnegative(writePosition, "writePosition");
 			var fileInfo = new FileInfo(_filename);
 			if (!fileInfo.Exists)
@@ -331,24 +348,12 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			_logicalDataSize = writePosition;
 
 			SetAttributes(_filename, false);
-			CreateWriterWorkItemForExistingChunk(writePosition, out _chunkHeader);
+			CreateWriterWorkItemForExistingChunk(writePosition, getTransformFactory, out _chunkHeader);
 			Log.Debug("Opened ongoing {chunk} as version {version}", _filename, _chunkHeader.Version);
 			if (_chunkHeader.Version != (byte)ChunkVersions.Aligned &&
 			    _chunkHeader.Version != (byte)ChunkVersions.Unaligned)
 				throw new CorruptDatabaseException(new WrongFileVersionException(_filename, _chunkHeader.Version,
 					CurrentChunkVersion));
-
-			if (checkSize) {
-				var expectedFileSize = _chunkHeader.ChunkSize + ChunkHeader.Size + ChunkFooter.Size;
-				if (_writerWorkItem.WorkingStream.Length != expectedFileSize) {
-					throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-						string.Format(
-							"Chunk file '{0}' should have file size {1} bytes, but instead has {2} bytes length.",
-							_filename,
-							expectedFileSize,
-							_writerWorkItem.WorkingStream.Length)));
-				}
-			}
 
 			_readSide = new TFChunkReadSideUnscavenged(this, tracker);
 
@@ -366,19 +371,25 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			Interlocked.Add(ref _fileStreamCount, _fileStreams.Count);
 		}
 
-		private void CreateInMemChunk(ChunkHeader chunkHeader, int fileSize) {
+		private void CreateInMemChunk(ChunkHeader chunkHeader, int fileSize, ReadOnlyMemory<byte> transformHeader) {
 			var md5 = MD5.Create();
 
 			// ALLOCATE MEM
 			_cacheStatus = CacheStatus.Cached;
 			_cachedLength = fileSize;
 			_cachedData = Marshal.AllocHGlobal(_cachedLength);
+			_cachedDataTransformed = true;
 			GC.AddMemoryPressure(_cachedLength);
 
+
+			// WRITE HEADERS
+			using (var headerStream = new UnmanagedMemoryStream((byte*)_cachedData, _cachedLength, _cachedLength, FileAccess.ReadWrite)) {
+				WriteHeader(md5, headerStream, chunkHeader);
+				WriteTransformHeader(md5, headerStream, transformHeader);
+			}
+
 			// WRITER STREAM
-			var writerWorkItem = new WriterWorkItem(_cachedData, _cachedLength, md5);
-			WriteHeader(writerWorkItem.MD5, writerWorkItem.WorkingStream, chunkHeader);
-			writerWorkItem.WorkingStream.Position = ChunkHeader.Size;
+			var writerWorkItem = new WriterWorkItem(_cachedData, _cachedLength, md5, _transform.Write, ChunkHeader.Size + transformHeader.Length);
 
 			// READER STREAMS
 			_memStreams = new();
@@ -409,7 +420,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			}
 		}
 
-		private void CreateWriterWorkItemForNewChunk(ChunkHeader chunkHeader, int fileSize) {
+		private void CreateWriterWorkItemForNewChunk(ChunkHeader chunkHeader, int fileSize, ReadOnlyMemory<byte> transformHeader) {
 			var md5 = MD5.Create();
 
 			// create temp file first and set desired length
@@ -431,22 +442,24 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			// we need to write header into temp file before moving it into correct chunk place, so in case of crash
 			// we don't end up with seemingly valid chunk file with no header at all...
 			WriteHeader(md5, tempFile, chunkHeader);
+			WriteTransformHeader(md5, tempFile, transformHeader);
 
 			tempFile.FlushToDisk();
 			tempFile.Close();
 			File.Move(tempFilename, _filename);
+
 			_handle = File.OpenHandle(_filename, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, WritableHandleOptions);
-			_writerWorkItem = new(_handle, md5, _unbuffered);
-			_writerWorkItem.WorkingStream.Position = ChunkHeader.Size;
+			_writerWorkItem = new(_handle, md5, _unbuffered, _transform.Write, ChunkHeader.Size + transformHeader.Length);
 			Flush(); // persist file move result
 		}
 
-		private void CreateWriterWorkItemForExistingChunk(int writePosition, out ChunkHeader chunkHeader) {
+		private void CreateWriterWorkItemForExistingChunk(int writePosition,
+			Func<TransformType, IChunkTransformFactory> getTransformFactory, out ChunkHeader chunkHeader) {
 			_handle = File.OpenHandle(_filename, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, WritableHandleOptions);
-			var workItem = new WriterWorkItem(_handle, MD5.Create(), _unbuffered);
 
 			try {
-				chunkHeader = ReadHeader(workItem.WorkingStream);
+				using var stream = _handle.AsUnbufferedStream(FileAccess.ReadWrite);
+				chunkHeader = ReadHeader(stream);
 				if (chunkHeader.Version == (byte)ChunkVersions.Unaligned) {
 					Log.Debug("Upgrading ongoing file {chunk} to version 3", _filename);
 					var newHeader = new ChunkHeader((byte)ChunkVersions.Aligned,
@@ -454,22 +467,26 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 						chunkHeader.ChunkStartNumber,
 						chunkHeader.ChunkEndNumber,
 						false,
-						chunkHeader.ChunkId);
-					workItem.WorkingStream.Seek(0, SeekOrigin.Begin);
+						chunkHeader.ChunkId,
+						chunkHeader.TransformType);
+					stream.Seek(0, SeekOrigin.Begin);
 					chunkHeader = newHeader;
 					var head = newHeader.AsByteArray();
-					workItem.WorkingStream.Write(head, 0, head.Length);
-					workItem.FlushToDisk();
-					workItem.WorkingStream.Seek(0, SeekOrigin.Begin);
+					stream.Write(head, 0, head.Length);
+					stream.Flush();
 				}
+
+				var transformFactory = getTransformFactory(chunkHeader.TransformType);
+				_transformHeader = transformFactory.ReadTransformHeader(stream);
+				_transform = transformFactory.CreateTransform(_transformHeader);
 			} catch {
 				_handle.Dispose();
-				workItem.Dispose();
 				throw;
 			}
 
+			var workItem = new WriterWorkItem(_handle, MD5.Create(), _unbuffered, _transform.Write, 0);
 			var realPosition = GetRawPosition(writePosition);
-			MD5Hash.ContinuousHashFor(workItem.MD5, workItem.WorkingStream, 0, realPosition);
+			// the writer work item's stream is responsible for computing the current checksum when the position is set
 			workItem.WorkingStream.Position = realPosition;
 			_writerWorkItem = workItem;
 		}
@@ -478,6 +495,15 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			var chunkHeaderBytes = chunkHeader.AsByteArray();
 			md5.TransformBlock(chunkHeaderBytes, 0, ChunkHeader.Size, null, 0);
 			stream.Write(chunkHeaderBytes, 0, ChunkHeader.Size);
+		}
+
+		private void WriteTransformHeader(HashAlgorithm md5, Stream stream, ReadOnlyMemory<byte> transformHeader) {
+			if (transformHeader.IsEmpty)
+				return;
+
+			var transformHeaderBytes = transformHeader.ToArray();
+			md5.TransformBlock(transformHeaderBytes, 0, transformHeaderBytes.Length, null, 0);
+			stream.Write(transformHeaderBytes);
 		}
 
 		private void SetAttributes(string filename, bool isReadOnly) {
@@ -497,20 +523,15 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				throw new InvalidOperationException("You can't verify hash of not-completed TFChunk.");
 
 			Log.Debug("Verifying hash for TFChunk '{chunk}'...", _filename);
-			using (var reader = AcquireReader()) {
+			using (var reader = AcquireRawReader()) {
 				reader.Stream.Seek(0, SeekOrigin.Begin);
 				var stream = reader.Stream;
 				var footer = _chunkFooter;
 
 				byte[] hash;
 				using (var md5 = MD5.Create()) {
-					// hash header and data
-					MD5Hash.ContinuousHashFor(md5, stream, 0, ChunkHeader.Size + footer.PhysicalDataSize);
-					// hash mapping and footer except MD5 hash sum which should always be last
-					MD5Hash.ContinuousHashFor(md5,
-						stream,
-						ChunkHeader.Size + footer.PhysicalDataSize,
-						stream.Length - ChunkHeader.Size - footer.PhysicalDataSize - ChunkFooter.ChecksumSize);
+					// hash whole chunk except MD5 hash sum which should always be last
+					MD5Hash.ContinuousHashFor(md5, stream, 0, _fileSize - ChunkFooter.ChecksumSize);
 					md5.TransformFinalBlock(Empty.ByteArray, 0, 0);
 					hash = md5.Hash;
 				}
@@ -597,7 +618,27 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				// we won the right to cache
 				var sw = new Timestamp();
 				try {
-					BuildCacheArray();
+					// note: we do not want to cache transformed data for the active chunk as we would be incurring the cost of
+					// transformation twice - once when writing to the filestream and once when writing to the memory stream.
+					// however, we want to cache (already) transformed data for completed/read-only chunks as we would otherwise
+					// incur the cost of transforming the whole chunk when loading data from the file into memory.
+
+					if (!IsReadOnly)
+						// we do not cache the header for the active chunk -
+						// it's not necessary as the cache is used only for reading data.
+						BuildCacheArray(
+							size: GetAlignedSize(ChunkHeader.Size + _chunkHeader.ChunkSize + ChunkFooter.Size),
+							reader: AcquireFileReader(raw: false),
+							offset: ChunkHeader.Size,
+							count: _physicalDataSize,
+							transformed: false);
+					else
+						BuildCacheArray(
+							size: _fileSize,
+							reader: AcquireFileReader(raw: true),
+							offset: 0,
+							count: _fileSize,
+							transformed: true);
 				} catch (OutOfMemoryException) {
 					Log.Error("CACHING FAILED due to OutOfMemory exception in TFChunk {chunk}.", this);
 					return;
@@ -638,26 +679,20 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			}
 		}
 
-		private void BuildCacheArray() {
-			var workItem = AcquireFileReader();
+		private void BuildCacheArray(int size, TFChunkBulkReader reader, int offset, int count, bool transformed) {
 			try {
-				if (workItem.IsMemory)
+				if (reader.IsMemory)
 					throw new InvalidOperationException(
 						"When trying to build cache, reader worker is already in-memory reader.");
 
-				var dataSize = IsReadOnly ? _physicalDataSize + ChunkFooter.MapSize : _chunkHeader.ChunkSize;
-				_cachedLength = GetAlignedSize(ChunkHeader.Size + dataSize + ChunkFooter.Size);
+				_cachedLength = size;
 				var cachedData = Marshal.AllocHGlobal(_cachedLength);
 				GC.AddMemoryPressure(_cachedLength);
 
 				try {
-					// in ongoing chunk there is no need to read everything, it's enough to read just actual data written
-					Span<byte> memoryView = new(
-						cachedData.ToPointer(),
-						IsReadOnly ? _cachedLength : ChunkHeader.Size + _physicalDataSize);
-
-					workItem.Stream.Seek(0, SeekOrigin.Begin);
-					workItem.Stream.ReadExactly(memoryView);
+					Span<byte> memoryView = new(IntPtr.Add(cachedData, offset).ToPointer(), count);
+					reader.Stream.Seek(offset, SeekOrigin.Begin);
+					reader.Stream.ReadExactly(memoryView);
 				} catch {
 					Marshal.FreeHGlobal(cachedData);
 					GC.RemoveMemoryPressure(_cachedLength);
@@ -665,8 +700,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				}
 
 				_cachedData = cachedData;
+				_cachedDataTransformed = transformed;
 			} finally {
-				workItem.Dispose();
+				reader.Dispose();
 			}
 		}
 
@@ -779,14 +815,12 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 		private static long WriteRawData(WriterWorkItem workItem, byte[] buf, int len) {
 			var curPos = GetDataPosition(workItem);
-			workItem.MD5.TransformBlock(buf, 0, len, null, 0);
+			// the writer work item's stream is responsible for updating the checksum
 			workItem.AppendData(buf, 0, len);
 			return curPos;
 		}
 
 		public void Flush() {
-			if (_inMem)
-				return;
 			if (IsReadOnly)
 				return;
 			_writerWorkItem.FlushToDisk();
@@ -833,13 +867,19 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			if (!_inMem)
 				CreateReaderStreams();
 
-			_chunkFooter = ReadFooter(_writerWorkItem.WorkingStream);
 			IsReadOnly = true;
 
 			_writerWorkItem?.Dispose();
 			_writerWorkItem = null;
 
 			SetAttributes(_filename, true);
+
+			if (!_inMem) {
+				using var stream = _handle.AsUnbufferedStream(FileAccess.Read);
+				_chunkFooter = ReadFooter(stream);
+			} else {
+				_chunkFooter = ReadFooter(_sharedMemStream);
+			}
 		}
 
 		private ChunkFooter WriteFooter(ICollection<PosMap> mapping) {
@@ -871,15 +911,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 			workItem.FlushToDisk();
 
-			if (_chunkHeader.Version >= (byte)ChunkVersions.Aligned) {
-				var alignedSize = GetAlignedSize(ChunkHeader.Size + _physicalDataSize + mapSize + ChunkFooter.Size);
-				var bufferSize = alignedSize - workItem.WorkingStream.Position - ChunkFooter.Size;
-				Log.Debug("Buffer size is {bufferSize}", bufferSize);
-				if (bufferSize > 0) {
-					byte[] buffer = new byte[bufferSize];
-					WriteRawData(workItem, buffer, buffer.Length);
-				}
-			}
+			_transform.Write.CompleteData(
+				footerSize: ChunkFooter.Size,
+				alignmentSize: _chunkHeader.Version >= (byte)ChunkVersions.Aligned ? AlignmentSize : 1);
 
 			Flush();
 
@@ -891,11 +925,11 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			//FILE
 			var footerWithHash =
 				new ChunkFooter(true, true, _physicalDataSize, LogicalDataSize, mapSize, workItem.MD5.Hash);
-			workItem.AppendData(footerWithHash.AsByteArray(), 0, ChunkFooter.Size);
+			_transform.Write.WriteFooter(footerWithHash.AsByteArray(), out var fileSize);
 
 			Flush();
 
-			_fileSize = (int)workItem.WorkingStream.Length;
+			_fileSize = fileSize;
 			return footerWithHash;
 		}
 
@@ -966,8 +1000,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		}
 
 		public static int GetAlignedSize(int size) {
-			if (size % 4096 == 0) return size;
-			return (size / 4096 + 1) * 4096;
+			if (size % AlignmentSize == 0) return size;
+			return (size / AlignmentSize + 1) * AlignmentSize;
 		}
 
 		private bool TryDestructMemStreams() {
@@ -1017,7 +1051,11 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 			// try get memory stream reader first
 			if (_sharedMemStream is { } sharedMemStream) {
-				if (_memStreams.TryTake(sharedMemStream, &CreateMemoryStreamWorkItem) is { } memoryWorkItem)
+				var transform = _cachedDataTransformed
+					? _transform.Read
+					: _identityReadTransform;
+
+				if (_memStreams.TryTake(sharedMemStream, transform, &CreateMemoryStreamWorkItem) is { } memoryWorkItem)
 					return memoryWorkItem;
 
 				if (_selfdestructin54321) {
@@ -1027,7 +1065,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				// The pool is empty, this is a worst case. Instead of throwing exception we create a work item out of the
 				// pool which will be disposed on return.
 				Interlocked.Increment(ref _memStreamCount);
-				return new(sharedMemStream);
+				return new(sharedMemStream, transform);
 			}
 
 			if (!IsReadOnly) {
@@ -1038,7 +1076,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			}
 
 			// get a filestream from the pool, or create one if the pool is empty.
-			if (_fileStreams.TryTake(_handle, &CreateFileStreamWorkItem) is { } fileStreamWorkItem)
+			if (_fileStreams.TryTake(_handle, _transform.Read, &CreateFileStreamWorkItem) is { } fileStreamWorkItem)
 				return fileStreamWorkItem;
 
 			Interlocked.Increment(ref _fileStreamCount);
@@ -1049,13 +1087,13 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				throw new FileBeingDeletedException();
 			}
 
-			return new(_handle);
+			return new(_handle, _transform.Read);
 
-			static ReaderWorkItem CreateFileStreamWorkItem(SafeFileHandle handle, int index)
-				=> new(handle) { PositionInPool = index };
+			static ReaderWorkItem CreateFileStreamWorkItem(SafeFileHandle handle, IChunkReadTransform transform, int index)
+				=> new(handle, transform) { PositionInPool = index };
 
-			static ReaderWorkItem CreateMemoryStreamWorkItem(Stream sharedMemStream, int index)
-				=> new(sharedMemStream) { PositionInPool = index };
+			static ReaderWorkItem CreateMemoryStreamWorkItem(Stream sharedMemStream, IChunkReadTransform transform, int index)
+				=> new(sharedMemStream, transform) { PositionInPool = index };
 		}
 
 		private void ReturnReaderWorkItem(ReaderWorkItem item) {
@@ -1108,14 +1146,21 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			}
 		}
 
-		public TFChunkBulkReader AcquireReader() {
-			if (TryAcquireBulkMemReader(out var reader))
+		public TFChunkBulkReader AcquireDataReader() {
+			if (TryAcquireBulkMemReader(raw: false, out var reader))
 				return reader;
 
-			return AcquireFileReader();
+			return AcquireFileReader(raw: false);
 		}
 
-		private TFChunkBulkReader AcquireFileReader() {
+		public TFChunkBulkReader AcquireRawReader() {
+			if (TryAcquireBulkMemReader(raw: true, out var reader))
+				return reader;
+
+			return AcquireFileReader(raw: true);
+		}
+
+		private TFChunkBulkReader AcquireFileReader(bool raw) {
 			Interlocked.Increment(ref _fileStreamCount);
 			if (_selfdestructin54321) {
 				if (Interlocked.Decrement(ref _fileStreamCount) == 0) {
@@ -1127,7 +1172,14 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 			// if we get here, then we reserved TFChunk for sure so no one should dispose of chunk file
 			// until client returns dedicated reader
-			return new TFChunkBulkReader(this, CreateFileStreamForBulkReader(), isMemory: false);
+			var stream = CreateFileStreamForBulkReader();
+
+			if (raw) {
+				return new TFChunkBulkRawReader(this, stream, isMemory: false);
+			}
+
+			var streamToUse = _transform.Read.TransformData(new ChunkDataReadStream(stream));
+			return new TFChunkBulkDataReader(this, streamToUse, isMemory: false);
 		}
 
 		private Stream CreateFileStreamForBulkReader() => _inMem
@@ -1139,7 +1191,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		// (a) doesn't block if a file reader would be acceptable instead
 		//     (we might be in the middle of caching which could take a while)
 		// (b) _does_ throw if we can't get a memstream and a filestream is not acceptable
-		private bool TryAcquireBulkMemReader(out TFChunkBulkReader reader) {
+		private bool TryAcquireBulkMemReader(bool raw, out TFChunkBulkReader reader) {
 			reader = null;
 
 			if (IsReadOnly) {
@@ -1150,7 +1202,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 					return false;
 
 				try {
-					return TryCreateBulkMemReader(out reader);
+					return TryCreateBulkMemReader(raw, out reader);
 				} finally {
 					Monitor.Exit(_cachedDataLock);
 				}
@@ -1158,7 +1210,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 			// chunk is not readonly so it should be cached and let us create a mem reader
 			// (but might become readonly at any moment!)
-			if (TryCreateBulkMemReader(out reader))
+			if (TryCreateBulkMemReader(raw, out reader))
 				return true;
 
 			// we couldn't get a memreader, maybe we just became readonly and got uncached.
@@ -1173,7 +1225,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		}
 
 		// creates a bulk reader over a memstream as long as we are cached
-		private bool TryCreateBulkMemReader(out TFChunkBulkReader reader) {
+		private bool TryCreateBulkMemReader(bool raw, out TFChunkBulkReader reader) {
 			lock (_cachedDataLock) {
 				if (_cacheStatus != CacheStatus.Cached) {
 					reader = null;
@@ -1185,7 +1237,19 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 				Interlocked.Increment(ref _memStreamCount);
 				var stream = new UnmanagedMemoryStream((byte*)_cachedData, _cachedLength);
-				reader = new TFChunkBulkReader(this, stream, isMemory: true);
+
+				if (raw) {
+					reader = new TFChunkBulkRawReader(chunk: this, streamToUse: stream, isMemory: true);
+					return true;
+				}
+
+				var streamToUse = new ChunkDataReadStream(stream);
+				streamToUse = _cachedDataTransformed
+					? _transform.Read.TransformData(streamToUse)
+					: _identityReadTransform.TransformData(streamToUse);
+
+				reader = new TFChunkBulkDataReader(chunk: this, streamToUse: streamToUse, isMemory: true);
+
 				return true;
 			}
 		}
@@ -1280,11 +1344,11 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 			internal readonly int Count => _indices.Count;
 
-			internal ReaderWorkItem TryTake<T>(T arg, delegate*<T, int, ReaderWorkItem> factory) {
+			internal ReaderWorkItem TryTake<T1, T2>(T1 arg1, T2 arg2, delegate*<T1, T2, int, ReaderWorkItem> factory) {
 				Debug.Assert(factory is not null);
 
 				return Array is { } array && _indices.TryTake(out int index)
-					? UnsafeGetElement(array, index) ??= factory(arg, index)
+					? UnsafeGetElement(array, index) ??= factory(arg1, arg2, index)
 					: null;
 			}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Security.Cryptography;
 using DotNext;
 using DotNext.IO;
+using EventStore.Core.Transforms;
 using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
@@ -11,23 +12,33 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		public Stream WorkingStream { get; private set; }
 
 		private readonly Stream _fileStream;
-		private UnmanagedMemoryStream _memStream;
+		private Stream _memStream;
 
 		public readonly MemoryStream Buffer;
 		public readonly BinaryWriter BufferWriter;
 		public readonly HashAlgorithm MD5;
 
-		public unsafe WriterWorkItem(nint memoryPtr, int length, HashAlgorithm md5) {
-			WorkingStream = _memStream = new UnmanagedMemoryStream((byte*)memoryPtr, length, length, FileAccess.ReadWrite);
+		public unsafe WriterWorkItem(nint memoryPtr, int length, HashAlgorithm md5,
+			IChunkWriteTransform chunkWriteTransform, int initialStreamPosition) {
+			var memStream = new UnmanagedMemoryStream((byte*)memoryPtr, length, length, FileAccess.ReadWrite);
+			memStream.Position = initialStreamPosition;
+			var chunkDataWriteStream = new ChunkDataWriteStream(memStream, md5);
+
+			WorkingStream = _memStream = chunkWriteTransform.TransformData(chunkDataWriteStream);
 			Buffer = new(BufferSize);
 			BufferWriter = new(Buffer);
 			MD5 = md5;
 		}
 
-		public WriterWorkItem(SafeFileHandle handle, HashAlgorithm md5, bool unbuffered) {
-			WorkingStream = _fileStream = unbuffered
+		public WriterWorkItem(SafeFileHandle handle, HashAlgorithm md5, bool unbuffered,
+			IChunkWriteTransform chunkWriteTransform, int initialStreamPosition) {
+			var fileStream = unbuffered
 				? handle.AsUnbufferedStream(FileAccess.ReadWrite)
 				: new BufferedStream(handle.AsUnbufferedStream(FileAccess.ReadWrite), BufferSize);
+			fileStream.Position = initialStreamPosition;
+			var chunkDataWriteStream = new ChunkDataWriteStream(fileStream, md5);
+
+			WorkingStream = _fileStream = chunkWriteTransform.TransformData(chunkDataWriteStream);
 			Buffer = new(BufferSize);
 			BufferWriter = new(Buffer);
 			MD5 = md5;
@@ -64,7 +75,10 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			base.Dispose(disposing);
 		}
 
-		public void FlushToDisk() => _fileStream?.Flush();
+		public void FlushToDisk() {
+			_fileStream?.Flush();
+			_memStream?.Flush();
+		}
 
 		public void DisposeMemStream() {
 			_memStream?.Dispose();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkDataReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkDataReader.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using EventStore.Common.Utils;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+namespace EventStore.Core.TransactionLog.Chunks;
+
+public sealed class TFChunkBulkDataReader(TFChunk.TFChunk chunk, Stream streamToUse, bool isMemory)
+	: TFChunkBulkReader(chunk, streamToUse, isMemory) {
+
+	public override void SetPosition(long dataPosition) {
+		var rawPos = dataPosition + ChunkHeader.Size;
+		Stream.Position = rawPos;
+	}
+
+	public override BulkReadResult ReadNextBytes(int count, byte[] buffer) {
+		Ensure.NotNull(buffer, "buffer");
+		Ensure.Nonnegative(count, "count");
+
+		if (Stream.Position == 0)
+			Stream.Position = ChunkHeader.Size;
+
+		if (count > buffer.Length)
+			count = buffer.Length;
+
+		var oldPos = (int)Stream.Position - ChunkHeader.Size;
+		var toRead = Math.Min(Chunk.PhysicalDataSize - oldPos, count);
+		Debug.Assert(toRead >= 0);
+		Stream.Position = Stream.Position; // flush read buffer
+		int bytesRead = Stream.Read(buffer, 0, toRead);
+		return new BulkReadResult(oldPos,
+			bytesRead,
+			isEof: Chunk.IsReadOnly && oldPos + bytesRead == Chunk.PhysicalDataSize);
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkRawReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkRawReader.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using EventStore.Common.Utils;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+namespace EventStore.Core.TransactionLog.Chunks;
+
+public sealed class TFChunkBulkRawReader(TFChunk.TFChunk chunk, Stream streamToUse, bool isMemory)
+	: TFChunkBulkReader(chunk, streamToUse, isMemory) {
+
+	public override void SetPosition(long rawPosition) {
+		if (rawPosition >= Stream.Length)
+			throw new ArgumentOutOfRangeException("rawPosition",
+				string.Format("Raw position {0} is out of bounds.", rawPosition));
+		Stream.Position = rawPosition;
+
+	}
+
+	public override BulkReadResult ReadNextBytes(int count, byte[] buffer) {
+		Ensure.NotNull(buffer, "buffer");
+		Ensure.Nonnegative(count, "count");
+
+		if (count > buffer.Length)
+			count = buffer.Length;
+
+		var oldPos = (int)Stream.Position;
+		int bytesRead = Stream.Read(buffer, 0, count);
+		return new BulkReadResult(oldPos, bytesRead, isEof: Stream.Length == Stream.Position);
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -194,7 +194,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					unbuffered: _db.Config.Unbuffered,
 					writethrough: _db.Config.WriteThrough,
 					reduceFileCachePressure: _db.Config.ReduceFileCachePressure,
-					tracker: new TFChunkTracker.NoOp());
+					tracker: new TFChunkTracker.NoOp(),
+					transformFactory: _db.TransformManager.GetFactoryForNewChunk());
 			} catch (IOException exc) {
 				_logger.Error(exc,
 					"IOException during creating new chunk for scavenging purposes. Stopping scavenging process...");
@@ -428,7 +429,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					unbuffered: db.Config.Unbuffered,
 					writethrough: db.Config.WriteThrough,
 					reduceFileCachePressure: db.Config.ReduceFileCachePressure,
-					tracker: new TFChunkTracker.NoOp());
+					tracker: new TFChunkTracker.NoOp(),
+					transformFactory: db.TransformManager.GetFactoryForNewChunk());
 			} catch (IOException exc) {
 				logger.Error(exc,
 					"IOException during creating new chunk for scavenging merge purposes. Stopping scavenging merge process...");

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -106,14 +106,14 @@ namespace EventStore.Core.TransactionLog.Chunks {
 
 		public bool HasOpenTransaction() => _inTransaction;
 
-		public void AddNewChunk(ChunkHeader chunkHeader = null, int? chunkSize = null) {
+		public void AddNewChunk(ChunkHeader chunkHeader = null, ReadOnlyMemory<byte> transformHeader = default, int? chunkSize = null) {
 			var nextChunkNumber = _currentChunk?.ChunkHeader.ChunkEndNumber + 1 ?? 0;
 			VerifyChunkNumberLimits(nextChunkNumber);
 
 			if (chunkHeader == null)
 				_currentChunk = _db.Manager.AddNewChunk();
 			else
-				_currentChunk = _db.Manager.AddNewChunk(chunkHeader, chunkSize!.Value);
+				_currentChunk = _db.Manager.AddNewChunk(chunkHeader, transformHeader, chunkSize!.Value);
 		}
 
 		private void CompleteChunkInTransaction() {

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForExecutor.cs
@@ -2,6 +2,7 @@
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
 using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
@@ -9,17 +10,19 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		private readonly ILogger _logger;
 		private readonly TFChunkManager _manager;
 		private readonly TFChunkDbConfig _dbConfig;
+		private readonly DbTransformManager _transformManager;
 
-		public ChunkManagerForExecutor(ILogger logger, TFChunkManager manager, TFChunkDbConfig dbConfig) {
+		public ChunkManagerForExecutor(ILogger logger, TFChunkManager manager, TFChunkDbConfig dbConfig, DbTransformManager transformManager) {
 			_logger = logger;
 			_manager = manager;
 			_dbConfig = dbConfig;
+			_transformManager = transformManager;
 		}
 
 		public IChunkWriterForExecutor<TStreamId, ILogRecord> CreateChunkWriter(
 			IChunkReaderForExecutor<TStreamId, ILogRecord> sourceChunk) {
 
-			return new ChunkWriterForExecutor<TStreamId>(_logger, this, _dbConfig, sourceChunk);
+			return new ChunkWriterForExecutor<TStreamId>(_logger, this, _dbConfig, sourceChunk, _transformManager);
 		}
 
 		public IChunkReaderForExecutor<TStreamId, ILogRecord> GetChunkReaderFor(long position) {

--- a/src/EventStore.Core/Transforms/ChunkDataReadStream.cs
+++ b/src/EventStore.Core/Transforms/ChunkDataReadStream.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+
+namespace EventStore.Core.Transforms;
+
+public class ChunkDataReadStream(Stream chunkFileStream) : Stream {
+	public Stream ChunkFileStream => chunkFileStream;
+
+	public sealed override bool CanRead => true;
+	public sealed override bool CanSeek => true;
+	public sealed override bool CanWrite => false;
+	public sealed override void Write(byte[] buffer, int offset, int count) => throw new InvalidOperationException();
+	public sealed override void Flush() => throw new InvalidOperationException();
+	public sealed override void SetLength(long value) => throw new InvalidOperationException();
+	public override long Length => throw new NotSupportedException();
+
+	// reads must always return exactly `count` bytes as we never read past the (flushed) writer checkpoint
+	public override int Read(byte[] buffer, int offset, int count) => ChunkFileStream.Read(buffer, offset, count);
+
+	// seeks need to support only `SeekOrigin.Begin`
+	public override long Seek(long offset, SeekOrigin origin) {
+		if (origin != SeekOrigin.Begin)
+			throw new NotSupportedException();
+
+		return ChunkFileStream.Seek(offset, origin);
+	}
+
+	public override long Position {
+		get => ChunkFileStream.Position;
+		set => ChunkFileStream.Position = value;
+	}
+
+	protected override void Dispose(bool disposing) {
+		try {
+			if (!disposing)
+				return;
+
+			chunkFileStream.Dispose();
+		} finally {
+			base.Dispose(disposing);
+		}
+	}
+}

--- a/src/EventStore.Core/Transforms/ChunkDataWriteStream.cs
+++ b/src/EventStore.Core/Transforms/ChunkDataWriteStream.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace EventStore.Core.Transforms;
+
+public class ChunkDataWriteStream(Stream chunkFileStream, HashAlgorithm checksumAlgorithm) : Stream {
+	public Stream ChunkFileStream => chunkFileStream;
+	public HashAlgorithm ChecksumAlgorithm => checksumAlgorithm;
+
+	public sealed override bool CanRead => false;
+	public sealed override bool CanSeek => false;
+	public sealed override bool CanWrite => true;
+	public sealed override int Read(byte[] buffer, int offset, int count) => throw new InvalidOperationException();
+	public sealed override long Seek(long offset, SeekOrigin origin) => throw new InvalidOperationException();
+
+	public override void Write(byte[] buffer, int offset, int count) {
+		ChunkFileStream.Write(buffer, offset, count);
+		ChecksumAlgorithm.TransformBlock(buffer, 0, count, null, 0);
+	}
+
+	public override void Flush() => ChunkFileStream.Flush();
+	public override void SetLength(long value) => ChunkFileStream.SetLength(value);
+	public override long Length => ChunkFileStream.Length;
+	public override long Position {
+		get => ChunkFileStream.Position;
+		set {
+			if (ChunkFileStream.Position != 0)
+				throw new InvalidOperationException("Writer's position can only be moved from 0 to a higher value.");
+
+			ReadAndChecksum(value);
+
+			if (ChunkFileStream.Position != value)
+				throw new Exception($"Writer's position ({ChunkFileStream.Position:N0}) is not at the expected position ({value:N0})");
+		}
+	}
+
+	private void ReadAndChecksum(long count) {
+		var buffer = new byte[4096];
+		long toRead = count;
+		while (toRead > 0) {
+			int read = ChunkFileStream.Read(buffer, 0, (int)Math.Min(toRead, buffer.Length));
+			if (read == 0)
+				break;
+
+			ChecksumAlgorithm.TransformBlock(buffer, 0, read, null, 0);
+			toRead -= read;
+		}
+	}
+
+	protected override void Dispose(bool disposing) {
+		try {
+			if (!disposing)
+				return;
+
+			chunkFileStream.Dispose();
+		} finally {
+			base.Dispose(disposing);
+		}
+	}
+}

--- a/src/EventStore.Core/Transforms/DbTransformManager.cs
+++ b/src/EventStore.Core/Transforms/DbTransformManager.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventStore.Core.Transforms;
+
+public class DbTransformManager {
+	private readonly IReadOnlyList<IDbTransform> _transforms;
+	private IDbTransform _activeTransform;
+
+	public DbTransformManager(IReadOnlyList<IDbTransform> transforms, TransformType activeTransformType) {
+		_transforms = transforms;
+		_activeTransform = FindTransform(activeTransformType);
+
+		// the identity transform is always required
+		_ = FindTransform(TransformType.Identity);
+	}
+
+	private IDbTransform FindTransform(TransformType type) =>
+		_transforms.FirstOrDefault(t => t.Type == type) ??
+		       throw new Exception($"Failed to load transform: {type}");
+
+	public IChunkTransformFactory GetFactoryForNewChunk() => _activeTransform.ChunkFactory;
+	public IChunkTransformFactory GetFactoryForExistingChunk(TransformType type) => FindTransform(type).ChunkFactory;
+
+	public void SetActiveTransform(TransformType type) {
+		_activeTransform = FindTransform(type);
+	}
+
+	public bool SupportsTransform(TransformType type) {
+		try {
+			FindTransform(type);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/src/EventStore.Core/Transforms/IChunkReadTransform.cs
+++ b/src/EventStore.Core/Transforms/IChunkReadTransform.cs
@@ -1,0 +1,5 @@
+namespace EventStore.Core.Transforms;
+
+public interface IChunkReadTransform {
+	ChunkDataReadStream TransformData(ChunkDataReadStream stream);
+}

--- a/src/EventStore.Core/Transforms/IChunkTransform.cs
+++ b/src/EventStore.Core/Transforms/IChunkTransform.cs
@@ -1,0 +1,6 @@
+namespace EventStore.Core.Transforms;
+
+public interface IChunkTransform {
+	IChunkReadTransform Read { get; }
+	IChunkWriteTransform Write { get; }
+}

--- a/src/EventStore.Core/Transforms/IChunkTransformFactory.cs
+++ b/src/EventStore.Core/Transforms/IChunkTransformFactory.cs
@@ -1,0 +1,12 @@
+using System;
+using System.IO;
+
+namespace EventStore.Core.Transforms;
+
+public interface IChunkTransformFactory {
+	TransformType Type { get; }
+	int TransformDataPosition(int dataPosition);
+	ReadOnlyMemory<byte> CreateTransformHeader();
+	ReadOnlyMemory<byte> ReadTransformHeader(Stream stream);
+	IChunkTransform CreateTransform(ReadOnlyMemory<byte> transformHeader);
+}

--- a/src/EventStore.Core/Transforms/IChunkWriteTransform.cs
+++ b/src/EventStore.Core/Transforms/IChunkWriteTransform.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace EventStore.Core.Transforms;
+
+public interface IChunkWriteTransform {
+	ChunkDataWriteStream TransformData(ChunkDataWriteStream stream);
+	void CompleteData(int footerSize, int alignmentSize);
+	void WriteFooter(ReadOnlySpan<byte> footer, out int fileSize);
+}

--- a/src/EventStore.Core/Transforms/IDbTransform.cs
+++ b/src/EventStore.Core/Transforms/IDbTransform.cs
@@ -1,0 +1,7 @@
+namespace EventStore.Core.Transforms;
+
+public interface IDbTransform {
+	string Name { get; }
+	TransformType Type { get; }
+	IChunkTransformFactory ChunkFactory { get; }
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkReadTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkReadTransform.cs
@@ -1,0 +1,6 @@
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityChunkReadTransform : IChunkReadTransform {
+	public static readonly IdentityChunkReadTransform Instance = new();
+	public ChunkDataReadStream TransformData(ChunkDataReadStream stream) => stream;
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkTransform.cs
@@ -1,0 +1,6 @@
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityChunkTransform : IChunkTransform {
+	public IChunkReadTransform Read => IdentityChunkReadTransform.Instance;
+	public IChunkWriteTransform Write { get; } = new IdentityChunkWriteTransform();
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkTransformFactory.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkTransformFactory.cs
@@ -1,0 +1,12 @@
+using System;
+using System.IO;
+
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityChunkTransformFactory : IChunkTransformFactory {
+	public TransformType Type => TransformType.Identity;
+	public int TransformDataPosition(int dataPosition) => dataPosition;
+	public ReadOnlyMemory<byte> CreateTransformHeader() => ReadOnlyMemory<byte>.Empty;
+	public ReadOnlyMemory<byte> ReadTransformHeader(Stream stream) => ReadOnlyMemory<byte>.Empty;
+	public IChunkTransform CreateTransform(ReadOnlyMemory<byte> transformHeader) => new IdentityChunkTransform();
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkWriteTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkWriteTransform.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityChunkWriteTransform : IChunkWriteTransform {
+	private ChunkDataWriteStream _stream;
+
+	public ChunkDataWriteStream TransformData(ChunkDataWriteStream stream) {
+		_stream = stream;
+		return _stream;
+	}
+
+	public void CompleteData(int footerSize, int alignmentSize) {
+		var chunkHeaderAndDataSize = (int)_stream.Position;
+		var alignedSize = GetAlignedSize(chunkHeaderAndDataSize + footerSize, alignmentSize);
+		var paddingSize = alignedSize - chunkHeaderAndDataSize - footerSize;
+		if (paddingSize > 0)
+			_stream.Write(new byte[paddingSize]);
+	}
+
+	public void WriteFooter(ReadOnlySpan<byte> footer, out int fileSize) {
+		_stream.ChunkFileStream.Write(footer);
+		fileSize = (int)_stream.Length;
+	}
+
+	private static int GetAlignedSize(int size, int alignmentSize) {
+		if (size % alignmentSize == 0) return size;
+		return (size / alignmentSize + 1) * alignmentSize;
+	}
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityDbTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityDbTransform.cs
@@ -1,0 +1,7 @@
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityDbTransform : IDbTransform {
+	public string Name => "identity";
+	public TransformType Type => TransformType.Identity;
+	public IChunkTransformFactory ChunkFactory { get; } = new IdentityChunkTransformFactory();
+}

--- a/src/EventStore.Core/Transforms/TransformType.cs
+++ b/src/EventStore.Core/Transforms/TransformType.cs
@@ -1,0 +1,6 @@
+namespace EventStore.Core.Transforms;
+
+public enum TransformType {
+	Identity = 0,
+	Composite = 1,
+}


### PR DESCRIPTION
Changed: Refactoring to support chunk data transformation

This PR introduces a data transformation layer to the database. At the moment, only chunk data is transformed but the interfaces have been designed to allow for future expansion (e.g we might also want index data to be transformed later on).

This allows the database to support data transformation operations like encryption, compression, etc. The primary goal of this PR at the moment is to enable the development of an encryption-at-rest plugin.

- chunk headers & footers are not transformed
- only the chunk's data is transformed (scavenge posmaps are also considered as part of the data)
- the transformed data's size does not necessarily need to match the original data's size, it could be larger or smaller.
- the default transform is the `identity` transform which doesn't change anything in the data
- one additional byte is used in the chunk header to store the transform type. this also implies that we can support only up to 256 transforms.
- a new header type, called the transform header is written just after the chunk's header and before the data starts
  - the transform header is specific to the transform and can be of any size
  - the `identity` transform has an empty transform header
  - the transform header is considered to be part of the data, however it is designed to be replicated separately from the data (because the follower needs to know the transform header in advance to be able to create the transform. the created transform is then applied to the data being replicated)
  - at the moment, the transform header is not replicated to the follower, this will be done in a separate PR.
- replication:
  - data chunks are replicated to followers in their untransformed state.
  - raw (scavenged) chunks are replicated in their transformed state.
- caching:
  - the active chunk is cached in its untransformed state in memory (as we would otherwise incur the cost of transformation twice - once when writing to the file stream and once when writing to the memory stream)
  - read-only chunks are cached in their transformed state in memory (as we would otherwise incur the cost of untransforming the whole chunk when loading it)
- checksum:
  - checksum computation is done on transformed data
  - checksum verification is done simply by hashing the whole chunk file except the last 16 bytes (the data doesn't need to be untransformed)
- truncation
  - the position at which a chunk needs to be truncated is transformed before truncating the file
- scavenging
  - scavenged chunks are transformed normally just as non-scavenged chunk. the posmaps are also transformed as they are considered part of the data.