### PR TITLE
[DBX-31] Fix events missing from $all

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering_and_transactions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering_and_transactions.cs
@@ -1,0 +1,91 @@
+﻿using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.AllReader {
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint), Ignore = "Explicit transactions are not supported yet by Log V3")]
+	public class when_reading_all_with_filtering_and_transactions<TLogFormat, TStreamId>
+		: RepeatableDbTestScenario<TLogFormat, TStreamId> {
+
+		[Test]
+		public void should_receive_all_events_forward() {
+			// create a db with explicit transactions, some of which are filtered out on read.
+			// previously, a bug caused those filtered-out records to prevent the successful
+			// reading of subsequent events that are contained within an explicit transaction.
+
+			static Rec[] ExplicitTransaction(int transaction, string stream) => [
+				Rec.TransSt(transaction, stream),
+				Rec.Prepare(transaction, stream),
+				Rec.TransEnd(transaction, stream),
+				Rec.Commit(transaction, stream),
+			];
+
+			var i = 0;
+			CreateDb([
+				.. ExplicitTransaction(i++, "excludedStream"),
+				.. ExplicitTransaction(i++, "includedStream0"),
+				.. ExplicitTransaction(i++, "includedStream1"),
+				.. ExplicitTransaction(i++, "includedStream2"),
+				.. ExplicitTransaction(i++, "includedStream3"),
+				.. ExplicitTransaction(i++, "includedStream4"),
+				.. ExplicitTransaction(i++, "includedStream5"),
+				.. ExplicitTransaction(i++, "includedStream6"),
+				.. ExplicitTransaction(i++, "includedStream7"),
+				.. ExplicitTransaction(i++, "includedStream8"),
+				.. ExplicitTransaction(i++, "includedStream9"),
+			]);
+
+			var read = ReadIndex.ReadAllEventsForwardFiltered(
+				pos: new Data.TFPos(0, 0),
+				maxCount: 10,
+				maxSearchWindow: int.MaxValue,
+				eventFilter: EventFilter.StreamName.Prefixes(false, "included"));
+
+			Assert.AreEqual(10, read.Records.Count);
+			for (int j = 0; j < 10; j++)
+				Assert.AreEqual($"includedStream{j}", read.Records[j].Event.EventStreamId);
+		}
+
+		[Test]
+		public void should_receive_all_events_backward() {
+			// create a db with explicit transactions, some of which are filtered out on read.
+			// previously, a bug caused those filtered-out records to prevent the successful
+			// reading of subsequent events that are contained within an explicit transaction.
+
+			static Rec[] ExplicitTransaction(int transaction, string stream) => [
+				Rec.TransSt(transaction, stream),
+				Rec.Prepare(transaction, stream),
+				Rec.TransEnd(transaction, stream),
+				Rec.Commit(transaction, stream),
+			];
+
+			var i = 0;
+			CreateDb([
+				.. ExplicitTransaction(i++, "includedStream0"),
+				.. ExplicitTransaction(i++, "includedStream1"),
+				.. ExplicitTransaction(i++, "includedStream2"),
+				.. ExplicitTransaction(i++, "includedStream3"),
+				.. ExplicitTransaction(i++, "includedStream4"),
+				.. ExplicitTransaction(i++, "includedStream5"),
+				.. ExplicitTransaction(i++, "includedStream6"),
+				.. ExplicitTransaction(i++, "includedStream7"),
+				.. ExplicitTransaction(i++, "includedStream8"),
+				.. ExplicitTransaction(i++, "includedStream9"),
+				.. ExplicitTransaction(i++, "excludedStream"),
+			]);
+
+			var writerCp = DbRes.Db.Config.WriterCheckpoint.Read();
+			var read = ReadIndex.ReadAllEventsBackwardFiltered(
+				pos: new TFPos(writerCp, writerCp),
+				maxCount: 10,
+				maxSearchWindow: int.MaxValue,
+				eventFilter: EventFilter.StreamName.Prefixes(false, "included"));
+
+			Assert.AreEqual(10, read.Records.Count);
+			for (int j = 9; j <= 0; j--)
+				Assert.AreEqual($"includedStream{j}", read.Records[j].Event.EventStreamId);
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/AllReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/AllReader.cs
@@ -131,7 +131,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 							}
 
 							reader.Reposition(commit.TransactionPosition);
-							while (consideredEventsCount < maxCount) {
+							while (records.Count < maxCount && consideredEventsCount < maxSearchWindow) {
 								result = reader.TryReadNext();
 								if (!result.Success) // no more records in TF
 									break;
@@ -266,7 +266,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 							var commitPostPos = result.RecordPostPosition;
 							// as we don't know exact position of the last record of transaction,
 							// we have to sequentially scan backwards, so no need to reposition
-							while (consideredEventsCount < maxCount) {
+							while (records.Count < maxCount && consideredEventsCount < maxSearchWindow) {
 								result = reader.TryReadPrev();
 								if (!result.Success) // no more records in TF
 									break;


### PR DESCRIPTION
Fixed: Events written in explicit transactions via TCP can be missing from $all reads/subscriptions

Fixes #4250

- The bug only affects events written in explicit transactions (which are deprecated and can only be written via the old TCP client)
- The bug appears to affect Filtered all reads when the window is bigger than the maxcount
- The bug can affect regular all reads/subscriptions
