### PR TITLE
[DB-21-5] Fixed concurrency between GetReaderWorkItem() and TryDestructMemStreams()

### DIFF
--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkReadTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkReadTransform.cs
@@ -2,5 +2,10 @@ namespace EventStore.Core.Transforms.Identity;
 
 public sealed class IdentityChunkReadTransform : IChunkReadTransform {
 	public static readonly IdentityChunkReadTransform Instance = new();
+
+	private IdentityChunkReadTransform() {
+
+	}
+
 	public ChunkDataReadStream TransformData(ChunkDataReadStream stream) => stream;
 }


### PR DESCRIPTION
Fixed: [DB-21-5](https://eventstore.aha.io/develop/requirements/DB-21-5)

The concurrency leads to `ObjectDisposedException` or SEGFAULT because the underlying memory stream has been disposed.