### PR TITLE
Prevent 64bit integer overflow calculating midpoint indexes

### DIFF
--- a/src/EventStore.Core.Tests/Index/IndexV4/ptable_midpoint_calculations_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV4/ptable_midpoint_calculations_should.cs
@@ -61,5 +61,16 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 		public void construct_same_midpoint_indexes_for_any_combination_of_params_small() {
 			construct_same_midpoint_indexes_for_any_combination_of_params(200);
 		}
+
+		[Test]
+		public void return_a_positive_index_even_for_really_big_ptables() {
+			var depth = 28;
+			var index = PTable.GetMidpointIndex(
+				k: 265_000_000,
+				numIndexEntries: 46_000_000_000,
+				numMidpoints: 2L << depth);
+
+			Assert.Positive(index);
+		}
 	}
 }

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -831,8 +831,12 @@ namespace EventStore.Core.Index {
 		}
 
 		public static long GetMidpointIndex(long k, long numIndexEntries, long numMidpoints) {
-			if (numIndexEntries == 1 && numMidpoints == 2 && (k == 0 || k == 1)) return 0;
-			return (long)k * (numIndexEntries - 1) / (numMidpoints - 1);
+			if (numIndexEntries == 1 && numMidpoints == 2 && (k == 0 || k == 1))
+				return 0;
+
+			// float so that we don't overflow the long in large ptables
+			var index = (float)k * (numIndexEntries - 1) / (numMidpoints - 1);
+			return (long)index;
 		}
 
 		public static bool IsMidpointIndex(long index, long numIndexEntries, long numMidpoints) {


### PR DESCRIPTION
tbd: is it safe to do it with floats?