### PR TITLE
[DB-26-16] Log an error when node certificate is not a valid server certificate

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -119,7 +119,21 @@ Anonymous access is still always granted to `/ping`, `/info`, the static content
 
 ### Certificates configuration
 
-In this section, you can find settings related to protocol security (HTTPS and TLS).
+To run a cluster securely, you will need to generate and configure certificates for the nodes.
+
+The node certificate must adhere to the following requirements:
+- All node certificates in a cluster share a common root CA.
+- The root CA is trusted by the node.
+- The certificate Extended Key Usages (EKUs) either:
+  - Contains both the ClientAuth EKU and the ServerAuth EKU, or
+  - Is empty.
+- The certificate Key Usages contains either:
+  - DigitalSignature and KeyEncipherment, or
+  - DigitalSignature and KeyAgreement.
+- The certificate must be in date.
+- The CN matches the [CertificateReservedNodeCommonName](#certificate-common-name).
+
+You can generate a certificate that meets these requirements with the [Certificate Generation Tool](#certificate-generation-tool).
 
 #### Certificate common name
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -76,6 +76,27 @@ A number of configuration options have been removed as part of this. EventStoreD
 - `NodeTcpPort`
 - `NodeTcpPortAdvertiseAs`
 
+##### Stricter node certificate requirements
+
+EventStoreDB 24.2.0 has stricter requirements for Key Usages in node certificates.
+
+These requirements are:
+- The certificate Extended Key Usages (EKUs) either:
+  - Contains both the ClientAuth EKU and the ServerAuth EKU, or
+  - Is empty.
+- The certificate Key Usages contains either:
+  - DigitalSignature and KeyEncipherment, or
+  - DigitalSignature and KeyAgreement.
+
+If a node certificate does not meet these requirements, the nodes in the cluster will be unable to make gossip and election requests.
+In this case, you will see the following logs:
+
+```
+[16480,21,14:57:06.209,WRN] Failed authorization check for "(anonymous)" in 00:00:00.0000826 with "node/gossip : update Deny : Policy : Legacy 1 9999-12-31 11:59:59 PM +00:00 : default:denied by default:Deny, $"
+```
+
+You can correct this by regenerating the certificates with the correct key usages. See the [Certificate Configuration](./security.md#certificates-configuration) documentation for more information about configuring and generating certificates.
+
 #### From version 22.10 and earlier
 
 The updates to anonymous access described in the [release notes](https://www.eventstore.com/blog/23.10.0-release-notes) have introduced some breaking changes. We have also removed, renamed, and deprecated some options in EventStoreDB.

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/NodeCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/NodeCertificateAuthenticationProvider.cs
@@ -95,8 +95,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 				.IsNotEmpty();
 
 			if (!isServerCertificate && !hasReservedNodeCN && !hasIpOrDnsSan) {
-				// We are sure that this is a client certificate,
-				// Not a misconfigured server certificate with incorrect EKUs
+				// We are sure that this is not a misconfigured node certificate with incorrect EKUs, missing SANs, etc. It could be a user certificate.
 				return false;
 			}
 			if (!hasReservedNodeCN) {
@@ -104,20 +103,17 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 				Log.Error(
 					"Connection from node: {ip} was denied because its CN: {clientCertificateCN} does not match with the reserved node CN: {reservedNodeCN}",
 					ip, clientCertificateCN, reservedNodeCN);
-				return false;
 			}
 			if (!hasIpOrDnsSan) {
 				Log.Error("Connection from node: {ip} was denied because its certificate does not have any IP or DNS Subject Alternative Names (SAN).", ip);
-				return false;
 			}
 			if (!isServerCertificate) {
 				Log.Error(
 					"Connection from node: {ip} was denied because it is not configured as a server certificate: {failReason}",
 					ip, serverCertReason);
-				return false;
 			}
 
-			return true;
+			return hasReservedNodeCN && hasIpOrDnsSan && isServerCertificate;
 		}
 	}
 }


### PR DESCRIPTION
Added: Log an error when the node certificate is not a valid server certificate

Update the documentation to include the stricter certificate requirements.

If you provide a node certificate with invalid key usages (e.g. missing a required key usage), the server will now log an error:

```
[24448,26,12:47:42.882,ERR] Connection from node: "127.0.0.1" was denied because it is not configured as a valid server certificate: "Missing key usage: Digital Signature"
```

The error is only logged if the provided certificate matches the reserved node common name, and has IP or DNS addresses in the SAN.
