### PR TITLE
[ESDB-147-14] Update actions/checkout to v4, use fetch-depth: 0 instead of subsequent fetch

### DIFF
--- a/.github/workflows/build-container-reusable.yml
+++ b/.github/workflows/build-container-reusable.yml
@@ -15,7 +15,7 @@ jobs:
     name: ci/github/build-${{ inputs.container-runtime }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Install net8.0

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -20,10 +20,9 @@ jobs:
     name: ci/github/build-${{ inputs.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
-    - shell: bash
-      run: |
-        git fetch --prune --unshallow
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Install netcoreapp3.1
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/cherry-pick-pr-for-label.yml
+++ b/.github/workflows/cherry-pick-pr-for-label.yml
@@ -7,7 +7,7 @@ jobs:
     name: Cherry pick PR commits for label
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cherry Pick PR for label
         uses: EventStore/Automations/cherry-pick-pr-for-label@master
         with:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -23,7 +23,7 @@ jobs:
     name: ci/github/scan-vulnerabilities
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install net8.0
       uses: actions/setup-dotnet@v3
       with:
@@ -39,7 +39,7 @@ jobs:
     name: ci/github/protolock
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Protolock Status
       shell: bash
       run: |
@@ -49,7 +49,7 @@ jobs:
     name: ci/github/docker-compose
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Github Registry Docker Login
       uses: azure/docker-login@v1
       with:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: FantasticFiasco/action-update-license-year@v2

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check pull requests
         uses: EventStore/Automations/pr-check@master
         with:


### PR DESCRIPTION
The purpose was and is to obtain the tags so that the version is calculated correctly. fetch-depth is the neater way to do this now