### PR TITLE
[DBX-46] Workaround of Runtime/Compiler bug that causes unexpected .NET Runtime crash

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1383,14 +1383,10 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			}
 
 			[StructLayout(LayoutKind.Auto)]
-			internal readonly ref struct Slot {
-				internal readonly ref ReaderWorkItem ValueRef;
-				internal readonly int Index;
+			internal readonly ref struct Slot(ReaderWorkItem[] array, int index) {
+				public int Index => index;
 
-				public Slot(ReaderWorkItem[] array, int index) {
-					ValueRef = ref UnsafeGetElement(array, index);
-					Index = index;
-				}
+				public ref ReaderWorkItem ValueRef => ref UnsafeGetElement(array, index);
 			}
 		}
 	}


### PR DESCRIPTION
Changed: internal changes to code introduced during this release

For .NET Runtime version `< 8.0.3XX` there is a bug in Runtime or Roslyn that leads to runtime crash. The crash is caused by `ref` field. The proposed change replaces `ref` field with a regular field.