### PR TITLE
[DB-26-19] Warn when projection state becomes greater than 8mb

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/PartitionState.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/PartitionState.cs
@@ -10,7 +10,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings {
 			DateParseHandling = DateParseHandling.None,
 		};
-		
+
 		public bool IsChanged(PartitionState newState) {
 			return State != newState.State || Result != newState.Result;
 		}
@@ -48,6 +48,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		private readonly string _state;
 		private readonly string _result;
 		private readonly CheckpointTag _causedBy;
+		private int _size;
 
 		public PartitionState(string state, string result, CheckpointTag causedBy) {
 			if (state == null) throw new ArgumentNullException("state");
@@ -56,6 +57,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			_state = state;
 			_result = result;
 			_causedBy = causedBy;
+			_size = _state.Length + _result?.Length ?? 0;
 		}
 
 		public string State {
@@ -68,6 +70,10 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		public string Result {
 			get { return _result; }
+		}
+
+		public int Size {
+			get { return _size; }
 		}
 
 		public string Serialize() {

--- a/src/EventStore.Projections.Core/Services/Processing/PartitionStateUpdateManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/PartitionStateUpdateManager.cs
@@ -46,7 +46,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				}
 
 				//NOTE: order yb is required to satisfy internal emit events validation
-				// which ensures that events are ordered by causedBy tag.  
+				// which ensures that events are ordered by causedBy tag.
 				// it is too strong check, but ...
 				eventWriter.ValidateOrderAndEmitEvents(list.OrderBy(v => v.Event.CausedByTag).ToArray());
 			}


### PR DESCRIPTION
Added : A warning to the log when a projection state size becomes greater than 8 MB. https://eventstore.aha.io/develop/requirements/DB-26-19