### PR TITLE
[DB-29-1] Backport: Remove minver. Drive version prefix from build version and suffix from version.properties

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,11 +2,5 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "minver-cli": {
-      "version": "4.3.0",
-      "commands": [
-        "minver"
-      ]
-    }
   }
 }

--- a/.github/workflows/build-container-reusable.yml
+++ b/.github/workflows/build-container-reusable.yml
@@ -32,11 +32,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Calculate Version
-      run: |
-        dotnet tool restore
-        version=$(dotnet tool run minver -- --tag-prefix=oss-v)-${{ inputs.container-runtime }}
-        echo "VERSION=${version}" >> $GITHUB_ENV
     - name: Setup Variables
       id: variables
       uses: kanga333/variable-mapper@master
@@ -95,16 +90,3 @@ jobs:
       with:
         name: test-results-${{ inputs.container-runtime }}
         path: test-results
-    - name: Push GitHub Container Registry
-      if: always() && github.event_name == 'push'
-      shell: bash
-      run: |
-        docker tag eventstore ghcr.io/eventstore/eventstore:${{ env.VERSION }}
-        docker push ghcr.io/eventstore/eventstore:${{ env.VERSION }}
-    - name: Push GitHub Container Registry (CI)
-      if: always() && github.event_name == 'push' && inputs.container-runtime == 'jammy' && github.ref == 'refs/heads/master'
-      shell: bash
-      run: |
-        docker tag eventstore ghcr.io/eventstore/eventstore:ci
-        docker push ghcr.io/eventstore/eventstore:ci
-

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,22 +14,10 @@
 		<LangVersion>12.0</LangVersion>
 		<Platforms>AnyCPU;x64;ARM64</Platforms>
 		<IsPackable>false</IsPackable>
-		<MinVerTagPrefix>oss-v</MinVerTagPrefix>
-		<MinVerMinimumMajorMinor>22.2</MinVerMinimumMajorMinor>
+		<Version>24.4.0</Version>
 	</PropertyGroup>
-	<Target Name="UpdateAssemblyVersion" AfterTargets="MinVer">
-		<PropertyGroup>
-			<AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).0</AssemblyVersion>
-		</PropertyGroup>
-	</Target>
 	<ItemGroup>
 		<None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" />
 		<None Include="..\..\ouro.png" Pack="true" PackagePath="\" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="MinVer" Version="4.3.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-		</PackageReference>
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Common/Utils/VersionInfo.cs
+++ b/src/EventStore.Common/Utils/VersionInfo.cs
@@ -1,16 +1,21 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace EventStore.Common.Utils {
 	public static class VersionInfo {
-		public const string DefaultVersion = "0.0.0-prerelease";
+		public const string DefaultVersion = "default_version";
 		public const string OldVersion = "old_version";
 		public const string UnknownVersion = "unknown_version";
 
 		public static string BuildId { get; private set; } = "";
 		public static string Edition { get; private set; } = "";
-		public static string Version { get; private set; } = DefaultVersion;
+		public static string VersionPrefix { get; private set; } = "";
+		public static string VersionSuffix { get; private set; } = "";
+		public static string Version => string.IsNullOrWhiteSpace(VersionSuffix)
+			? VersionPrefix
+			: VersionPrefix + "-" + VersionSuffix;
 
 		public static string CommitSha { get; private set; } = ThisAssembly.Git.Commit;
 		public static string Timestamp { get; private set; } = ThisAssembly.Git.CommitDate;
@@ -18,13 +23,20 @@ namespace EventStore.Common.Utils {
 		public static string Text => $"EventStoreDB version {Version} {Edition} ({BuildId}/{CommitSha})";
 
 		static VersionInfo() {
+			// the prefix is baked into the assemblies but the suffix is not, so that they can be
+			// promoted. e.g. rc1 -> rtm
+			var versionPrefix = Assembly.GetEntryAssembly().GetName().Version.ToString();
+			if (versionPrefix.EndsWith(".0"))
+				versionPrefix = versionPrefix[..^2];
+			VersionPrefix = versionPrefix;
+
 			var versionFilePath = Path.Join(
 				Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory),
 				"version.properties");
 			var properties = LoadProperties(versionFilePath);
 
-			if (properties.TryGetValue("version", out var version))
-				Version = version;
+			if (properties.TryGetValue("version_suffix", out var versionSuffix))
+				VersionSuffix = versionSuffix;
 
 			if (properties.TryGetValue("commit_sha", out var commitSha))
 				CommitSha = commitSha;

--- a/src/EventStore.Common/Utils/version.properties
+++ b/src/EventStore.Common/Utils/version.properties
@@ -1,1 +1,2 @@
-version=24.2.0
+version_suffix=prerelease
+edition=local


### PR DESCRIPTION
Changed: version number mechanism

Original PR: https://github.com/EventStore/EventStore/pull/4233
Original commit: 0ae3cd73c37e0c664bccba01d9b41f69fa17fe1c
Cherry pick was reasonably clean