### PR TITLE
Change status for incomplete scavenges from Failed to Interrupted

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/ScavengeLogManager/ScavengeLogHelper.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/ScavengeLogManager/ScavengeLogHelper.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge.ScavengeLogManager {
 			return new Dictionary<string, object> {
 				{ "scavengeId", scavengeId },
 				{ "nodeEndpoint", nodeEndpoint },
-				{ "result", ScavengeResult.Failed },
+				{ "result", ScavengeResult.Interrupted },
 				{ "error", "The node was restarted." },
 				{ "timeTaken", timeTaken },
 				{ "spaceSaved", spaceSaved },

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_processing_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_processing_chunk.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 		[Test]
 		public void no_exception_is_thrown_to_caller() {
 			Assert.That(Log.Completed);
-			Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Failed));
+			Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Interrupted));
 		}
 
 		[Test]

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/MiscellaneousTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/MiscellaneousTests.cs
@@ -423,7 +423,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 				.RunAsync();
 
 			Assert.True(logger.Completed);
-			Assert.Equal(EventStore.Core.TransactionLog.Chunks.ScavengeResult.Failed, logger.Result);
+			Assert.Equal(EventStore.Core.TransactionLog.Chunks.ScavengeResult.Interrupted, logger.Result);
 			Assert.Equal("Error while scavenging DB: Found metadata in transaction in stream $$ab-1.", logger.Error);
 		}
 

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/TombstoneTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/TombstoneTests.cs
@@ -109,7 +109,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 				.RunAsync();
 
 			Assert.True(logger.Completed);
-			Assert.Equal(EventStore.Core.TransactionLog.Chunks.ScavengeResult.Failed, logger.Result);
+			Assert.Equal(EventStore.Core.TransactionLog.Chunks.ScavengeResult.Interrupted, logger.Result);
 			Assert.Equal("Error while scavenging DB: Found Tombstone in metadata stream $$ab-1.", logger.Error);
 		}
 
@@ -132,7 +132,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 				.RunAsync();
 
 			Assert.True(logger.Completed);
-			Assert.Equal(EventStore.Core.TransactionLog.Chunks.ScavengeResult.Failed, logger.Result);
+			Assert.Equal(EventStore.Core.TransactionLog.Chunks.ScavengeResult.Interrupted, logger.Result);
 			Assert.Equal("Error while scavenging DB: Found Tombstone in transaction in stream ab-1.", logger.Error);
 		}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 
 	public enum ScavengeResult {
 		Success,
-		Failed,
+		Interrupted,
 		Stopped
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -106,7 +106,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					_logger.Information("SCAVENGING: Scavenge cancelled.");
 					result = ScavengeResult.Stopped;
 				} catch (Exception exc) {
-					result = ScavengeResult.Failed;
+					result = ScavengeResult.Interrupted;
 					_logger.Error(exc, "SCAVENGING: Error while scavenging DB.");
 					error = string.Format("Error while scavenging DB: {0}.", exc.Message);
 				} finally {
@@ -262,7 +262,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 						// Since we replaced the ones we don't want with `default`, the success flag will only be true on the ones we want to keep.
 						var recordReadResult = threadLocalCache.Records[i];
 
-						// Check log record, if not present then assume we can skip. 
+						// Check log record, if not present then assume we can skip.
 						if (recordReadResult.LogRecord != null)
 							positionMapping.Add(WriteRecord(newChunk, recordReadResult.LogRecord));
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
@@ -240,7 +240,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 
 			var log = CreateLogInternal(incompleteScavengeStats.ScavengeId);
 
-			log.ScavengeCompleted(ScavengeResult.Failed,
+			log.ScavengeCompleted(ScavengeResult.Interrupted,
 				"The node was restarted.",
 				incompleteScavengeStats.TimeTaken,
 				incompleteScavengeStats.SpaceSaved,

--- a/src/EventStore.Core/TransactionLog/Scavenging/Scavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Scavenger.cs
@@ -97,7 +97,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					stopwatch.Elapsed);
 				result = ScavengeResult.Stopped;
 			} catch (Exception exc) {
-				result = ScavengeResult.Failed;
+				result = ScavengeResult.Interrupted;
 				_logger.Error(exc, "SCAVENGING: Scavenge Failed. Total time taken: {elapsed}.",
 					stopwatch.Elapsed);
 				error = string.Format("Error while scavenging DB: {0}.", exc.Message);


### PR DESCRIPTION
Changed: Change status for incomplete scavenges from "Failed" to "Interrupted". https://linear.app/eventstore/issue/DB-707/scavenge-consider-changing-the-status-for-incomplete-scavenges

Before this fix/change, incomplete scavenges were marked as "Failed" which made it look like there was an error in the scavenge process.