### PR TITLE
[DBX-43] Prevent GitInfo from overriding the assembly version

### DIFF
--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<GitVersion>false</GitVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
Fixed: Version numbering of EventStore.Common.dll

Brings this project into line with all the others. Previously it would come out along the lines of 0.0.1, now it will be similar to 24.6.0

This one needs special treatment because it contains the reference to the GitInfo package