### PR TITLE
[DB-26-12] Identify nodes with advertised addresses for Scavenge log

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1390,7 +1390,7 @@ namespace EventStore.Core {
 			}
 
 			var scavengerLogManager = new TFChunkScavengerLogManager(
-				nodeEndpoint: _options.Interface.ReplicationHostAdvertiseAs == null ? NodeInfo.HttpEndPoint.ToString() : (_options.Interface.ReplicationHostAdvertiseAs + ":" + NodeInfo.HttpEndPoint.GetPort()),
+				nodeEndpoint: $"{GossipAdvertiseInfo.HttpEndPoint.Host}:{GossipAdvertiseInfo.HttpEndPoint.Port}",
 				scavengeHistoryMaxAge: TimeSpan.FromDays(options.Database.ScavengeHistoryMaxAge),
 				ioDispatcher: scavengerDispatcher);
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1390,7 +1390,7 @@ namespace EventStore.Core {
 			}
 
 			var scavengerLogManager = new TFChunkScavengerLogManager(
-				nodeEndpoint: NodeInfo.HttpEndPoint.ToString(),
+				nodeEndpoint: _options.Interface.ReplicationHostAdvertiseAs == null ? NodeInfo.HttpEndPoint.ToString() : (_options.Interface.ReplicationHostAdvertiseAs + ":" + NodeInfo.HttpEndPoint.GetPort()),
 				scavengeHistoryMaxAge: TimeSpan.FromDays(options.Database.ScavengeHistoryMaxAge),
 				ioDispatcher: scavengerDispatcher);
 


### PR DESCRIPTION
Fixed : Use the advertised addresses for identifying nodes in the scavenge log.

https://eventstore.aha.io/develop/requirements/DB-26-12 . Linear issue : https://linear.app/eventstore/issue/DB-706/scavenge-identify-nodes-with-advertised-addresses