### PR TITLE
[DB-21-2] Deprecate and unwire the Unbuffered config setting

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -444,7 +444,7 @@ namespace EventStore.Core {
 					indexChk,
 					streamExistenceFilterChk,
 					options.Database.MemDb,
-					options.Database.Unbuffered,
+					unbuffered: false,
 					options.Database.WriteThrough,
 					options.Database.OptimizeIndexMerge,
 					options.Database.ReduceFileCachePressure,

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -372,6 +372,8 @@ namespace EventStore.Core {
 
 			[Description("Enables Unbuffered/DirectIO when writing to the file system, this bypasses filesystem " +
 			             "caches.")]
+			[Deprecated("The Unbuffered setting has been deprecated as of version 24.6.0 and currently has no effect. " +
+			            "Please contact EventStore if this feature is of interest to you.")]
 			public bool Unbuffered { get; init; } = false;
 
 			[Description("The initial number of readers to start when opening a TFChunk.")]


### PR DESCRIPTION
With the recent work in DB-272 the implementation and behaviour of the Unbuffered setting has changed. The feature, as far as we know, is not used. We've decided to mark it as deprecated and unwire it. The code remains for now in case anyone reaches out.