### PR TITLE
Fix gossip on single node

### DIFF
--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -76,7 +76,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				));
 				_nodes.Add(endPoint, inputBus);
 
-				var gossip = new NodeGossipService(outputBus, seedSource, memberInfo, writerCheckpoint, readerCheckpoint,
+				var gossip = new NodeGossipService(outputBus, 3, seedSource, memberInfo, writerCheckpoint, readerCheckpoint,
 					epochManager, lastCommitPosition, 0, TimeSpan.FromMilliseconds(500), TimeSpan.FromDays(1),
 					TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1800), _fakeTimeProvider);
 				inputBus.Subscribe<SystemMessage.SystemInit>(gossip);

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 
 		[SetUp]
 		public void Setup() {
-			SUT = new NodeGossipService(_bus, _gossipSeedSource, MemberInfoForVNode(_currentNode, DateTime.UtcNow),
+			SUT = new NodeGossipService(_bus, 3, _gossipSeedSource, MemberInfoForVNode(_currentNode, DateTime.UtcNow),
 				new InMemoryCheckpoint(0), new InMemoryCheckpoint(0), new FakeEpochManager(), () => 0L, 0,
 				_gossipInterval, _allowedTimeDifference, _gossipTimeout, _deadMemberRemovalPeriod, _timeProvider, _getNodeToGossipTo);
 
@@ -349,7 +349,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow))));
 		}
 	}
-	
+
 	public class if_gossip_reply_includes_es_version : NodeGossipServiceTestFixture {
 		private Message _capturedMessage;
 		protected override Message[] Given() =>
@@ -424,7 +424,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 				MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, epochNumber: 1, esVersion: "1.1.1.2"),
 				MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, epochNumber: 1, esVersion: "1.1.1.3")), _currentNode.HttpEndPoint.GetHost(), _currentNode.HttpEndPoint.GetPort());
 		}
-		
+
 		[Test]
 		public void reply_should_have_version_info() {
 			_capturedMessage.Should()

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1524,6 +1524,7 @@ namespace EventStore.Core {
 
 				var gossip = new NodeGossipService(
 					_mainQueue,
+					options.Cluster.ClusterSize,
 					gossipSeedSource,
 					memberInfo,
 					Db.Config.WriterCheckpoint.AsReadOnly(),

--- a/src/EventStore.Core/Services/Gossip/NodeGossipService.cs
+++ b/src/EventStore.Core/Services/Gossip/NodeGossipService.cs
@@ -18,6 +18,7 @@ namespace EventStore.Core.Services.Gossip {
 		private readonly ITimeProvider _timeProvider;
 
 		public NodeGossipService(IPublisher bus,
+			int clusterSize,
 			IGossipSeedSource gossipSeedSource,
 			MemberInfo memberInfo,
 			IReadOnlyCheckpoint writerCheckpoint,
@@ -31,7 +32,7 @@ namespace EventStore.Core.Services.Gossip {
 			TimeSpan deadMemberRemovalPeriod,
 			ITimeProvider timeProvider,
 			Func<MemberInfo[], MemberInfo> getNodeToGossipTo = null)
-			: base(bus, gossipSeedSource, memberInfo, gossipInterval, allowedTimeDifference, gossipTimeout, deadMemberRemovalPeriod, timeProvider, getNodeToGossipTo) {
+			: base(bus, clusterSize, gossipSeedSource, memberInfo, gossipInterval, allowedTimeDifference, gossipTimeout, deadMemberRemovalPeriod, timeProvider, getNodeToGossipTo) {
 			Ensure.NotNull(writerCheckpoint, nameof(writerCheckpoint));
 			Ensure.NotNull(chaserCheckpoint, nameof(chaserCheckpoint));
 			Ensure.NotNull(epochManager, nameof(epochManager));


### PR DESCRIPTION
Fixed: Gossip on single node

While testing https://github.com/EventStore/EventStore/pull/4224, I noticed that gossip requests were being scheduled every 100ms (the `GossipStartupInterval`) on single nodes.

The gossip interval is designed to be 100ms only for a short time after startup for faster cluster discovery, then it's increased to 2000ms. However, for single nodes, it would always stay at 100ms. This would cause unnecessary CPU usage and processing by the timer service / scheduler.

Furthermore, the gossip information (timestamp, writer checkpoint, chaser checkpoint, etc.) was never updated.

This PR fixes this by always updating the gossip information for single nodes every 2s (by default).