### PR TITLE
Create a new buffer for each request, because they are sent concurrently

### DIFF
--- a/src/EventStore.TestClient/GrpcCommands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/GrpcCommands/WriteFloodProcessor.cs
@@ -100,8 +100,8 @@ namespace EventStore.TestClient.GrpcCommands {
 				var rnd = new Random();
 				List<Task> pending = new List<Task>(capacity);
 				await start.Task;
-				var events = new EventData[batchSize];
 				for (int j = 0; j < count; ++j) {
+					var events = new EventData[batchSize];
 
 					for (int q = 0; q < batchSize; q++) {
 						events[q] = new EventData(Uuid.FromGuid(Guid.NewGuid()), "TakeSomeSpaceEvent", data, metadata);


### PR DESCRIPTION
Fixed: Test client wrflgrpc no longer produces accidental idempotent writes

Otherwise some events are accidentally sent in multiple requests, resulting in unexpected  idempotent writes