### PR TITLE
Bump up EventStore.Plugins to v24.6.0-alpha9

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
@@ -188,11 +188,11 @@ public sealed class TelemetryServiceTests : IAsyncLifetime {
 
 	class FakePlugableComponent(string name = "fakeComponent") : Plugin(name) {
 		public void PublishSomeTelemetry() {
-			PublishDiagnostics(new() {
+			PublishDiagnosticsData(new() {
 				["enabled"] = Enabled
 			});
 
-			PublishDiagnostics(new() {
+			PublishDiagnosticsData(new() {
 				["foo"] = "bar"
 			});
 		}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -7,7 +7,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="EventStore.Plugins" Version="24.6.0-alpha4" />
+		<PackageReference Include="EventStore.Plugins" Version="24.6.0-alpha9" />
 		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.59.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.59.0">

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
 		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-		<PackageReference Include="EventStore.Plugins" Version="24.6.0-alpha4" />
+		<PackageReference Include="EventStore.Plugins" Version="24.6.0-alpha9" />
 		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.59.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.59.0">


### PR DESCRIPTION
Changed: Bump up EventStore.Plugins to v24.6.0-alpha9
Fixed: Telemetry service/tests following plugin interface changes