### PR TITLE
[ESDB-106-16] Replicate the transform header to followers

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -2169,6 +2169,11 @@
                 "id": 5,
                 "name": "is_scavenged_chunk",
                 "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "transform_header_bytes",
+                "type": "bytes"
               }
             ]
           },

--- a/src/EventStore.Core/Cluster/ReplicationPartials.cs
+++ b/src/EventStore.Core/Cluster/ReplicationPartials.cs
@@ -1,4 +1,5 @@
-﻿using EventStore.Common.Utils;
+﻿using System;
+using EventStore.Common.Utils;
 using Google.Protobuf;
 
 // ReSharper disable once CheckNamespace
@@ -73,7 +74,7 @@ namespace EventStore.Cluster {
 
 	partial class CreateChunk {
 		public CreateChunk(byte[] leaderId, byte[] subscriptionId, byte[] chunkHeaderBytes, int fileSize,
-			bool isScavengedChunk) {
+			bool isScavengedChunk, ReadOnlySpan<byte> transformHeaderBytes) {
 			Ensure.NotNull(leaderId, "leaderId");
 			Ensure.NotNull(subscriptionId, "subscriptionId");
 			Ensure.NotNull(chunkHeaderBytes, "chunkHeaderBytes");
@@ -83,6 +84,7 @@ namespace EventStore.Cluster {
 			ChunkHeaderBytes = ByteString.CopyFrom(chunkHeaderBytes);
 			FileSize = fileSize;
 			IsScavengedChunk = isScavengedChunk;
+			TransformHeaderBytes = ByteString.CopyFrom(transformHeaderBytes);
 		}
 	}
 

--- a/src/EventStore.Core/Messages/ReplicationMessage.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessage.cs
@@ -316,8 +316,10 @@ namespace EventStore.Core.Messages {
 			public readonly int FileSize;
 			public bool IsScavengedChunk;
 
+			public ReadOnlyMemory<byte> TransformHeader;
+
 			public CreateChunk(Guid leaderId, Guid subscriptionId, ChunkHeader chunkHeader, int fileSize,
-				bool isScavengedChunk) {
+				bool isScavengedChunk, ReadOnlyMemory<byte> transformHeader) {
 				Ensure.NotEmptyGuid(leaderId, "leaderId");
 				Ensure.NotEmptyGuid(subscriptionId, "subscriptionId");
 				Ensure.NotNull(chunkHeader, "chunkHeader");
@@ -327,12 +329,13 @@ namespace EventStore.Core.Messages {
 				ChunkHeader = chunkHeader;
 				FileSize = fileSize;
 				IsScavengedChunk = isScavengedChunk;
+				TransformHeader = transformHeader;
 			}
 
 			public override string ToString() {
 				return string.Format(
-					"CreateChunk message: LeaderId: {0}, SubscriptionId: {1}, ChunkHeader: {2}, FileSize: {3}, IsScavengedChunk: {4}",
-					LeaderId, SubscriptionId, ChunkHeader, FileSize, IsScavengedChunk);
+					"CreateChunk message: LeaderId: {0}, SubscriptionId: {1}, ChunkHeader: {2}, FileSize: {3}, IsScavengedChunk: {4}, TransformHeader size: {5}",
+					LeaderId, SubscriptionId, ChunkHeader, FileSize, IsScavengedChunk, TransformHeader.Length);
 			}
 		}
 

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -216,9 +216,8 @@ namespace EventStore.Core.Services {
 			if (message.IsScavengedChunk) {
 				_activeChunk = Db.Manager.CreateTempChunk(message.ChunkHeader, message.FileSize);
 			} else {
-				var identityTransformHeader = ReadOnlyMemory<byte>.Empty;
 				if (message.ChunkHeader.ChunkStartNumber == Db.Manager.ChunksCount) {
-					Writer.AddNewChunk(message.ChunkHeader, identityTransformHeader, message.FileSize);
+					Writer.AddNewChunk(message.ChunkHeader, message.TransformHeader, message.FileSize);
 				} else if (message.ChunkHeader.ChunkStartNumber + 1 == Db.Manager.ChunksCount) {
 					// the requested chunk was already created. this is fine, it can happen if the follower created the
 					// chunk in a previous run, was killed and re-subscribed to the leader at the beginning of the chunk.

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -388,7 +388,8 @@ namespace EventStore.Core.Services.Replication {
 						sub.SubscriptionId,
 						chunk.ChunkHeader,
 						chunk.FileSize,
-						isScavengedChunk: true));
+						isScavengedChunk: true,
+						chunk.TransformHeader));
 				} else {
 					if (verbose)
 						Log.Information(
@@ -409,7 +410,8 @@ namespace EventStore.Core.Services.Replication {
 							sub.SubscriptionId,
 							chunk.ChunkHeader,
 							chunk.FileSize,
-							isScavengedChunk: false));
+							isScavengedChunk: false,
+							chunk.TransformHeader));
 					}
 				}
 

--- a/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
@@ -105,7 +105,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			}
 
 			return new ReplicationMessage.CreateChunk(new Guid(dto.LeaderId.Span), new Guid(dto.SubscriptionId.Span), chunkHeader,
-				dto.FileSize, dto.IsScavengedChunk);
+				dto.FileSize, dto.IsScavengedChunk, dto.TransformHeaderBytes.Memory);
 		}
 
 		private TcpPackage WrapCreateChunk(ReplicationMessage.CreateChunk msg) {
@@ -113,7 +113,8 @@ namespace EventStore.Core.Services.Transport.Tcp {
 				msg.SubscriptionId.ToByteArray(),
 				msg.ChunkHeader.AsByteArray(),
 				msg.FileSize,
-				msg.IsScavengedChunk);
+				msg.IsScavengedChunk,
+				msg.TransformHeader.Span);
 			return new TcpPackage(TcpCommand.CreateChunk, Guid.NewGuid(), dto.Serialize());
 		}
 

--- a/src/Protos/Grpc/cluster.proto
+++ b/src/Protos/Grpc/cluster.proto
@@ -198,6 +198,7 @@ message CreateChunk{
 	bytes chunk_header_bytes = 3;
 	int32 file_size = 4;
 	bool is_scavenged_chunk = 5;
+	bytes transform_header_bytes = 6;
 }
 
 message RawChunkBulk{


### PR DESCRIPTION
Added: Replicate the transform header to followers

This PR builds upon https://github.com/EventStore/EventStore/pull/4217
It replicates the transform header to followers in the `CreateChunk` message.

This change is both backwards/forwards compatible:
- old follower subscribing to new leader:
works because the follower will just ignore the `transform_header_bytes` proto addition (of course assuming there is no transform applied on the leader)

- new follower subscribing to old leader:
works because `transform_header_bytes` is set to the default which is an empty byte array
