### PR TITLE
[DBX-64] Don't write default projection execution timeout into the persisted projection state

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/Jint/TestFixtureWithInterpretedProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/TestFixtureWithInterpretedProjection.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using EventStore.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -44,7 +43,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint
 
 		protected virtual IProjectionStateHandler CreateStateHandler() {
 			return _stateHandlerFactory.Create(
-				_projectionType, _projection, true, logger: (s, _) => {
+				_projectionType, _projection, true, null, logger: (s, _) => {
 					if (s.StartsWith("P:"))
 						Console.WriteLine(s);
 					else

--- a/src/EventStore.Projections.Core.Tests/Services/Jint/when_creating_jint_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/when_creating_jint_projection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using EventStore.Common;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
 using EventStore.Projections.Core.Services.Processing;
@@ -19,14 +18,14 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
 
 		[Test, Category(_projectionType)]
 		public void it_can_be_created() {
-			using (_stateHandlerFactory.Create(_projectionType, @"", true)) {
+			using (_stateHandlerFactory.Create(_projectionType, @"", true, null)) {
 			}
 		}
 
 		[Test, Category(_projectionType)]
 		public void js_syntax_errors_are_reported() {
 			try {
-				using (_stateHandlerFactory.Create(_projectionType, @"log(1;", true, logger: (s, _) => { })) {
+				using (_stateHandlerFactory.Create(_projectionType, @"log(1;", true, null, logger: (s, _) => { })) {
 				}
 			} catch (Exception ex) {
 				Assert.IsInstanceOf<Esprima.ParserException>(ex);
@@ -36,7 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
 		[Test, Category(_projectionType)]
 		public void js_exceptions_errors_are_reported() {
 			try {
-				using (_stateHandlerFactory.Create(_projectionType, @"throw 123;", true, logger: (s, _) => { })) {
+				using (_stateHandlerFactory.Create(_projectionType, @"throw 123;", true, null, logger: (s, _) => { })) {
 				}
 			} catch (Exception ex) {
 				Assert.IsInstanceOf<JavaScriptException>(ex);
@@ -53,6 +52,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
                                 while (true) i++;
                     ",
 					true,
+					null,
 					logger: (s, _) => { },
 					cancelCallbackFactory: (timeout, action) => { })) {
 				}
@@ -75,6 +75,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
                         });
                     ",
 					true,
+					null,
 					logger: Console.WriteLine)) {
 					h.Initialize();
 					string newState;
@@ -112,6 +113,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
                         });
                     ",
 					true,
+					null,
 					logger: Console.WriteLine)) {
 					h.Initialize();
 					string newState;
@@ -140,7 +142,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
                             while (true) i++;
                         }
                     });
-                ", true, logger: Console.WriteLine)) {
+                ", true, null, logger: Console.WriteLine)) {
 						h.Initialize();
 						string newState;
 						EmittedEventEnvelope[] emittedevents;

--- a/src/EventStore.Projections.Core.Tests/Services/Jint/when_running_with_content_type_validation.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/when_running_with_content_type_validation.cs
@@ -21,7 +21,9 @@ namespace EventStore.Projections.Core.Tests.Services.Jint
 			protected override IProjectionStateHandler CreateStateHandler() {
 				return _stateHandlerFactory.Create(
 					_projectionType, _projection, 
-					enableContentTypeValidation: true, logger: (s, _) => {
+					enableContentTypeValidation: true,
+					projectionExecutionTimeout: null,
+					logger: (s, _) => {
 						if (s.StartsWith("P:"))
 							Console.WriteLine(s);
 						else
@@ -71,8 +73,10 @@ namespace EventStore.Projections.Core.Tests.Services.Jint
 
 			protected override IProjectionStateHandler CreateStateHandler() {
 				return _stateHandlerFactory.Create(
-					_projectionType, _projection, 
-					enableContentTypeValidation: false, logger: (s, _) => {
+					_projectionType, _projection,
+					enableContentTypeValidation: false,
+					projectionExecutionTimeout: null,
+					logger: (s, _) => {
 						if (s.StartsWith("P:"))
 							Console.WriteLine(s);
 						else

--- a/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services {
 			_projectionNamesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
 			_emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher,
 				new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false,
-					_trackEmittedStreams, 10000, 1), _projectionNamesBuilder);
+					_trackEmittedStreams, 10000, 1, 250), _projectionNamesBuilder);
 			_emittedStreamsDeleter = new EmittedStreamsDeleter(_ioDispatcher,
 				_projectionNamesBuilder.GetEmittedStreamsName(),
 				_projectionNamesBuilder.GetEmittedStreamsCheckpointName());

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
@@ -93,7 +93,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold, GivenPendingEventsThreshold(),
 				GivenMaxWriteBatchLength(), GivenEmitEventEnabled(), GivenCheckpointsEnabled(), _createTempStreams,
 				GivenStopOnEof(), GivenTrackEmittedStreams(), GivenCheckpointAfterMs(),
-				GivenMaximumAllowedWritesInFlight());
+				GivenMaximumAllowedWritesInFlight(), 250);
 		}
 
 		protected virtual int GivenMaxWriteBatchLength() {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
 			_config = new ProjectionConfig(null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold,
 				_pendingEventsThreshold, _maxWriteBatchLength, _emitEventEnabled,
 				_checkpointsEnabled, _createTempStreams, _stopOnEof, _trackEmittedStreams, _checkpointAfterMs,
-				_maximumAllowedWritesInFlight);
+				_maximumAllowedWritesInFlight, 250);
 			When();
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
@@ -35,7 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
 			_projectionVersion = new ProjectionVersion(3, 1, 2);
 			_projectionConfig = new ProjectionConfig(SystemAccounts.System, 10, 1000, 1000, 10, true, true, true,
 				false,
-				false, 5000, 10);
+				false, 5000, 10, 250);
 			_positionTagger = new MultiStreamPositionTagger(3, _streams);
 			_positionTagger.AdjustTag(CheckpointTag.FromStreamPositions(3,
 				new Dictionary<string, long> {{"a", 0}, {"b", 0}, {"c", 0}}));

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
@@ -21,7 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 		}
 
 		private readonly ProjectionConfig _defaultProjectionConfig = new ProjectionConfig(
-			null, 5, 10, 1000, 250, true, true, true, true, true, 10000, 1);
+			null, 5, 10, 1000, 250, true, true, true, true, true, 10000, 1, 250);
 
 		private IODispatcher _ioDispatcher;
 
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, 250);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,
@@ -64,7 +64,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, 250);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,
@@ -264,7 +264,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, 250);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -56,7 +56,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 			_bus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher);
 			IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 			_projectionConfig =
