### PR TITLE
[DBX-41] Fix finalizer when AlignedMemory failed to allocate

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/DataStructures/ProbabilisticFilter/AlignedMemoryTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/DataStructures/ProbabilisticFilter/AlignedMemoryTests.cs
@@ -1,4 +1,5 @@
-﻿using EventStore.Core.DataStructures.ProbabilisticFilter;
+﻿using System;
+using EventStore.Core.DataStructures.ProbabilisticFilter;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.DataStructures.ProbabilisticFilter {
@@ -18,6 +19,13 @@ namespace EventStore.Core.XUnit.Tests.DataStructures.ProbabilisticFilter {
 				Assert.Equal(size, sut.AsSpan().Length);
 				sut.AsSpan().Clear(); // can write to the span
 			}
+		}
+
+		[Fact]
+		public void finalizer_does_not_crash_process_when_oom() {
+			Assert.Throws<OutOfMemoryException>(() => new AlignedMemory(1_000_000_000_000, 1));
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
 		}
 	}
 }

--- a/src/EventStore.Core/DataStructures/ProbabilisticFilter/AlignedMemory.cs
+++ b/src/EventStore.Core/DataStructures/ProbabilisticFilter/AlignedMemory.cs
@@ -42,6 +42,12 @@ namespace EventStore.Core.DataStructures.ProbabilisticFilter {
 
 			_disposed = true;
 			GC.SuppressFinalize(this);
+
+			if (_intPtr == IntPtr.Zero) {
+				// didn't manage to allocate or add pressure (OOM), so do not free.
+				return;
+			}
+
 			Marshal.FreeHGlobal(_intPtr);
 			GC.RemoveMemoryPressure(_bytesAllocated);
 		}


### PR DESCRIPTION
Fixed: Finalizer bug no longer causes process exit if a memory allocation fails.

Before this fix the finalizer's call to `GC.RemoveMemoryPressure(0)` would throw an ArgumentOutOfRangeException, exiting the process.