### PR TITLE
[DBX-51-3][DBX-51-4] Prevent 64-bit integer overflow in GetMidpointIndex() / IsMidpointIndex()

### DIFF
--- a/src/EventStore.Core.Tests/Index/IndexV1/corrupt_index_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/corrupt_index_should.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			else if (version == PTableVersions.IndexV4)
 				indexEntryKeySize = PTable.IndexKeyV4Size;
 
-			uint numMidpoints = PTable.GetRequiredMidpointCountCached(numIndexEntries, version);
+			int numMidpoints = PTable.GetRequiredMidpointCountCached(numIndexEntries, version);
 
 			byte[] data = new byte[255];
 

--- a/src/EventStore.Core.Tests/Index/IndexV4/Utils.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV4/Utils.cs
@@ -1,0 +1,24 @@
+using System.Numerics;
+
+namespace EventStore.Core.Tests.Index.IndexV4;
+
+public static class Utils {
+	public static bool IsMidpointIndex(long index, long numIndexEntries, int numMidpoints) {
+		//special cases
+		if (numIndexEntries < 1) return false;
+		if (numIndexEntries == 1) {
+			if (numMidpoints == 2 && index == 0) return true;
+			return false;
+		}
+
+		//a midpoint index entry satisfies:
+		//index = floor (k * (numIndexEntries - 1) / (numMidpoints - 1));    for k = 0 to numMidpoints-1
+		//we need to find if there exists an integer x, such that:
+		//index*(numMidpoints-1)/(numIndexEntries-1) <= x < (index+1)*(numMidpoints-1)/(numIndexEntries-1)
+		var lower = (BigInteger) index * (numMidpoints - 1) / (numIndexEntries - 1);
+		if (((BigInteger) index * (numMidpoints - 1)) % (numIndexEntries - 1) != 0) lower++;
+		var upper = (BigInteger) (index + 1) * (numMidpoints - 1) / (numIndexEntries - 1);
+		if (((BigInteger) (index + 1) * (numMidpoints - 1)) % (numIndexEntries - 1) == 0) upper--;
+		return lower <= upper;
+	}
+}

