### PR TITLE
Extend ESDB metrics for Persistent Subscriptions

### DIFF
--- a/src/EventStore.ClusterNode/metricsconfig.json
+++ b/src/EventStore.ClusterNode/metricsconfig.json
@@ -3,8 +3,7 @@
 	"ExpectedScrapeIntervalSeconds": 15,
 
 	"Meters": [
-		"EventStore.Core",
-		"EventStore.Projections.Core"
+		"EventStore.Core"
 	],
 
 	"Statuses": {
@@ -16,6 +15,8 @@
 	"ElectionsCount": true,
 
 	"ProjectionStats": true,
+
+	"PersistentSubscriptionStats": true,
 
 	"Checkpoints": {
 		"Writer": true,

--- a/src/EventStore.Common/Configuration/MetricsConfiguration.cs
+++ b/src/EventStore.Common/Configuration/MetricsConfiguration.cs
@@ -146,6 +146,8 @@ namespace EventStore.Common.Configuration {
 
 		public bool ProjectionStats { get; set; }
 
+		public bool PersistentSubscriptionStats { get; set; } = false;
+
 		public bool ElectionsCount { get; set; } = false;
 
 		public bool CacheResources { get; set; } = false;

--- a/src/EventStore.Common/Utils/EventPositionParser.cs
+++ b/src/EventStore.Common/Utils/EventPositionParser.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace EventStore.Common.Utils;
+
+public abstract class EventPositionParser {
+	public static (long commit, long prepare) ParseCommitPreparePosition(string position) {
+		if (string.IsNullOrEmpty(position))
+			return (-1, -1);
+
+		string[] parts = position.Split('/');
+		if (parts.Length != 2 || parts[0][0] != 'C' || parts[1][0] != 'P')
+			throw new Exception($"Invalid event position: {position}");
+
+		if (!long.TryParse(parts[0].Substring(2), out long commit))
+			throw new Exception($"Invalid commit position in event position: {position}");
+
+		if (!long.TryParse(parts[1].Substring(2), out long prepare))
+			throw new Exception($"Invalid prepare position in event position: {position}");
+
+		return (commit, prepare);
+	}
+}

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -58,7 +58,6 @@ namespace EventStore.Core.Tests.Helpers {
 		private readonly TestServer _kestrelTestServer;
 		private readonly TaskCompletionSource<bool> _started;
 		private readonly TaskCompletionSource<bool> _adminUserCreated;
-
 		public Task Started => _started.Task;
 		public Task AdminUserCreated => _adminUserCreated.Task;
 

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/when_an_error_occurs.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/when_an_error_occurs.cs
@@ -28,13 +28,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 				_expectedResult = expectedResult;
 				_replySource = new TaskCompletionSource<Message>();
 				var bus = new InMemoryBus("bus");
+				var trackers = new Trackers();
 				_sut = new PersistentSubscriptionService<TStreamId>(
 					QueuedHandler.CreateQueuedHandler(bus, "test",
 						new QueueStatsManager(), new QueueTrackers()),
 					new FakeReadIndex<TLogFormat, TStreamId>(_ => false, new MetaStreamLookup()),
 					new IODispatcher(bus, new PublishEnvelope(bus)), bus,
 					new PersistentSubscriptionConsumerStrategyRegistry(bus, bus,
-						Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>()));
+						Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>()), trackers.PersistentSubscriptionTracker);
 				_envelope = new CallbackEnvelope(_replySource.SetResult);
 				_sut.Start();
 			}

--- a/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionTrackerTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using EventStore.Core.Messages;
+using EventStore.Core.Metrics;
+using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Tests;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Metrics;
+
+
+public class PersistentSubscriptionTrackerTests : IDisposable {
+	private readonly Disposables _disposables = new();
+	private readonly List<MonitoringMessage.PersistentSubscriptionInfo> _fakeStatsList = [];
+
+	public PersistentSubscriptionTrackerTests() {
+		var statsSampleOne = new MonitoringMessage.PersistentSubscriptionInfo() {
+			EventSource = "test",
+			GroupName = "testGroup",
+			Status = PersistentSubscriptionState.Live.ToString(),
+			Connections = new List<MonitoringMessage.ConnectionInfo>(),
+			AveragePerSecond = 1,
+			LastCheckpointedEventPosition = 10.ToString(),
+			LastKnownEventPosition = 20.ToString(),
+			TotalItems = 30,
+			CountSinceLastMeasurement = 5,
+			CheckPointAfterMilliseconds = 1000,
+			BufferSize = 500,
+			LiveBufferSize = 500,
+			MaxCheckPointCount = 500,
+			MaxRetryCount = 5,
+			MessageTimeoutMilliseconds = 1000,
+			MinCheckPointCount = 10,
+			ReadBatchSize = 20,
+			ResolveLinktos = true,
+			StartFrom = 0.ToString(),
+			ReadBufferCount = 0,
+			RetryBufferCount = 0,
+			LiveBufferCount = 0,
+			ExtraStatistics = false,
+			TotalInFlightMessages = 10,
+			OutstandingMessagesCount = 2,
+			NamedConsumerStrategy = "Round Robin",
+			MaxSubscriberCount = 10,
+			ParkedMessageCount = 10,
+			OldestParkedMessage = 50
+		};
+
+		var statsSampleTwo = new MonitoringMessage.PersistentSubscriptionInfo() {
+			EventSource = "$all",
+			GroupName = "testGroup",
+			Status = PersistentSubscriptionState.Live.ToString(),
+			Connections = new List<MonitoringMessage.ConnectionInfo>(),
+			AveragePerSecond = 1,
+			LastCheckpointedEventPosition = "C:211845/P:211845",
+			LastKnownEventPosition = "C:211200/P:211200",
+			TotalItems = 30,
+			CountSinceLastMeasurement = 5,
+			CheckPointAfterMilliseconds = 1000,
+			BufferSize = 500,
+			LiveBufferSize = 500,
+			MaxCheckPointCount = 500,
+			MaxRetryCount = 5,
+			MessageTimeoutMilliseconds = 1000,
+			MinCheckPointCount = 10,
+			ReadBatchSize = 20,
+			ResolveLinktos = true,
+			StartFrom = 0.ToString(),
+			ReadBufferCount = 0,
+			RetryBufferCount = 0,
+			LiveBufferCount = 0,
+			ExtraStatistics = false,
+			TotalInFlightMessages = 10,
+			OutstandingMessagesCount = 2,
+			NamedConsumerStrategy = "Round Robin",
+			MaxSubscriberCount = 10,
+			ParkedMessageCount = 10,
+			OldestParkedMessage = 50
+		};
+
+		_fakeStatsList.Add(statsSampleOne);
+		_fakeStatsList.Add(statsSampleTwo);
+	}
+
+	public void Dispose() {
+		_disposables?.Dispose();
+	}
+
+	private (PersistentSubscriptionTracker, TestMeterListener<long>) GenSut(
+		[CallerMemberName] string callerName = "") {
+
+		var meter = new Meter($"{typeof(PersistentSubscriptionTrackerTests)}-{callerName}").DisposeWith(_disposables);
+		var listener = new TestMeterListener<long>(meter).DisposeWith(_disposables);
+		var metric = new PersistentSubscriptionMetric(meter, "test-metric");
+		var sut = new PersistentSubscriptionTracker(metric);
+
+		return (sut, listener);
+	}
+
+	[Fact]
+	public void number_of_instruments_to_observe() {
+		var (sut, listener) = GenSut();
+		sut.Register(_fakeStatsList);
+
+		listener.Observe();
+
+		var measurements = listener.RetrieveMeasurements("test-metric");
+		Assert.Equal(14 , measurements.Count);
+	}
+
+	[Fact]
+	public void observe_all_metrics() {
+		var (sut, listener) = GenSut();
+		sut.Register(_fakeStatsList);
+
+		AssertMeasurements(listener,
+			AssertMeasurement("test/testGroup", "subscription-total-items-processed", 30),
+			AssertMeasurement("test/testGroup", "subscription-connection-count", 0),
+			AssertMeasurement("test/testGroup", "subscription-total-in-flight-messages", 10),
+			AssertMeasurement("test/testGroup", "subscription-total-number-of-parked-messages", 10),
+			AssertMeasurement("test/testGroup", "subscription-oldest-parked-message", 50),
+			AssertMeasurement("test/testGroup", "subscription-last-processed-event-number", 10),
+			AssertMeasurement("test/testGroup", "subscription-last-known-event-number", 20),
+			AssertMeasurement("$all/testGroup", "subscription-total-items-processed", 30),
+			AssertMeasurement("$all/testGroup", "subscription-connection-count", 0),
+			AssertMeasurement("$all/testGroup", "subscription-total-in-flight-messages", 10),
+			AssertMeasurement("$all/testGroup", "subscription-total-number-of-parked-messages", 10),
+			AssertMeasurement("$all/testGroup", "subscription-oldest-parked-message", 50),
+			AssertMeasurement("$all/testGroup", "subscription-last-checkpointed-event-commit-position", 211845),
+			AssertMeasurement("$all/testGroup", "subscription-last-known-event-commit-position", 211200));
+	}
+
+	static Action<TestMeterListener<long>.TestMeasurement> AssertMeasurement(
+		string subscriptionName,
+		string metricName,
+		long expectedValue) =>
+
+		actualMeasurement => {
+			Assert.Equal(expectedValue, actualMeasurement.Value);
+			Assert.Collection(
+				actualMeasurement.Tags.ToArray(),
+				tag => {
+					Assert.Equal("subscription", tag.Key);
+					Assert.Equal(subscriptionName, tag.Value);
+				},
+				tag => {
+					Assert.Equal("kind", tag.Key);
+					Assert.Equal(metricName, tag.Value);
+				}
+			);
+		};
+
+
+	static void AssertMeasurements(
+		TestMeterListener<long> listener,
+		params Action<TestMeterListener<long>.TestMeasurement>[] actions) {
+
+		listener.Observe();
+
+		Assert.Collection(listener.RetrieveMeasurements("test-metric"), actions);
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1198,7 +1198,7 @@ namespace EventStore.Core {
 			var consumerStrategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry(_mainQueue, _mainBus,
 				additionalPersistentSubscriptionConsumerStrategyFactories);
 			var persistentSubscription = new PersistentSubscriptionService<TStreamId>(perSubscrQueue, readIndex, psubDispatcher,
-				_mainQueue, consumerStrategyRegistry);
+				_mainQueue, consumerStrategyRegistry, trackers.PersistentSubscriptionTracker);
 			perSubscrBus.Subscribe<SystemMessage.BecomeShuttingDown>(persistentSubscription);
 			perSubscrBus.Subscribe<SystemMessage.BecomeLeader>(persistentSubscription);
 			perSubscrBus.Subscribe<SystemMessage.StateChangeMessage>(persistentSubscription);

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -104,6 +104,7 @@ namespace EventStore.Core.Messages {
 			public string NamedConsumerStrategy { get; set; }
 			public int MaxSubscriberCount { get; set; }
 			public long ParkedMessageCount { get; set; }
+			public long OldestParkedMessage { get; set; }
 		}
 
 		public class ConnectionInfo {
@@ -208,7 +209,7 @@ namespace EventStore.Core.Messages {
 		[DerivedMessage(CoreMessage.Misc)]
 		public partial class DynamicCacheManagerTick : Message {
 		}
-		
+
 		[DerivedMessage(CoreMessage.Misc)]
 		public partial class CheckCertificateExpiry : Message {
 		}

--- a/src/EventStore.Core/Metrics/PersistentSubscriptionMetric.cs
+++ b/src/EventStore.Core/Metrics/PersistentSubscriptionMetric.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using EventStore.Common.Utils;
+using EventStore.Core.Messages;
+
+namespace EventStore.Core.Metrics;
+
+public class PersistentSubscriptionMetric {
+	private readonly ObservableUpDownMetric<long> _statsMetric;
+
+	public PersistentSubscriptionMetric(Meter meter, string name) {
+		_statsMetric = new ObservableUpDownMetric<long>(meter, name);
+	}
+
+	public void Register(List<MonitoringMessage.PersistentSubscriptionInfo> statsList) {
+		foreach (var stat in statsList) {
+			var subscriptionName = $"{stat.EventSource}/{stat.GroupName}";
+
+			Register(_statsMetric, subscriptionName, "subscription-total-items-processed", () => stat.TotalItems);
+			Register(_statsMetric, subscriptionName, "subscription-connection-count",
+				() => stat.Connections.Count);
+			Register(_statsMetric, subscriptionName, "subscription-total-in-flight-messages",
+				() => stat.TotalInFlightMessages);
+			Register(_statsMetric, subscriptionName, "subscription-total-number-of-parked-messages",
+				() => stat.ParkedMessageCount);
+			Register(_statsMetric, subscriptionName, "subscription-oldest-parked-message", () => stat.OldestParkedMessage);
+
+			if (stat.EventSource == "$all") {
+				var (checkpointedCommitPosition, _) = EventPositionParser.ParseCommitPreparePosition(stat.LastCheckpointedEventPosition);
+				var (eventCommitPosition, _) =
+					EventPositionParser.ParseCommitPreparePosition(stat.LastKnownEventPosition);
+
+				Register(_statsMetric, subscriptionName, "subscription-last-checkpointed-event-commit-position",
+					() => checkpointedCommitPosition);
+
+				Register(_statsMetric, subscriptionName, "subscription-last-known-event-commit-position",
+					() => eventCommitPosition);
+			} else {
+				Register(_statsMetric, subscriptionName, "subscription-last-processed-event-number",
+					() => long.TryParse(stat.LastCheckpointedEventPosition, out var lastEventPos)
+						? lastEventPos
+						: 0);
+
+				Register(_statsMetric, subscriptionName, "subscription-last-known-event-number",
+					() => long.TryParse(stat.LastKnownEventPosition, out var lastKnownMsg)
+						? lastKnownMsg
+						: 0);
+			}
+		}
+	}
+
+	private static void Register(
+		ObservableUpDownMetric<long> metric,
+		string subscriptionName,
+		string metricName,
+		Func<long> measurementProvider) {
+		var tags = new KeyValuePair<string, object>[] {
+			new("subscription", subscriptionName),
+			new("kind", metricName)
+		};
+
+		metric.Register(() => new(measurementProvider(), tags));
+	}
+}

--- a/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
+++ b/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using EventStore.Core.Messages;
+
+namespace EventStore.Core.Metrics;
+
+public interface IPersistentSubscriptionTracker {
+	public void Register(List<MonitoringMessage.PersistentSubscriptionInfo> statsList);
+}
+
+public class PersistentSubscriptionTracker : IPersistentSubscriptionTracker {
+
+	private readonly PersistentSubscriptionMetric _metrics;
+
+	public PersistentSubscriptionTracker(PersistentSubscriptionMetric metrics) {
+		_metrics = metrics;
+	}
+
+	public void Register(List<MonitoringMessage.PersistentSubscriptionInfo> statsList) {
+		_metrics.Register(statsList);
+	}
+
+	public class NoOp : IPersistentSubscriptionTracker {
+		public void Register(List<MonitoringMessage.PersistentSubscriptionInfo> statsList) { }
+	}
+}

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
+using EventStore.Core.Bus;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.Index;
@@ -32,6 +33,8 @@ public class Trackers {
 	public ICacheHitsMissesTracker CacheHitsMissesTracker { get; set; } = new CacheHitsMissesTracker.NoOp();
 	public ICacheResourcesTracker CacheResourcesTracker { get; set; } = new CacheResourcesTracker.NoOp();
 	public IElectionCounterTracker ElectionCounterTracker { get; set; } = new ElectionsCounterTracker.NoOp();
+	public IPersistentSubscriptionTracker PersistentSubscriptionTracker { get; set; } =
+		new PersistentSubscriptionTracker.NoOp();
 }
 
 public class GrpcTrackers {
@@ -152,6 +155,15 @@ public static class MetricsBootstrapper {
 
 			if (conf.Gossip.TryGetValue(Conf.GossipTracker.ProcessingRequestFromHttpClient, out var processingRequestFromHttpClient) && processingRequestFromHttpClient)
 				trackers.GossipTrackers.ProcessingRequestFromHttpClient = new DurationTracker(gossipProcessingMetric, "request-from-http-client");
+		}
+
+		// persistent subscriptions
+
+		if (conf.PersistentSubscriptionStats) {
+			var metric =
+				new PersistentSubscriptionMetric(coreMeter, "eventstore-persistent-subscriptions-stats");
+			trackers.PersistentSubscriptionTracker =
+				new PersistentSubscriptionTracker(metric);
 		}
 
 		// checkpoints

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -6,9 +6,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 	public interface IPersistentSubscriptionMessageParker {
 		void BeginParkMessage(ResolvedEvent ev, string reason, Action<ResolvedEvent, OperationResult> completed);
 		void BeginReadEndSequence(Action<long?> completed);
-		void BeginMarkParkedMessagesReprocessed(long sequence);
+		void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? oldestParkedMessageTimestamp, bool updateOldestParkedMessage);
 		void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed);
 		long ParkedMessageCount { get; }
 		public void BeginLoadStats(Action completed);
+		DateTime? GetOldestParkedMessage { get; }
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -38,6 +38,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public MonitoringMessage.PersistentSubscriptionInfo GetStatistics() {
+			long oldestParkedMessage = 0;
 			var totalTime = _totalTimeWatch.Elapsed;
 			var totalItems = Interlocked.Read(ref _totalItems);
 
@@ -75,6 +76,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 			long parkedMessageCount = _settings.MessageParker.ParkedMessageCount;
 
+			var timeStamp = _settings.MessageParker.GetOldestParkedMessage;
+
+			if (timeStamp.HasValue) {
+				oldestParkedMessage = (long)(DateTime.UtcNow - timeStamp.Value).TotalSeconds;
+			}
+
 			var gotBuffer = _parent.TryGetStreamBuffer(out var streamBuffer);
 
 			return new MonitoringMessage.PersistentSubscriptionInfo() {
@@ -105,7 +112,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				OutstandingMessagesCount = _parent.OutstandingMessageCount,
 				NamedConsumerStrategy = _settings.ConsumerStrategy.Name,
 				MaxSubscriberCount = _settings.MaxSubscriberCount,
-				ParkedMessageCount = parkedMessageCount
+				ParkedMessageCount = parkedMessageCount,
+				OldestParkedMessage = oldestParkedMessage
 			};
 		}
 	}


### PR DESCRIPTION
Added: Extend ESDB metrics for Persistent Subscriptions

Fixes ESDB-116-2

Having some formatting issues after upgraded the Rider version to 2024.1.1. The settings are in place for whitespace handling but for some reasons replacing the curly braces at the end of file/function/class adding new formatted lines.

