### PR TITLE
DB-26-18 Make `DoTiming` wait longer if it is able to

### DIFF
--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -10,25 +10,27 @@ using EventStore.Core.Metrics;
 using Serilog;
 
 namespace EventStore.Core.Services.TimerService {
-	public class ThreadBasedScheduler : IMonitoredQueue, IScheduler, IDisposable {
+	public sealed class ThreadBasedScheduler : IMonitoredQueue, IScheduler {
 		private static readonly ILogger Log = Serilog.Log.ForContext<ThreadBasedScheduler>();
 		public string Name {
 			get { return _queueStats.Name; }
 		}
 
 		private readonly ConcurrentQueueWrapper<ScheduledTask> _pending = new ConcurrentQueueWrapper<ScheduledTask>();
+		private readonly ManualResetEventSlim _pendingEvent = new ManualResetEventSlim(false);
 
 		private readonly PairingHeap<ScheduledTask> _tasks =
 			new PairingHeap<ScheduledTask>((x, y) => x.DueTime < y.DueTime);
 
 		private readonly IClock _timeProvider;
 
-		private readonly Thread _timerThread;
 		private volatile bool _stop;
 
 		private readonly QueueStatsCollector _queueStats;
 		private readonly QueueTracker _tracker;
 		private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
+
+		private long _nextWakeupTimeTicks = long.MinValue;
 
 		public Task Task {
 			get { return _tcs.Task; }
@@ -38,15 +40,14 @@ namespace EventStore.Core.Services.TimerService {
 			QueueStatsManager queueStatsManager,
 			QueueTrackers trackers,
 			IClock timeProvider = null) {
-
 			_timeProvider = timeProvider ?? Clock.Instance;
 			_queueStats = queueStatsManager.CreateQueueStatsCollector("Timer");
 			_tracker = trackers.GetTrackerForQueue("Timer");
 
-			_timerThread = new Thread(DoTiming);
-			_timerThread.IsBackground = true;
-			_timerThread.Name = Name;
-			_timerThread.Start();
+			new Thread(DoTiming) {
+				IsBackground = true,
+				Name = Name
+			}.Start();
 		}
 
 		public void Stop() {
@@ -54,22 +55,33 @@ namespace EventStore.Core.Services.TimerService {
 		}
 
 		public void Schedule(TimeSpan after, Action<IScheduler, object> callback, object state) {
-			_pending.Enqueue(new ScheduledTask(_timeProvider.Now.Add(after), callback, state));
+			var nextWakeup = Interlocked.Read(ref _nextWakeupTimeTicks);
+			var now = _timeProvider.Now;
+
+			var dueTime = now.Add(after);
+			_pending.Enqueue(new ScheduledTask(dueTime, callback, state));
+
+			// don't unnecessarily wake up the timer thread if it's going to wake up before this task's due time anyway
+			if (nextWakeup < now.Ticks || nextWakeup > dueTime.Ticks)
+				_pendingEvent.Set();
 		}
 
 		private void DoTiming() {
-
 			_queueStats.Start();
 			QueueMonitor.Default.Register(this);
+
+			var minTimeout = TimeSpan.FromMilliseconds(1);
+			var maxTimeout = TimeSpan.FromSeconds(5);
 
 			while (!_stop) {
 				try {
 					_queueStats.EnterBusy();
 					_queueStats.ProcessingStarted<SchedulePendingTasks>(_pending.Count);
 
+					_pendingEvent.Reset();
+
 					int pending = 0;
-					ScheduledTask task;
-					while (_pending.TryDequeue(out task)) {
+					while (_pending.TryDequeue(out var task)) {
 						_tasks.Add(task);
 						pending += 1;
 					}
@@ -78,7 +90,18 @@ namespace EventStore.Core.Services.TimerService {
 
 					_queueStats.ProcessingStarted<ExecuteScheduledTasks>(_tasks.Count);
 					int processed = 0;
-					while (_tasks.Count > 0 && _tasks.FindMin().DueTime <= _timeProvider.Now) {
+
+					Instant? nextTaskDueTime;
+					while (true) {
+						if (_tasks.Count == 0) {
+							nextTaskDueTime = null;
+							break;
+						}
+
+						nextTaskDueTime = _tasks.FindMin().DueTime;
+						if (nextTaskDueTime > _timeProvider.Now)
+							break;
+
 						processed += 1;
 						var scheduledTask = _tasks.DeleteMin();
 						var now = _tracker.RecordMessageDequeued(enqueuedAt: scheduledTask.DueTime);
@@ -89,10 +112,21 @@ namespace EventStore.Core.Services.TimerService {
 
 					_queueStats.ProcessingEnded(processed);
 
-					if (processed == 0) {
+					if (processed == 0 && !_pendingEvent.IsSet) {
 						_queueStats.EnterIdle();
 
-						Thread.Sleep(10);
+						// give some processor time to other threads since we're free right now
+						Thread.Yield();
+
+						var timeout = nextTaskDueTime?.ElapsedTimeSince(_timeProvider.Now) ?? maxTimeout;
+
+						if (timeout <= TimeSpan.Zero)
+							// we have already reached the due time of the next task, so we process it immediately
+							continue;
+
+						timeout = new TimeSpan(Math.Clamp(timeout.Ticks, minTimeout.Ticks, maxTimeout.Ticks));
+						Interlocked.Exchange(ref _nextWakeupTimeTicks, _timeProvider.Now.Add(timeout).Ticks);
+						_pendingEvent.Wait(timeout);
 					}
 
 				} catch (Exception ex) {
@@ -103,6 +137,7 @@ namespace EventStore.Core.Services.TimerService {
 
 			_queueStats.Stop();
 			QueueMonitor.Default.Unregister(this);
+			_pendingEvent.Dispose();
 		}
 
 		public void Dispose() {
@@ -125,10 +160,8 @@ namespace EventStore.Core.Services.TimerService {
 			}
 		}
 
-		private class SchedulePendingTasks {
-		}
+		private class SchedulePendingTasks;
 
-		private class ExecuteScheduledTasks {
-		}
+		private class ExecuteScheduledTasks;
 	}
 }


### PR DESCRIPTION
Fixed: Optimize CPU usage of the timer service when the database is idle

Hi,

This is a continuation of my previous tracing ([here](https://github.com/EventStore/EventStore/pull/4223)) in an effort to make EventStoreDB at idle use as little CPU as possible.

`ThreadBasedScheduler.DoTiming` is responsible for a lot of CPU usage when the database is not being used.

![image](https://github.com/EventStore/EventStore/assets/1189399/0141cade-d397-4a85-89c7-bb3d58148b46)

It rate limits itself with a call to `Thread.Sleep(10)` which means it is executing quite a bit, even if there are no scheduled tasks to be dispatched.

I have added a calculation for the next due scheduled task, and to delay until then, but no more than 30 seconds. The delay is interrupted by any scheduled task being enqueued, because the calculation may now be wrong.
 
Note that originally this loop was rate limited somewhat by a `Thread.Sleep(1)` and the method (among other things) was changed to use `Thread.Sleep(10)` to reduce idle CPU. You can see the history here: 95be10a0e40c85e1a32fbb760abbaea3ca4f7949.

Any feedback is welcome.