### PR TITLE
Serilog packages update & minor logging improvements

### DIFF
--- a/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
+++ b/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
@@ -3,6 +3,6 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="Serilog" Version="3.1.1" />
+	  <PackageReference Include="Serilog" Version="4.0.0" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
+++ b/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
@@ -3,6 +3,6 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="Serilog" Version="4.0.0" />
+	  <PackageReference Include="Serilog" Version="4.0.1" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
-		<PackageReference Include="Serilog" Version="4.0.0" />
+		<PackageReference Include="Serilog" Version="4.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
 		<PackageReference Include="Serilog.Expressions" Version="5.0.0" />

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -15,15 +15,17 @@
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Serilog" Version="3.1.1" />
-		<PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
-		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-		<PackageReference Include="Serilog.Expressions" Version="4.0.0" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-		<PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
-		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+
+		<PackageReference Include="Serilog" Version="4.0.0" />
+		<PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+		<PackageReference Include="Serilog.Expressions" Version="5.0.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
+		<PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="YamlDotnet" Version="13.7.1" />

--- a/src/EventStore.Core/Configuration/EventStoreConfiguration.cs
+++ b/src/EventStore.Core/Configuration/EventStoreConfiguration.cs
@@ -2,13 +2,8 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using EventStore.Common.Configuration;
-using EventStore.Common.Utils;
 using EventStore.Core.Configuration.Sources;
