### PR TITLE
[release/oss-v23.10] Backport net8 upgrade

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,22 +2,10 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnet-retire": {
-      "version": "4.0.1",
-      "commands": [
-        "dotnet-retire"
-      ]
-    },
     "minver-cli": {
-      "version": "2.2.0",
+      "version": "4.3.0",
       "commands": [
         "minver"
-      ]
-    },
-    "gpr": {
-      "version": "0.1.122",
-      "commands": [
-        "gpr"
       ]
     }
   }

--- a/.github/workflows/build-container-bookworm-slim.yml
+++ b/.github/workflows/build-container-bookworm-slim.yml
@@ -1,4 +1,4 @@
-name: Build Bullseye Slim Container
+name: Build Bookworm Slim Container
 
 on:
   pull_request:
@@ -21,5 +21,5 @@ jobs:
   build-container:
     uses: ./.github/workflows/build-container-reusable.yml
     with:
-      container-runtime: bullseye-slim
+      container-runtime: bookworm-slim
 

--- a/.github/workflows/build-container-jammy.yml
+++ b/.github/workflows/build-container-jammy.yml
@@ -1,4 +1,4 @@
-name: Build Focal Container
+name: Build Jammy Container
 
 on:
   pull_request:
@@ -21,5 +21,5 @@ jobs:
   build-container:
     uses: ./.github/workflows/build-container-reusable.yml
     with:
-      container-runtime: focal
+      container-runtime: jammy
 

--- a/.github/workflows/build-container-reusable.yml
+++ b/.github/workflows/build-container-reusable.yml
@@ -18,10 +18,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Install net7.0
+    - name: Install net8.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
@@ -47,11 +47,11 @@ jobs:
             "jammy": {
               "runtime": "linux-x64"
             },
-            "bullseye-slim": {
+            "bookworm-slim": {
               "runtime": "linux-x64"
             },
             "alpine": {
-              "runtime": "alpine-x64"
+              "runtime": "linux-musl-x64"
             }
           }
         export_to: output

