### PR TITLE
Revert "Improved encapsulation of singletons"

### DIFF
--- a/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Data.Redaction;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.RedactionService {
@@ -133,7 +134,7 @@ namespace EventStore.Core.Tests.Services.RedactionService {
 			newChunk = $"{nameof(cannot_switch_with_chunk_having_mismatched_range)}-chunk-0-2.tmp";
 			var chunkHeader = new ChunkHeader(1, 1024, 0, 2, true, Guid.NewGuid(), TransformType.Identity);
 			var chunk = TFChunk.CreateWithHeader(Path.Combine(PathName, newChunk), chunkHeader, 1024, false, false, false, false,
-				new TFChunkTracker.NoOp(), IChunkTransformFactory.Identity, ReadOnlyMemory<byte>.Empty);
+				new TFChunkTracker.NoOp(), new IdentityChunkTransformFactory(), ReadOnlyMemory<byte>.Empty);
 			chunk.Dispose();
 			msg = await SwitchChunk(GetChunk(0, 0), newChunk);
 			Assert.AreEqual(SwitchChunkResult.ChunkRangeDoesNotMatch, msg.Result);

--- a/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationWithExistingDbFixture.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationWithExistingDbFixture.cs
@@ -6,6 +6,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 
 namespace EventStore.Core.Tests.Services.Replication.LogReplication;
 
@@ -48,7 +49,7 @@ public abstract class LogReplicationWithExistingDbFixture<TLogFormat, TStreamId>
 			writethrough: db.Config.WriteThrough,
 			reduceFileCachePressure: db.Config.ReduceFileCachePressure,
 			tracker: new TFChunkTracker.NoOp(),
-			transformFactory: IChunkTransformFactory.Identity,
+			transformFactory: new IdentityChunkTransformFactory(),
 			transformHeader: ReadOnlyMemory<byte>.Empty);
 
 		var posMaps = new List<PosMap>();