-using EventStore.Core.Util;
 using Microsoft.Extensions.Configuration;
 
 namespace EventStore.Core.Configuration {
@@ -39,6 +34,12 @@ namespace EventStore.Core.Configuration {
 				// Load all json files in the  `config` subdirectory (if it exists) of each configuration
 				// directory. We use the subdirectory to ensure that we only load configuration files.
 				.AddEsdbConfigFiles("*.json")
+
+				#if DEBUG
+				// load all json files in the current directory
+				.AddJsonFile("appsettings.json", true)
+				.AddJsonFile("appsettings.Development.json", true)
+				#endif
 
 				.AddEnvironmentVariables()
 				.AddEventStoreEnvironmentVariables(environment)

--- a/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
@@ -77,10 +77,11 @@ namespace EventStore.Common.Log {
 
 		public static bool AdjustMinimumLogLevel(LogLevel logLevel) {
 			lock (_defaultLogLevelSwitchLock) {
+#if !DEBUG
 				if (_defaultLogLevelSwitch == null) {
 					throw new InvalidOperationException("The logger configuration has not yet been initialized.");
 				}
-
+#endif
 				if (!Enum.TryParse<LogEventLevel>(logLevel.ToString(), out var serilogLogLevel)) {
 					throw new ArgumentException($"'{logLevel}' is not a valid log level.");
 				}

--- a/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
@@ -13,16 +13,19 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Filters;
 using Serilog.Templates;
+using Serilog.Templates.Themes;
 
 namespace EventStore.Common.Log {
 	public class EventStoreLoggerConfiguration {
-		private const string ConsoleOutputTemplate =
-			"[{ProcessId,5},{ThreadId,2},{Timestamp:HH:mm:ss.fff},{Level:u3}] {Message}{NewLine}{Exception}";
+		static readonly ExpressionTemplate ConsoleOutputExpressionTemplate = new(
+			"[{ProcessId,5},{ThreadId,2},{@t:HH:mm:ss.fff},{@l:u3}] {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)} {@m}\n{@x}",
+			theme: TemplateTheme.Literate
+		);
 
 		private const string CompactJsonTemplate = "{ {@t, @mt, @r, @l, @i, @x, ..@p} }\n";
 
 		public static readonly Logger ConsoleLog = StandardLoggerConfiguration
-			.WriteTo.Console(outputTemplate: ConsoleOutputTemplate)
+			.WriteTo.Console(ConsoleOutputExpressionTemplate)
 			.CreateLogger();
 
 		private static readonly Func<LogEvent, bool> RegularStats = Matching.FromSource("REGULAR-STATS-LOGGER");
@@ -67,7 +70,9 @@ namespace EventStore.Common.Log {
 			Serilog.Debugging.SelfLog.Enable(ConsoleLog.Information);
 
 			Serilog.Log.Logger = (configurationRoot.GetSection("Serilog").Exists()
-					? FromConfiguration(configurationRoot)
+					? new LoggerConfiguration()
+						.Enrich.WithProperty(Constants.SourceContextPropertyName, "EventStore")
+						.ReadFrom.Configuration(configurationRoot)
 					: Default(logsDirectory, componentName, configurationRoot, logConsoleFormat, logFileInterval,
 						logFileSize, logFileRetentionCount, disableLogFile))
 				.CreateLogger();
@@ -77,11 +82,11 @@ namespace EventStore.Common.Log {
 
 		public static bool AdjustMinimumLogLevel(LogLevel logLevel) {
 			lock (_defaultLogLevelSwitchLock) {
-#if !DEBUG
+				#if !DEBUG
 				if (_defaultLogLevelSwitch == null) {
 					throw new InvalidOperationException("The logger configuration has not yet been initialized.");
 				}
-#endif
+				#endif
 				if (!Enum.TryParse<LogEventLevel>(logLevel.ToString(), out var serilogLogLevel)) {
 					throw new ArgumentException($"'{logLevel}' is not a valid log level.");
 				}
@@ -91,9 +96,6 @@ namespace EventStore.Common.Log {
 				return true;
 			}
 		}
-
-		private static LoggerConfiguration FromConfiguration(IConfiguration configuration) =>
-			new LoggerConfiguration().ReadFrom.Configuration(configuration);
 
 		private static LoggerConfiguration Default(string logsDirectory, string componentName,
 			IConfigurationRoot logLevelConfigurationRoot, LogConsoleFormat logConsoleFormat,
@@ -150,11 +152,10 @@ namespace EventStore.Common.Log {
 			}
 
 			void Default(LoggerConfiguration configuration) {
-				if (logConsoleFormat == LogConsoleFormat.Plain) {
-					configuration.WriteTo.Console(outputTemplate: ConsoleOutputTemplate);
-				} else {
-					configuration.WriteTo.Console(new ExpressionTemplate(CompactJsonTemplate));
-				}
+				configuration.WriteTo.Console(
+					logConsoleFormat == LogConsoleFormat.Plain
+						? ConsoleOutputExpressionTemplate
+						: new(CompactJsonTemplate));
 
 				if (!disableLogFile) {
 					configuration.WriteTo
@@ -199,6 +200,7 @@ namespace EventStore.Common.Log {
 
 		private static LoggerConfiguration StandardLoggerConfiguration =>
 			new LoggerConfiguration()
+				.Enrich.WithProperty(Constants.SourceContextPropertyName, "EventStore")
 				.Enrich.WithProcessId()
 				.Enrich.WithThreadId()
 				.Enrich.FromLogContext();

--- a/src/EventStore.Core/Services/Transport/Enumerators/ReadResponseException.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/ReadResponseException.cs
@@ -41,7 +41,7 @@ public abstract class ReadResponseException : Exception {
 		public readonly Type UnknownMessageType;
 		public readonly Type ExpectedMessageType;
 
-		private UnknownMessage(Type unknownMessageType, Type expectedMessageType) {
+		public UnknownMessage(Type unknownMessageType, Type expectedMessageType) {
 			UnknownMessageType = unknownMessageType;
 			ExpectedMessageType = expectedMessageType;
 		}

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="NUnit" Version="3.14.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
+		<PackageReference Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
 		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.59.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.SystemRuntime/EventStore.SystemRuntime.csproj
+++ b/src/EventStore.SystemRuntime/EventStore.SystemRuntime.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-	  <PackageReference Include="Serilog" Version="4.0.0" />
+	  <PackageReference Include="Serilog" Version="4.0.1" />
 	  <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
 	</ItemGroup>
 

--- a/src/EventStore.SystemRuntime/EventStore.SystemRuntime.csproj
+++ b/src/EventStore.SystemRuntime/EventStore.SystemRuntime.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-	  <PackageReference Include="Serilog" Version="3.1.1" />
+	  <PackageReference Include="Serilog" Version="4.0.0" />
 	  <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Changed: upgraded all serilog packages
Changed: disabled logger init check when debugging
Changed: console logging now includes SourceContext with component name
Changed: default log uses `EventStore` as the name
Changed: when adding serilog to the host we now correctly clear all existing providers
Changed: if debug, no exception is thrown if logging was not initialized
Changed: if debug, any background service exception stops the host
Changed: if debug, configuration tries to load appsettings.json and appsettings.Development.json