### PR TITLE
[DBX-49] Support old persistent subscription checkpoints

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionCheckpointReaderTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionCheckpointReaderTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.PersistentSubscription;
+
+public class PersistentSubscriptionCheckpointReaderTests {
+	[TestCase("SubscriptionCheckpoint")] // old checkpoints
+	[TestCase("$SubscriptionCheckpoint")] // new checkpoints
+	public void can_read_checkpoints(string checkpointEventType) {
+		var bus = new InMemoryBus("persistent subscription test bus");
+
+		bus.Subscribe(new AdHocHandler<Messages.ClientMessage.ReadStreamEventsBackward>(msg => {
+			var lastEventNumber = msg.FromEventNumber + 1;
+			var nextEventNumber = lastEventNumber + 1;
+
+			var events = IODispatcherTestHelpers.CreateResolvedEvent<LogFormat.V2, string>(
+				stream: msg.EventStreamId,
+				eventType: checkpointEventType,
+				data: "\"the checkpoint data\"");
+
+			msg.Envelope.ReplyWith(new Messages.ClientMessage.ReadStreamEventsBackwardCompleted(
+				correlationId: msg.CorrelationId,
+				eventStreamId: msg.EventStreamId,
+				fromEventNumber: msg.FromEventNumber,
+				maxCount: msg.MaxCount,
+				result: Data.ReadStreamResult.Success,
+				events: events,
+				streamMetadata: null,
+				isCachePublic: false,
+				error: "",
+				nextEventNumber: nextEventNumber,
+				lastEventNumber: lastEventNumber,
+				isEndOfStream: false,
+				tfLastCommitPosition: 0));
+		}));
+
+		var ioDispatcher = new IODispatcher(bus, new PublishEnvelope(bus));
+		IODispatcherTestHelpers.SubscribeIODispatcher(ioDispatcher, bus);
+		var sut = new PersistentSubscriptionCheckpointReader(ioDispatcher);
+
+		var loadedState = "";
+		sut.BeginLoadState("subscriptionA", state => {
+			loadedState = state;
+		});
+
+		AssertEx.IsOrBecomesTrue(() => loadedState == "the checkpoint data");
+	}
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointReader.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointReader.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Linq;
 using EventStore.Common.Utils;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
@@ -30,11 +29,13 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 			public void LoadStateCompleted(ClientMessage.ReadStreamEventsBackwardCompleted msg) {
 				if (msg.Events.Length > 0) {
-					var checkpoint = msg.Events.Where(v => v.Event.EventType == "$SubscriptionCheckpoint")
-						.Select(x => x.Event).FirstOrDefault();
-					if (checkpoint != null) {
-						string lastEvent = checkpoint.Data.ParseJson<string>();
-						_onStateLoaded(lastEvent);
+					var checkpoint = msg.Events[0].Event;
+
+					if (checkpoint.EventType == "SubscriptionCheckpoint" ||
+						checkpoint.EventType == "$SubscriptionCheckpoint") {
+				
+						var checkpointJson = checkpoint.Data.ParseJson<string>();
+						_onStateLoaded(checkpointJson);
 						return;
 					}
 				}


### PR DESCRIPTION
Fixed: A bug that was introduced during this release. Old persistent subscription checkpoints are now supported again

Recently (during this release) the checkpoint type was changed to include a $ at the front since it is a system event.
However we still need to support checkpoints written before the change, which is what this commit does.

https://github.com/EventStore/EventStore/pull/4213/files