--- a/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Optimization {
@@ -92,7 +92,7 @@ namespace EventStore.Core.Tests.TransactionLog.Optimization {
 				chunkNumber, chunkNumber, scavenged, false, false, false,
 				false,
 				new TFChunkTracker.NoOp(),
-				IChunkTransformFactory.Identity);
+				new IdentityChunkTransformFactory());
 			long offset = chunkNumber * 1024 * 1024;
 			long logPos = 0 + offset;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Scavenging {
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 			var chunk = TFChunk.CreateNew(Filename, 1024 * 1024, 0, 0, true, false, false, false,
 				false,
 				new TFChunkTracker.NoOp(),
-				IChunkTransformFactory.Identity);
+				new IdentityChunkTransformFactory());
 			long logPos = 0;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {
 				map.Add(new PosMap(logPos, (int)logPos));

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -3,7 +3,7 @@ using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -70,7 +70,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			return TFChunk.CreateNew(fileName, chunkSize, 0, 0,
 				isScavenged: isScavenged, inMem: false, unbuffered: false,
 				writethrough: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
-				transformFactory: IChunkTransformFactory.Identity);
+				transformFactory: new IdentityChunkTransformFactory());
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateScenario.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Services.Storage;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
 	public abstract class TruncateScenario<TLogFormat, TStreamId> : ReadIndexTestScenario<TLogFormat, TStreamId> {
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			Db.Close();
 			Db.Dispose();
 
-			var truncator = new TFChunkDbTruncator(Db.Config, _ => IChunkTransformFactory.Identity);
+			var truncator = new TFChunkDbTruncator(Db.Config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(TruncateCheckpoint);
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		[Test]
 		public void truncate_above_max_throws_exception() {
 			Assert.Throws<Exception>(() => {
-				var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+				var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 				truncator.TruncateDb(0);
 			});
 		}
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public void truncate_within_max_does_not_throw_exception() {
 
 			Assert.DoesNotThrow(() => {
-				var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+				var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 				truncator.TruncateDb(4800);
 			});
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
@@ -8,7 +8,7 @@ using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateSingleChunk(_config, 2, GetFilePathFor("chunk-000002.000000"));
 			DbUtil.CreateSingleChunk(_config, 3, GetFilePathFor("chunk-000003.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
@@ -5,7 +5,7 @@ using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateMultiChunk(_config, 8, 9, GetFilePathFor("chunk-000008.000001"));
 			DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
@@ -8,7 +8,7 @@ using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateSingleChunk(_config, 0, GetFilePathFor("chunk-000000.000001"), contents: _file1Contents);
 			DbUtil.CreateOngoingChunk(_config, 1, GetFilePathFor("chunk-000001.000002"), contents: _file2Contents);
 
-			var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
@@ -5,7 +5,7 @@ using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -27,7 +27,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateMultiChunk(_config, 11, 12, GetFilePathFor("chunk-000011.000001"));
 			DbUtil.CreateOngoingChunk(_config, 13, GetFilePathFor("chunk-000013.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_data_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_data_chunk_boundary.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateSingleChunk(_config, 4, GetFilePathFor("chunk-000004.000000"));
 			DbUtil.CreateOngoingChunk(_config, 5, GetFilePathFor("chunk-000005.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_scavenged_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_scavenged_chunk_boundary.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateSingleChunk(_config, 4, GetFilePathFor("chunk-000004.000000"));
 			DbUtil.CreateOngoingChunk(_config, 5, GetFilePathFor("chunk-000005.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
@@ -5,7 +5,7 @@ using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			DbUtil.CreateMultiChunk(_config, 7, 8, GetFilePathFor("chunk-000007.000001"));
 			DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
 
-			var truncator = new TFChunkDbTruncator(_config, _ => IChunkTransformFactory.Identity);
+			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -2,7 +2,7 @@ using System;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -18,7 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Complete();
 			_testChunk = TFChunk.FromCompletedFile(Filename, true, false,
 				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
-				getTransformFactory: _ => IChunkTransformFactory.Identity);
+				getTransformFactory: _ => new IdentityChunkTransformFactory());
 		}
 
 		[TearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -1,7 +1,7 @@
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -11,7 +11,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void it_should_throw_a_file_not_found_exception() {
 			Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true,
 				unbufferedRead: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
-				getTransformFactory: _ => IChunkTransformFactory.Identity));
+				getTransformFactory: _ => new IdentityChunkTransformFactory()));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -3,7 +3,7 @@ using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Complete();
 			_cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
 				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
-				getTransformFactory: _ => IChunkTransformFactory.Identity);
+				getTransformFactory: _ => new IdentityChunkTransformFactory());
 			_cachedChunk.CacheInMemory();
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -3,7 +3,7 @@ using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
-using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog {
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Complete();
 			_uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
 				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
-				getTransformFactory: _ => IChunkTransformFactory.Identity);
+				getTransformFactory: _ => new IdentityChunkTransformFactory());
 			_uncachedChunk.CacheInMemory();
 			_uncachedChunk.UnCacheFromMemory();
 		}

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -24,6 +24,7 @@ using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.TransactionLog.Scavenging;
 using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using EventStore.Core.Util;
 using Xunit;
 using static EventStore.Core.XUnit.Tests.Scavenge.StreamMetadatas;
@@ -210,7 +211,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 			});
 
 			var dbConfig = TFChunkHelper.CreateSizedDbConfig(_dbPath, 0, chunkSize: 1024 * 1024);
-			var dbTransformManager = new DbTransformManager([IDbTransform.Identity], IDbTransform.Identity.Type);
+			var dbTransformManager = new DbTransformManager(new[] { new IdentityDbTransform() }, TransformType.Identity);
 
 			var dbResult = _getDb(dbConfig, logFormat);
 			var keptRecords = getExpectedKeptRecords != null

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -62,6 +62,7 @@ using EventStore.Core.Telemetry;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using EventStore.Core.Util;
 using EventStore.Plugins.Authentication;
 using EventStore.Plugins.Authorization;
@@ -325,8 +326,8 @@ namespace EventStore.Core {
 
 			MetricsBootstrapper.Bootstrap(MetricsConfiguration.Get(configuration), dbConfig, trackers);
 
-			var dbIdentityTransform = IDbTransform.Identity;
-			var dbTransformManager = new DbTransformManager([dbIdentityTransform], activeTransformType: dbIdentityTransform.Type);
+			var dbIdentityTransform = new IdentityDbTransform();
+			var dbTransformManager = new DbTransformManager(new [] { dbIdentityTransform }, activeTransformType: dbIdentityTransform.Type);
 			Db = new TFChunkDb(dbConfig, tracker: trackers.TransactionFileTracker, transformManager: dbTransformManager);
 
 			TFChunkDbConfig CreateDbConfig(

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -15,6 +15,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using EventStore.Core.Util;
 using Microsoft.Win32.SafeHandles;
 using ILogger = Serilog.ILogger;
@@ -1061,7 +1062,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				if (slot.ValueRef is not { } memoryWorkItem) {
 					memoryWorkItem = slot.ValueRef = new(
 						_sharedMemStream,
-						_cachedDataTransformed ? _transform.Read : IChunkReadTransform.Identity) { PositionInPool = slot.Index };
+						_cachedDataTransformed ? _transform.Read : IdentityChunkReadTransform.Instance) { PositionInPool = slot.Index };
 				}
 
 				return memoryWorkItem;
@@ -1079,7 +1080,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				// change or become invalid, so we don't use them. Instead fallback to filestream.
 				Debug.Assert(_sharedMemStream is not null);
 
-				return new(_sharedMemStream, _cachedDataTransformed ? _transform.Read : IChunkReadTransform.Identity);
+				return new(_sharedMemStream, _cachedDataTransformed ? _transform.Read : IdentityChunkReadTransform.Instance);
 			}
 
 			if (!IsReadOnly) {
@@ -1261,7 +1262,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 				var streamToUse = new ChunkDataReadStream(stream);
 				streamToUse = (_cachedDataTransformed
 					? _transform.Read
-					: IChunkReadTransform.Identity).TransformData(streamToUse);
+					: IdentityChunkReadTransform.Instance).TransformData(streamToUse);
 
 				reader = new TFChunkBulkDataReader(chunk: this, streamToUse: streamToUse, isMemory: true);
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
 using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.TransactionLog.Chunks {
@@ -22,7 +23,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			Ensure.NotNull(config, "config");
 
 			Config = config;
-			TransformManager = transformManager ?? new DbTransformManager([IDbTransform.Identity], IDbTransform.Identity.Type);
+			TransformManager = transformManager ?? new DbTransformManager(new [] { new IdentityDbTransform() }, TransformType.Identity);
 			_tracker = tracker ?? new TFChunkTracker.NoOp();
 			Manager = new TFChunkManager(Config, _tracker, TransformManager);
 			_log = log ?? Serilog.Log.ForContext<TFChunkDb>();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using EventStore.Common.Utils;
 using System.Linq;
 using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.TransactionLog.Chunks {
@@ -109,7 +110,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				// since the raw data being replicated is already transformed, we use
 				// the identity transform as we don't want to transform the data again
 				// when appending raw data to the chunk.
-				IChunkTransformFactory.Identity,
+				new IdentityChunkTransformFactory(),
 				ReadOnlyMemory<byte>.Empty);
 		}
 

--- a/src/EventStore.Core/Transforms/IChunkReadTransform.cs
+++ b/src/EventStore.Core/Transforms/IChunkReadTransform.cs
@@ -1,18 +1,5 @@
-using DotNext.Patterns;
-
 namespace EventStore.Core.Transforms;
 
 public interface IChunkReadTransform {
 	ChunkDataReadStream TransformData(ChunkDataReadStream stream);
-
-	public static IChunkReadTransform Identity => IdentityChunkReadTransform.Instance;
-}
-
-file sealed class IdentityChunkReadTransform : IChunkReadTransform, ISingleton<IdentityChunkReadTransform> {
-	public static IdentityChunkReadTransform Instance { get; } = new();
-
-	private IdentityChunkReadTransform() {
-	}
-
-	public ChunkDataReadStream TransformData(ChunkDataReadStream stream) => stream;
 }

--- a/src/EventStore.Core/Transforms/IChunkTransform.cs
+++ b/src/EventStore.Core/Transforms/IChunkTransform.cs
@@ -3,11 +3,4 @@ namespace EventStore.Core.Transforms;
 public interface IChunkTransform {
 	IChunkReadTransform Read { get; }
 	IChunkWriteTransform Write { get; }
-
-	public static IChunkTransform CreateIdentityTransform() => new IdentityChunkTransform();
-}
-
-file sealed class IdentityChunkTransform : IChunkTransform {
-	public IChunkReadTransform Read => IChunkReadTransform.Identity;
-	public IChunkWriteTransform Write { get; } = IChunkWriteTransform.CreateIdentityTransform();
 }

--- a/src/EventStore.Core/Transforms/IChunkTransformFactory.cs
+++ b/src/EventStore.Core/Transforms/IChunkTransformFactory.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using DotNext.Patterns;
 
 namespace EventStore.Core.Transforms;
 
@@ -10,20 +9,4 @@ public interface IChunkTransformFactory {
 	ReadOnlyMemory<byte> CreateTransformHeader();
 	ReadOnlyMemory<byte> ReadTransformHeader(Stream stream);
 	IChunkTransform CreateTransform(ReadOnlyMemory<byte> transformHeader);
-
-	public static IChunkTransformFactory Identity => IdentityChunkTransformFactory.Instance;
-}
-
-file sealed class IdentityChunkTransformFactory : IChunkTransformFactory, ISingleton<IdentityChunkTransformFactory> {
-	public static IdentityChunkTransformFactory Instance { get; } = new();
-
-	private IdentityChunkTransformFactory() {
-
-	}
-
-	public TransformType Type => TransformType.Identity;
-	public int TransformDataPosition(int dataPosition) => dataPosition;
-	public ReadOnlyMemory<byte> CreateTransformHeader() => ReadOnlyMemory<byte>.Empty;
-	public ReadOnlyMemory<byte> ReadTransformHeader(Stream stream) => ReadOnlyMemory<byte>.Empty;
-	public IChunkTransform CreateTransform(ReadOnlyMemory<byte> transformHeader) => IChunkTransform.CreateIdentityTransform();
 }

--- a/src/EventStore.Core/Transforms/IChunkWriteTransform.cs
+++ b/src/EventStore.Core/Transforms/IChunkWriteTransform.cs
@@ -6,33 +6,4 @@ public interface IChunkWriteTransform {
 	ChunkDataWriteStream TransformData(ChunkDataWriteStream stream);
 	void CompleteData(int footerSize, int alignmentSize);
 	void WriteFooter(ReadOnlySpan<byte> footer, out int fileSize);
-
-	public static IChunkWriteTransform CreateIdentityTransform() => new IdentityChunkWriteTransform();
-}
-
-file sealed class IdentityChunkWriteTransform : IChunkWriteTransform {
-	private ChunkDataWriteStream _stream;
-
-	public ChunkDataWriteStream TransformData(ChunkDataWriteStream stream) {
-		_stream = stream;
-		return _stream;
-	}
-
-	public void CompleteData(int footerSize, int alignmentSize) {
-		var chunkHeaderAndDataSize = (int)_stream.Position;
-		var alignedSize = GetAlignedSize(chunkHeaderAndDataSize + footerSize, alignmentSize);
-		var paddingSize = alignedSize - chunkHeaderAndDataSize - footerSize;
-		if (paddingSize > 0)
-			_stream.Write(new byte[paddingSize]);
-	}
-
-	public void WriteFooter(ReadOnlySpan<byte> footer, out int fileSize) {
-		_stream.ChunkFileStream.Write(footer);
-		fileSize = (int)_stream.Length;
-	}
-
-	private static int GetAlignedSize(int size, int alignmentSize) {
-		if (size % alignmentSize == 0) return size;
-		return (size / alignmentSize + 1) * alignmentSize;
-	}
 }

--- a/src/EventStore.Core/Transforms/IDbTransform.cs
+++ b/src/EventStore.Core/Transforms/IDbTransform.cs
@@ -1,23 +1,7 @@
-using DotNext.Patterns;
-
 namespace EventStore.Core.Transforms;
 
 public interface IDbTransform {
 	string Name { get; }
 	TransformType Type { get; }
 	IChunkTransformFactory ChunkFactory { get; }
-
-	public static IDbTransform Identity => IdentityDbTransform.Instance;
-}
-
-file sealed class IdentityDbTransform : IDbTransform, ISingleton<IdentityDbTransform> {
-	public static IdentityDbTransform Instance { get; } = new();
-
-	private IdentityDbTransform() {
-
-	}
-
-	public string Name => "identity";
-	public TransformType Type => TransformType.Identity;
-	public IChunkTransformFactory ChunkFactory => IChunkTransformFactory.Identity;
 }

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkReadTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkReadTransform.cs
@@ -1,0 +1,11 @@
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityChunkReadTransform : IChunkReadTransform {
+	public static readonly IdentityChunkReadTransform Instance = new();
+
+	private IdentityChunkReadTransform() {
+
+	}
+
+	public ChunkDataReadStream TransformData(ChunkDataReadStream stream) => stream;
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkTransform.cs
@@ -1,0 +1,6 @@
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityChunkTransform : IChunkTransform {
+	public IChunkReadTransform Read => IdentityChunkReadTransform.Instance;
+	public IChunkWriteTransform Write { get; } = new IdentityChunkWriteTransform();
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkTransformFactory.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkTransformFactory.cs
@@ -1,0 +1,12 @@
+using System;
+using System.IO;
+
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityChunkTransformFactory : IChunkTransformFactory {
+	public TransformType Type => TransformType.Identity;
+	public int TransformDataPosition(int dataPosition) => dataPosition;
+	public ReadOnlyMemory<byte> CreateTransformHeader() => ReadOnlyMemory<byte>.Empty;
+	public ReadOnlyMemory<byte> ReadTransformHeader(Stream stream) => ReadOnlyMemory<byte>.Empty;
+	public IChunkTransform CreateTransform(ReadOnlyMemory<byte> transformHeader) => new IdentityChunkTransform();
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkWriteTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkWriteTransform.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityChunkWriteTransform : IChunkWriteTransform {
+	private ChunkDataWriteStream _stream;
+
+	public ChunkDataWriteStream TransformData(ChunkDataWriteStream stream) {
+		_stream = stream;
+		return _stream;
+	}
+
+	public void CompleteData(int footerSize, int alignmentSize) {
+		var chunkHeaderAndDataSize = (int)_stream.Position;
+		var alignedSize = GetAlignedSize(chunkHeaderAndDataSize + footerSize, alignmentSize);
+		var paddingSize = alignedSize - chunkHeaderAndDataSize - footerSize;
+		if (paddingSize > 0)
+			_stream.Write(new byte[paddingSize]);
+	}
+
+	public void WriteFooter(ReadOnlySpan<byte> footer, out int fileSize) {
+		_stream.ChunkFileStream.Write(footer);
+		fileSize = (int)_stream.Length;
+	}
+
+	private static int GetAlignedSize(int size, int alignmentSize) {
+		if (size % alignmentSize == 0) return size;
+		return (size / alignmentSize + 1) * alignmentSize;
+	}
+}

--- a/src/EventStore.Core/Transforms/Identity/IdentityDbTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityDbTransform.cs
@@ -1,0 +1,7 @@
+namespace EventStore.Core.Transforms.Identity;
+
+public sealed class IdentityDbTransform : IDbTransform {
+	public string Name => "identity";
+	public TransformType Type => TransformType.Identity;
+	public IChunkTransformFactory ChunkFactory { get; } = new IdentityChunkTransformFactory();
+}


### PR DESCRIPTION
Changed: Internal changes

This reverts commit 2b58fb9f7100337755399e4b450269f3be2fc199.

There are other PRs in the queue that conflict this this change and it will be easier to remove it and reapply it again as appropriate