### PR TITLE
[DBX-56-11] Add padding after the SourceContext in the console logging template

### DIFF
--- a/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
@@ -18,7 +18,7 @@ using Serilog.Templates.Themes;
 namespace EventStore.Common.Log {
 	public class EventStoreLoggerConfiguration {
 		static readonly ExpressionTemplate ConsoleOutputExpressionTemplate = new(
-			"[{ProcessId,5},{ThreadId,2},{@t:HH:mm:ss.fff},{@l:u3}] {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)} {@m}\n{@x}",
+			"[{ProcessId,5},{ThreadId,2},{@t:HH:mm:ss.fff},{@l:u3}] {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1), -30} {@m}\n{@x}",
 			theme: TemplateTheme.Literate
 		);
 


### PR DESCRIPTION
Added: padding after the SourceContext in the console log output

To make it easier for the eye to scan to the core part of the log message

result:
![image](https://github.com/user-attachments/assets/1c5c716b-04d0-49f0-b89b-5b7fdd7937fb)