-				new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, true, 10000, 1);
+				new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, true, 10000, 1, 250);
 			var version = new ProjectionVersion(1, 0, 0);
 			var projectionProcessingStrategy = new ContinuousProjectionProcessingStrategy(
 				"projection", version, projectionStateHandler, _projectionConfig,

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service/when_stopping_the_projection_core_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service/when_stopping_the_projection_core_service.cs
@@ -39,7 +39,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			_bus.Subscribe<CoreProjectionStatusMessage.Suspended>(_service);
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
 				_projectionId, _workerId, "test-projection", 
-				new ProjectionVersion(), ProjectionConfig.GetTest(),
+				new ProjectionVersion(),
+				new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000, 1, 250),
 				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 		}
@@ -74,7 +75,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			_bus.Unsubscribe<CoreProjectionStatusMessage.Suspended>(_service);
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
 				_projectionId, _workerId, "test-projection", 
-				new ProjectionVersion(), ProjectionConfig.GetTest(),
+				new ProjectionVersion(),
+				new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000, 1, 250),
 				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCoreTimeout(_stopCorrelationId));
@@ -102,7 +104,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			_bus.Unsubscribe<CoreProjectionStatusMessage.Suspended>(_service);
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
 				_projectionId, _workerId, "test-projection", 
-				new ProjectionVersion(), ProjectionConfig.GetTest(),
+				new ProjectionVersion(),
+				new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000, 1, 250),
 				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCoreTimeout(Guid.NewGuid()));

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
@@ -88,7 +88,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 				readerBuilder.AllEvents();
 			}
 
-			var config = ProjectionConfig.GetTest();
+			var config = new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000,
+				1, 250);
 			IQuerySources sources = readerBuilder.Build();
 			var readerStrategy = Core.Services.Processing.ReaderStrategy.Create(
 				"test",

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using EventStore.Core;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Services.TimeService;
@@ -62,8 +61,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 					_getStateDispatcher,
 					_getResultDispatcher,
 					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-					ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
+					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 			});
 		}
 
@@ -85,8 +83,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 					_getStateDispatcher,
 					_getResultDispatcher,
 					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-					ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
+					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 			});
 		}
 
@@ -108,8 +105,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 					_getStateDispatcher,
 					_getResultDispatcher,
 					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-					ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
+					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 			});
 		}
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using EventStore.Core.Bus;
+using EventStore.Core;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Services.TimeService;
@@ -45,7 +45,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 
 
 		[Test]
-		public void empty_guid_throws_invali_argument_exception() {
+		public void empty_guid_throws_invalid_argument_exception() {
 			Assert.Throws<ArgumentException>(() => {
 				new ManagedProjection(
 					Guid.NewGuid(),
@@ -62,39 +62,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 					_getStateDispatcher,
 					_getResultDispatcher,
 					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
-			});
-		}
-
-		[Test]
-		public void empty_guid_throws_invali_argument_exception2() {
-			Assert.Throws<ArgumentException>(() => {
-				new ManagedProjection(
-					Guid.NewGuid(),
-					Guid.Empty,
-					1,
-					"name",
-					true,
-					null,
-					_streamDispatcher,
-					_writeDispatcher,
-					_readDispatcher,
-					_bus,
-					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
-					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+					ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 			});
 		}
 
@@ -113,52 +82,11 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 					_readDispatcher,
 					_bus,
 					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
+					_getStateDispatcher,
+					_getResultDispatcher,
 					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
-			});
-		}
-
-		[Test]
-		public void null_name_throws_argument_null_exception2() {
-			Assert.Throws<ArgumentNullException>(() => {
-				new ManagedProjection(
-					Guid.NewGuid(),
-					Guid.NewGuid(),
-					1,
-					null,
-					true,
-					null,
-					_streamDispatcher,
-					_writeDispatcher,
-					_readDispatcher,
-					_bus,
-					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
-					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+					ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 			});
 		}
 
@@ -177,52 +105,11 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 					_readDispatcher,
 					_bus,
 					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
+					_getStateDispatcher,
+					_getResultDispatcher,
 					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
-			});
-		}
-
-		[Test]
-		public void empty_name_throws_argument_exception2() {
-			Assert.Throws<ArgumentException>(() => {
-				new ManagedProjection(
-					Guid.NewGuid(),
-					Guid.NewGuid(),
-					1,
-					"",
-					true,
-					null,
-					_streamDispatcher,
-					_writeDispatcher,
-					_readDispatcher,
-					_bus,
-					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							new PublishEnvelope(_bus)),
-					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+					ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 			});
 		}
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
@@ -1,10 +1,12 @@
 using System;
+using EventStore.Core;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.Util;
+using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -44,7 +46,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 		}
 
 		[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
@@ -1,12 +1,9 @@
 using System;
-using EventStore.Core;
-using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.Util;
-using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -46,8 +43,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 		}
 
 		[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_existing_projection_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_existing_projection_state.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using EventStore.Common.Utils;
+using EventStore.Core;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
@@ -61,7 +62,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 		}
 
 		[Test]
@@ -119,7 +121,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 		}
 
 		[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_existing_projection_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_existing_projection_state.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using EventStore.Common.Utils;
-using EventStore.Core;
-using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests;
@@ -62,8 +60,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 		}
 
 		[Test]
