### PR TITLE
[ESDB-106-18] Redaction: Return the chunk's `MinCompatibleVersion` instead of `Version` when retrieving event positions

### DIFF
--- a/src/EventStore.Core.Tests/Services/RedactionService/EventPositionTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/EventPositionTests.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.Services.RedactionService {
 			var chunk = Db.Manager.GetChunkFor(eventRecord.LogPosition);
 			var eventOffset = chunk.GetActualRawPosition(eventRecord.LogPosition);
 			var eventPosition = new EventPosition(
-				eventRecord.LogPosition, Path.GetFileName(chunk.FileName), chunk.ChunkHeader.Version, chunk.IsReadOnly, (uint)eventOffset);
+				eventRecord.LogPosition, Path.GetFileName(chunk.FileName), chunk.ChunkHeader.MinCompatibleVersion, chunk.IsReadOnly, (uint)eventOffset);
 			_positions[eventNumber].Add(eventPosition);
 		}
 

--- a/src/EventStore.Core/Services/RedactionService.cs
+++ b/src/EventStore.Core/Services/RedactionService.cs
@@ -84,7 +84,7 @@ namespace EventStore.Core.Services {
 				eventPositions[i] = new EventPosition(
 					logPosition: logPos,
 					chunkFile: Path.GetFileName(chunk.FileName),
-					chunkVersion: chunk.ChunkHeader.Version,
+					chunkVersion: chunk.ChunkHeader.MinCompatibleVersion,
 					chunkComplete: chunk.ChunkFooter is { IsCompleted: true },
 					chunkEventOffset: (uint) chunkEventOffset);
 			}


### PR DESCRIPTION
Fixed: Redaction: Return the chunk's `MinCompatibleVersion` instead of `Version` when retrieving event positions