### PR TITLE
[DBX-56-10] Publish projections shutdown timeout check on the correct thread

### DIFF
--- a/src/EventStore.Core/Messaging/PublishEnvelope.cs
+++ b/src/EventStore.Core/Messaging/PublishEnvelope.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Threading;
 using EventStore.Core.Bus;
@@ -6,17 +7,37 @@ namespace EventStore.Core.Messaging {
 	public class PublishEnvelope : IEnvelope {
 		private readonly IPublisher _publisher;
 		private readonly int _createdOnThread;
+		private readonly string _createdOnThreadName;
 
 		public PublishEnvelope(IPublisher publisher, bool crossThread = false) {
 			_publisher = publisher;
 			_createdOnThread = crossThread ? -1 : Thread.CurrentThread.ManagedThreadId;
+			_createdOnThreadName = Thread.CurrentThread.Name;
 		}
 
 		public void ReplyWith<T>(T message) where T : Message {
-			Debug.Assert(_createdOnThread == -1 ||
-			             Thread.CurrentThread.ManagedThreadId == _createdOnThread ||
-			             _publisher is IThreadSafePublisher);
+			EnsureCorrectThread(message);
 			_publisher.Publish(message);
+		}
+
+		[Conditional("DEBUG")]
+		void EnsureCorrectThread(Message message) {
+			if (_createdOnThread == -1 ||
+				 Thread.CurrentThread.ManagedThreadId == _createdOnThread ||
+				_publisher is IThreadSafePublisher) {
+				return;
+			}
+
+			var publisher = _publisher is InMemoryBus bus
+				? bus.Name :
+				_publisher.GetType().Name;
+
+			throw new InvalidOperationException($"""
+				DEBUG: Publishing message "{message}" on the wrong thread. 
+				Publisher: {publisher}
+				Expected thread: {_createdOnThread} "{_createdOnThreadName}"
+				Actual thread: {Thread.CurrentThread.ManagedThreadId} "{Thread.CurrentThread.Name}"
+				""");
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -111,7 +111,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			} else {
 				_publisher.Publish(TimerMessage.Schedule.Create(
 					TimeSpan.FromMilliseconds(_projectionStopTimeoutMs),
-					new PublishEnvelope(_publisher),
+					new PublishEnvelope(_inputQueue),
 					new ProjectionCoreServiceMessage.StopCoreTimeout(_stopQueueId)));
 			}
 		}


### PR DESCRIPTION
Fixed: Projections shutdown timeout check is now published on the correct thread

- Previously the timeout was published on the timer thread, now we queue it for publishing on the projection core thread
- Also improved the error message produced