@@ -121,8 +118,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 		}
 
 		[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
@@ -10,10 +10,8 @@ using EventStore.Projections.Core.Services.Management;
 using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using EventStore.Core;
 using EventStore.Core.Tests;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed_projection {
@@ -76,8 +74,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 		}
 
 		protected override IEnumerable<WhenStep> When() {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using EventStore.Core;
 using EventStore.Core.Tests;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed_projection {
@@ -75,7 +76,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 		}
 
 		protected override IEnumerable<WhenStep> When() {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_follower_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_follower_projections.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using EventStore.Core;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests;
@@ -59,8 +58,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)), _ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 		}
 
 		protected override IEnumerable<WhenStep> When() {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_follower_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_follower_projections.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using EventStore.Core;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests;
@@ -58,7 +59,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)), _ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 		}
 
 		protected override IEnumerable<WhenStep> When() {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
@@ -22,7 +22,6 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 		private ManagedProjection _mp;
 		private Guid _projectionId = Guid.NewGuid();
 		private ProjectionManagementMessage.ProjectionConfig _config;
-		private int _fallbackExecutionTimeout = 1000;
 		private EventRecord _persistedStateWrite;
 
 		private ManagedProjection.PersistedState _persistedState = new ManagedProjection.PersistedState {
@@ -50,7 +49,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 
 		protected override void Given() {
 			_timeProvider = new FakeTimeProvider();
-			_mp = CreateManagedProjection(_fallbackExecutionTimeout);
+			_mp = CreateManagedProjection();
 
 			_mp.InitializeNew(
 				_persistedState,
@@ -180,7 +179,6 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 		private ProjectionManagementMessage.ProjectionConfig _config;
 		private EventRecord _persistedStateWrite;
 		private ProjectionManagementMessage.Command.UpdateConfig _updateConfig;
-		private readonly int _fallbackProjectionExecutionTimeout = 1100;
 
 		private ManagedProjection.PersistedState _persistedState => new ManagedProjection.PersistedState {
 			Enabled = false,
@@ -208,7 +206,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 
 		protected override void Given() {
 			_timeProvider = new FakeTimeProvider();
-			_mp = CreateManagedProjection(_fallbackProjectionExecutionTimeout);
+			_mp = CreateManagedProjection();
 
 			_mp.InitializeNew(
 				_persistedState,
@@ -241,7 +239,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 		public void persisted_state_should_have_null_projection_execution_timeout() {
 		Assert.IsNotNull(_persistedStateWrite);
 			var actualState = _persistedStateWrite.Data.ParseJson<ManagedProjection.PersistedState>();
-			Assert.AreEqual(null, actualState.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
+			Assert.IsNull(actualState.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
 		}
 	}
 
@@ -403,7 +401,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 	public abstract class projection_config_test_base<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
 		protected const string ProjectionName = "name";
 		protected readonly string ProjectionStreamId = ProjectionNamesBuilder.ProjectionsStreamPrefix + ProjectionName;
-		protected ManagedProjection CreateManagedProjection(int defaultProjectionExecutionTimeout = ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout) {
+		protected ManagedProjection CreateManagedProjection() {
 			return new ManagedProjection(
 				Guid.NewGuid(),
 				Guid.NewGuid(),
@@ -427,8 +425,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-				defaultProjectionExecutionTimeout);
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 		}
 
 		protected ProjectionManagementMessage.Command.UpdateConfig CreateConfig() {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Linq;
+using EventStore.Common.Utils;
 using EventStore.Core;
+using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.Util;
+using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -15,11 +18,79 @@ using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed_projection {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_getting_config<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
+	public class when_initializing_projection_with_default_options<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
 		private ManagedProjection _mp;
 		private Guid _projectionId = Guid.NewGuid();
 		private ProjectionManagementMessage.ProjectionConfig _config;
+		private int _fallbackExecutionTimeout = 1000;
+		private EventRecord _persistedStateWrite;
+
+		private ManagedProjection.PersistedState _persistedState = new ManagedProjection.PersistedState {
+			Enabled = true,
+			HandlerType = "JS",
+			Query = "fromAll().when({});",
+			Mode = ProjectionMode.Continuous,
+			CheckpointsDisabled = null,
+			Epoch = null,
+			Version = null,
+			RunAs = null,
+			EmitEnabled = null,
+			TrackEmittedStreams = null,
+			CheckpointAfterMs = (int)ProjectionConsts.CheckpointAfterMs.TotalMilliseconds,
+			CheckpointHandledThreshold = ProjectionConsts.CheckpointHandledThreshold,
+			CheckpointUnhandledBytesThreshold = ProjectionConsts.CheckpointUnhandledBytesThreshold,
+			MaxAllowedWritesInFlight = ProjectionConsts.MaxAllowedWritesInFlight,
+			ProjectionExecutionTimeout = null,
+			CreateTempStreams = null
+		};
+
+		public when_initializing_projection_with_default_options() {
+			AllWritesQueueUp();
+		}
+
+		protected override void Given() {
+			_timeProvider = new FakeTimeProvider();
+			_mp = CreateManagedProjection(_fallbackExecutionTimeout);
+
+			_mp.InitializeNew(
+				_persistedState,
+				null);
+			_mp.Handle(new CoreProjectionStatusMessage.Prepared(_projectionId, new ProjectionSourceDefinition()));
+
+			// Complete write of persisted state to start projection
+			OneWriteCompletes();
+			_config = GetProjectionConfig(_mp);
+			_persistedStateWrite = _streams[ProjectionStreamId].LastOrDefault();
+		}
+
+		[Test]
+		public void projection_execution_timeout_should_be_null() {
+			Assert.IsNotNull(_config);
+			Assert.IsNull(_config.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
+		}
+
+		[Test]
+		public void emit_options_should_default_to_false() {
+			Assert.IsNotNull(_config);
+			Assert.AreEqual(false, _config.EmitEnabled, "EmitEnabled");
+			Assert.AreEqual(false, _config.TrackEmittedStreams, "TrackEmittedStreams");
+		}
+
+		[Test]
+		public void persisted_state_should_leave_fallback_options_unset() {
+			Assert.IsNotNull(_persistedStateWrite);
+			var actualState = _persistedStateWrite.Data.ParseJson<ManagedProjection.PersistedState>();
+			Assert.IsNull(actualState.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class when_initializing_projection_with_persisted_state<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
+		private ManagedProjection _mp;
+		private Guid _projectionId = Guid.NewGuid();
+		private ProjectionManagementMessage.ProjectionConfig _config;
+		private EventRecord _persistedStateWrite;
 
 		private ManagedProjection.PersistedState _persistedState = new ManagedProjection.PersistedState {
 			Enabled = true,
@@ -41,7 +112,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 			ProjectionExecutionTimeout = 11
 		};
 
-		public when_getting_config() {
+		public when_initializing_projection_with_persisted_state() {
 			AllWritesQueueUp();
 		}
 
@@ -57,6 +128,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 			// Complete write of persisted state to start projection
 			OneWriteCompletes();
 			_config = GetProjectionConfig(_mp);
+			_persistedStateWrite = _streams[ProjectionStreamId].LastOrDefault();
 		}
 
 		[Test]
@@ -76,6 +148,100 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 				"MaxAllowedWritesInFlight");
 			Assert.AreEqual(_persistedState.ProjectionExecutionTimeout, _config.ProjectionExecutionTimeout,
 				"ProjectionExecutionTimeout");
+		}
+
+		[Test]
+		public void persisted_state_is_written_correctly() {
+			Assert.IsNotNull(_persistedStateWrite);
+			var actualState = _persistedStateWrite.Data.ParseJson<ManagedProjection.PersistedState>();
+
+			Assert.AreEqual(_persistedState.EmitEnabled, actualState.EmitEnabled, "EmitEnabled");
+			Assert.AreEqual(_persistedState.TrackEmittedStreams, actualState.TrackEmittedStreams, "TrackEmittedStreams");
+			Assert.AreEqual(_persistedState.CheckpointAfterMs, actualState.CheckpointAfterMs, "CheckpointAfterMs");
+			Assert.AreEqual(_persistedState.CheckpointHandledThreshold, actualState.CheckpointHandledThreshold,
+				"CheckpointHandledThreshold");
+			Assert.AreEqual(_persistedState.CheckpointUnhandledBytesThreshold,
+				actualState.CheckpointUnhandledBytesThreshold, "CheckpointUnhandledBytesThreshold");
+			Assert.AreEqual(_persistedState.PendingEventsThreshold, actualState.PendingEventsThreshold,
+				"PendingEventsThreshold");
+			Assert.AreEqual(_persistedState.MaxWriteBatchLength, actualState.MaxWriteBatchLength, "MaxWriteBatchLength");
+			Assert.AreEqual(_persistedState.MaxAllowedWritesInFlight, actualState.MaxAllowedWritesInFlight,
+				"MaxAllowedWritesInFlight");
+			Assert.AreEqual(_persistedState.ProjectionExecutionTimeout, actualState.ProjectionExecutionTimeout,
+				"ProjectionExecutionTimeout");
+		}
+	}
+
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_updating_projection_config_to_remove_execution_timeout<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
+		private ManagedProjection _mp;
+		private Guid _projectionId = Guid.NewGuid();
+		private ProjectionManagementMessage.ProjectionConfig _config;
+		private EventRecord _persistedStateWrite;
+		private ProjectionManagementMessage.Command.UpdateConfig _updateConfig;
+		private readonly int _fallbackProjectionExecutionTimeout = 1100;
+
+		private ManagedProjection.PersistedState _persistedState => new ManagedProjection.PersistedState {
+			Enabled = false,
+			HandlerType = "JS",
+			Query = "fromAll().when({});",
+			Mode = ProjectionMode.Continuous,
+			CheckpointsDisabled = false,
+			Epoch = -1,
+			Version = -1,
+			RunAs = SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous),
+			EmitEnabled = false,
+			TrackEmittedStreams = true,
+			CheckpointAfterMs = 1,
+			CheckpointHandledThreshold = 2,
+			CheckpointUnhandledBytesThreshold = 3,
+			PendingEventsThreshold = 4,
+			MaxWriteBatchLength = 5,
+			MaxAllowedWritesInFlight = 6,
+			ProjectionExecutionTimeout = 11
+		};
+
+		public when_updating_projection_config_to_remove_execution_timeout() {
+			AllWritesQueueUp();
+		}
+
+		protected override void Given() {
+			_timeProvider = new FakeTimeProvider();
+			_mp = CreateManagedProjection(_fallbackProjectionExecutionTimeout);
+
+			_mp.InitializeNew(
+				_persistedState,
+				null);
+			_mp.Handle(new CoreProjectionStatusMessage.Prepared(_projectionId, new ProjectionSourceDefinition()));
+			OneWriteCompletes();
+			_mp.Handle(new CoreProjectionStatusMessage.Stopped(_projectionId, ProjectionName, false));
+
+			_updateConfig = new ProjectionManagementMessage.Command.UpdateConfig(
+				new NoopEnvelope(), ProjectionName, _persistedState.EmitEnabled ?? false, _persistedState.TrackEmittedStreams ?? false,
+				_persistedState.CheckpointAfterMs, _persistedState.CheckpointHandledThreshold, _persistedState.CheckpointUnhandledBytesThreshold,
+				_persistedState.PendingEventsThreshold, _persistedState.MaxWriteBatchLength, _persistedState.MaxAllowedWritesInFlight,
+				_persistedState.RunAs,
+				projectionExecutionTimeout: null);
+			_mp.Handle(_updateConfig);
+			OneWriteCompletes();
+
+			_config = GetProjectionConfig(_mp);
+			_persistedStateWrite = _streams[ProjectionStreamId].LastOrDefault();
+
+		}
+
+		[Test]
+		public void config_should_have_null_projection_execution_timeout() {
+			Assert.IsNotNull(_config);
+			Assert.IsNull(_config.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
+		}
+
+		[Test]
+		public void persisted_state_should_have_null_projection_execution_timeout() {
+		Assert.IsNotNull(_persistedStateWrite);
+			var actualState = _persistedStateWrite.Data.ParseJson<ManagedProjection.PersistedState>();
+			Assert.AreEqual(null, actualState.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
 		}
 	}
 
@@ -129,7 +295,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 		public void persisted_state_is_written() {
 			var writeEvents = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().ToList();
 			Assert.AreEqual(1, writeEvents.Count());
-			Assert.AreEqual("$projections-name", writeEvents[0].EventStreamId);
+			Assert.AreEqual(ProjectionStreamId, writeEvents[0].EventStreamId);
 		}
 
 		[Test]
@@ -235,12 +401,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 	}
 
 	public abstract class projection_config_test_base<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
-		protected ManagedProjection CreateManagedProjection() {
+		protected const string ProjectionName = "name";
+		protected readonly string ProjectionStreamId = ProjectionNamesBuilder.ProjectionsStreamPrefix + ProjectionName;
+		protected ManagedProjection CreateManagedProjection(int defaultProjectionExecutionTimeout = ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout) {
 			return new ManagedProjection(
 				Guid.NewGuid(),
 				Guid.NewGuid(),
 				1,
-				"name",
+				ProjectionName,
 				true,
 				null,
 				_streamDispatcher,
@@ -259,12 +427,13 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 						v => v.CorrelationId,
 						new PublishEnvelope(_bus)),
 				_ioDispatcher,
-				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+				defaultProjectionExecutionTimeout);
 		}
 
 		protected ProjectionManagementMessage.Command.UpdateConfig CreateConfig() {
 			return new ProjectionManagementMessage.Command.UpdateConfig(
-				new NoopEnvelope(), "name", true, false, 100, 200, 300, 400, 500, 600,
+				new NoopEnvelope(), ProjectionName, true, false, 100, 200, 300, 400, 500, 600,
 				ProjectionManagementMessage.RunAs.Anonymous, ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
@@ -8,6 +8,7 @@ using EventStore.Core.Tests;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
+using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager {
@@ -45,13 +46,23 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 
 		[Test, Category("v8")]
 		public void a_projection_created_event_is_written() {
-			Assert.AreEqual(
-				ProjectionEventTypes.ProjectionCreated,
-				_consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().First().Events[0].EventType);
-			Assert.AreEqual(
-				_projectionName,
-				Helper.UTF8NoBom.GetString(_consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().First()
-					.Events[0].Data));
+			var createdEventWrite = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().FirstOrDefault();
+			Assert.NotNull(createdEventWrite);
+			Assert.AreEqual(ProjectionNamesBuilder.ProjectionsRegistrationStream, createdEventWrite.EventStreamId);
+			Assert.AreEqual(ProjectionEventTypes.ProjectionCreated, createdEventWrite.Events[0].EventType);
+			Assert.AreEqual(_projectionName, Helper.UTF8NoBom.GetString(createdEventWrite.Events[0].Data));
+		}
+
+		[Test, Category("v8")]
+		public void persisted_projection_state_is_written_with_empty_execution_timeout() {
+			var persistedStateStream = ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName;
+			var persistedStateWrite = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+				.FirstOrDefault(x => x.EventStreamId == persistedStateStream);
+
+			Assert.NotNull(persistedStateWrite);
+			Assert.AreEqual(ProjectionEventTypes.ProjectionUpdated, persistedStateWrite.Events[0].EventType);
+			var actualState = persistedStateWrite.Events[0].Data.ParseJson<ManagedProjection.PersistedState>();
+			Assert.IsNull(actualState.ProjectionExecutionTimeout);
 		}
 
 		[Test, Category("v8")]

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -343,12 +343,12 @@ namespace EventStore.Projections.Core.Messages {
 				private readonly int _pendingEventsThreshold;
 				private readonly int _maxWriteBatchLength;
 				private readonly int _maxAllowedWritesInFlight;
-				private readonly int _projectionExecutionTimeout;
+				private readonly int? _projectionExecutionTimeout;
 
 				public UpdateConfig(IEnvelope envelope, string name, bool emitEnabled, bool trackEmittedStreams,
 					int checkpointAfterMs,
 					int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold, int pendingEventsThreshold,
-					int maxWriteBatchLength, int maxAllowedWritesInFlight, RunAs runAs, int projectionExecutionTimeout) :
+					int maxWriteBatchLength, int maxAllowedWritesInFlight, RunAs runAs, int? projectionExecutionTimeout) :
 					base(envelope, runAs) {
 					_name = name;
 					_emitEnabled = emitEnabled;
@@ -398,7 +398,7 @@ namespace EventStore.Projections.Core.Messages {
 					get { return _maxAllowedWritesInFlight; }
 				}
 
-				public int ProjectionExecutionTimeout { get => _projectionExecutionTimeout; }
+				public int? ProjectionExecutionTimeout { get => _projectionExecutionTimeout; }
 			}
 
 			[DerivedMessage(ProjectionMessage.Management)]
@@ -800,12 +800,12 @@ namespace EventStore.Projections.Core.Messages {
 			private readonly int _pendingEventsThreshold;
 			private readonly int _maxWriteBatchLength;
 			private readonly int _maxAllowedWritesInFlight;
-			private readonly int _projectionExecutionTimeout;
+			private readonly int? _projectionExecutionTimeout;
 
 			public ProjectionConfig(bool emitEnabled, bool trackEmittedStreams, int checkpointAfterMs,
 				int checkpointHandledThreshold,
 				int checkpointUnhandledBytesThreshold, int pendingEventsThreshold, int maxWriteBatchLength,
-				int maxAllowedWritesInFlight, int projectionExecutionTimeout) {
+				int maxAllowedWritesInFlight, int? projectionExecutionTimeout) {
 				_emitEnabled = emitEnabled;
 				_trackEmittedStreams = trackEmittedStreams;
 				_checkpointAfterMs = checkpointAfterMs;
@@ -849,7 +849,7 @@ namespace EventStore.Projections.Core.Messages {
 				get { return _maxAllowedWritesInFlight; }
 			}
 			
-			public int ProjectionExecutionTimeout { get => _projectionExecutionTimeout; }
+			public int? ProjectionExecutionTimeout { get => _projectionExecutionTimeout; }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core {
 				new RealTimeProvider(),
 				projectionsStandardComponents.RunProjections,
 				ioDispatcher,
-				projectionQueryExpiry, defaultProjectionExecutionTimeout: projectionsStandardComponents.ProjectionExecutionTimeout);
+				projectionQueryExpiry);
 
 			SubscribeMainBus(
 				projectionsStandardComponents.LeaderMainBus,

--- a/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
+++ b/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
@@ -220,7 +220,7 @@ namespace EventStore.Projections.Core.Services.Http {
 						return;
 					}
 
-					if (config.ProjectionExecutionTimeout <= 0) {
+					if (config.ProjectionExecutionTimeout is not null && config.ProjectionExecutionTimeout <= 0) {
 						SendBadRequest(o, $"projectionExecutionTimeout should be positive. Found : {config.ProjectionExecutionTimeout}");
 						return;
 					}
@@ -655,9 +655,7 @@ namespace EventStore.Projections.Core.Services.Http {
 			public int PendingEventsThreshold { get; set; }
 			public int MaxWriteBatchLength { get; set; }
 			public int MaxAllowedWritesInFlight { get; set; }
-
-			public int ProjectionExecutionTimeout { get; set; } =
-				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout;
+			public int? ProjectionExecutionTimeout { get; set; }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -121,7 +121,6 @@ namespace EventStore.Projections.Core.Services.Management {
 		internal bool Created;
 		private bool _pendingWritePersistedState;
 		private readonly TimeSpan _projectionsQueryExpiry;
-		private readonly int _defaultProjectionExecutionTimeout;
 
 		private ManagedProjectionStateBase _stateHandler;
 		private IEnvelope _lastReplyEnvelope;
@@ -148,8 +147,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>
 				getResultDispatcher,
 			IODispatcher ioDispatcher,
-			TimeSpan projectionQueryExpiry,
-			int defaultProjectionExecutionTimeout) {
+			TimeSpan projectionQueryExpiry) {
 			if (id == Guid.Empty) throw new ArgumentException("id");
 			if (name == null) throw new ArgumentNullException("name");
 			if (output == null) throw new ArgumentNullException("output");
@@ -172,7 +170,6 @@ namespace EventStore.Projections.Core.Services.Management {
 			_lastAccessed = _timeProvider.UtcNow;
 			_ioDispatcher = ioDispatcher;
 			_projectionsQueryExpiry = projectionQueryExpiry;
-			_defaultProjectionExecutionTimeout = defaultProjectionExecutionTimeout;
 		}
 
 		private string HandlerType {
@@ -966,8 +963,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			var emitEventEnabled = PersistedProjectionState.EmitEnabled == true;
 			var createTempStreams = PersistedProjectionState.CreateTempStreams == true;
 			var stopOnEof = PersistedProjectionState.Mode <= ProjectionMode.OneTime;
-			var projectionExecutionTimeout = PersistedProjectionState.ProjectionExecutionTimeout ??
-			                                 _defaultProjectionExecutionTimeout;
+			var projectionExecutionTimeout = PersistedProjectionState.ProjectionExecutionTimeout;
 
 			var projectionConfig = new ProjectionConfig(
 				_runAs,
@@ -981,7 +977,8 @@ namespace EventStore.Projections.Core.Services.Management {
 				stopOnEof,
 				trackEmittedStreams,
 				checkpointAfterMs,
-				maximumAllowedWritesInFlight, projectionExecutionTimeout);
+				maximumAllowedWritesInFlight,
+				projectionExecutionTimeout);
 			return projectionConfig;
 		}
 

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
-using EventStore.Core;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -106,8 +105,6 @@ namespace EventStore.Projections.Core.Services.Management {
 
 		private readonly IODispatcher _ioDispatcher;
 
-		private readonly int _defaultProjectionExecutionTimeout;
-		
 		private Guid _instanceCorrelationId = Guid.Empty;
 
 		public ProjectionManager(
@@ -118,7 +115,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			ProjectionType runProjections,
 			IODispatcher ioDispatcher,
 			TimeSpan projectionQueryExpiry,
-			bool initializeSystemProjections = true, int defaultProjectionExecutionTimeout = ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout) {
+			bool initializeSystemProjections = true) {
 			if (inputQueue == null) throw new ArgumentNullException("inputQueue");
 			if (publisher == null) throw new ArgumentNullException("publisher");
 			if (queueMap == null) throw new ArgumentNullException("queueMap");
@@ -178,7 +175,6 @@ namespace EventStore.Projections.Core.Services.Management {
 						v => v.CorrelationId,
 						v => v.CorrelationId,
 						new PublishEnvelope(_inputQueue));
-			_defaultProjectionExecutionTimeout = defaultProjectionExecutionTimeout;
 		}
 
 		public void Handle(ProjectionSubsystemMessage.StartComponents message) {
@@ -244,7 +240,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				return;
 
 			if (message.Mode == ProjectionMode.Transient) {
-				var transientProjection = new PendingProjection(ProjectionQueryId, message, _defaultProjectionExecutionTimeout);
+				var transientProjection = new PendingProjection(ProjectionQueryId, message);
 				if (!ValidateProjections(new [] {transientProjection}, message)) return;
 
 				PostNewTransientProjection(transientProjection, message.Envelope);
@@ -254,7 +250,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				} else {
 					var expectedVersion = _projectionsRegistrationExpectedVersion;
 					var pendingProjections = new Dictionary<string, PendingProjection> {
-						{message.Name, new PendingProjection(expectedVersion + 1, message, _defaultProjectionExecutionTimeout)}
+						{message.Name, new PendingProjection(expectedVersion + 1, message)}
 					};
 					if (!ValidateProjections(pendingProjections.Values.ToArray(), message)) return;
 						
@@ -281,7 +277,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			
 				var projectionId = expectedVersion + 1;
 				foreach (var projection in message.Projections) {
-					pendingProjections.Add(projection.Name, new PendingProjection(projectionId, projection, _defaultProjectionExecutionTimeout));
+					pendingProjections.Add(projection.Name, new PendingProjection(projectionId, projection));
 					projectionId++;
 				}
 
@@ -1141,7 +1137,6 @@ namespace EventStore.Projections.Core.Services.Management {
 			private readonly ProjectionManagementMessage.RunAs _runAs;
 			private readonly IEnvelope _replyEnvelope;
 			private readonly string _name;
-			private readonly int _defaultProjectionExecutionTimeout;
 
 			public NewProjectionInitializer(
 				long projectionId,
@@ -1155,7 +1150,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				bool enableRunAs,
 				bool trackEmittedStreams,
 				ProjectionManagementMessage.RunAs runAs,
-				IEnvelope replyEnvelope, int defaultProjectionExecutionTimeout) {
+				IEnvelope replyEnvelope) {
 				if (projectionMode >= ProjectionMode.Continuous && !checkpointsEnabled)
 					throw new InvalidOperationException("Continuous mode requires checkpoints");
 
@@ -1174,7 +1169,6 @@ namespace EventStore.Projections.Core.Services.Management {
 				_runAs = runAs;
 				_replyEnvelope = replyEnvelope;
 				_name = name;
-				_defaultProjectionExecutionTimeout = defaultProjectionExecutionTimeout;
 			}
 
 			public void CreateAndInitializeNewProjection(
@@ -1231,8 +1225,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				_getStateDispatcher,
 				_getResultDispatcher,
 				_ioDispatcher,
-				_projectionsQueryExpiry,
-				_defaultProjectionExecutionTimeout);
+				_projectionsQueryExpiry);
 
 			_projectionsMap.Add(projectionCorrelationId, name);
 			_projections.Add(name, managedProjectionInstance);
@@ -1261,13 +1254,11 @@ namespace EventStore.Projections.Core.Services.Management {
 			public bool EnableRunAs { get; }
 			public bool TrackEmittedStreams { get; }
 			public long ProjectionId { get; }
-			
-			public int DefaultProjectionExecutionTimeout { get; }
 
 			public PendingProjection(
 				long projectionId, ProjectionMode mode, SerializedRunAs runAs, string name, string handlerType, string query,
 				bool enabled, bool checkpointsEnabled, bool emitEnabled, bool enableRunAs,
-				bool trackEmittedStreams, int defaultProjectionExecutionTimeout) {
+				bool trackEmittedStreams) {
 				ProjectionId = projectionId;
 				Mode = mode;
 				RunAs = runAs;
@@ -1279,18 +1270,17 @@ namespace EventStore.Projections.Core.Services.Management {
 				EmitEnabled = emitEnabled;
 				EnableRunAs = enableRunAs;
 				TrackEmittedStreams = trackEmittedStreams;
-				DefaultProjectionExecutionTimeout = defaultProjectionExecutionTimeout;
 			}
 
-			public PendingProjection(long projectionId, ProjectionManagementMessage.Command.PostBatch.ProjectionPost projection, int defaultProjectionExecutionTimeout)
+			public PendingProjection(long projectionId, ProjectionManagementMessage.Command.PostBatch.ProjectionPost projection)
 				: this(projectionId, projection.Mode, projection.RunAs, projection.Name, projection.HandlerType,
 					projection.Query, projection.Enabled, projection.CheckpointsEnabled,
-					projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams, defaultProjectionExecutionTimeout) { }
+					projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams) { }
 
-			public PendingProjection(long projectionId, ProjectionManagementMessage.Command.Post projection, int defaultProjectionExecutionTimeout)
+			public PendingProjection(long projectionId, ProjectionManagementMessage.Command.Post projection)
 				: this(projectionId, projection.Mode, projection.RunAs, projection.Name, projection.HandlerType,
 					projection.Query, projection.Enabled, projection.CheckpointsEnabled,
-					projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams, defaultProjectionExecutionTimeout) { }
+					projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams) { }
 
 			public NewProjectionInitializer CreateInitializer(IEnvelope replyEnvelope) {
 				return new NewProjectionInitializer(
@@ -1305,7 +1295,7 @@ namespace EventStore.Projections.Core.Services.Management {
 					EnableRunAs,
 					TrackEmittedStreams,
 					RunAs,
-					replyEnvelope, DefaultProjectionExecutionTimeout);
+					replyEnvelope);
 			}
 		}
 

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -1203,7 +1203,7 @@ namespace EventStore.Projections.Core.Services.Management {
 						Version = version,
 						RunAs = _enableRunAs ? SerializedRunAs.SerializePrincipal(_runAs) : null,
 						ProjectionSubsystemVersion = ProjectionsSubsystem.VERSION,
-						ProjectionExecutionTimeout = _defaultProjectionExecutionTimeout
+						ProjectionExecutionTimeout = null
 					},
 					_replyEnvelope);
 			}
@@ -1231,7 +1231,8 @@ namespace EventStore.Projections.Core.Services.Management {
 				_getStateDispatcher,
 				_getResultDispatcher,
 				_ioDispatcher,
-				_projectionsQueryExpiry);
+				_projectionsQueryExpiry,
+				_defaultProjectionExecutionTimeout);
 
 			_projectionsMap.Add(projectionCorrelationId, name);
 			_projections.Add(name, managedProjectionInstance);

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
-using EventStore.Core;
 using EventStore.Projections.Core.Services.Interpreted;
 
 namespace EventStore.Projections.Core.Services.Management {
 
-	
 	public class ProjectionStateHandlerFactory {
 		private readonly TimeSpan _javascriptCompilationTimeout;
 		private readonly TimeSpan _javascriptExecutionTimeout;
@@ -16,7 +14,8 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 		public IProjectionStateHandler Create(
 			string factoryType, string source,
-			bool enableContentTypeValidation, int projectionExecutionTimeout = ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout,
+			bool enableContentTypeValidation,
+			int? projectionExecutionTimeout,
 			Action<int, Action> cancelCallbackFactory = null,
 			Action<string, object[]> logger = null) {
 			var colonPos = factoryType.IndexOf(':');
@@ -30,9 +29,9 @@ namespace EventStore.Projections.Core.Services.Management {
 			}
 
 			IProjectionStateHandler result;
-			var executionTimeout = projectionExecutionTimeout <= 0
-				? _javascriptExecutionTimeout
-				: TimeSpan.FromMilliseconds(projectionExecutionTimeout);
+			var executionTimeout = projectionExecutionTimeout is > 0
+				? TimeSpan.FromMilliseconds(projectionExecutionTimeout.Value)
+				: _javascriptExecutionTimeout;
 			switch (kind.ToLowerInvariant()) {
 				case "js":
 					result = new JintProjectionStateHandler(source, enableContentTypeValidation,

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -153,7 +153,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					_logger,
 					message.HandlerType,
 					message.Query,
-					message.EnableContentTypeValidation, message.Config.ProjectionExecutionTimeout);
+					message.EnableContentTypeValidation,
+					message.Config.ProjectionExecutionTimeout);
 
 				string name = message.Name;
 				var sourceDefinition = ProjectionSourceDefinition.From(stateHandler.GetSourceDefinition());
@@ -301,11 +302,13 @@ namespace EventStore.Projections.Core.Services.Processing {
 			ILogger logger,
 			string handlerType,
 			string query,
-			bool enableContentTypeValidation, int projectionExecutionTimeout) {
+			bool enableContentTypeValidation,
+			int? projectionExecutionTimeout) {
 			var stateHandler = factory.Create(
 				handlerType,
 				query,
-				enableContentTypeValidation, projectionExecutionTimeout,
+				enableContentTypeValidation,
+				projectionExecutionTimeout,
 				logger: logger.Verbose,
 				cancelCallbackFactory:
 				singletonTimeoutScheduler == null ? null : singletonTimeoutScheduler.Schedule);

--- a/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
@@ -1,7 +1,6 @@
 using EventStore.Projections.Core.Common;
 using System;
 using System.Security.Claims;
-using EventStore.Core;
 
 namespace EventStore.Projections.Core.Services {
 	public class ProjectionConfig {
@@ -21,7 +20,7 @@ namespace EventStore.Projections.Core.Services {
 		public ProjectionConfig(ClaimsPrincipal runAs, int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold,
 			int pendingEventsThreshold, int maxWriteBatchLength, bool emitEventEnabled, bool checkpointsEnabled,
 			bool createTempStreams, bool stopOnEof, bool trackEmittedStreams,
-			int checkpointAfterMs, int maximumAllowedWritesInFlight, int projectionExecutionTimeout = ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout) {
+			int checkpointAfterMs, int maximumAllowedWritesInFlight, int projectionExecutionTimeout) {
 			if (checkpointsEnabled) {
 				if (checkpointHandledThreshold <= 0)
 					throw new ArgumentOutOfRangeException("checkpointHandledThreshold");
@@ -109,10 +108,5 @@ namespace EventStore.Projections.Core.Services {
 		}
 		
 		public int ProjectionExecutionTimeout { get; }
-
-		public static ProjectionConfig GetTest() {
-			return new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000,
-				1);
-		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
@@ -20,7 +20,7 @@ namespace EventStore.Projections.Core.Services {
 		public ProjectionConfig(ClaimsPrincipal runAs, int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold,
 			int pendingEventsThreshold, int maxWriteBatchLength, bool emitEventEnabled, bool checkpointsEnabled,
 			bool createTempStreams, bool stopOnEof, bool trackEmittedStreams,
-			int checkpointAfterMs, int maximumAllowedWritesInFlight, int projectionExecutionTimeout) {
+			int checkpointAfterMs, int maximumAllowedWritesInFlight, int? projectionExecutionTimeout) {
 			if (checkpointsEnabled) {
 				if (checkpointHandledThreshold <= 0)
 					throw new ArgumentOutOfRangeException("checkpointHandledThreshold");
@@ -39,7 +39,7 @@ namespace EventStore.Projections.Core.Services {
 					$"The Maximum Number of Allowed Writes in Flight cannot be less than {AllowedWritesInFlight.Unbounded}");
 			}
 
-			if (projectionExecutionTimeout <= 0) {
+			if (projectionExecutionTimeout is not null && projectionExecutionTimeout <= 0) {
 				throw new ArgumentException(
 					$"The projection execution timeout should be positive. Found : {projectionExecutionTimeout}");
 			}
@@ -107,6 +107,6 @@ namespace EventStore.Projections.Core.Services {
 			get { return _maximumAllowedWritesInFlight; }
 		}
 		
-		public int ProjectionExecutionTimeout { get; }
+		public int? ProjectionExecutionTimeout { get; }
 	}
 }


### PR DESCRIPTION
Fixed: Don't write the database default `ProjectionExecutionTimeout` in the projection persisted state on creation.

Fixes https://github.com/EventStore/EventStore/issues/4416

This means that projections that have not explicitly set their own `ProjectionExecutionTimeout` will be affected by any changes to the database-level `ProjectionExecutionTimeout`.

This does not attempt to fix projections that had the database-level `ProjectionExecutionTimeout` written to the projection's persisted state. Projections that were created on v23.10 will need to be updated to remove the persisted `ProjectionExecutionTimeout` in order for the database-level setting to affect them again.
This update can be done over HTTP, through the admin UI, or using the legacy TCP client.