### PR TITLE
[DB-26-10] Make changes to guidelines for setting the value for StreamInfoCacheCapacity

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -330,8 +330,11 @@ EventStoreDb was 100,000 entries.
 ::: note
 The default value of 0 for `StreamInfoCacheCapacity` might not always be the best value for optimal performance. Ideally, it should be set to double the number of streams in the anticipated working set.
 
-The number of streams can be obtained from the `$streams` system projection. Firstly, the `$streams` system projection would need to be enabled. Once it is complete to 100% (which can be verified from the UI on the Projections page under the "Done" column),
-open the event stream "$streams", and the most recent event number in that stream would indicate the total number of streams in the database.
+The total number of streams can be obtained by checking the event count in the `$streams` system stream. This stream is created by the [$streams system projection](https://developers.eventstore.com/server/v24.2/projections.html#streams-projection).
+:::
+
+::: disclaimer
+The total number of streams does not necessarily give you the anticipated working set. The working set of streams is the set of streams that you intend on actively reading, writing, and/or subscribing to. This can be much lower than the total number of streams in certain cases, especially in systems that have many short-lived streams.
 :::
 
 ### ReaderThreadsCount

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -331,10 +331,8 @@ EventStoreDb was 100,000 entries.
 The default value of 0 for `StreamInfoCacheCapacity` might not always be the best value for optimal performance. Ideally, it should be set to double the number of streams in the anticipated working set.
 
 The total number of streams can be obtained by checking the event count in the `$streams` system stream. This stream is created by the [$streams system projection](https://developers.eventstore.com/server/v24.2/projections.html#streams-projection).
-:::
 
-::: disclaimer
-The total number of streams does not necessarily give you the anticipated working set. The working set of streams is the set of streams that you intend on actively reading, writing, and/or subscribing to. This can be much lower than the total number of streams in certain cases, especially in systems that have many short-lived streams.
+It should be noted that the total number of streams does not necessarily give you the anticipated working set. The working set of streams is the set of streams that you intend on actively reading, writing, and/or subscribing to. This can be much lower than the total number of streams in certain cases, especially in systems that have many short-lived streams.
 :::
 
 ### ReaderThreadsCount

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -327,6 +327,13 @@ By default, the cache dynamically resizes according to the amount of free memory
 The option is set to 0 by default, which enables dynamic resizing. The default on previous versions of
 EventStoreDb was 100,000 entries.
 
+::: note
+The default value of 0 for `StreamInfoCacheCapacity` might not always be the best value for optimal performance. Ideally, it should be set to double the number of streams in the anticipated working set.
+
+The number of streams can be obtained from the `$streams` system projection. Firstly, the `$streams` system projection would need to be enabled. Once it is complete to 100% (which can be verified from the UI on the Projections page under the "Done" column),
+open the event stream "$streams", and the most recent event number in that stream would indicate the total number of streams in the database.
+:::
+
 ### ReaderThreadsCount
 
 This option configures the number of reader threads available to EventStoreDb. Having more reader threads


### PR DESCRIPTION
Fixed : https://eventstore.aha.io/develop/requirements/DB-26-10. Made changes to the documentation for setting StreamInfoCacheCapacity to double the number of streams in the anticipated working set.