--- a/.github/workflows/build-container-reusable.yml
+++ b/.github/workflows/build-container-reusable.yml
@@ -18,10 +18,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Install net6.0
+    - name: Install net7.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
@@ -44,7 +44,7 @@ jobs:
         key: "${{ inputs.container-runtime }}"
         map: |
           {
-            "focal": {
+            "jammy": {
               "runtime": "linux-x64"
             },
             "bullseye-slim": {
@@ -102,7 +102,7 @@ jobs:
         docker tag eventstore ghcr.io/eventstore/eventstore:${{ env.VERSION }}
         docker push ghcr.io/eventstore/eventstore:${{ env.VERSION }}
     - name: Push GitHub Container Registry (CI)
-      if: always() && github.event_name == 'push' && inputs.container-runtime == 'focal' && github.ref == 'refs/heads/master'
+      if: always() && github.event_name == 'push' && inputs.container-runtime == 'jammy' && github.ref == 'refs/heads/master'
       shell: bash
       run: |
         docker tag eventstore ghcr.io/eventstore/eventstore:ci

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -28,10 +28,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.x
-    - name: Install net7.0
+    - name: Install net8.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Clear Nuget Cache
       shell: powershell
       if: inputs.os == 'windows-2019'

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -28,10 +28,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.x
-    - name: Install net6.0
+    - name: Install net7.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Clear Nuget Cache
       shell: powershell
       if: inputs.os == 'windows-2019'

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install net7.0
+    - name: Install net8.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Scan for Vulnerabilities
       run: |
         cd src

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install net6.0
+    - name: Install net7.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Scan for Vulnerabilities
       run: |
         cd src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # "build" image
-ARG CONTAINER_RUNTIME=focal
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+ARG CONTAINER_RUNTIME=jammy
+FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build
 ARG RUNTIME=linux-x64
 
 WORKDIR /build/ci
@@ -31,7 +31,7 @@ RUN find /build/src -maxdepth 1 -type d -name "*.Tests" -print0 | xargs -I{} -0 
     'dotnet publish --runtime=${RUNTIME} --no-self-contained --configuration Release --output /build/published-tests/`basename $1` $1' - '{}'
 
 # "test" image
-FROM mcr.microsoft.com/dotnet/sdk:6.0-${CONTAINER_RUNTIME} as test
+FROM mcr.microsoft.com/dotnet/sdk:7.0-${CONTAINER_RUNTIME} as test
 WORKDIR /build
 COPY --from=build ./build/published-tests ./published-tests
 COPY --from=build ./build/ci ./ci
@@ -53,10 +53,10 @@ FROM build as publish
 ARG RUNTIME=linux-x64
 
 RUN dotnet publish --configuration=Release --runtime=${RUNTIME} --self-contained \
-     --framework=net6.0 --output /publish EventStore.ClusterNode
+     --framework=net7.0 --output /publish EventStore.ClusterNode
 
 # "runtime" image
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-${CONTAINER_RUNTIME} AS runtime
+FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-${CONTAINER_RUNTIME} AS runtime
 ARG RUNTIME=linux-x64
 ARG UID=1000
 ARG GID=1000

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The build scripts: `build.sh` and `build.ps1` are also available for Linux and W
 To start a single node, you can then run:
 
 ```
-dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net6.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
+dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net7.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
 ```
 
 ### Running the tests
@@ -160,9 +160,9 @@ Currently, we support the following configurations:
 - `CONTAINER_RUNTIME=bullseye-slim`
 - `RUNTIME=linux-x64`
 
-2. Focal:
+2. Jammy:
 
-- `CONTAINER_RUNTIME=focal`
+- `CONTAINER_RUNTIME=Jammy`
 - `RUNTIME=linux-x64`
 
 3. Alpine:
@@ -194,4 +194,4 @@ docker run --rm myeventstore --insecure --what-if
 
 ![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-bullseye-slim.yml/badge.svg)
 
-![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-focal.yml/badge.svg)
+![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-jammy.yml/badge.svg)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ EventStoreDB is written in a mixture of C# and JavaScript. It can run on Windows
 
 **Prerequisites**
 
-- [.NET Core SDK 6.0](https://dotnet.microsoft.com/download/dotnet/6.0)
+- [.NET Core SDK 8.0](https://dotnet.microsoft.com/download/dotnet/8.0)
 
 Once you've installed the prerequisites for your system, you can launch a `Release` build of EventStore as follows:
 
@@ -116,7 +116,7 @@ The build scripts: `build.sh` and `build.ps1` are also available for Linux and W
 To start a single node, you can then run:
 
 ```
-dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net7.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
+dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net8.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
 ```
 
 ### Running the tests
@@ -141,7 +141,7 @@ For instance:
 
 ```
 docker build --tag myeventstore . \
---build-arg CONTAINER_RUNTIME=bullseye-slim \
+--build-arg CONTAINER_RUNTIME=bookworm-slim \
 --build-arg RUNTIME=linux-x64
 ```
 
@@ -149,15 +149,15 @@ docker build --tag myeventstore . \
 
 ```
 $env:DOCKER_BUILDKIT=0; docker build --tag myeventstore . `
---build-arg CONTAINER_RUNTIME=bullseye-slim `
+--build-arg CONTAINER_RUNTIME=bookworm-slim `
 --build-arg RUNTIME=linux-x64
 ```
 
 Currently, we support the following configurations:
 
-1. Bullseye slim:
+1. Bookworm slim:
 
-- `CONTAINER_RUNTIME=bullseye-slim`
+- `CONTAINER_RUNTIME=bookworm-slim`
 - `RUNTIME=linux-x64`
 
 2. Jammy:
@@ -168,7 +168,7 @@ Currently, we support the following configurations:
 3. Alpine:
 
 - `CONTAINER_RUNTIME=alpine`
-- `RUNTIME=alpine-x64`
+- `RUNTIME=linux-musl-x64`
 
 You can verify the built image by running:
 
@@ -192,6 +192,6 @@ docker run --rm myeventstore --insecure --what-if
 
 ![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-alpine.yml/badge.svg)
 
-![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-bullseye-slim.yml/badge.svg)
+![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-bookworm-slim.yml/badge.svg)
 
 ![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-jammy.yml/badge.svg)

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ COPYRIGHT="Copyright 2021 Event Store Ltd. All rights reserved."
 
 CONFIGURATION="Release"
 BUILD_UI="no"
-NET_FRAMEWORK="net7.0"
+NET_FRAMEWORK="net8.0"
 
 function usage() {    
 cat <<EOF

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ COPYRIGHT="Copyright 2021 Event Store Ltd. All rights reserved."
 
 CONFIGURATION="Release"
 BUILD_UI="no"
-NET_FRAMEWORK="net6.0"
+NET_FRAMEWORK="net7.0"
 
 function usage() {    
 cat <<EOF

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,7 +25,7 @@
 		<None Include="..\..\ouro.png" Pack="true" PackagePath="\"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="MinVer" Version="4.2.0">
+		<PackageReference Include="MinVer" Version="4.3.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
+++ b/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<DebugSymbols>true</DebugSymbols>
 		<Platforms>x64;ARM64</Platforms>
@@ -10,10 +10,10 @@
 		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
+++ b/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<DebugSymbols>true</DebugSymbols>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
+++ b/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
+++ b/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.ClusterNode.Web/EventStore.ClusterNode.Web.csproj
+++ b/src/EventStore.ClusterNode.Web/EventStore.ClusterNode.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.ClusterNode.Web/EventStore.ClusterNode.Web.csproj
+++ b/src/EventStore.ClusterNode.Web/EventStore.ClusterNode.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
@@ -9,9 +9,6 @@
 		<Content Include="projections\es.projections.environment.js">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</Content>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="clusternode-web\apple-touch-icon.png">

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<OutputType>Exe</OutputType>
 		<ApplicationIcon>app2.ico</ApplicationIcon>

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<OutputType>Exe</OutputType>
 		<ApplicationIcon>app2.ico</ApplicationIcon>
@@ -9,7 +9,7 @@
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.ClusterNode.Web\EventStore.ClusterNode.Web.csproj" />

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -190,6 +190,8 @@ namespace EventStore.ClusterNode {
 							.ConfigureServices(services => services.Configure<KestrelServerOptions>(
 								EventStoreKestrelConfiguration.GetConfiguration()))
 							.ConfigureServices(services => services.Configure<MetricsConfiguration>(metricsConfiguration))
+							.ConfigureServices(services => services.Configure<HostOptions>(
+							 	opts => opts.ShutdownTimeout = TimeSpan.FromSeconds(5)))
 							.ConfigureWebHostDefaults(builder => builder
 								.UseKestrel(server => {
 									server.Limits.Http2.KeepAlivePingDelay =

--- a/src/EventStore.Common.Tests/Configuration/ConfigurationRootExtensionsTest.cs
+++ b/src/EventStore.Common.Tests/Configuration/ConfigurationRootExtensionsTest.cs
@@ -10,7 +10,7 @@ public class ConfigurationRootExtensionsTest {
 	
 	[Fact]
 	public void successful_comma_separated_value() {
-		var config = new Dictionary<string, string> {
+		var config = new Dictionary<string, string?> {
 			{ GOSSIP_SEED, "nodeb.eventstore.test:2113,nodec.eventstore.test:3113" }
 		};
 		IConfigurationRoot configuration = MemoryConfigurationBuilderExtensions
@@ -24,7 +24,7 @@ public class ConfigurationRootExtensionsTest {
 
 	[Fact]
 	public void invalid_delimiter() {
-		var config = new Dictionary<string, string> {
+		var config = new Dictionary<string, string?> {
 			{ GOSSIP_SEED, "nodeb.eventstore.test:2113;nodec.eventstore.test:3113" }
 		};
 		IConfigurationRoot configuration = MemoryConfigurationBuilderExtensions
@@ -38,7 +38,7 @@ public class ConfigurationRootExtensionsTest {
 	
 	[Fact]
 	public void mixed_invalid_delimiter() {
-		var config = new Dictionary<string, string> {
+		var config = new Dictionary<string, string?> {
 			{ GOSSIP_SEED, "nodea.eventstore.test:2113,nodeb.eventstore.test:2113;nodec.eventstore.test:3113" }
 		};
 

--- a/src/EventStore.Common.Tests/Configuration/OptionsDumperTest.cs
+++ b/src/EventStore.Common.Tests/Configuration/OptionsDumperTest.cs
@@ -72,11 +72,11 @@ public class OptionsDumperTest {
 
 		Assert.True(printable.TryGetValue(nameof(TestOptions.FirstSection.SensitiveOption), out var actualText));
 		Assert.DoesNotContain(secretText, actualText.Value);
-		Assert.Equal(actualText.Value, new string('*', 8));
+		Assert.Equal(new string('*', 8), actualText.Value);
 
 		Assert.True(printable.TryGetValue(nameof(TestOptions.SecondSection.SecretNumber), out var actualNumber));
 		Assert.DoesNotContain("7", actualNumber.Value);
-		Assert.Equal(actualNumber.Value, new string('*', 8));
+		Assert.Equal(new string('*', 8), actualNumber.Value);
 	}
 
 	[Fact]

--- a/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
+++ b/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
+++ b/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -10,16 +10,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/EventStore.Common.Utils/EventStore.Common.Utils.csproj
+++ b/src/EventStore.Common.Utils/EventStore.Common.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/EventStore.Common.Utils/EventStore.Common.Utils.csproj
+++ b/src/EventStore.Common.Utils/EventStore.Common.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/EventStore.Common/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace EventStore.Common.Configuration {
 			var root = builder.Build(); // need to build twice as on disk config is configurable
 			
 			var yamlSource = new YamlSource {
-				Path = root.GetValue<string>(configFileKey),
+				Path = root.GetString(configFileKey),
 				Optional = !root.IsUserSpecified(configFileKey),
 				ReloadOnChange = true
 			};

--- a/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
@@ -78,5 +78,9 @@ namespace EventStore.Common.Configuration {
 				
 			return builder.ToString().PadRight(optionColumnWidth, ' ') + description;
 		}
+
+		public static string GetString(this IConfigurationRoot configurationRoot, string key) {
+			return configurationRoot.GetValue<string>(key) ?? string.Empty;
+		}
 	}
 }

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
@@ -17,22 +17,21 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.9" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="Serilog" Version="2.12.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Serilog" Version="3.1.1" />
 		<PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-		<PackageReference Include="Serilog.Expressions" Version="3.4.0" />
-		<PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+		<PackageReference Include="Serilog.Expressions" Version="4.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
 		<PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
-		<PackageReference Include="YamlDotnet" Version="12.0.1" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+		<PackageReference Include="YamlDotnet" Version="13.7.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.Common.Utils\EventStore.Common.Utils.csproj" />

--- a/src/EventStore.Core.Tests/AssertEx.cs
+++ b/src/EventStore.Core.Tests/AssertEx.cs
@@ -1,36 +1,11 @@
 using System;
 using System.Threading;
-using System.Globalization;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using KellermanSoftware.CompareNetObjects;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests {
 	public static class AssertEx {
-		private static ComparisonConfig Configuration = new ComparisonConfig {
-			IgnoreCollectionOrder = false,
-			MaxDifferences = 10,
-		};
-		public static void AssertUsingDeepCompare(object actual, object expected) {
-			var compareLogic = new CompareLogic(Configuration);
-			var result = compareLogic.Compare(actual, expected);
-			Assert.IsTrue(result.AreEqual, string.Join(Environment.NewLine, result.Differences.Select(x =>
-				$"{x.GetWhatIsCompared()}, Values ({FormatString(x.Object1)},{FormatString(x.Object2)})")));
-		}
-
-		private static string FormatString(object o) {
-			if (o == null)
-				return string.Empty;
-			if (o is DateTime time) {
-				return time.ToString("MM/dd/yyyy HH:mm:ss.fff",
-					CultureInfo.InvariantCulture);
-			}
-
-			return o.ToString();
-		}
-
 		public static async Task<TException> ThrowsAsync<TException>(Func<Task> code)
 			where TException : Exception {
 			var expected = default(TException);

--- a/src/EventStore.Core.Tests/Caching/DynamicCacheManagerTests.cs
+++ b/src/EventStore.Core.Tests/Caching/DynamicCacheManagerTests.cs
@@ -323,7 +323,7 @@ namespace EventStore.Core.Tests.Caching {
 				{"es-cache-test2-utilizationPercent", 100.0 * 10 / 15},
 			};
 
-			AssertEx.AssertUsingDeepCompare(msg.Stats, expectedStats);
+			CollectionAssert.AreEquivalent(expectedStats, msg.Stats);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/ClientAPI/connect.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connect.cs
@@ -13,10 +13,10 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V3), typeof(uint), TcpType.Normal)]
 	[TestFixture(typeof(LogFormat.V2), typeof(string), TcpType.Ssl)]
 	[TestFixture(typeof(LogFormat.V3), typeof(uint), TcpType.Ssl)]
-	public class connect<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
+	public class Connect<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
 		private readonly TcpType _tcpType;
 
-		public connect(TcpType tcpType) {
+		public Connect(TcpType tcpType) {
 			_tcpType = tcpType;
 		}
 

--- a/src/EventStore.Core.Tests/ClientAPI/transaction.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/transaction.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[Category("ClientAPI"), Category("LongRunning")]
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(uint), Ignore = "Explicit transactions are not supported yet by Log V3")]
-	public class transaction<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
+	public class Transaction<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
 		private MiniNode<TLogFormat, TStreamId> _node;
 
 		[OneTimeSetUp]

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>
@@ -27,7 +27,6 @@
 
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		<ProjectReference Include="..\EventStore.PluginHosting\EventStore.PluginHosting.csproj" />

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-		<PackageReference Include="Grpc.Core" Version="2.46.5" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.16" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Grpc.Core" Version="2.46.6" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.59.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-		<PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.5" />
-		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="CompareNETObjects" Version="4.78.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.52.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.10" />
+		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.59.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Core.Tests/FakePlugin/FakePlugin.csproj
+++ b/src/EventStore.Core.Tests/FakePlugin/FakePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/EventStore.Core.Tests/FakePlugin/FakePlugin.csproj
+++ b/src/EventStore.Core.Tests/FakePlugin/FakePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/EventStore.Core.Tests/Http/Streams/filtered.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/filtered.cs
@@ -9,7 +9,7 @@ using HttpStatusCode = System.Net.HttpStatusCode;
 using EventStore.Transport.Http;
 
 namespace EventStore.Core.Tests.Http.Streams {
-	public class filtered {
+	public class Filtered {
 		public abstract class SpecificationWithLongFeed<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
 			protected int NumberOfEvents;
 

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -130,7 +130,7 @@ namespace EventStore.Core.Tests.Integration {
 			_conn = CreateConnection();
 			await _conn.ConnectAsync();
 
-			await Given().WithTimeout(TimeSpan.FromMinutes(2));
+			await Given().WithTimeout(TimeSpan.FromMinutes(2), onFail: MiniNodeLogging.WriteLogs);
 		}
 
 		protected virtual IEventStoreConnection CreateConnection() =>

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -10,6 +10,7 @@ using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.TransactionLog.Checkpoint;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.ElectionsService {
@@ -86,7 +87,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(0)),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -104,7 +106,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.SendViewChangeProof()),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -213,7 +215,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(1)),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -256,7 +258,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.SendViewChangeProof()),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -296,7 +298,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.SendViewChangeProof()),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -388,7 +390,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.ElectionsTimedOut(10)),
 			};
 
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -436,7 +438,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.Prepare(_node.InstanceId, _node.HttpEndPoint, 0),
 					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout))
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -539,7 +541,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						_node.InstanceId, _node.HttpEndPoint, -1, -1, Guid.Empty, Guid.Empty, 0, 0, 0, 0, _clusterInfo),
 					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -660,7 +662,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						proposalMessage.LeaderHttpEndPoint, 0, 0, 0, _epochId, Guid.Empty, 0, 0, 0, 0),
 					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout))
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -835,7 +837,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						_nodeThree.HttpEndPoint, 0),
 					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -963,7 +965,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						_nodeTwo.HttpEndPoint, null, 0, 0, 0, 0, 0, 0, 0, _epochId, 0,
 						_nodeTwo.IsReadOnlyReplica)),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -1011,7 +1013,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GossipMessage.UpdateNodePriority(nodePriority)
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -1071,7 +1073,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.LeaderIsResigning(_node.InstanceId, _node.HttpEndPoint),
 					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -1095,7 +1097,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						_node.InstanceId, _node.HttpEndPoint),
 					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -1128,7 +1130,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new SystemMessage.InitiateLeaderResignation(),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -1179,7 +1181,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						_nodeTwo.HttpEndPoint, null, 0, 0, 0, 0, 0, 0, 0, _epochId, 0,
 						_nodeTwo.IsReadOnlyReplica)),
 			};
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -1263,7 +1265,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						_nodeThree.IsReadOnlyReplica)),
 			};
 
-			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+			_publisher.Messages.Should().BeEquivalentTo(expected);
 		}
 	}
 
@@ -1352,7 +1354,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 							_nodeTwo.IsReadOnlyReplica)),
 				};
 
-				AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+				_publisher.Messages.Should().BeEquivalentTo(expected);
 			}
 		}
 
@@ -1385,7 +1387,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 							_nodeTwo.IsReadOnlyReplica)),
 				};
 
-				AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+				_publisher.Messages.Should().BeEquivalentTo(expected);
 			}
 		}
 
@@ -1436,7 +1438,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 							_nodeTwo.IsReadOnlyReplica)),
 				};
 
-				AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+				_publisher.Messages.Should().BeEquivalentTo(expected);
 			}
 		}
 
@@ -1469,7 +1471,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 							_nodeTwo.IsReadOnlyReplica)),
 				};
 
-				AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+				_publisher.Messages.Should().BeEquivalentTo(expected);
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/GossipService/ClusterMultipleVersionsLoggerTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/ClusterMultipleVersionsLoggerTests.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Cluster;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Gossip;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.GossipService;
@@ -51,13 +52,14 @@ public abstract class ClusterMultipleVersionsLoggerTests {
 			Dictionary<EndPoint, string> ipAddressVsVersion =
 				ClusterMultipleVersionsLogger.GetIPAddressVsVersion(GetExpectedClusterInfo(),
 					out int numDistinctKnownVersions);
-			AssertEx.AssertUsingDeepCompare(ipAddressVsVersion, GetExpectedEndPointVsVersion());
+			ipAddressVsVersion.Should().BeEquivalentTo(GetExpectedEndPointVsVersion());
+			
 			Assert.AreEqual(2, numDistinctKnownVersions);
 		}
 
 		private void AssertGossipReply(Message message) {
-			AssertEx.AssertUsingDeepCompare(message,
-				new GossipMessage.SendGossip(GetExpectedClusterInfo(), _currentNode.HttpEndPoint));
+			message.Should()
+				.BeEquivalentTo(new GossipMessage.SendGossip(GetExpectedClusterInfo(), _currentNode.HttpEndPoint));
 		}
 	}
 
@@ -101,7 +103,7 @@ public abstract class ClusterMultipleVersionsLoggerTests {
 			Dictionary<EndPoint, string> ipAddressVsVersion =
 				ClusterMultipleVersionsLogger.GetIPAddressVsVersion(GetExpectedClusterInfo(),
 					out int numDistinctKnownVersions);
-			AssertEx.AssertUsingDeepCompare(ipAddressVsVersion, GetExpectedEndPointVsVersion());
+			ipAddressVsVersion.Should().BeEquivalentTo(GetExpectedEndPointVsVersion());
 			Assert.AreEqual(2, numDistinctKnownVersions);
 		}
 	}
@@ -177,7 +179,7 @@ public abstract class ClusterMultipleVersionsLoggerTests {
 			Dictionary<EndPoint, string> ipAddressVsVersion =
 				ClusterMultipleVersionsLogger.GetIPAddressVsVersion(GetExpectedClusterInfo(),
 					out int numDistinctKnownVersions);
-			AssertEx.AssertUsingDeepCompare(ipAddressVsVersion, GetExpectedEndPointVsVersion());
+			ipAddressVsVersion.Should().BeEquivalentTo(GetExpectedEndPointVsVersion());
 			Assert.AreEqual(2, numDistinctKnownVersions);
 		}
 	}
@@ -221,7 +223,7 @@ public abstract class ClusterMultipleVersionsLoggerTests {
 			Dictionary<EndPoint, string> ipAddressVsVersion =
 				ClusterMultipleVersionsLogger.GetIPAddressVsVersion(GetExpectedClusterInfo(),
 					out int numDistinctKnownVersions);
-			AssertEx.AssertUsingDeepCompare(ipAddressVsVersion, GetExpectedEndPointVsVersion());
+			ipAddressVsVersion.Should().BeEquivalentTo(GetExpectedEndPointVsVersion());
 			Assert.AreEqual(3, numDistinctKnownVersions);
 		}
 	}
@@ -266,7 +268,7 @@ public abstract class ClusterMultipleVersionsLoggerTests {
 			Dictionary<EndPoint, string> ipAddressVsVersion =
 				ClusterMultipleVersionsLogger.GetIPAddressVsVersion(GetExpectedClusterInfo(),
 					out int numDistinctKnownVersions);
-			AssertEx.AssertUsingDeepCompare(ipAddressVsVersion, GetExpectedEndPointVsVersion());
+			ipAddressVsVersion.Should().BeEquivalentTo(GetExpectedEndPointVsVersion());
 			Assert.AreEqual(2, numDistinctKnownVersions);
 		}
 	}
@@ -310,7 +312,7 @@ public abstract class ClusterMultipleVersionsLoggerTests {
 			Dictionary<EndPoint, string> ipAddressVsVersion =
 				ClusterMultipleVersionsLogger.GetIPAddressVsVersion(GetExpectedClusterInfo(),
 					out int numDistinctKnownVersions);
-			AssertEx.AssertUsingDeepCompare(ipAddressVsVersion, GetExpectedEndPointVsVersion());
+			ipAddressVsVersion.Should().BeEquivalentTo(GetExpectedEndPointVsVersion());
 			Assert.AreEqual(2, numDistinctKnownVersions);
 		}
 	}
@@ -385,7 +387,7 @@ public abstract class ClusterMultipleVersionsLoggerTests {
 			Dictionary<EndPoint, string> ipAddressVsVersion =
 				ClusterMultipleVersionsLogger.GetIPAddressVsVersion(GetExpectedClusterInfo(),
 					out int numDistinctKnownVersions);
-			AssertEx.AssertUsingDeepCompare(ipAddressVsVersion, GetExpectedEndPointVsVersion());
+			ipAddressVsVersion.Should().BeEquivalentTo(GetExpectedEndPointVsVersion());
 			Assert.AreEqual(2, numDistinctKnownVersions);
 		}
 	}
@@ -429,7 +431,7 @@ public abstract class ClusterMultipleVersionsLoggerTests {
 			Dictionary<EndPoint, string> ipAddressVsVersion =
 				ClusterMultipleVersionsLogger.GetIPAddressVsVersion(GetExpectedClusterInfo(),
 					out int numDistinctKnownVersions);
-			AssertEx.AssertUsingDeepCompare(ipAddressVsVersion, GetExpectedEndPointVsVersion());
+			ipAddressVsVersion.Should().BeEquivalentTo(GetExpectedEndPointVsVersion());
 			Assert.AreEqual(3, numDistinctKnownVersions);
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -13,6 +13,7 @@ using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Services.ElectionsService;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.TransactionLog.Checkpoint;
+using FluentAssertions;
 using NUnit.Framework;
 using MemberInfo = EventStore.Core.Cluster.MemberInfo;
 
@@ -94,7 +95,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 		protected virtual Message When() => null;
 
 		protected void ExpectMessages(params Message[] expected) =>
-			AssertEx.AssertUsingDeepCompare(_bus.Messages.ToArray(), expected);
+			_bus.Messages.Should().BeEquivalentTo(expected);
 
 		protected void ExpectNoMessages() =>
 			Assert.IsEmpty(_bus.Messages);
@@ -371,7 +372,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			//updated cluster info should have version info of currentNode, nodeTwo and nodeThree
 			ExpectMessages(new GossipMessage.GossipUpdated(GetExpectedClusterInfo()));
 			//gossip reply should have version info of currentNode, nodeTwo and nodeThree
-			AssertEx.AssertUsingDeepCompare(_capturedMessage, new GossipMessage.SendGossip(GetExpectedClusterInfo(), _currentNode.HttpEndPoint));
+			_capturedMessage.Should().BeEquivalentTo(new GossipMessage.SendGossip(GetExpectedClusterInfo(), _currentNode.HttpEndPoint));
 		}
 
 		private void CaptureGossipReply(Message message) => _capturedMessage = message;
@@ -399,8 +400,8 @@ namespace EventStore.Core.Tests.Services.GossipService {
 
 		[Test]
 		public void reply_should_have_version_info() {
-			AssertEx.AssertUsingDeepCompare(_capturedMessage,
-				new GossipMessage.SendGossip(GetExpectedClusterInfo(), _currentNode.HttpEndPoint));
+			_capturedMessage.Should()
+				.BeEquivalentTo(new GossipMessage.SendGossip(GetExpectedClusterInfo(), _currentNode.HttpEndPoint));
 		}
 
 		private void CaptureGossipReply(Message message) => _capturedMessage = message;
@@ -426,8 +427,8 @@ namespace EventStore.Core.Tests.Services.GossipService {
 		
 		[Test]
 		public void reply_should_have_version_info() {
-			AssertEx.AssertUsingDeepCompare(_capturedMessage,
-				new GossipMessage.SendClientGossip(GetExpectedClusterInfo()));
+			_capturedMessage.Should()
+				.BeEquivalentTo(new GossipMessage.SendClientGossip(GetExpectedClusterInfo()));
 		}
 
 		private void CaptureGossipReply(Message message) => _capturedMessage = message;

--- a/src/EventStore.Core.Tests/Services/RedactionService/EventPositionTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/EventPositionTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using EventStore.Core.Data.Redaction;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.RedactionService {
@@ -44,7 +45,7 @@ namespace EventStore.Core.Tests.Services.RedactionService {
 			var msg = await GetEventPosition(0);
 			Assert.AreEqual(GetEventPositionResult.Success, msg.Result);
 			Assert.AreEqual(1, msg.EventPositions.Length);
-			AssertEx.AssertUsingDeepCompare(msg.EventPositions, _positions[0].ToArray());
+			msg.EventPositions.Should().BeEquivalentTo(_positions[0].ToArray());
 		}
 
 		[Test]
@@ -52,7 +53,7 @@ namespace EventStore.Core.Tests.Services.RedactionService {
 			var msg = await GetEventPosition(1);
 			Assert.AreEqual(GetEventPositionResult.Success, msg.Result);
 			Assert.AreEqual(1, msg.EventPositions.Length);
-			AssertEx.AssertUsingDeepCompare(msg.EventPositions, _positions[1].ToArray());
+			msg.EventPositions.Should().BeEquivalentTo(_positions[1].ToArray());
 		}
 
 		[Test]
@@ -60,7 +61,7 @@ namespace EventStore.Core.Tests.Services.RedactionService {
 			var msg = await GetEventPosition(2);
 			Assert.AreEqual(GetEventPositionResult.Success, msg.Result);
 			Assert.AreEqual(2, msg.EventPositions.Length);
-			AssertEx.AssertUsingDeepCompare(msg.EventPositions, _positions[2].ToArray());
+			msg.EventPositions.Should().BeEquivalentTo(_positions[2].ToArray());
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/basic_http_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/basic_http_authentication_provider.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 
 			protected static HttpContext CreateTestEntityWithCredentials(string username, string password) {
 				var context = new DefaultHttpContext();
-				context.Request.Headers.Add("authorization",
+				context.Request.Headers.Append("authorization",
 					"Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}")));
 				return context;
 			}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
@@ -55,5 +55,23 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 				Assert.That(_hash1 != _hash2);
 			}
 		}
+		
+		[TestFixture]
+		public class when_upgrading_the_hashes {
+			private Rfc2898PasswordHashAlgorithm _algorithm;
+			private readonly string _password = "Pa55w0rd!";
+			private readonly string _hash = "HKoq6xw3Oird4KqU4RyoY9aFFRc=";
+			private readonly string _salt = "+6eoSEkays/BOpzGMLE6Uw==";
+
+			[SetUp]
+			public void SetUp() {
+				_algorithm = new Rfc2898PasswordHashAlgorithm();
+			}
+
+			[Test]
+			public void old_hashes_should_successfully_verify() {
+				Assert.True(_algorithm.Verify(_password, _hash, _salt));
+			}
+		}
 	}
 }

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -16,7 +16,7 @@ using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
 
 namespace EventStore.Core.Tests {
 	[TestFixture]
-	public class options {
+	public class Options {
 		[TestCaseSource(typeof(ParseCaseData), nameof(ParseCaseData.TestCases))]
 		public object are_parsed_correctly_when_well_formed(string option, string[] args) {
 			var sut = new TestOptions(args);

--- a/src/EventStore.Core.XUnit.Tests/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/ClusterVNodeOptionsTests.cs
@@ -30,7 +30,7 @@ public class ClusterVNodeOptionsTests {
 		var c = BuildConfiguration("--cluster-size 3");
 
 		var values = c.Unknown.Options;
-		Assert.Equal(0, values.Count);
+		Assert.Empty(values);
 	}
 
 	[Fact]

--- a/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.Core.XUnit.Tests/Metrics/ProcessMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/ProcessMetricsTests.cs
@@ -103,7 +103,7 @@ public class ProcessMetricsTests : IDisposable {
 	[Fact]
 	public void can_collect_proc_cpu() {
 		Assert.Collection(
-			_intListener.RetrieveMeasurements("eventstore-proc-cpu"),
+			_doubleListener.RetrieveMeasurements("eventstore-proc-cpu"),
 			m => {
 				Assert.True(m.Value >= 0);
 				Assert.Empty(m.Tags);
@@ -228,7 +228,7 @@ public class ProcessMetricsTests : IDisposable {
 		Assert.Collection(
 			_longListener.RetrieveMeasurements("eventstore-gc-generation-size-bytes"),
 			m => {
-				Assert.True(m.Value > 0);
+				Assert.True(m.Value >= 0);
 				Assert.Collection(
 					m.Tags,
 					tag => {

--- a/src/EventStore.Core.XUnit.Tests/PluginLoaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/PluginLoaderTests.cs
@@ -88,7 +88,7 @@ public class PluginLoaderTests : IAsyncLifetime {
 		using var process = new Process {
 			StartInfo = new ProcessStartInfo {
 				FileName = "dotnet",
-				Arguments = $"publish --configuration {BuildConfiguration} --framework=net6.0 --output {outputFolder.FullName}",
+				Arguments = $"publish --configuration {BuildConfiguration} --framework=net7.0 --output {outputFolder.FullName}",
 				WorkingDirectory = PluginSourceDirectory,
 				UseShellExecute = false,
 				RedirectStandardError = true,

--- a/src/EventStore.Core.XUnit.Tests/PluginLoaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/PluginLoaderTests.cs
@@ -88,7 +88,7 @@ public class PluginLoaderTests : IAsyncLifetime {
 		using var process = new Process {
 			StartInfo = new ProcessStartInfo {
 				FileName = "dotnet",
-				Arguments = $"publish --configuration {BuildConfiguration} --framework=net7.0 --output {outputFolder.FullName}",
+				Arguments = $"publish --configuration {BuildConfiguration} --framework=net8.0 --output {outputFolder.FullName}",
 				WorkingDirectory = PluginSourceDirectory,
 				UseShellExecute = false,
 				RedirectStandardError = true,

--- a/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
@@ -51,7 +51,7 @@ namespace EventStore.Core {
 				from option in section.GetProperties()
 				let deprecationWarning = option.GetCustomAttribute<DeprecatedAttribute>()?.Message
 				where deprecationWarning is not null
-				let value = ConfigurationRoot.GetValue<string?>(option.Name)
+				let value = ConfigurationRoot?.GetValue<string?>(option.Name)
 				where defaultValues.TryGetValue(option.Name, out var defaultValue)
 				      && !string.Equals(value, defaultValue?.ToString(), StringComparison.OrdinalIgnoreCase)
 				      select deprecationWarning;

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -101,8 +101,8 @@ namespace EventStore.Core {
 			public string DefaultOpsPassword { get; init; } = "changeit";
  
 			internal static DefaultUserOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				DefaultAdminPassword = configurationRoot.GetValue<string>(nameof(DefaultAdminPassword)),
-				DefaultOpsPassword = configurationRoot.GetValue<string>(nameof(DefaultOpsPassword))
+				DefaultAdminPassword = configurationRoot.GetString(nameof(DefaultAdminPassword)),
+				DefaultOpsPassword = configurationRoot.GetString(nameof(DefaultOpsPassword))
 			};
 		}
 		
@@ -178,7 +178,7 @@ namespace EventStore.Core {
 			public bool TelemetryOptout { get; init; } = false;
 
 			internal static ApplicationOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				Config = configurationRoot.GetValue<string>(nameof(Config)),
+				Config = configurationRoot.GetString(nameof(Config)),
 				Help = configurationRoot.GetValue<bool>(nameof(Help)),
 				Version = configurationRoot.GetValue<bool>(nameof(Version)),
 				EnableHistograms = configurationRoot.GetValue<bool>(nameof(EnableHistograms)),
@@ -227,8 +227,8 @@ namespace EventStore.Core {
 			public bool DisableLogFile { get; init; } = false;
 
 			public static LoggingOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				Log = configurationRoot.GetValue<string>(nameof(Log)),
-				LogConfig = configurationRoot.GetValue<string>(nameof(LogConfig)),
+				Log = configurationRoot.GetString(nameof(Log)),
+				LogConfig = configurationRoot.GetString(nameof(LogConfig)),
 				LogLevel = configurationRoot.GetValue<LogLevel>(nameof(LogLevel)),
 				LogConsoleFormat = configurationRoot.GetValue<LogConsoleFormat>(nameof(LogConsoleFormat)),
 				LogFileSize = configurationRoot.GetValue<int>(nameof(LogFileSize)),
@@ -257,9 +257,9 @@ namespace EventStore.Core {
 			public bool DisableFirstLevelHttpAuthorization { get; init; } = false;
 
 			internal static AuthOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				AuthorizationType = configurationRoot.GetValue<string>(nameof(AuthorizationType)),
+				AuthorizationType = configurationRoot.GetString(nameof(AuthorizationType)),
 				AuthenticationConfig = configurationRoot.GetValue<string>(nameof(AuthenticationConfig)),
-				AuthenticationType = configurationRoot.GetValue<string>(nameof(AuthenticationType)),
+				AuthenticationType = configurationRoot.GetString(nameof(AuthenticationType)),
 				AuthorizationConfig = configurationRoot.GetValue<string>(nameof(AuthorizationConfig)),
 				DisableFirstLevelHttpAuthorization =
 					configurationRoot.GetValue<bool>(nameof(DisableFirstLevelHttpAuthorization))
@@ -304,8 +304,7 @@ namespace EventStore.Core {
 
 			internal static CertificateOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				TrustedRootCertificatesPath = configurationRoot.GetValue<string>(nameof(TrustedRootCertificatesPath)),
-				CertificateReservedNodeCommonName =
-					configurationRoot.GetValue<string>(nameof(CertificateReservedNodeCommonName))
+				CertificateReservedNodeCommonName = configurationRoot.GetString(nameof(CertificateReservedNodeCommonName))
 			};
 		}
 
@@ -336,18 +335,14 @@ namespace EventStore.Core {
 			public string TrustedRootCertificateThumbprint { get; init; } = string.Empty;
 
 			internal static CertificateStoreOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				CertificateStoreLocation = configurationRoot.GetValue<string>(nameof(CertificateStoreLocation)),
-				CertificateStoreName = configurationRoot.GetValue<string>(nameof(CertificateStoreName)),
-				CertificateSubjectName = configurationRoot.GetValue<string>(nameof(CertificateSubjectName)),
-				CertificateThumbprint = configurationRoot.GetValue<string>(nameof(CertificateThumbprint)),
-				TrustedRootCertificateStoreLocation =
-					configurationRoot.GetValue<string>(nameof(TrustedRootCertificateStoreLocation)),
-				TrustedRootCertificateStoreName =
-					configurationRoot.GetValue<string>(nameof(TrustedRootCertificateStoreName)),
-				TrustedRootCertificateThumbprint =
-					configurationRoot.GetValue<string>(nameof(TrustedRootCertificateThumbprint)),
-				TrustedRootCertificateSubjectName =
-					configurationRoot.GetValue<string>(nameof(TrustedRootCertificateSubjectName))
+				CertificateStoreLocation = configurationRoot.GetString(nameof(CertificateStoreLocation)),
+				CertificateStoreName = configurationRoot.GetString(nameof(CertificateStoreName)),
+				CertificateSubjectName = configurationRoot.GetString(nameof(CertificateSubjectName)),
+				CertificateThumbprint = configurationRoot.GetString(nameof(CertificateThumbprint)),
+				TrustedRootCertificateStoreLocation = configurationRoot.GetString(nameof(TrustedRootCertificateStoreLocation)),
+				TrustedRootCertificateStoreName = configurationRoot.GetString(nameof(TrustedRootCertificateStoreName)),
+				TrustedRootCertificateThumbprint = configurationRoot.GetString(nameof(TrustedRootCertificateThumbprint)),
+				TrustedRootCertificateSubjectName = configurationRoot.GetString(nameof(TrustedRootCertificateSubjectName))
 			};
 		}
 
@@ -405,7 +400,7 @@ namespace EventStore.Core {
 				DiscoverViaDns = configurationRoot.GetValue<bool>(nameof(DiscoverViaDns)),
 				ClusterSize = configurationRoot.GetValue<int>(nameof(ClusterSize)),
 				NodePriority = configurationRoot.GetValue<int>(nameof(NodePriority)),
-				ClusterDns = configurationRoot.GetValue<string>(nameof(ClusterDns)),
+				ClusterDns = configurationRoot.GetString(nameof(ClusterDns)),
 				ClusterGossipPort = configurationRoot.GetValue<int>(nameof(ClusterGossipPort)),
 				GossipIntervalMs = configurationRoot.GetValue<int>(nameof(GossipIntervalMs)),
 				GossipAllowedDifferenceMs = configurationRoot.GetValue<int>(nameof(GossipAllowedDifferenceMs)),
@@ -587,7 +582,7 @@ namespace EventStore.Core {
 				MinFlushDelayMs = configurationRoot.GetValue<double>(nameof(MinFlushDelayMs)),
 				DisableScavengeMerging = configurationRoot.GetValue<bool>(nameof(DisableScavengeMerging)),
 				MemDb = configurationRoot.GetValue<bool>(nameof(MemDb)),
-				Db = configurationRoot.GetValue<string>(nameof(Db)),
+				Db = configurationRoot.GetString(nameof(Db)),
 				ScavengeHistoryMaxAge = configurationRoot.GetValue<int>(nameof(ScavengeHistoryMaxAge)),
 				CachedChunks = configurationRoot.GetValue<int>(nameof(CachedChunks)),
 				ChunksCacheSize = configurationRoot.GetValue<long>(nameof(ChunksCacheSize)),

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -232,7 +232,6 @@ namespace EventStore.Core {
 								return default;
 							})
 							.AddPrometheusExporter())
-						.StartWithHost()
 						.Services
 
 						// gRPC

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>
@@ -15,34 +15,29 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="EventStore.Plugins" Version="23.10.1" />
-		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.52.0">
+		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.59.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.59.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
-		<PackageReference Include="Microsoft.FASTER.Core" Version="1.9.5" />
-		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.1" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.1" />
+		<PackageReference Include="Microsoft.FASTER.Core" Version="1.9.16" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
 		<PackageReference Include="Quickenshtein" Version="1.5.1" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
-		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
-		<PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
+		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.328102" />
-		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.5" />
+		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.452401" />
+		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.6" />
 		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 		<PackageReference Include="HostStat.NET" Version="1.0.2" />
-		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.10" />
-		<!-- CVE-2022-35737 -->
-		<PackageReference Include="SQLitePCLRaw.core" Version="2.1.2" />
-		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.2" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />
 		<ProjectReference Include="..\EventStore.Common.Utils\EventStore.Common.Utils.csproj" />
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.LogV3\EventStore.LogV3.csproj" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
@@ -23,8 +23,8 @@
 		</PackageReference>
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
 		<PackageReference Include="Microsoft.FASTER.Core" Version="1.9.16" />
-		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.1" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.1" />
 		<PackageReference Include="Quickenshtein" Version="1.5.1" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.Core/LogV3/FASTER/MaintenanceFunctions.cs
+++ b/src/EventStore.Core/LogV3/FASTER/MaintenanceFunctions.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.LogV3.FASTER {
 
 		public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) {
 		}
-		
+
 		#region not needed
 		public void ConcurrentReader(ref SpanByte key, ref TValue input, ref TValue value, ref TValue dst) =>
 			throw new NotImplementedException();
@@ -19,13 +19,13 @@ namespace EventStore.Core.LogV3.FASTER {
 		public bool ConcurrentWriter(ref SpanByte key, ref TValue src, ref TValue dst) =>
 			throw new NotImplementedException();
 
-		public void CopyUpdater(ref SpanByte key, ref TValue input, ref TValue oldValue, ref TValue newValue) =>
+		public void CopyUpdater(ref SpanByte key, ref TValue input, ref TValue oldValue, ref TValue newValue, ref TValue output) =>
 			throw new NotImplementedException();
 
-		public void InitialUpdater(ref SpanByte key, ref TValue input, ref TValue value) =>
+		public void InitialUpdater(ref SpanByte key, ref TValue input, ref TValue value, ref TValue output) =>
 			throw new NotImplementedException();
 
-		public bool InPlaceUpdater(ref SpanByte key, ref TValue input, ref TValue value) =>
+		public bool InPlaceUpdater(ref SpanByte key, ref TValue input, ref TValue value, ref TValue output) =>
 			throw new NotImplementedException();
 
 		public void Lock(ref RecordInfo recordInfo, ref SpanByte key, ref TValue value, LockType lockType, ref long lockContext) =>
@@ -34,7 +34,7 @@ namespace EventStore.Core.LogV3.FASTER {
 		public void ReadCompletionCallback(ref SpanByte key, ref TValue input, ref TValue output, Empty ctx, Status status) =>
 			throw new NotImplementedException();
 
-		public void RMWCompletionCallback(ref SpanByte key, ref TValue input, Empty ctx, Status status) =>
+		public void RMWCompletionCallback(ref SpanByte key, ref TValue input, ref TValue output, Empty ctx, Status status) =>
 			throw new NotImplementedException();
 
 		public void SingleReader(ref SpanByte key, ref TValue input, ref TValue value, ref TValue dst) =>

--- a/src/EventStore.Core/LogV3/FASTER/ReaderFunctions.cs
+++ b/src/EventStore.Core/LogV3/FASTER/ReaderFunctions.cs
@@ -34,16 +34,16 @@ namespace EventStore.Core.LogV3.FASTER {
 		}
 
 		#region not needed
-		public void CopyUpdater(ref SpanByte key, ref TValue input, ref TValue oldValue, ref TValue newValue) =>
+		public void CopyUpdater(ref SpanByte key, ref TValue input, ref TValue oldValue, ref TValue newValue, ref TValue output) =>
 			throw new NotImplementedException();
 
-		public void InitialUpdater(ref SpanByte key, ref TValue input, ref TValue value) =>
+		public void InitialUpdater(ref SpanByte key, ref TValue input, ref TValue value, ref TValue output) =>
 			throw new NotImplementedException();
 
-		public bool InPlaceUpdater(ref SpanByte key, ref TValue input, ref TValue value) =>
+		public bool InPlaceUpdater(ref SpanByte key, ref TValue input, ref TValue value, ref TValue output) =>
 			throw new NotImplementedException();
 
-		public void RMWCompletionCallback(ref SpanByte key, ref TValue input, Context<TValue> context, Status status) =>
+		public void RMWCompletionCallback(ref SpanByte key, ref TValue input, ref TValue output, Context<TValue> ctx, Status status) =>
 			throw new NotImplementedException();
 
 		public void DeleteCompletionCallback(ref SpanByte key, Context<TValue> context) =>

--- a/src/EventStore.Core/LogV3/FASTER/WriterFunctions.cs
+++ b/src/EventStore.Core/LogV3/FASTER/WriterFunctions.cs
@@ -32,16 +32,16 @@ namespace EventStore.Core.LogV3.FASTER {
 		public void ReadCompletionCallback(ref SpanByte key, ref TValue input, ref TValue output, Empty context, Status status) =>
 			throw new NotImplementedException();
 
-		public void CopyUpdater(ref SpanByte key, ref TValue input, ref TValue oldValue, ref TValue newValue) =>
+		public void CopyUpdater(ref SpanByte key, ref TValue input, ref TValue oldValue, ref TValue newValue, ref TValue output) =>
 			throw new NotImplementedException();
 
-		public void InitialUpdater(ref SpanByte key, ref TValue input, ref TValue value) =>
+		public void InitialUpdater(ref SpanByte key, ref TValue input, ref TValue value, ref TValue output) =>
 			throw new NotImplementedException();
 
-		public bool InPlaceUpdater(ref SpanByte key, ref TValue input, ref TValue value) =>
+		public bool InPlaceUpdater(ref SpanByte key, ref TValue input, ref TValue value, ref TValue output) =>
 			throw new NotImplementedException();
 
-		public void RMWCompletionCallback(ref SpanByte key, ref TValue input, Empty context, Status status) =>
+		public void RMWCompletionCallback(ref SpanByte key, ref TValue input, ref TValue output, Empty ctx, Status status) =>
 			throw new NotImplementedException();
 
 		public void DeleteCompletionCallback(ref SpanByte key, Empty context) =>

--- a/src/EventStore.Core/Metrics/ProcessMetrics.cs
+++ b/src/EventStore.Core/Metrics/ProcessMetrics.cs
@@ -41,7 +41,7 @@ public class ProcessMetrics {
 			.Assembly
 			.GetType("System.Diagnostics.Tracing.RuntimeEventSourceHelper")!
 			.GetMethod("GetCpuUsage", BindingFlags.Static | BindingFlags.NonPublic)!
-			.CreateDelegate<Func<int>>();
+			.CreateDelegate<Func<double>>();
 
 		var getExceptionCount = typeof(Exception)
 			.GetMethod("GetExceptionCount", BindingFlags.Static | BindingFlags.NonPublic)!

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -5,19 +5,23 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 	public class Rfc2898PasswordHashAlgorithm : PasswordHashAlgorithm {
 		private const int HashSize = 20;
 		private const int SaltSize = 16;
-
+		private const int Iterations = 1000;
+		
 		public override void Hash(string password, out string hash, out string salt) {
-			var salt_ = new byte[SaltSize];
-			RandomNumberGenerator.Fill(salt_);
-			var hash_ = new Rfc2898DeriveBytes(password, salt_).GetBytes(HashSize);
-			hash = System.Convert.ToBase64String(hash_);
-			salt = System.Convert.ToBase64String(salt_);
+			var saltData = new byte[SaltSize];
+			RandomNumberGenerator.Fill(saltData);
+			
+			using var rfcBytes = new Rfc2898DeriveBytes(password, saltData, Iterations, HashAlgorithmName.SHA1);
+			var hashData = rfcBytes.GetBytes(HashSize);
+			hash = System.Convert.ToBase64String(hashData);
+			salt = System.Convert.ToBase64String(saltData);
 		}
 
 		public override bool Verify(string password, string hash, string salt) {
-			var salt_ = System.Convert.FromBase64String(salt);
+			var saltData = System.Convert.FromBase64String(salt);
 
-			var newHash = System.Convert.ToBase64String(new Rfc2898DeriveBytes(password, salt_).GetBytes(HashSize));
+			using var rfcBytes = new Rfc2898DeriveBytes(password, saltData, Iterations, HashAlgorithmName.SHA1);
+			var newHash = System.Convert.ToBase64String(rfcBytes.GetBytes(HashSize));
 
 			return hash == newHash;
 		}

--- a/src/EventStore.Core/Services/Transport/Http/AuthenticationMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AuthenticationMiddleware.cs
@@ -50,7 +50,7 @@ namespace EventStore.Core.Services.Transport.Http {
 					break;
 				case HttpAuthenticationRequestStatus.NotReady:
 					context.Response.StatusCode = HttpStatusCode.ServiceUnavailable;
-					context.Response.Headers.Add("Retry-After", "5");
+					context.Response.Headers.Append("Retry-After", "5");
 					break;
 				case HttpAuthenticationRequestStatus.Unauthenticated:
 				default:
@@ -79,7 +79,7 @@ namespace EventStore.Core.Services.Transport.Http {
 				case HttpAuthenticationRequestStatus.NotReady:
 					// negative RetryPushbackHeader asks the grpc client not to retry the request.
 					// the user is then explicit about what retries they want and aware of the delays incurred
-					trailersDestination.Add(GrpcProtocolHelpers.RetryPushbackHeader, "-1");
+					trailersDestination.Append(GrpcProtocolHelpers.RetryPushbackHeader, "-1");
 					grpcStatus = new Status(StatusCode.Unavailable, "Server not ready");
 					break;
 				case HttpAuthenticationRequestStatus.Unauthenticated:
@@ -114,7 +114,7 @@ namespace EventStore.Core.Services.Transport.Http {
 			var authSchemes = _authenticationProvider.GetSupportedAuthenticationSchemes();
 			if (authSchemes != null && authSchemes.Any()) {
 				//add "X-" in front to prevent any default browser behaviour e.g Basic Auth popups
-				context.Response.Headers.Add("WWW-Authenticate", $"X-{authSchemes.First()} realm=\"ESDB\"");
+				context.Response.Headers.Append("WWW-Authenticate", $"X-{authSchemes.First()} realm=\"ESDB\"");
 				var properties = _authenticationProvider.GetPublicProperties();
 				if (properties != null && properties.Any()) {
 					await context.Response.WriteAsync(JsonConvert.SerializeObject(properties))

--- a/src/EventStore.LogCommon/EventStore.LogCommon.csproj
+++ b/src/EventStore.LogCommon/EventStore.LogCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.LogCommon/EventStore.LogCommon.csproj
+++ b/src/EventStore.LogCommon/EventStore.LogCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.LogV3.Tests/EventStore.LogV3.Tests.csproj
+++ b/src/EventStore.LogV3.Tests/EventStore.LogV3.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.LogV3.Tests/EventStore.LogV3.Tests.csproj
+++ b/src/EventStore.LogV3.Tests/EventStore.LogV3.Tests.csproj
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="ObjectLayoutInspector" Version="0.1.4" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/EventStore.LogV3/EventStore.LogV3.csproj
+++ b/src/EventStore.LogV3/EventStore.LogV3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.LogV3/EventStore.LogV3.csproj
+++ b/src/EventStore.LogV3/EventStore.LogV3.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.52.0">
+		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.59.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.MicroBenchmarks/EventStore.MicroBenchmarks.csproj
+++ b/src/EventStore.MicroBenchmarks/EventStore.MicroBenchmarks.csproj
@@ -2,12 +2,12 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/EventStore.MicroBenchmarks/EventStore.MicroBenchmarks.csproj
+++ b/src/EventStore.MicroBenchmarks/EventStore.MicroBenchmarks.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="System.ServiceModel.Http" Version="6.2.0" />
 		<!-- CVE-2023-29331 -->
-		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
-		<PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateMatchException.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateMatchException.cs
@@ -4,26 +4,14 @@
 
 namespace System
 {
-    using System.Runtime.Serialization;
-    using System.Runtime.CompilerServices;
+	using System.Runtime.CompilerServices;
 
     [TypeForwardedFrom("System.ServiceModel.Web, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
     [Serializable]
     public class UriTemplateMatchException : SystemException
     {
-        public UriTemplateMatchException()
-        {
-        }
         public UriTemplateMatchException(string message)
             : base(message)
-        {
-        }
-        public UriTemplateMatchException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-        protected UriTemplateMatchException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/UrlUtility.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/UrlUtility.cs
@@ -487,11 +487,6 @@ namespace System.Runtime
                 IsReadOnly = false;
             }
 
-            protected HttpValueCollection(SerializationInfo info, StreamingContext context)
-                : base(info, context)
-            {
-            }
-
             internal void FillFromString(string s, bool urlencoded, Encoding encoding)
             {
                 int l = (s != null) ? s.Length : 0;

--- a/src/EventStore.Native/EventStore.Native.csproj
+++ b/src/EventStore.Native/EventStore.Native.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.Native/EventStore.Native.csproj
+++ b/src/EventStore.Native/EventStore.Native.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.PluginHosting/EventStore.PluginHosting.csproj
+++ b/src/EventStore.PluginHosting/EventStore.PluginHosting.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.PluginHosting/EventStore.PluginHosting.csproj
+++ b/src/EventStore.PluginHosting/EventStore.PluginHosting.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Projections.Core.Javascript.Tests/EventStore.Projections.Core.Javascript.Tests.csproj
+++ b/src/EventStore.Projections.Core.Javascript.Tests/EventStore.Projections.Core.Javascript.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 

--- a/src/EventStore.Projections.Core.Javascript.Tests/EventStore.Projections.Core.Javascript.Tests.csproj
+++ b/src/EventStore.Projections.Core.Javascript.Tests/EventStore.Projections.Core.Javascript.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 
@@ -29,14 +29,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
@@ -38,7 +38,7 @@ namespace EventStore.Projections.Core.Javascript.Tests.Integration {
 			_mainBus = new InMemoryBus("main");
 			_mainQueue = QueuedHandler.CreateQueuedHandler(_mainBus, "bossQ", new QueueStatsManager(), new());
 			_writerCheckpoint = new InMemoryCheckpoint(0);
-			_miniStore = new MiniStore(_writerCheckpoint, _mainBus);
+			_miniStore = new MiniStore(_writerCheckpoint, _mainQueue);
 			TestTimeout = testTimeout;
 			_complete = _miniStore.NotifyAll(TestTimeout);
 			_notifications = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();

--- a/src/EventStore.Projections.Core.Javascript.Tests/SpecRunner.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/SpecRunner.cs
@@ -397,9 +397,10 @@ namespace EventStore.Projections.Core.Javascript.Tests {
 
 		[Theory]
 		[MemberData(nameof(GetTestCases))]
-		public ValueTask Test(TestDefinition def) {
-			return def.Execute(_output);
+		public Task Test(TestDefinition def) {
+			return def.Execute(_output).AsTask();
 		}
+		
 		public class TestDefinition {
 			private readonly string _name;
 			private readonly Func<ITestOutputHelper, ValueTask> _step;

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -23,17 +23,15 @@ namespace EventStore.Projections.Core.Tests.ClientAPI {
 		protected UserCredentials _admin = DefaultData.AdminCredentials;
 		protected ProjectionsManager _manager;
 		protected QueryManager _queryManager;
-#if DEBUG
+
 		private Task _projectionsCreated;
 		private ProjectionsSubsystem _projections;
 		private MiniNode<TLogFormat, TStreamId> _node;
-#endif
+
 		[OneTimeSetUp]
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
-#if (!DEBUG)
-            Assert.Ignore("These tests require DEBUG conditional");
-#else
+			
 			var projectionWorkerThreadCount = GivenWorkerThreadCount();
 			var configuration = new ProjectionSubsystemOptions(
 				projectionWorkerThreadCount,
@@ -85,8 +83,6 @@ namespace EventStore.Projections.Core.Tests.ClientAPI {
 			} catch (Exception ex) {
 				throw new Exception("When Failed", ex);
 			}
-
-#endif
 		}
 
 		protected virtual int GivenWorkerThreadCount() {
@@ -95,18 +91,13 @@ namespace EventStore.Projections.Core.Tests.ClientAPI {
 
 		[TearDown]
 		public async Task PostTestAsserts() {
-			var all = await _manager.ListAllAsync(_admin);
-			if (all.Any(p => p.Name == "Faulted"))
-				Assert.Fail("Projections faulted while running the test" + "\r\n" + all);
-#if DEBUG
-			_node?.Shutdown();
-#endif
+ 			var all = await _manager.ListAllAsync(_admin);
+ 			if (all.Any(p => p.Name == "Faulted"))
+ 				Assert.Fail("Projections faulted while running the test" + "\r\n" + all);
 		}
 
 		protected async Task EnableStandardProjections() {
-#if DEBUG
 			await _projectionsCreated;
-#endif
 			await EnableProjection(ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection);
 			await EnableProjection(ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection);
 			await EnableProjection(ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection);
@@ -136,10 +127,10 @@ namespace EventStore.Projections.Core.Tests.ClientAPI {
 		public override async Task TestFixtureTearDown() {
 			if (_conn != null)
 				_conn.Close();
-#if DEBUG
+
 			if (_node != null)
 				await _node.Shutdown();
-#endif
+
 			await base.TestFixtureTearDown();
 		}
 

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
@@ -20,14 +20,14 @@
 		<None Remove="Services\Jint\Serialization\big_state.json" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.52.0">
+		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.59.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
@@ -13,7 +13,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 		[Ignore("Persistent projections are admin only")]
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
 		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		public class Authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 			private ClaimsPrincipal _testUserPrincipal;
 
@@ -70,7 +70,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
 		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class anonymous<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		public class Anonymous<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 
 			private string _projectionBody = @"fromAll().when({$any:function(s,e){return s;}});";

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -12,7 +12,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 	namespace when_posting_a_transient_projection {
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
 		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		public class Authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 			private ClaimsPrincipal _testUserPrincipal;
 
@@ -69,7 +69,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
 		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class anonymous<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		public class Anonymous<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 
 			private string _projectionBody = @"fromAll().when({$any:function(s,e){return s;}});";

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
@@ -30,14 +30,14 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Grpc.Tools" Version="2.49.1">
+		<PackageReference Include="Grpc.Tools" Version="2.59.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Jint" Version="3.0.0-beta-2048" />
+		<PackageReference Include="Jint" Version="3.0.0-beta-2055" />
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		<ProjectReference Include="..\EventStore.Transport.Http\EventStore.Transport.Http.csproj" />

--- a/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
@@ -91,7 +91,7 @@ namespace EventStore.Projections.Core.Services.Interpreted {
 				if (_state == null || _state == JsValue.Undefined)
 					_state = new JsArray(_engine, new[]
 					{
-						PropertyDescriptor.Undefined, PropertyDescriptor.Undefined
+						JsValue.Undefined, JsValue.Undefined
 					});
 
 				_state.AsArray()[0] = jsValue;
@@ -115,7 +115,7 @@ namespace EventStore.Projections.Core.Services.Interpreted {
 				if (_state == null || _state == JsValue.Undefined)
 					_state = new JsArray(_engine, new[]
 					{
-						PropertyDescriptor.Undefined, PropertyDescriptor.Undefined
+						JsValue.Undefined, JsValue.Undefined,
 					});
 
 				_state.AsArray()[1] = jsValue;

--- a/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
+++ b/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
@@ -35,7 +35,7 @@
 		<!-- upgrade because of transitive dependency vulnerability -->
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<!-- upgrade because of transitive dependency vulnerability -->
-		<PackageReference Include="NuGet.Protocol" Version="6.7.0" />
+		<PackageReference Include="NuGet.Protocol" Version="6.7.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 		<!-- upgrade because of transitive dependency vulnerability -->
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
+++ b/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>
@@ -28,25 +28,25 @@
 	  </None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<!-- upgrade because of transitive dependency vulnerability -->
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<!-- upgrade because of transitive dependency vulnerability -->
-		<PackageReference Include="NuGet.Protocol" Version="6.0.6" />
+		<PackageReference Include="NuGet.Protocol" Version="6.7.0" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 		<!-- upgrade because of transitive dependency vulnerability -->
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<!-- upgrade because of transitive dependency vulnerability -->
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.2.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
+++ b/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.SourceGenerators.Tests/Messaging/Cases/Message.g.cs
+++ b/src/EventStore.SourceGenerators.Tests/Messaging/Cases/Message.g.cs
@@ -8,6 +8,7 @@ namespace EventStore.SourceGenerators.Tests.Messaging
 	{
 		private static int _nextMsgId = -1;
 		protected static ref int NextMsgId => ref _nextMsgId;
+
 		private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 		public virtual int MsgTypeId => TypeId;
 		public virtual string Label => "";

--- a/src/EventStore.SourceGenerators/EventStore.SourceGenerators.csproj
+++ b/src/EventStore.SourceGenerators/EventStore.SourceGenerators.csproj
@@ -3,14 +3,15 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
+		<RunAnalyzers>false</RunAnalyzers>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -20,7 +20,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
+		<PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<OutputType>Exe</OutputType>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
@@ -14,14 +14,13 @@
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
 		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
 		<PackageReference Include="EventStore.Plugins" Version="23.10.1" />
-		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.52.0">
+		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.59.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.59.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-		<PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20574.7" />
+		<PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<OutputType>Exe</OutputType>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>

--- a/src/EventStore.Transport.Http/Atom/AtomExceptions.cs
+++ b/src/EventStore.Transport.Http/Atom/AtomExceptions.cs
@@ -1,30 +1,14 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace EventStore.Transport.Http.Atom {
 	public class AtomSpecificationViolationException : Exception {
-		public AtomSpecificationViolationException() {
-		}
-
 		public AtomSpecificationViolationException(string message) : base(message) {
-		}
-
-		public AtomSpecificationViolationException(string message, Exception innerException) : base(message,
-			innerException) {
-		}
-
-		protected AtomSpecificationViolationException(SerializationInfo info, StreamingContext context) : base(info,
-			context) {
 		}
 	}
 
 	public class ThrowHelper {
 		public static void ThrowSpecificationViolation(string message) {
 			throw new AtomSpecificationViolationException(message);
-		}
-
-		public static void ThrowSpecificationViolation(string message, Exception innnerException) {
-			throw new AtomSpecificationViolationException(message, innnerException);
 		}
 	}
 }

--- a/src/EventStore.Transport.Http/EntityManagement/CoreHttpResponseAdapter.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/CoreHttpResponseAdapter.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 
 namespace EventStore.Transport.Http.EntityManagement {
@@ -8,7 +9,7 @@ namespace EventStore.Transport.Http.EntityManagement {
 		public CoreHttpResponseAdapter(Microsoft.AspNetCore.Http.HttpResponse inner) {
 			_inner = inner;
 		}
-		public void AddHeader(string name, string value) => _inner.Headers.Add(name, value);
+		public void AddHeader(string name, string value) => _inner.Headers.Append(name, value);
 
 		public void Close() {
 			_inner.Body.Close();

--- a/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
+++ b/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
+++ b/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
+		<PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />

--- a/src/EventStore.Transport.Tcp/EventStore.Transport.Tcp.csproj
+++ b/src/EventStore.Transport.Tcp/EventStore.Transport.Tcp.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Transport.Tcp/EventStore.Transport.Tcp.csproj
+++ b/src/EventStore.Transport.Tcp/EventStore.Transport.Tcp.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Transport.Tcp/Framing/PackageFramingException.cs
+++ b/src/EventStore.Transport.Tcp/Framing/PackageFramingException.cs
@@ -3,16 +3,7 @@ using System.Runtime.Serialization;
 
 namespace EventStore.Transport.Tcp.Framing {
 	public class PackageFramingException : Exception {
-		public PackageFramingException() {
-		}
-
 		public PackageFramingException(string message) : base(message) {
-		}
-
-		public PackageFramingException(string message, Exception innerException) : base(message, innerException) {
-		}
-
-		protected PackageFramingException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }


### PR DESCRIPTION
Changed: Upgrade to net8

Cherry-picks the following PRs:
- https://github.com/EventStore/EventStore/pull/4031
- https://github.com/EventStore/EventStore/pull/4046
- https://github.com/EventStore/EventStore/pull/4110
- https://github.com/EventStore/EventStore/pull/4207
- https://github.com/EventStore/EventStore/pull/4165

Remain on Prometheus exporter 1.4.0-rc.1 due to https://github.com/EventStore/EventStore/pull/4142