### PR TITLE
Make changes to deletion of parked message documentation

### DIFF
--- a/docs/persistent-subscriptions.md
+++ b/docs/persistent-subscriptions.md
@@ -46,7 +46,7 @@ You can also specify the number of parked messages to replay over the HTTP endpo
 curl -i -X POST -d {} https://localhost:2113/subscriptions/{stream}/{groupnanme}/replayParked?stopAt={numberofevents} -u "admin:changeit"
 ```
 
-If you don't want to replay any of the parked messages for a subscription and want to clear them out, you can do this by deleting the parked stream like a normal stream.
+If you want to delete parked messages without replaying them, you can delete the parked messages stream. However, the parkedMessageCount parameter from the subscriptions/{stream}/{subscription}/info does not reset and will continue from the previous number even after restarting the node. To fully reset the count, delete the parked messages stream and then resign the leader node. This forces a new election and will reset the count if a new leader is chosen.
 
 ## Checkpointing
 


### PR DESCRIPTION
**Description**
Based on Ticket https://eventstore.freshdesk.com/a/tickets/111215, we should update our docs to reflect that deleting the parked messages stream is not the recommended way of deleting/clearing the stream, and that the recommended way to clear the stream is by replaying the parked events and nacking or skipping the replayed parked events.

However, if the parked events cannot be replayed due to the customer's application logic, then the parked stream can be deleted to clear out the stream. Deleting the stream however won't reset the parkedMessageCount parameter from the subscriptions/stream-name/group-name/info endpoint. To reset it to 0, they can lower the node priority of the current leader node and then resign the leader node, which would trigger a new round of elections, and with the new leader being elected, the counter would be reset to 0.

**Documentation Error**
In the current documentation , the following sentence needs to be corrected or clarified:

"If you don't want to replay any of the parked messages for a subscription and want to clear them out, you can do this by deleting the parked stream like a normal stream."

This does not mention that the ParkedMessageCount will not reset immediately and will continue from the previous value after restarting the node.

**Proposed Solution**
Update the documentation to reflect the current behavior and provide guidance on how to handle this scenario. For example:

Explain that the ParkedMessageCount does not reset immediately and continues from the previous value.
Suggest a workaround to delete the parked messages stream and then resign the leader node to start a new election, which should reset the count if a new leader is elected.

**Additional Context**
This behavior can be confusing for users who expect the count to reset to 0 after deleting the parked messages stream. Providing clear documentation will help users understand and manage this behavior effectively.