### PR TITLE
[ESDB-106-19] LeaderReplicationService: Remove redundant check which is always true

### DIFF
--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -358,7 +358,7 @@ namespace EventStore.Core.Services.Replication {
 					"Chunk for LogPosition {0} (0x{0:X}) is null in LeaderReplicationService! Replica: [{1},C:{2},S:{3}]",
 					logPosition, sub.ReplicaEndPoint, sub.ConnectionId, sub.SubscriptionId));
 				var bulkReader = chunk.AcquireReader();
-				if (chunk.ChunkHeader.IsScavenged && (chunkId == Guid.Empty || chunkId != chunk.ChunkHeader.ChunkId)) {
+				if (chunk.ChunkHeader.IsScavenged) {
 					var chunkStartPos = chunk.ChunkHeader.ChunkStartPosition;
 					if (verbose) {
 						Log.Information(


### PR DESCRIPTION
Fixed: Remove redundant check which is always true

In the early days, read-only/completed chunks were being replicated raw. The check `(chunkId == Guid.Empty || chunkId != chunk.ChunkHeader.ChunkId)` was added [here](https://github.com/EventStore/retrospective/commit/7ca25db712ad3293db424cb59f05aadce51f629b#diff-0445e1b603206bd559a907655d4f02c9d210d9dd6a7ab2d94b4da4fe3c6f3316R218) to support resuming the replication of read-only chunks. However, later this commit was [added](https://github.com/EventStore/retrospective/commit/be2c712fa43936e28e7eb1a452001d774c7268bc#diff-0445e1b603206bd559a907655d4f02c9d210d9dd6a7ab2d94b4da4fe3c6f3316R218) to make only scavenged chunks use raw replication but the check remained there.

The check `(chunkId == Guid.Empty || chunkId != chunk.ChunkHeader.ChunkId)` should always be `true`:

- During replication, when the leader replication service reaches the end of a chunk, it uses `chunkId = Guid.Empty` as parameter to `SetSubscriptionPosition()` to set the position to the next chunk, so the check would be `true` in that case.
- We're left to deal with the case when `a follower is subscribing directly to a leader with a specified chunkId`:
- (Excluding the behaviour in the early days, ) Leader and follower nodes *always* create their own data chunks with a chunk header having a unique `Guid`, so it shouldn't be possible for a follower's data chunk's id to match with the leader's data chunk's id. However, scavenged chunk headers are replicated as-is from the leader to follower. So we're left with the case: `a follower is subscribing directly to a leader with a specified chunkId belonging to a scavenged chunk`:
- Scavenged chunks are replicated to a temporary file then switched in atomically, so the only time the follower's chunk id could match the leader's chunk id would be when a scavenged chunk has been replicated and switched in but the writer checkpoint wasn't moved forward. As shown in https://github.com/EventStore/EventStore/pull/4264 this would result in a `CorruptDatabaseException` due to a bug solved by that PR. Presumably, nobody has encountered this bug yet as it would have been noticed/fixed earlier. Anyway, after the fix, the writer checkpoint is moved forward to the next new chunk, which isn't scavenged and the follower will be subscribe from there. (so the leader/follower chunk IDs won't match and the check will be `true`)

