### PR TITLE
[release/oss-v23.10] Handle deleted or truncated input streams in multi-stream projections

### DIFF
--- a/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpontManagerTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpontManagerTests.cs
@@ -1,0 +1,229 @@
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.XUnit.Tests.TestHelpers;
+using Xunit;
+using ExistingEvent = EventStore.Projections.Core.XUnit.Tests.TestHelpers.ExistingStreamsHelper.ExistingEvent;
+
+namespace EventStore.Projections.Core.XUnit.Tests.CheckpointManagers;
+
+/// More tests for MultiStreamMultiOutputCheckpointManager exist in the NUnit tests,
+/// and derive from <see cref="EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager.multi_stream.TestFixtureWithMultiStreamCheckpointManager"/>
+public class MultiStreamMultiOutputCheckpointManagerTests {
+	private const string ProjectionName = "test-projection";
+	private const string OrderStreamName = $"$projections-{ProjectionName}-order";
+	private const int ProjectionPhase = 0;
+	private readonly MultiStreamMultiOutputCheckpointManager _sut;
+	private readonly FakePublisher _publisher;
+	private readonly IODispatcher _ioDispatcher;
+	private readonly CoreProjectionCheckpointWriter _checkpointWriter;
+	private readonly ExistingStreamsHelper _existingStreams;
+
+	public MultiStreamMultiOutputCheckpointManagerTests() {
+		var projectionId = Guid.NewGuid();
+		var projectionVersion = new ProjectionVersion(3, ProjectionPhase, 5);
+		var namingBuilder = new ProjectionNamesBuilder(ProjectionName, new ProjectionSourceDefinition());
+		_publisher = new FakePublisher();
+		var envelope = new FakeEnvelope();
+		_ioDispatcher = new IODispatcher(_publisher, envelope);
+		_checkpointWriter = new CoreProjectionCheckpointWriter(
+				namingBuilder.MakeCheckpointStreamName(),_ioDispatcher, projectionVersion, ProjectionName);
+		_existingStreams = new ExistingStreamsHelper();
+
+		var projectionConfig = new ProjectionConfig(SystemAccounts.System, 10, 1000, 20, 2,
+			true, true, false, false, false, 10000, 100, null);
+		var positionTagger = new FakePositionTagger(ProjectionPhase);
+
+		_sut = new MultiStreamMultiOutputCheckpointManager(
+			_publisher, projectionId, projectionVersion, SystemAccounts.System, _ioDispatcher, projectionConfig, ProjectionName,
+			positionTagger, namingBuilder, usePersistentCheckpoints: true, producesRunningResults: true, definesFold: false,
+			_checkpointWriter);
+	}
+
+	[Theory]
+	[MemberData(nameof(PreRecordedEvents))]
+	public void when_loading_prerecorded_events(PreRecordedEventsScenario scenario) {
+		_existingStreams.AddEvents(scenario.WithExistingEvents);
+		_existingStreams.HardDeleteStreams(scenario.WithHardDeletedStreams);
+
+		var checkpointTag = CheckpointTag.Empty;
+		_checkpointWriter.StartFrom(checkpointTag, 0);
+		_sut.BeginLoadPrerecordedEvents(checkpointTag);
+
+		// Read the order stream to find prerecorded events
+		var orderStreamRead = _publisher.Messages
+			.OfType<ClientMessage.ReadStreamEventsBackward>()
+			.FirstOrDefault();
+		Assert.NotNull(orderStreamRead);
+		Assert.Equal(OrderStreamName, orderStreamRead.EventStreamId);
+		_ioDispatcher.BackwardReader.Handle(
+			_existingStreams.ReadStreamBackward(orderStreamRead));
+
+		// Read each event in the input streams 1 event at a time
+		var readRequests = _publisher.Messages
+			.OfType<ClientMessage.ReadStreamEventsBackward>()
+			.Skip(1) // Order stream read
+			.ToArray();
+		for (var i = 0; i < scenario.ExpectedInputStreamReads.Length; i++) {
+			var (expectedStream, expectedFrom) = scenario.ExpectedInputStreamReads[i];
+			var actual = readRequests[i];
+			Assert.Equal(expectedStream, actual.EventStreamId);
+			Assert.Equal(expectedFrom, actual.FromEventNumber);
+			Assert.Equal(1, actual.MaxCount);
+			_ioDispatcher.BackwardReader.Handle(_existingStreams.ReadStreamBackward(actual));
+		}
+
+		// Publish a CommittedEventReceived for the prerecorded events that were found
+		var committedEvents = _publisher.Messages
+			.OfType<EventReaderSubscriptionMessage.CommittedEventReceived>().ToArray();
+		Assert.Equal(scenario.ExpectedCommittedEvents.Length, committedEvents.Length);
+		for (var i = 0; i < scenario.ExpectedCommittedEvents.Length; i++) {
+			var exp = scenario.ExpectedCommittedEvents[i];
+			var act = committedEvents[i];
+			Assert.Equal(exp.EventStreamId, act.Data.EventStreamId);
+			Assert.Equal(exp.EventNumber, act.Data.EventSequenceNumber);
+			Assert.Equal(i, act.SubscriptionMessageSequenceNumber);
+			Assert.Equal(exp.PreparePosition, act.Data.Position.PreparePosition);
+		}
+
+		// Publish completed message
+		var completeMessage = _publisher.Messages
+			.OfType<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>()
+			.SingleOrDefault();
+		Assert.NotNull(completeMessage);
+	}
+
+	public readonly struct PreRecordedEventsScenario(
+		string scenarioName,
+		ExistingEvent[] withExistingEvents,
+		ExistingEvent[] expectedCommittedEvents,
+		Tuple<string, long>[] expectedInputStreamReads,
+		string[]? withHardDeletedStreams = null) {
+		private string ScenarioName { get; } = scenarioName;
+		public ExistingEvent[] WithExistingEvents { get; } = withExistingEvents;
+		public ExistingEvent[] ExpectedCommittedEvents { get; } = expectedCommittedEvents;
+		public Tuple<string, long>[] ExpectedInputStreamReads { get; } = expectedInputStreamReads;
+		public string[] WithHardDeletedStreams { get; } = withHardDeletedStreams ?? [];
+
+		public override string ToString() => ScenarioName;
+	}
+
+	public static TheoryData<PreRecordedEventsScenario> PreRecordedEvents() =>
+		new() {
+			new PreRecordedEventsScenario("No prerecorded events", [], [], []),
+			new PreRecordedEventsScenario("All prerecorded events can be read",
+				withExistingEvents: new ExistingEvent[] {
+					new("a", 0, 100, """{ "data": "a0" }"""),
+					new(OrderStreamName, 0, 200, "0@a", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new("b", 0, 300, """{ "data": "b0" }"""),
+					new(OrderStreamName, 1, 400, "0@b", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new("a", 1, 500, """{ "data": "a1" }"""),
+					new(OrderStreamName, 2, 600, "1@a", """{"s": { "a": 1, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new("b", 1, 700, """{ "data": "b1" }"""),
+					new(OrderStreamName, 3, 800, "1@b", """{"s": { "a": 1, "b": 1 }}""", SystemEventTypes.LinkTo),
+				},
+				expectedCommittedEvents: new ExistingEvent[] {
+					new("a", 0, 100, """{ "data": "a0" }"""),
+					new("b", 0, 300, """{ "data": "b0" }"""),
+					new("a", 1, 500, """{ "data": "a1" }"""),
+					new("b", 1, 700, """{ "data": "b1" }"""),
+				},
+				expectedInputStreamReads: new Tuple<string, long>[] {
+					new("b", 1),
+					new("a", 1),
+					new("b", 0),
+					new("a", 0),
+				}
+			),
+			new PreRecordedEventsScenario("Some prerecorded events have been truncated",
+				withExistingEvents: new ExistingEvent[] {
+					new("a", 0, 100, """{ "data": "a0" }""", ""),
+					new(OrderStreamName, 0, 200, "0@a", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					// b@0 has been deleted
+					new(OrderStreamName, 1, 400, "0@b", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new("a", 1, 500, """{ "data": "a1" }"""),
+					new(OrderStreamName, 2, 600, "1@a", """{"s": { "a": 1, "b": 0 }}""", SystemEventTypes.LinkTo),
+					// b@1 has been deleted
+					new(OrderStreamName, 3, 800, "1@b", """{"s": { "a": 1, "b": 1 }}""", SystemEventTypes.LinkTo),
+					new("a", 2, 900, """{ "data": "a2" }"""),
+					new(OrderStreamName, 4, 1000, "2@a", """{"s": { "a": 2, "b": 1 }}""", SystemEventTypes.LinkTo),
+					new("b", 2, 1100, """{ "data": "b2" }"""),
+					new(OrderStreamName, 5, 1200, "2@b", """{"s": { "a": 2, "b": 2 }}""", SystemEventTypes.LinkTo)
+				},
+				expectedCommittedEvents: new ExistingEvent[] {
+					new("a", 0, 100, """{ "data": "a0" }"""),
+					new("a", 1, 500, """{ "data": "a1" }"""),
+					new("a", 2, 900, """{ "data": "a2" }"""),
+					new("b", 2, 1100, """{ "data": "b2" }"""),
+				},
+				expectedInputStreamReads: new Tuple<string, long>[] {
+					new("b", 2),
+					new("a", 2),
+					new("b", 1),
+					new("a", 1),
+					new("b", 0),
+					new("a", 0),
+				}),
+			new PreRecordedEventsScenario("All prerecorded events have been truncated",
+				withExistingEvents: new ExistingEvent[] {
+					new(OrderStreamName, 0, 200, "0@a", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 1, 400, "0@b", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 2, 600, "1@a", """{"s": { "a": 1, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 3, 800, "1@b", """{"s": { "a": 1, "b": 1 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 4, 1000, "2@a", """{"s": { "a": 2, "b": 1 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 5, 1200, "2@b", """{"s": { "a": 2, "b": 2 }}""", SystemEventTypes.LinkTo),
+					// We must write events at the end of the input stream because this is a different scenario to stream not found.
+					new("a", 3, 1300, """{ "data": "a3" }"""),
+					new("b", 3, 1400, """{ "data": "b3" }"""),
+				},
+				expectedCommittedEvents: new ExistingEvent[] { },
+				expectedInputStreamReads: new Tuple<string, long>[] {
+					new("b", 2),
+					new("a", 2),
+					new("b", 1),
+					new("a", 1),
+					new("b", 0),
+					new("a", 0),
+				}),
+			new PreRecordedEventsScenario("All input streams have been soft deleted",
+				withExistingEvents: new ExistingEvent[] {
+					new(OrderStreamName, 0, 200, "0@a", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 1, 400, "0@b", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 2, 600, "1@a", """{"s": { "a": 1, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 3, 800, "1@b", """{"s": { "a": 1, "b": 1 }}""", SystemEventTypes.LinkTo),
+				},
+				expectedCommittedEvents: new ExistingEvent[] { },
+				expectedInputStreamReads: new Tuple<string, long>[] {
+					new("b", 1),
+					new("a", 1),
+					new("b", 0),
+					new("a", 0),
+				}),
+			new PreRecordedEventsScenario("One of the input streams has been hard deleted",
+				withExistingEvents: new ExistingEvent[] {
+					new("a", 0, 100, """{ "data": "a0" }"""),
+					new(OrderStreamName, 0, 200, "0@a", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 1, 400, "0@b", """{"s": { "a": 0, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new("a", 1, 500, """{ "data": "a1" }"""),
+					new(OrderStreamName, 2, 600, "1@a", """{"s": { "a": 1, "b": 0 }}""", SystemEventTypes.LinkTo),
+					new(OrderStreamName, 3, 800, "1@b", """{"s": { "a": 1, "b": 1 }}""", SystemEventTypes.LinkTo),
+				},
+				withHardDeletedStreams: new string[] { "b" },
+				expectedCommittedEvents: new ExistingEvent[] {
+					new("a", 0, 100, """{ "data": "a0" }"""),
+					new("a", 1, 500, """{ "data": "a1" }"""),
+				},
+				expectedInputStreamReads: new Tuple<string, long>[] {
+					new("b", 1),
+					new("a", 1),
+					new("b", 0),
+					new("a", 0),
+				})
+		};
+}

--- a/src/EventStore.Projections.Core.XUnit.Tests/EventStore.Projections.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Projections.Core.XUnit.Tests/EventStore.Projections.Core.XUnit.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+      <PackageReference Include="xunit" Version="2.6.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\EventStore.Core.Tests\EventStore.Core.Tests.csproj" />
+      <ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/EventStore.Projections.Core.XUnit.Tests/TestHelpers/ExistingStreamsHelper.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/TestHelpers/ExistingStreamsHelper.cs
@@ -1,0 +1,115 @@
+using System.Text;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Projections.Core.XUnit.Tests.TestHelpers;
+
+// TODO: Flesh out this helper as more tests need it
+public class ExistingStreamsHelper {
+	private readonly Dictionary<string, List<ExistingEvent>> _streams = new();
+	private readonly List<string> _hardDeletedStreams = new();
+	private long _lastPosition;
+
+	public void AddEvents(params ExistingEvent[] newEvents) {
+		foreach (var newEvent in newEvents) {
+			if (_streams.TryGetValue(newEvent.EventStreamId, out var existingEvents)) {
+				existingEvents.Add(newEvent);
+			} else {
+				_streams.Add(newEvent.EventStreamId, [newEvent]);
+			}
+
+			if (newEvent.PreparePosition > _lastPosition) {
+				_lastPosition = newEvent.PreparePosition;
+			}
+		}
+	}
+
+	public void HardDeleteStreams(string[] deletedStreams) {
+		foreach (var stream in deletedStreams) {
+			if (!_hardDeletedStreams.Contains(stream)) {
+				_hardDeletedStreams.Add(stream);
+			}
+		}
+	}
+
+	public long GetLastEventNumberForStream(string streamId) {
+		if (_hardDeletedStreams.Contains(streamId)) {
+			return EventNumber.DeletedStream;
+		}
+
+		return _streams.TryGetValue(streamId, out var existingEvents)
+			? existingEvents.Max(x => x.EventNumber)
+			: EventNumber.Invalid;
+	}
+
+	public ClientMessage.ReadStreamEventsBackwardCompleted ReadStreamBackward(
+		ClientMessage.ReadStreamEventsBackward request) {
+		if (_hardDeletedStreams.Contains(request.EventStreamId)) {
+			return CreateReadBackwardCompleted(request, ReadStreamResult.StreamDeleted, []);
+		}
+
+		if (!_streams.TryGetValue(request.EventStreamId, out var existingEvents)) {
+			return CreateReadBackwardCompleted(request, ReadStreamResult.NoStream, []);
+		}
+
+		var resolvedEvents = new List<ResolvedEvent>();
+		var lastEventNumber = GetLastEventNumberForStream(request.EventStreamId);
+		var current = request.FromEventNumber == -1 ? lastEventNumber : request.FromEventNumber;
+		for (var i = 0; i < request.MaxCount; i++) {
+			var foundEvent = existingEvents.FirstOrDefault(x => x.EventNumber == current);
+			if (foundEvent is not null) {
+				resolvedEvents.Add(ResolvedEvent.ForUnresolvedEvent(foundEvent.ToEventRecord(request.CorrelationId)));
+			}
+
+			current--;
+		}
+
+		return CreateReadBackwardCompleted(request, ReadStreamResult.Success, resolvedEvents.ToArray());
+	}
+
+	private ClientMessage.ReadStreamEventsBackwardCompleted CreateReadBackwardCompleted(
+		ClientMessage.ReadStreamEventsBackward request, ReadStreamResult result, ResolvedEvent[] events) {
+		if (result is ReadStreamResult.NoStream) {
+			return new ClientMessage.ReadStreamEventsBackwardCompleted(request.CorrelationId, request.EventStreamId,
+				request.FromEventNumber, request.MaxCount, result, [], StreamMetadata.Empty, false,
+				"", -1, EventNumber.Invalid, true, _lastPosition);
+		}
+
+		long nextEventNumber = 0;
+		if (events.Length > 0) {
+			nextEventNumber = events.Last().OriginalEventNumber;
+		}
+
+		var isEof = nextEventNumber == 0;
+		return new ClientMessage.ReadStreamEventsBackwardCompleted(
+			request.CorrelationId, request.EventStreamId, request.FromEventNumber, request.MaxCount,
+			ReadStreamResult.Success, events.ToArray(), StreamMetadata.Empty, false, string.Empty,
+			nextEventNumber, GetLastEventNumberForStream(request.EventStreamId), isEof, _lastPosition);
+	}
+
+	public class ExistingEvent {
+		public ExistingEvent(string eventStreamId, long eventNumber, long position, string data,
+			string metadata = "", string eventType = "test-event") {
+			EventStreamId = eventStreamId;
+			EventNumber = eventNumber;
+			PreparePosition = position;
+			Data = data;
+			Metadata = metadata;
+			EventType = eventType;
+		}
+
+		public string EventStreamId { get; }
+		public string EventType { get; }
+		public long EventNumber { get; }
+		public long PreparePosition { get; }
+		public string Data { get; }
+		public string Metadata { get; }
+
+		public EventRecord ToEventRecord(Guid correlationId) =>
+			new(EventNumber, PreparePosition, correlationId, Guid.NewGuid(), transactionPosition: 0,
+				transactionOffset: 0,
+				EventStreamId, EventNumber, DateTime.Now, PrepareFlags.IsCommitted, EventType,
+				Encoding.UTF8.GetBytes(Data), Encoding.UTF8.GetBytes(Metadata));
+	}
+}

--- a/src/EventStore.Projections.Core.XUnit.Tests/TestHelpers/FakePositionTagger.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/TestHelpers/FakePositionTagger.cs
@@ -1,0 +1,38 @@
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+
+namespace EventStore.Projections.Core.XUnit.Tests.TestHelpers;
+
+// TODO: Flesh out this helper as more tests need it
+public class FakePositionTagger : PositionTagger {
+	public FakePositionTagger(int phase) : base(phase) {
+	}
+
+	public override bool IsMessageAfterCheckpointTag(CheckpointTag previous, ReaderSubscriptionMessage.CommittedEventDistributed committedEvent) {
+		throw new NotImplementedException();
+	}
+
+	public override CheckpointTag MakeCheckpointTag(CheckpointTag previous, ReaderSubscriptionMessage.CommittedEventDistributed committedEvent) {
+		throw new NotImplementedException();
+	}
+
+	public override CheckpointTag MakeCheckpointTag(CheckpointTag previous, ReaderSubscriptionMessage.EventReaderPartitionEof partitionEof) {
+		throw new NotImplementedException();
+	}
+
+	public override CheckpointTag MakeCheckpointTag(CheckpointTag previous, ReaderSubscriptionMessage.EventReaderPartitionDeleted partitionDeleted) {
+		throw new NotImplementedException();
+	}
+
+	public override CheckpointTag MakeZeroCheckpointTag() {
+		return CheckpointTag.Empty;
+	}
+
+	public override bool IsCompatible(CheckpointTag checkpointTag) {
+		throw new NotImplementedException();
+	}
+
+	public override CheckpointTag AdjustTag(CheckpointTag tag) {
+		return tag;
+	}
+}

--- a/src/EventStore.sln
+++ b/src/EventStore.sln
@@ -62,6 +62,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.Common.Tests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.PluginHosting", "EventStore.PluginHosting\EventStore.PluginHosting.csproj", "{8B021F57-D4B1-47D6-85AA-DE2D20486840}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventStore.Projections.Core.XUnit.Tests", "EventStore.Projections.Core.XUnit.Tests\EventStore.Projections.Core.XUnit.Tests.csproj", "{173FB572-44B2-45AC-A494-FED21E56C5FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -372,6 +374,18 @@ Global
 		{8B021F57-D4B1-47D6-85AA-DE2D20486840}.Release|ARM64.Build.0 = Release|ARM64
 		{8B021F57-D4B1-47D6-85AA-DE2D20486840}.Release|x64.ActiveCfg = Release|x64
 		{8B021F57-D4B1-47D6-85AA-DE2D20486840}.Release|x64.Build.0 = Release|x64
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Debug|x64.Build.0 = Debug|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Release|ARM64.Build.0 = Release|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Release|x64.ActiveCfg = Release|Any CPU
+		{173FB572-44B2-45AC-A494-FED21E56C5FA}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixed: Multistream projections don't always start properly when the input stream is truncated or deleted.

Cherry-picked from https://github.com/EventStore/EventStore/pull/4422