### PR TITLE
[DBX-63] Handle the case where the user provides a regex but no label in the metricsconfig

### DIFF
--- a/src/EventStore.Common/Configuration/MetricsConfiguration.cs
+++ b/src/EventStore.Common/Configuration/MetricsConfiguration.cs
@@ -116,8 +116,8 @@ namespace EventStore.Common.Configuration {
 		}
 
 		public class LabelMappingCase {
-			public string Regex { get; set; }
-			public string Label { get; set; }
+			public string Regex { get; set; } = "";
+			public string Label { get; set; } = "";
 		}
 
 		public string[] Meters { get; set; } = Array.Empty<string>();

--- a/src/EventStore.Core.XUnit.Tests/Metrics/MessageLabelConfiguratorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/MessageLabelConfiguratorTests.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using EventStore.Common.Configuration;
 using EventStore.Core.Messaging;
 using EventStore.Core.Metrics;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Metrics;
@@ -116,5 +115,31 @@ public class MessageLabelConfiguratorTests {
 		Assert.Equal("Other", new ReadAllBackward().Label);
 		Assert.Equal("Forward", new ReadStreamForward().Label);
 		Assert.Equal("Stream", new ReadStreamBackward().Label);
+	}
+
+	[Fact]
+	public void unspecified_label() {
+		Run(new MetricsConfiguration.LabelMappingCase() {
+			Regex = "TestGroup-Reads-ReadAll.*",
+			// no Label
+		});
+
+		Assert.Equal("TestGroup-Reads-ReadAllForward", new ReadAllForward().Label);
+		Assert.Equal("TestGroup-Reads-ReadAllBackward", new ReadAllBackward().Label);
+		Assert.Equal("TestGroup-Reads-ReadStreamForward", new ReadStreamForward().Label);
+		Assert.Equal("TestGroup-Reads-ReadStreamBackward", new ReadStreamBackward().Label);
+	}
+
+	[Fact]
+	public void unspecified_regex() {
+		Run(new MetricsConfiguration.LabelMappingCase() {
+			// no Regex
+			Label = "TheLabel",
+		});
+
+		Assert.Equal("TestGroup-Reads-ReadAllForward", new ReadAllForward().Label);
+		Assert.Equal("TestGroup-Reads-ReadAllBackward", new ReadAllBackward().Label);
+		Assert.Equal("TestGroup-Reads-ReadStreamForward", new ReadStreamForward().Label);
+		Assert.Equal("TestGroup-Reads-ReadStreamBackward", new ReadStreamBackward().Label);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Metrics/QueueTrackersTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/QueueTrackersTests.cs
@@ -49,6 +49,30 @@ namespace EventStore.Core.XUnit.Tests.Metrics {
 		}
 
 		[Fact]
+		public void unspecified_label_yields_no_op() {
+			var sut = GenSut(
+				new Conf.LabelMappingCase {
+					Regex = "MainQueue",
+					// no Label
+				});
+
+			var tracker = sut.GetTrackerForQueue("MainQueue");
+			Assert.Equal("NoOp", tracker.Name);
+		}
+
+		[Fact]
+		public void unspecified_regex_does_not_match() {
+			var sut = GenSut(
+				new Conf.LabelMappingCase {
+					// no Regex
+					Label = "MainQueue",
+				});
+
+			var tracker = sut.GetTrackerForQueue("MainQueue");
+			Assert.Equal("NoOp", tracker.Name);
+		}
+
+		[Fact]
 		public void patterns_applied_in_order() {
 			var sut = GenSut(
 				new Conf.LabelMappingCase {

--- a/src/EventStore.Core/Metrics/MessageLabelConfigurator.cs
+++ b/src/EventStore.Core/Metrics/MessageLabelConfigurator.cs
@@ -47,11 +47,18 @@ public class MessageLabelConfigurator {
 			oldLabel = "";
 		}
 
-
 		foreach (var @case in configuration) {
 			var pattern = $"^{@case.Regex}$";
 			var match = Regex.Match(input: oldLabel, pattern: pattern);
 			if (match.Success) {
+				if (string.IsNullOrWhiteSpace(@case.Label)) {
+					Log.Warning(
+						"Label for message {message} matching pattern {pattern} was not specified.",
+						oldLabel, @case.Regex);
+					label = oldLabel;
+					return true;
+				}
+
 				label = Regex.Replace(
 					input: oldLabel,
 					pattern: pattern,

--- a/src/EventStore.Core/Metrics/QueueTrackers.cs
+++ b/src/EventStore.Core/Metrics/QueueTrackers.cs
@@ -62,6 +62,14 @@ public class QueueTrackers {
 			var pattern = $"^{@case.Regex}$";
 			var match = Regex.Match(input: queueName, pattern: pattern);
 			if (match.Success) {
+				if (string.IsNullOrWhiteSpace(@case.Label)) {
+					Log.Warning(
+						"Label for queue {queueName} matching pattern {pattern} was not specified. " +
+						"Metrics will not be collected for this queue",
+						queueName, @case.Regex);
+					return _noOpShared;
+				}
+
 				var label = Regex.Replace(
 					input: queueName,
 					pattern: pattern,


### PR DESCRIPTION
Added: Handling for missing labels in metricsconfig.json

Previously they would get a null reference exception without a clear indication of the problem Now a warning is logged