--- a/src/EventStore.Core.Tests/Index/IndexV4/ptable_midpoint_calculations_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV4/ptable_midpoint_calculations_should.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 
 					List<long> calculatedMidpoints = new List<long>();
 					for (var k = 0; k < numIndexEntries; k++) {
-						if (PTable.IsMidpointIndex(k, numIndexEntries, requiredMidpointsCount)) {
+						if (Utils.IsMidpointIndex(k, numIndexEntries, requiredMidpointsCount)) {
 							calculatedMidpoints.Add(k);
 						}
 					}

--- a/src/EventStore.Core.Tests/Index/IndexV4/ptable_midpoint_calculations_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV4/ptable_midpoint_calculations_should.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using EventStore.Core.Index;
 using NUnit.Framework;
 using ILogger = Serilog.ILogger;
@@ -60,6 +61,41 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 		[Test]
 		public void construct_same_midpoint_indexes_for_any_combination_of_params_small() {
 			construct_same_midpoint_indexes_for_any_combination_of_params(200);
+		}
+
+		[Test]
+		public void return_a_positive_index_even_for_really_big_ptables() {
+			var depth = 28;
+			var index = PTable.GetMidpointIndex(
+				k: 265_000_000,
+				numIndexEntries: 46_000_000_000,
+				numMidpoints: 1 << depth);
+
+			Assert.Positive(index);
+		}
+
+		[Test]
+		public void return_correct_indexes_for_really_big_ptables() {
+			var numIndexEntries = 46_000_000_000;
+			var numMidpoints = 1 << 28;
+
+			for (var k = numMidpoints - 1000; k < numMidpoints; k++) {
+				var index = PTable.GetMidpointIndex(k, numIndexEntries, numMidpoints);
+				var correctIndex = GetMidpointIndexBigInt(k, numIndexEntries, numMidpoints);
+				Assert.Positive(correctIndex);
+				Assert.AreEqual(correctIndex, index);
+			}
+		}
+
+		private static long GetMidpointIndexBigInt(int k, long numIndexEntries, int numMidpoints) {
+			if (k == 0)
+				return 0;
+
+			if (k == numMidpoints - 1)
+				return numIndexEntries - 1;
+
+			var res = (BigInteger)k * (numIndexEntries - 1) / (numMidpoints - 1);
+			return (long)res;
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Index/IndexV4/when_merging_ptables_with_entries_to_nonexisting_record.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV4/when_merging_ptables_with_entries_to_nonexisting_record.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 
 			var position = 0;
 			foreach (var item in _newtable.IterateAllInOrder()) {
-				if (PTable.IsMidpointIndex(position, _newtable.Count, requiredMidpoints)) {
+				if (Utils.IsMidpointIndex(position, _newtable.Count, requiredMidpoints)) {
 					Assert.AreEqual(item.Stream, midpoints[position].Key.Stream);
 					Assert.AreEqual(item.Version, midpoints[position].Key.Version);
 					Assert.AreEqual(position, midpoints[position].ItemIndex);

--- a/src/EventStore.Core.XUnit.Tests/Index/MidpointIndexCalculatorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Index/MidpointIndexCalculatorTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using EventStore.Core.Index;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Index;
+
+public class MidpointIndexCalculatorTests {
+	[Fact]
+	public void return_correct_next_indexes() {
+		const int numIndexEntries = 100_000;
+		const int numMidpoints = 1 << 10;
+
+		var expectedMidpoints = new List<long>();
+		for (var i = 0; i < numMidpoints; i++)
+			expectedMidpoints.Add(PTable.GetMidpointIndex(i, numIndexEntries, numMidpoints));
+
+		var sut = new PTable.MidpointIndexCalculator(numIndexEntries, numMidpoints);
+		Assert.Equal(expectedMidpoints, ConsumeAll(sut));
+	}
+
+	[Fact]
+	public void return_correct_result_when_num_midpoints_is_zero() {
+		var sut = new PTable.MidpointIndexCalculator(numIndexEntries: 10, numMidpoints: 0);
+		Assert.Equal([], ConsumeAll(sut));
+	}
+
+	[Fact]
+	public void return_correct_result_when_num_index_entries_is_zero() {
+		var sut = new PTable.MidpointIndexCalculator(numIndexEntries: 0, numMidpoints: 2);
+		Assert.Equal([], ConsumeAll(sut));
+	}
+
+	[Fact]
+	public void return_correct_result_when_num_index_entries_is_one() {
+		var sut = new PTable.MidpointIndexCalculator(numIndexEntries: 1, numMidpoints: 2);
+		Assert.Equal([0, 0], ConsumeAll(sut));
+	}
+
+	[Fact]
+	public void return_correct_result_when_num_index_entries_is_large() {
+		const long numIndexEntries = 46_000_000_000;
+		const int numMidpoints = 1 << 28;
+
+		var sut = new PTable.MidpointIndexCalculator(numIndexEntries, numMidpoints, numMidpoints - 2);
+		Assert.Equal(
+			[
+				45_999_999_827,
+				45_999_999_999,
+			],
+			ConsumeAll(sut));
+	}
+
+	static IEnumerable<long> ConsumeAll(PTable.MidpointIndexCalculator sut) {
+		while (sut.NextMidpointIndex is not null) {
+			yield return sut.NextMidpointIndex.Value;
+			sut.Advance();
+		}
+	}
+}

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -567,7 +567,7 @@ namespace EventStore.Core.Index {
 		}
 
 		private static void ComputeMidpoints(BufferedStream bs, FileStream fs, byte version,
-			int indexEntrySize, long numIndexEntries, long requiredMidpointCount, UnmanagedMemoryAppendOnlyList<Midpoint> midpoints,
+			int indexEntrySize, long numIndexEntries, int requiredMidpointCount, UnmanagedMemoryAppendOnlyList<Midpoint> midpoints,
 			CancellationToken ct = default(CancellationToken)) {
 			int indexKeySize;
 			if (version == PTableVersions.IndexV4)
@@ -814,25 +814,36 @@ namespace EventStore.Core.Index {
 			return minDepth;
 		}
 
-		private static uint GetRequiredMidpointCount(long numIndexEntries, byte version, int minDepth) {
+		private static int GetRequiredMidpointCount(long numIndexEntries, byte version, int minDepth) {
 			if (numIndexEntries == 0) return 0;
 			if (numIndexEntries == 1) return 2;
 
 			int indexEntrySize = GetIndexEntrySize(version);
 			var depth = GetDepth(numIndexEntries * indexEntrySize, minDepth);
-			return (uint)Math.Max(2L, Math.Min((long)1 << depth, numIndexEntries));
+			return (int)Math.Max(2L, Math.Min((long)1 << depth, numIndexEntries));
 		}
 
 
-		public static uint GetRequiredMidpointCountCached(long numIndexEntries, byte version, int minDepth = 16) {
+		public static int GetRequiredMidpointCountCached(long numIndexEntries, byte version, int minDepth = 16) {
 			if (version >= PTableVersions.IndexV4)
 				return GetRequiredMidpointCount(numIndexEntries, version, minDepth);
 			return 0;
 		}
 
-		public static long GetMidpointIndex(long k, long numIndexEntries, long numMidpoints) {
-			if (numIndexEntries == 1 && numMidpoints == 2 && (k == 0 || k == 1)) return 0;
-			return (long)k * (numIndexEntries - 1) / (numMidpoints - 1);
+		public static long GetMidpointIndex(int k, long numIndexEntries, int numMidpoints) {
+			ArgumentOutOfRangeException.ThrowIfNegativeOrZero(numIndexEntries);
+			ArgumentOutOfRangeException.ThrowIfNegative(k);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(k, numMidpoints);
+
+			if (k == 0)
+				return 0;
+
+			if (k == numMidpoints - 1)
+				return numIndexEntries - 1;
+
+			// k * (numIndexEntries - 1) / (numMidpoints - 1), avoiding 64-bit integer overflows
+			var (q, r) = long.DivRem(numIndexEntries - 1, numMidpoints - 1);
+			return k * q + k * r / (numMidpoints - 1);
 		}
 
 		public static bool IsMidpointIndex(long index, long numIndexEntries, long numMidpoints) {

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -85,14 +85,17 @@ namespace EventStore.Core.Index {
 					var requiredMidpointCount = GetRequiredMidpointCountCached(table.Count, table.Version, cacheDepth);
 					using var midpoints = new UnmanagedMemoryAppendOnlyList<Midpoint>((int)requiredMidpointCount + MidpointsOverflowSafetyNet);
 
+					var midpointCalculator = new MidpointIndexCalculator(table.Count, requiredMidpointCount);
 					long indexEntry = 0L;
+
 					ulong? previousHash = null;
 					foreach (var rec in records) {
 						AppendRecordTo(bs, buffer, table.Version, rec, indexEntrySize);
 						dumpedEntryCount += 1;
 						if (table.Version >= PTableVersions.IndexV4 &&
-						    IsMidpointIndex(indexEntry, table.Count, requiredMidpointCount)) {
+							indexEntry == midpointCalculator.NextMidpointIndex) {
 							midpoints.Add(new Midpoint(new IndexEntryKey(rec.Stream, rec.Version), indexEntry));
+							midpointCalculator.Advance();
 						}
 
 						// WRITE BLOOM FILTER ENTRY
@@ -116,6 +119,13 @@ namespace EventStore.Core.Index {
 								GetRequiredMidpointCount(numIndexEntries, table.Version, cacheDepth);
 							ComputeMidpoints(bs, fs, table.Version, indexEntrySize, numIndexEntries,
 								requiredMidpointCount, midpoints);
+						}
+
+						if (midpoints.Count > 0) {
+							if (midpoints[0].ItemIndex != 0)
+								throw new Exception("First midpoint was not the first index entry");
+							if (midpoints[^1].ItemIndex != numIndexEntries - 1)
+								throw new Exception("Last midpoint was not the last index entry");
 						}
 
 						WriteMidpointsTo(bs, fs, table.Version, indexEntrySize, buffer, dumpedEntryCount,
@@ -190,10 +200,12 @@ namespace EventStore.Core.Index {
 						cs.Write(headerBytes, 0, headerBytes.Length);
 
 						var buffer = new byte[indexEntrySize];
-						long indexEntry = 0L;
-						var requiredMidpointCount =
-							GetRequiredMidpointCountCached(numIndexEntries, version, cacheDepth);
+
+						var requiredMidpointCount = GetRequiredMidpointCountCached(numIndexEntries, version, cacheDepth);
 						using var midpoints = new UnmanagedMemoryAppendOnlyList<Midpoint>((int)requiredMidpointCount + MidpointsOverflowSafetyNet);
+
+						var midpointCalculator = new MidpointIndexCalculator(numIndexEntries, requiredMidpointCount);
+						long indexEntry = 0L;
 
 						// WRITE INDEX ENTRIES
 						ulong? previousHash = null;
@@ -202,9 +214,9 @@ namespace EventStore.Core.Index {
 							var current = enumerators[idx].Current;
 							AppendRecordTo(bs, buffer, version, current, indexEntrySize);
 							if (version >= PTableVersions.IndexV4 &&
-								IsMidpointIndex(indexEntry, numIndexEntries, requiredMidpointCount)) {
-								midpoints.Add(new Midpoint(new IndexEntryKey(current.Stream, current.Version),
-									indexEntry));
+								indexEntry == midpointCalculator.NextMidpointIndex) {
+								midpoints.Add(new Midpoint(new IndexEntryKey(current.Stream, current.Version), indexEntry));
+								midpointCalculator.Advance();
 							}
 
 							// WRITE BLOOM FILTER ENTRY
@@ -232,6 +244,13 @@ namespace EventStore.Core.Index {
 								requiredMidpointCount = GetRequiredMidpointCount(numIndexEntries, version, cacheDepth);
 								ComputeMidpoints(bs, f, version, indexEntrySize, numIndexEntries,
 									requiredMidpointCount, midpoints);
+							}
+
+							if (midpoints.Count > 0) {
+								if (midpoints[0].ItemIndex != 0)
+									throw new Exception("First midpoint was not the first index entry");
+								if (midpoints[^1].ItemIndex != numIndexEntries - 1)
+									throw new Exception("Last midpoint was not the last index entry");
 							}
 
 							WriteMidpointsTo(bs, f, version, indexEntrySize, buffer, dumpedEntryCount, numIndexEntries,
@@ -310,10 +329,12 @@ namespace EventStore.Core.Index {
 
 						// WRITE INDEX ENTRIES
 						var buffer = new byte[indexEntrySize];
-						long indexEntry = 0L;
 						var requiredMidpointCount =
 							GetRequiredMidpointCountCached(numIndexEntries, version, cacheDepth);
 						using var midpoints = new UnmanagedMemoryAppendOnlyList<Midpoint>((int)requiredMidpointCount + MidpointsOverflowSafetyNet);
+
+						var midpointCalculator = new MidpointIndexCalculator(numIndexEntries, requiredMidpointCount);
+						long indexEntry = 0L;
 
 						var enum1 = enumerators[0];
 						var enum2 = enumerators[1];
@@ -337,9 +358,10 @@ namespace EventStore.Core.Index {
 
 							AppendRecordTo(bs, buffer, version, current, indexEntrySize);
 							if (version >= PTableVersions.IndexV4 &&
-							    IsMidpointIndex(indexEntry, numIndexEntries, requiredMidpointCount)) {
+								indexEntry == midpointCalculator.NextMidpointIndex) {
 								midpoints.Add(new Midpoint(new IndexEntryKey(current.Stream, current.Version),
 									indexEntry));
+								midpointCalculator.Advance();
 							}
 
 							// WRITE BLOOM FILTER ENTRY
@@ -362,6 +384,13 @@ namespace EventStore.Core.Index {
 								requiredMidpointCount = GetRequiredMidpointCount(numIndexEntries, version, cacheDepth);
 								ComputeMidpoints(bs, f, version, indexEntrySize, numIndexEntries,
 									requiredMidpointCount, midpoints);
+							}
+
+							if (midpoints.Count > 0) {
+								if (midpoints[0].ItemIndex != 0)
+									throw new Exception("First midpoint was not the first index entry");
+								if (midpoints[^1].ItemIndex != numIndexEntries - 1)
+									throw new Exception("Last midpoint was not the last index entry");
 							}
 
 							WriteMidpointsTo(bs, f, version, indexEntrySize, buffer, dumpedEntryCount, numIndexEntries,
@@ -846,23 +875,37 @@ namespace EventStore.Core.Index {
 			return k * q + k * r / (numMidpoints - 1);
 		}
 
-		public static bool IsMidpointIndex(long index, long numIndexEntries, long numMidpoints) {
-			//special cases
-			if (numIndexEntries < 1) return false;
-			if (numIndexEntries == 1) {
-				if (numMidpoints == 2 && index == 0) return true;
-				return false;
+		public class MidpointIndexCalculator {
+			private readonly long _numIndexEntries;
+			private readonly int _numMidpoints;
+			private int _midpointNumber;
+
+			public MidpointIndexCalculator(long numIndexEntries, int numMidpoints, int initialMidpointNumber = 0) {
+				ArgumentOutOfRangeException.ThrowIfNegative(numIndexEntries);
+				ArgumentOutOfRangeException.ThrowIfNegative(numMidpoints);
+
+				_numIndexEntries = numIndexEntries;
+				_numMidpoints = numMidpoints;
+				_midpointNumber = initialMidpointNumber;
+				Advance();
 			}
 
-			//a midpoint index entry satisfies:
-			//index = floor (k * (numIndexEntries - 1) / (numMidpoints - 1));    for k = 0 to numMidpoints-1
-			//we need to find if there exists an integer x, such that:
-			//index*(numMidpoints-1)/(numIndexEntries-1) <= x < (index+1)*(numMidpoints-1)/(numIndexEntries-1)
-			var lower = index * (numMidpoints - 1) / (numIndexEntries - 1);
-			if ((index * (numMidpoints - 1)) % (numIndexEntries - 1) != 0) lower++;
-			var upper = (index + 1) * (numMidpoints - 1) / (numIndexEntries - 1);
-			if (((index + 1) * (numMidpoints - 1)) % (numIndexEntries - 1) == 0) upper--;
-			return lower <= upper;
+			public long? NextMidpointIndex { get; private set; }
+
+			public void Advance() {
+				if (_numIndexEntries == 0) {
+					NextMidpointIndex = null;
+					return;
+				}
+
+				if (_midpointNumber >= _numMidpoints) {
+					// no more midpoints
+					NextMidpointIndex = null;
+					return;
+				}
+
+				NextMidpointIndex = GetMidpointIndex(_midpointNumber++, _numIndexEntries, _numMidpoints);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixed: Prevent 64-bit integer overflow in GetMidpointIndex() / IsMidpointIndex()

This PR fixes overflow bugs present in `GetMidpointIndex()` & `IsMidpointIndex()`. The bugs affect PTables that are very large - roughly around 1TB in size.

The overflow bugs would cause symptoms similar to the following to be visible in the server logs:

```
Not caching index midpoints to PTable due to count mismatch. Table entries: 47071332204 / Dumped entries: 47071332204, Required midpoint count: 268435456 /  Actual midpoint count: 268435455
```


```
EXCEPTION OCCURRED
System.ComponentModel.Win32Exception (0x80004005): An attempt was made to move the file pointer before the beginning of the file
   at EventStore.Core.TransactionLog.Unbuffered.NativeFileWindows.Seek(SafeFileHandle handle, Int64 position, SeekOrigin origin) in C:\..\src\EventStore.Native\TransactionLog\Unbuffered\NativeFileWindows.cs:line 96
   at EventStore.Core.TransactionLog.Unbuffered.UnbufferedFileStream.Seek(Int64 offset, SeekOrigin origin) in C:\..\src\EventStore.Core\TransactionLog\Unbuffered\UnbufferedFileStream.cs:line 146
   at EventStore.Core.Index.PTable.CacheMidpointsAndVerifyHash(Int32 depth, Boolean skipIndexVerify) in C:\..\src\EventStore.Core\Index\PTable.cs:line 361
   at EventStore.Core.Index.PTable..ctor(String filename, Guid id, Int32 initialReaders, Int32 maxReaders, Int32 depth, Boolean skipIndexVerify) in C:\..\src\EventStore.Core\Index\PTable.cs:line 207
```
(the above error would be slightly different on linux)