### PR TITLE
Support docker compose v2

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -58,8 +58,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Docker Compose Smoke Test
       run: |
-        docker-compose build
-        docker-compose up --detach
+        docker compose build
+        docker compose up --detach
         printf 'Waiting for cluster'
         timeout 60 bash -c -- 'until $(curl --output /dev/null --silent --insecure --fail https://localhost:2113/health/live); do printf '.'; sleep 2; done'
-        docker-compose down
+        docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   volumes-provisioner:
     image: hasnat/volumes-provisioner

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -189,7 +189,7 @@ Create file `docker-compose.yaml` with following content:
 Run the instance:
 
 ```bash:no-line-numbers
-docker-compose up
+docker compose up
 ```
 
 The command above would run EventStoreDB as a single node without SSL. You also get AtomPub protocol enabled, so you can get the stream browser to work in the Admin UI.


### PR DESCRIPTION
Support for docker compose v1 has been ended, and no longer runs in github actions.

- Change 'docker-compose' to 'docker compose'
- Remove obsolete 'version' from docker-compose file