### PR TITLE
[DB-29-1] Backport: Collect Telemetry from Plugins

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -142,7 +142,7 @@ namespace EventStore.Core.Tests.Helpers {
 				Projections = new() {
 					RunProjections = ProjectionType.None
 				},
-				Subsystems = subsystems ?? Array.Empty<ISubsystem>()
+				PlugableComponents = subsystems ?? Array.Empty<ISubsystem>()
 			};
 
 			var serverCertificate = useHttps ? ssl_connections.GetServerCertificate() : null;

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -130,7 +130,7 @@ namespace EventStore.Core.Tests.Helpers {
 						UnsafeDisableFlushToDisk = disableFlushToDisk,
 						StreamExistenceFilterSize = streamExistenceFilterSize,
 					},
-					Subsystems = new List<ISubsystem>(subsystems ?? Array.Empty<ISubsystem>())
+					PlugableComponents = new List<ISubsystem>(subsystems ?? Array.Empty<ISubsystem>())
 				}.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 					ssl_connections.GetServerCertificate())
 				.WithInternalSecureTcpOn(IntTcpEndPoint)

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -58,6 +58,7 @@ namespace EventStore.Core.Tests {
 		public void all_keys_are_read_from_configuration() {
 			string[] excluded = new[] {
 				nameof(ClusterVNodeOptions.ConfigurationRoot),
+				nameof(ClusterVNodeOptions.PlugableComponents),
 				nameof(ClusterVNodeOptions.Subsystems),
 				nameof(ClusterVNodeOptions.ServerCertificate),
 				nameof(ClusterVNodeOptions.TrustedRootCertificates),

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -16,6 +16,7 @@ using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Settings;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.Util;
+using EventStore.Plugins;
 using EventStore.Plugins.Subsystems;
 using Microsoft.Extensions.Configuration;
 using Serilog;
@@ -44,10 +45,12 @@ namespace EventStore.Core {
 
 		public byte IndexBitnessVersion { get; init; } = Index.PTableVersions.IndexV4;
 
-		public IReadOnlyList<ISubsystem> Subsystems { get; init; } = Array.Empty<ISubsystem>();
+		public IReadOnlyList<IPlugableComponent> PlugableComponents { get; init; } = [];
 
-		public ClusterVNodeOptions WithSubsystem(ISubsystem subsystem) => this with {
-			Subsystems = new List<ISubsystem>(Subsystems) { subsystem }
+		public IReadOnlyList<ISubsystem> Subsystems => PlugableComponents.OfType<ISubsystem>().ToArray();
+
+		public ClusterVNodeOptions WithPlugableComponent(IPlugableComponent plugableComponent) => this with {
+			PlugableComponents = [.. PlugableComponents, plugableComponent]
 		};
 
 		public X509Certificate2? ServerCertificate { get; init; }

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -7,7 +7,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="EventStore.Plugins" Version="24.2.1" />
+		<PackageReference Include="EventStore.Plugins" Version="24.4.2-alpha3" />
 		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.59.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.59.0">

--- a/src/EventStore.Core/Telemetry/TelemetryMessage.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryMessage.cs
@@ -19,15 +19,21 @@ public abstract partial class TelemetryMessage : Message {
 
 	[DerivedMessage(CoreMessage.Telemetry)]
 	public partial class Response : TelemetryMessage {
+		public readonly string Root;
 		public readonly string Key;
 		public readonly JsonNode Value;
 
-		public Response(string key, JsonNode value) {
+		public Response(string root, string key, JsonNode value) {
+			Ensure.NotNull(root, "root");
 			Ensure.NotNullOrEmpty(key, "key");
 			Ensure.NotNull(value, "value");
 
+			Root = root;
 			Key = key;
 			Value = value;
+		}
+
+		public Response(string key, JsonNode value) : this("", key, value) {
 		}
 	}
 

--- a/src/EventStore.Core/Telemetry/TelemetryService.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryService.cs
@@ -91,7 +91,21 @@ public sealed class TelemetryService : IDisposable,
 					break;
 
 				case TelemetryMessage.Response response:
-					data[response.Key] = response.Value;
+					if (string.IsNullOrWhiteSpace(response.Root)) {
+						data[response.Key] = response.Value;
+						break;
+					}
+
+					if (data.TryGetPropertyValue(response.Root, out var existing) &&
+						existing is JsonObject existingObject) {
+
+						existingObject[response.Key] = response.Value;
+						break;
+					}
+
+					data[response.Root] = new JsonObject {
+						[response.Key] = response.Value
+					};
 					break;
 
 				case TelemetryMessage.Flush:
@@ -138,6 +152,8 @@ public sealed class TelemetryService : IDisposable,
 				["enableAtomPubOverHttp"] = _nodeOptions.Interface.EnableAtomPubOverHttp,
 				["insecure"] = _nodeOptions.Application.Insecure,
 				["runProjections"] = _nodeOptions.Projections.RunProjections.ToString(),
+				["authorizationType"] = _nodeOptions.Auth.AuthorizationType,
+				["authenticationType"] = _nodeOptions.Auth.AuthenticationType
 			}));
 
 		message.Envelope.ReplyWith(new TelemetryMessage.Response(
@@ -157,6 +173,13 @@ public sealed class TelemetryService : IDisposable,
 				["totalDiskSpace"] = env.Machine.TotalDiskSpace,
 				["totalMemory"] = env.Machine.TotalMemory,
 			}));
+
+		Action<string, JsonNode> collect = (key, value) =>
+			message.Envelope.ReplyWith(new TelemetryMessage.Response("plugins", key, value));
+
+		foreach (var subsystem in _nodeOptions.PlugableComponents) {
+			subsystem.CollectTelemetry(collect);
+		}
 
 		_publisher.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(resp => OnGossipReceived(message.Envelope, resp))));
 	}

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
 		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-		<PackageReference Include="EventStore.Plugins" Version="24.2.1" />
+		<PackageReference Include="EventStore.Plugins" Version="24.4.2-alpha3" />
 		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.59.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.59.0">


### PR DESCRIPTION
Added: Infra to collect telemetry from plugins

Original PR: https://github.com/EventStore/EventStore/pull/4219
Original commit d7b531cc80cc8264ce494c2a8f6b5f0490b201f4 Lots of conflicts, I essentially copied the code across manually