### PR TITLE
[DBX-41] Continue index merge even if memory cannot be allocated for the bloom filter

### DIFF
--- a/src/EventStore.Core.Tests/Index/IndexV1/when_creating_large_bloom_filter.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_creating_large_bloom_filter.cs
@@ -21,5 +21,16 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				PTable.GenBloomFilterFilename(file)));
 			filter.Dispose();
 		}
+
+		[Test]
+		public void out_of_memory_returns_null() {
+			var filter = PTable.ConstructBloomFilter(
+				useBloomFilter: true,
+				filename: GetTempFilePath(),
+				indexEntryCount: 1,
+				genBloomFilterSizeBytes: _ => 1_000_000_000_000); // rly big
+
+			Assert.Null(filter);
+		}
 	}
 }

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -426,8 +426,8 @@ namespace EventStore.Core.Index {
 					if (workItem != null)
 						ReturnWorkItem(workItem);
 				} else {
-                    stream?.Dispose();
-                }
+					stream?.Dispose();
+				}
 			}
 		}
 
@@ -448,6 +448,9 @@ namespace EventStore.Core.Index {
 				return null;
 			} catch (CorruptedHashException ex) {
 				Log.Error(ex, "Bloom filter contents for index file {file} are corrupt. Performance will be degraded", _filename);
+				return null;
+			} catch (OutOfMemoryException ex) {
+				Log.Warning(ex, "Could not allocate enough memory for Bloom filter for index file {file}. Performance will be degraded", _filename);
 				return null;
 			} catch (Exception ex) {
 				Log.Error(ex, "Unexpected error opening bloom filter for index file {file}. Performance will be degraded", _filename);


### PR DESCRIPTION
Changed: Index merge now continues even if there is not enough memory to store the Bloom filter