### PR TITLE
Support docker compose v2

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -58,8 +58,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Docker Compose Smoke Test
       run: |
-        docker-compose build
-        docker-compose up --detach
+        docker compose build
+        docker compose up --detach
         printf 'Waiting for cluster'
         timeout 60 bash -c -- 'until $(curl --output /dev/null --silent --insecure --fail https://localhost:2113/health/live); do printf '.'; sleep 2; done'
-        docker-compose down
+        docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   volumes-provisioner:
     image: hasnat/volumes-provisioner

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -194,7 +194,7 @@ Create file `docker-compose.yaml` with following content:
 Run the instance:
 
 ```bash:no-line-numbers
-docker-compose up
+docker compose up
 ```
 
 The command above would run EventStoreDB as a single node without SSL and with the legacy TCP protocol

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -32,6 +32,10 @@
 		<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
 		<PackageReference Include="YamlDotnet" Version="13.7.1" />
+		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+		<PackageReference Include="System.Text.Json" Version="8.0.4" />
+		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-447r-wph3-92pm -->
+		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.Common.Utils\EventStore.Common.Utils.csproj" />

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -11,15 +11,15 @@
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
 		<PackageReference Include="Grpc.Core" Version="2.46.6" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.59.0" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.64.0" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.10" />
 		<PackageReference Include="NUnit" Version="3.14.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.59.0">
+		<PackageReference Include="Google.Protobuf" Version="3.27.2" />
+		<PackageReference Include="Grpc.Tools" Version="2.65.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
@@ -15,9 +15,9 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="EventStore.Plugins" Version="23.10.1" />
-		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.59.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.59.0">
+		<PackageReference Include="Google.Protobuf" Version="3.27.2" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.64.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.65.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.LogV3/EventStore.LogV3.csproj
+++ b/src/EventStore.LogV3/EventStore.LogV3.csproj
@@ -7,8 +7,8 @@
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.59.0">
+		<PackageReference Include="Google.Protobuf" Version="3.27.2" />
+		<PackageReference Include="Grpc.Tools" Version="2.65.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -9,5 +9,7 @@
 		<!-- CVE-2023-29331 -->
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-447r-wph3-92pm -->
+		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -26,8 +26,8 @@
 		<PackageReference Include="NUnit" Version="3.14.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.59.0">
+		<PackageReference Include="Google.Protobuf" Version="3.27.2" />
+		<PackageReference Include="Grpc.Tools" Version="2.65.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
@@ -30,7 +30,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Grpc.Tools" Version="2.59.0">
+		<PackageReference Include="Grpc.Tools" Version="2.65.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
+++ b/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
@@ -36,6 +36,8 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<!-- upgrade because of transitive dependency vulnerability -->
 		<PackageReference Include="NuGet.Protocol" Version="6.7.1" />
+		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-447r-wph3-92pm -->
+		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 		<!-- upgrade because of transitive dependency vulnerability -->
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
@@ -12,11 +12,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
-		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
+		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.3.3" />
 		<PackageReference Include="EventStore.Plugins" Version="23.10.1" />
-		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.59.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.59.0">
+		<PackageReference Include="Google.Protobuf" Version="3.27.2" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.64.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.65.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
Fixed: Package upgrades for CVEs CVE-2024-30105 and CVE-2024-38095

Cherry picked from https://github.com/EventStore/EventStore/pull/4370 and https://github.com/EventStore/EventStore/pull/4340

Support for docker compose v1 has been ended, and no longer runs in github actions.

- Change 'docker-compose' to 'docker compose'
- Remove obsolete 'version' from docker-compose file

Fixes CVEs
- https://github.com/advisories/GHSA-447r-wph3-92pm
- https://github.com/advisories/GHSA-hh2w-p6rv-4g7w