### PR TITLE
[master] Don't write default projection timeout on creation

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/Jint/TestFixtureWithInterpretedProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/TestFixtureWithInterpretedProjection.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using EventStore.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -44,7 +43,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint
 
 		protected virtual IProjectionStateHandler CreateStateHandler() {
 			return _stateHandlerFactory.Create(
-				_projectionType, _projection, true, logger: (s, _) => {
+				_projectionType, _projection, true, null, logger: (s, _) => {
 					if (s.StartsWith("P:"))
 						Console.WriteLine(s);
 					else

--- a/src/EventStore.Projections.Core.Tests/Services/Jint/when_creating_jint_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/when_creating_jint_projection.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using EventStore.Common;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
-using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Checkpointing;
-using EventStore.Projections.Core.Services.Processing.Emitting;
 using EventStore.Projections.Core.Services.Processing.Emitting.EmittedEvents;
 using Jint.Runtime;
 using NUnit.Framework;
@@ -22,14 +19,14 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
 
 		[Test, Category(_projectionType)]
 		public void it_can_be_created() {
-			using (_stateHandlerFactory.Create(_projectionType, @"", true)) {
+			using (_stateHandlerFactory.Create(_projectionType, @"", true, null)) {
 			}
 		}
 
 		[Test, Category(_projectionType)]
 		public void js_syntax_errors_are_reported() {
 			try {
-				using (_stateHandlerFactory.Create(_projectionType, @"log(1;", true, logger: (s, _) => { })) {
+				using (_stateHandlerFactory.Create(_projectionType, @"log(1;", true, null, logger: (s, _) => { })) {
 				}
 			} catch (Exception ex) {
 				Assert.IsInstanceOf<Esprima.ParserException>(ex);
@@ -39,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
 		[Test, Category(_projectionType)]
 		public void js_exceptions_errors_are_reported() {
 			try {
-				using (_stateHandlerFactory.Create(_projectionType, @"throw 123;", true, logger: (s, _) => { })) {
+				using (_stateHandlerFactory.Create(_projectionType, @"throw 123;", true, null, logger: (s, _) => { })) {
 				}
 			} catch (Exception ex) {
 				Assert.IsInstanceOf<JavaScriptException>(ex);
@@ -56,6 +53,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
                                 while (true) i++;
                     ",
 					true,
+					null,
 					logger: (s, _) => { },
 					cancelCallbackFactory: (timeout, action) => { })) {
 				}
@@ -78,6 +76,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
                         });
                     ",
 					true,
+					null,
 					logger: Console.WriteLine)) {
 					h.Initialize();
 					string newState;
@@ -115,6 +114,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
                         });
                     ",
 					true,
+					null,
 					logger: Console.WriteLine)) {
 					h.Initialize();
 					string newState;
@@ -143,7 +143,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint {
                             while (true) i++;
                         }
                     });
-                ", true, logger: Console.WriteLine)) {
+                ", true, null, logger: Console.WriteLine)) {
 						h.Initialize();
 						string newState;
 						EmittedEventEnvelope[] emittedevents;

--- a/src/EventStore.Projections.Core.Tests/Services/Jint/when_running_with_content_type_validation.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/when_running_with_content_type_validation.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using EventStore.Projections.Core.Services;
-using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Checkpointing;
-using EventStore.Projections.Core.Services.Processing.Emitting;
 using EventStore.Projections.Core.Services.Processing.Emitting.EmittedEvents;
 using NUnit.Framework;
 
@@ -13,7 +11,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint
 		public class when_running_with_content_type_validation_enabled : TestFixtureWithInterpretedProjection {
 			protected override void Given() {
 				_projection = @"
-                fromAll().when({$any: 
+                fromAll().when({$any:
                     function(state, event) {
                     linkTo('output-stream' + event.sequenceNumber, event);
                     return {};
@@ -23,8 +21,10 @@ namespace EventStore.Projections.Core.Tests.Services.Jint
 
 			protected override IProjectionStateHandler CreateStateHandler() {
 				return _stateHandlerFactory.Create(
-					_projectionType, _projection, 
-					enableContentTypeValidation: true, logger: (s, _) => {
+					_projectionType, _projection,
+					enableContentTypeValidation: true,
+					null,
+					logger: (s, _) => {
 						if (s.StartsWith("P:"))
 							Console.WriteLine(s);
 						else
@@ -64,7 +64,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint
 		public class when_running_with_content_type_validation_disabled : TestFixtureWithInterpretedProjection {
 			protected override void Given() {
 				_projection = @"
-                fromAll().when({$any: 
+                fromAll().when({$any:
                     function(state, event) {
                     linkTo('output-stream' + event.sequenceNumber, event);
                     return {};
@@ -74,8 +74,10 @@ namespace EventStore.Projections.Core.Tests.Services.Jint
 
 			protected override IProjectionStateHandler CreateStateHandler() {
 				return _stateHandlerFactory.Create(
-					_projectionType, _projection, 
-					enableContentTypeValidation: false, logger: (s, _) => {
+					_projectionType, _projection,
+					enableContentTypeValidation: false,
+					projectionExecutionTimeout: null,
+					logger: (s, _) => {
 						if (s.StartsWith("P:"))
 							Console.WriteLine(s);
 						else

--- a/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
-using EventStore.Core.Messaging;
 using EventStore.Core.Tests.ClientAPI;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
@@ -30,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services {
 			_projectionNamesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
 			_emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher,
 				new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false,
-					_trackEmittedStreams, 10000, 1), _projectionNamesBuilder);
+					_trackEmittedStreams, 10000, 1, null), _projectionNamesBuilder);
 			_emittedStreamsDeleter = new EmittedStreamsDeleter(_ioDispatcher,
 				_projectionNamesBuilder.GetEmittedStreamsName(),
 				_projectionNamesBuilder.GetEmittedStreamsCheckpointName());

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
@@ -94,7 +94,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold, GivenPendingEventsThreshold(),
 				GivenMaxWriteBatchLength(), GivenEmitEventEnabled(), GivenCheckpointsEnabled(), _createTempStreams,
 				GivenStopOnEof(), GivenTrackEmittedStreams(), GivenCheckpointAfterMs(),
-				GivenMaximumAllowedWritesInFlight());
+				GivenMaximumAllowedWritesInFlight(), null);
 		}
 
 		protected virtual int GivenMaxWriteBatchLength() {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -39,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
 			_config = new ProjectionConfig(null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold,
 				_pendingEventsThreshold, _maxWriteBatchLength, _emitEventEnabled,
 				_checkpointsEnabled, _createTempStreams, _stopOnEof, _trackEmittedStreams, _checkpointAfterMs,
-				_maximumAllowedWritesInFlight);
+				_maximumAllowedWritesInFlight, null);
 			When();
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
@@ -4,7 +4,6 @@ using EventStore.Core.Data;
 using EventStore.Core.Bus;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
-using EventStore.Core.Messaging;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Helpers.IODispatcherTests;
 using EventStore.Projections.Core.Services;
@@ -37,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
 			_projectionVersion = new ProjectionVersion(3, 1, 2);
 			_projectionConfig = new ProjectionConfig(SystemAccounts.System, 10, 1000, 1000, 10, true, true, true,
 				false,
-				false, 5000, 10);
+				false, 5000, 10, null);
 			_positionTagger = new MultiStreamPositionTagger(3, _streams);
 			_positionTagger.AdjustTag(CheckpointTag.FromStreamPositions(3,
 				new Dictionary<string, long> {{"a", 0}, {"b", 0}, {"c", 0}}));

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
@@ -1,6 +1,5 @@
 using System;
 using EventStore.Core.Helpers;
-using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Fakes;
@@ -21,7 +20,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 		}
 
 		private readonly ProjectionConfig _defaultProjectionConfig = new ProjectionConfig(
-			null, 5, 10, 1000, 250, true, true, true, true, true, 10000, 1);
+			null, 5, 10, 1000, 250, true, true, true, true, true, 10000, 1, null);
 
 		private IODispatcher _ioDispatcher;
 
@@ -35,7 +34,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, null);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,
@@ -62,7 +61,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, null);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,
@@ -262,7 +261,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, null);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
-using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Bus.Helpers;
@@ -56,7 +55,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 			_bus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher);
 			IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 			_projectionConfig =
-				new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, true, 10000, 1);
+				new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, true, 10000, 1, null);
 			var version = new ProjectionVersion(1, 0, 0);
 			var projectionProcessingStrategy = new ContinuousProjectionProcessingStrategy(
 				"projection", version, projectionStateHandler, _projectionConfig,

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service/when_stopping_the_projection_core_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service/when_stopping_the_projection_core_service.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 	[TestFixture]
-	public class when_stopping_the_projection_core_service_with_no_running_projections 
+	public class when_stopping_the_projection_core_service_with_no_running_projections
 		: TestFixtureWithProjectionCoreService {
 		private readonly Guid _stopCorrelationId = Guid.NewGuid();
 
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			base.Setup();
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 		}
-		
+
 		[Test]
 		public void should_handle_subcomponent_stopped() {
 			var componentStopped = _consumer.HandledMessages
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 	}
 
 	[TestFixture]
-	public class when_stopping_the_projection_core_service_with_running_projections 
+	public class when_stopping_the_projection_core_service_with_running_projections
 		: TestFixtureWithProjectionCoreService  {
 		private readonly Guid _projectionId = Guid.NewGuid();
 		private readonly Guid _stopCorrelationId = Guid.NewGuid();
@@ -38,8 +38,9 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			base.Setup();
 			_bus.Subscribe<CoreProjectionStatusMessage.Suspended>(_service);
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
-				_projectionId, _workerId, "test-projection", 
-				new ProjectionVersion(), ProjectionConfig.GetTest(),
+				_projectionId, _workerId, "test-projection",
+				new ProjectionVersion(), new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000,
+					1, 250),
 				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 		}
@@ -49,9 +50,9 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			var suspended = _consumer.HandledMessages
 				.OfType<CoreProjectionStatusMessage.Suspended>()
 				.LastOrDefault(x => x.ProjectionId == _projectionId);
-			Assert.IsNotNull(suspended);	
+			Assert.IsNotNull(suspended);
 		}
-		
+
 		[Test]
 		public void should_handle_subcomponent_stopped() {
 			var componentStopped = _consumer.HandledMessages
@@ -60,7 +61,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			Assert.IsNotNull(componentStopped);
 		}
 	}
-	
+
 	[TestFixture]
 	public class when_stopping_the_projection_core_service_times_out_suspending_projections
 		: TestFixtureWithProjectionCoreService  {
@@ -73,8 +74,9 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			// Don't subscribe to the suspended message
 			_bus.Unsubscribe<CoreProjectionStatusMessage.Suspended>(_service);
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
-				_projectionId, _workerId, "test-projection", 
-				new ProjectionVersion(), ProjectionConfig.GetTest(),
+				_projectionId, _workerId, "test-projection",
+				new ProjectionVersion(), new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000,
+					1, 250),
 				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCoreTimeout(_stopCorrelationId));
@@ -88,7 +90,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			Assert.IsNotNull(componentStopped);
 		}
 	}
-	
+
 	[TestFixture]
 	public class when_stopping_the_projection_core_service_and_timeout_for_wrong_correlation_received
 		: TestFixtureWithProjectionCoreService  {
@@ -101,8 +103,9 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			// Don't subscribe to the suspended message
 			_bus.Unsubscribe<CoreProjectionStatusMessage.Suspended>(_service);
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
-				_projectionId, _workerId, "test-projection", 
-				new ProjectionVersion(), ProjectionConfig.GetTest(),
+				_projectionId, _workerId, "test-projection",
+				new ProjectionVersion(), new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000,
+					1, 250),
 				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCoreTimeout(Guid.NewGuid()));

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
@@ -89,7 +89,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 				readerBuilder.AllEvents();
 			}
 
-			var config = ProjectionConfig.GetTest();
+			var config = new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000,
+				1, 250);
 			IQuerySources sources = readerBuilder.Build();
 			var readerStrategy = ReaderStrategy.Create(
 				"test",

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Services.TimeService;
@@ -45,7 +44,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 
 
 		[Test]
-		public void empty_guid_throws_invali_argument_exception() {
+		public void empty_guid_throws_invalid_argument_exception() {
 			Assert.Throws<ArgumentException>(() => {
 				new ManagedProjection(
 					Guid.NewGuid(),
@@ -67,38 +66,6 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 		}
 
 		[Test]
-		public void empty_guid_throws_invali_argument_exception2() {
-			Assert.Throws<ArgumentException>(() => {
-				new ManagedProjection(
-					Guid.NewGuid(),
-					Guid.Empty,
-					1,
-					"name",
-					true,
-					null,
-					_streamDispatcher,
-					_writeDispatcher,
-					_readDispatcher,
-					_bus,
-					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
-					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
-			});
-		}
-
-		[Test]
 		public void null_name_throws_argument_null_exception() {
 			Assert.Throws<ArgumentNullException>(() => {
 				new ManagedProjection(
@@ -113,50 +80,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 					_readDispatcher,
 					_bus,
 					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
-					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
-			});
-		}
-
-		[Test]
-		public void null_name_throws_argument_null_exception2() {
-			Assert.Throws<ArgumentNullException>(() => {
-				new ManagedProjection(
-					Guid.NewGuid(),
-					Guid.NewGuid(),
-					1,
-					null,
-					true,
-					null,
-					_streamDispatcher,
-					_writeDispatcher,
-					_readDispatcher,
-					_bus,
-					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
+					_getStateDispatcher,
+					_getResultDispatcher,
 					_ioDispatcher,
 					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 			});
@@ -177,50 +102,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 					_readDispatcher,
 					_bus,
 					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
-					_ioDispatcher,
-					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
-			});
-		}
-
-		[Test]
-		public void empty_name_throws_argument_exception2() {
-			Assert.Throws<ArgumentException>(() => {
-				new ManagedProjection(
-					Guid.NewGuid(),
-					Guid.NewGuid(),
-					1,
-					"",
-					true,
-					null,
-					_streamDispatcher,
-					_writeDispatcher,
-					_readDispatcher,
-					_bus,
-					_timeProvider,
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
-					new RequestResponseDispatcher
-						<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
-							_bus,
-							v => v.CorrelationId,
-							v => v.CorrelationId,
-							_bus),
+					_getStateDispatcher,
+					_getResultDispatcher,
 					_ioDispatcher,
 					TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
 			});

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Linq;
+using EventStore.Common.Utils;
 using EventStore.Core;
+using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.Util;
+using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -15,11 +18,78 @@ using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed_projection {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_getting_config<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
+	public class when_initializing_projection_with_default_options<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
 		private ManagedProjection _mp;
 		private Guid _projectionId = Guid.NewGuid();
 		private ProjectionManagementMessage.ProjectionConfig _config;
+		private EventRecord _persistedStateWrite;
+
+		private ManagedProjection.PersistedState _persistedState = new ManagedProjection.PersistedState {
+			Enabled = true,
+			HandlerType = "JS",
+			Query = "fromAll().when({});",
+			Mode = ProjectionMode.Continuous,
+			CheckpointsDisabled = null,
+			Epoch = null,
+			Version = null,
+			RunAs = null,
+			EmitEnabled = null,
+			TrackEmittedStreams = null,
+			CheckpointAfterMs = (int)ProjectionConsts.CheckpointAfterMs.TotalMilliseconds,
+			CheckpointHandledThreshold = ProjectionConsts.CheckpointHandledThreshold,
+			CheckpointUnhandledBytesThreshold = ProjectionConsts.CheckpointUnhandledBytesThreshold,
+			MaxAllowedWritesInFlight = ProjectionConsts.MaxAllowedWritesInFlight,
+			ProjectionExecutionTimeout = null,
+			CreateTempStreams = null
+		};
+
+		public when_initializing_projection_with_default_options() {
+			AllWritesQueueUp();
+		}
+
+		protected override void Given() {
+			_timeProvider = new FakeTimeProvider();
+			_mp = CreateManagedProjection();
+
+			_mp.InitializeNew(
+				_persistedState,
+				null);
+			_mp.Handle(new CoreProjectionStatusMessage.Prepared(_projectionId, new ProjectionSourceDefinition()));
+
+			// Complete write of persisted state to start projection
+			OneWriteCompletes();
+			_config = GetProjectionConfig(_mp);
+			_persistedStateWrite = _streams[ProjectionStreamId].LastOrDefault();
+		}
+
+		[Test]
+		public void projection_execution_timeout_should_be_null() {
+			Assert.IsNotNull(_config);
+			Assert.IsNull(_config.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
+		}
+
+		[Test]
+		public void emit_options_should_default_to_false() {
+			Assert.IsNotNull(_config);
+			Assert.AreEqual(false, _config.EmitEnabled, "EmitEnabled");
+			Assert.AreEqual(false, _config.TrackEmittedStreams, "TrackEmittedStreams");
+		}
+
+		[Test]
+		public void persisted_state_should_leave_fallback_options_unset() {
+			Assert.IsNotNull(_persistedStateWrite);
+			var actualState = _persistedStateWrite.Data.ParseJson<ManagedProjection.PersistedState>();
+			Assert.IsNull(actualState.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class when_initializing_projection_with_persisted_state<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
+		private ManagedProjection _mp;
+		private Guid _projectionId = Guid.NewGuid();
+		private ProjectionManagementMessage.ProjectionConfig _config;
+		private EventRecord _persistedStateWrite;
 
 		private ManagedProjection.PersistedState _persistedState = new ManagedProjection.PersistedState {
 			Enabled = true,
@@ -41,7 +111,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 			ProjectionExecutionTimeout = 11
 		};
 
-		public when_getting_config() {
+		public when_initializing_projection_with_persisted_state() {
 			AllWritesQueueUp();
 		}
 
@@ -57,6 +127,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 			// Complete write of persisted state to start projection
 			OneWriteCompletes();
 			_config = GetProjectionConfig(_mp);
+			_persistedStateWrite = _streams[ProjectionStreamId].LastOrDefault();
 		}
 
 		[Test]
@@ -76,6 +147,99 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 				"MaxAllowedWritesInFlight");
 			Assert.AreEqual(_persistedState.ProjectionExecutionTimeout, _config.ProjectionExecutionTimeout,
 				"ProjectionExecutionTimeout");
+		}
+
+		[Test]
+		public void persisted_state_is_written_correctly() {
+			Assert.IsNotNull(_persistedStateWrite);
+			var actualState = _persistedStateWrite.Data.ParseJson<ManagedProjection.PersistedState>();
+
+			Assert.AreEqual(_persistedState.EmitEnabled, actualState.EmitEnabled, "EmitEnabled");
+			Assert.AreEqual(_persistedState.TrackEmittedStreams, actualState.TrackEmittedStreams, "TrackEmittedStreams");
+			Assert.AreEqual(_persistedState.CheckpointAfterMs, actualState.CheckpointAfterMs, "CheckpointAfterMs");
+			Assert.AreEqual(_persistedState.CheckpointHandledThreshold, actualState.CheckpointHandledThreshold,
+				"CheckpointHandledThreshold");
+			Assert.AreEqual(_persistedState.CheckpointUnhandledBytesThreshold,
+				actualState.CheckpointUnhandledBytesThreshold, "CheckpointUnhandledBytesThreshold");
+			Assert.AreEqual(_persistedState.PendingEventsThreshold, actualState.PendingEventsThreshold,
+				"PendingEventsThreshold");
+			Assert.AreEqual(_persistedState.MaxWriteBatchLength, actualState.MaxWriteBatchLength, "MaxWriteBatchLength");
+			Assert.AreEqual(_persistedState.MaxAllowedWritesInFlight, actualState.MaxAllowedWritesInFlight,
+				"MaxAllowedWritesInFlight");
+			Assert.AreEqual(_persistedState.ProjectionExecutionTimeout, actualState.ProjectionExecutionTimeout,
+				"ProjectionExecutionTimeout");
+		}
+	}
+
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_updating_projection_config_to_remove_execution_timeout<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
+		private ManagedProjection _mp;
+		private Guid _projectionId = Guid.NewGuid();
+		private ProjectionManagementMessage.ProjectionConfig _config;
+		private EventRecord _persistedStateWrite;
+		private ProjectionManagementMessage.Command.UpdateConfig _updateConfig;
+
+		private ManagedProjection.PersistedState _persistedState => new ManagedProjection.PersistedState {
+			Enabled = false,
+			HandlerType = "JS",
+			Query = "fromAll().when({});",
+			Mode = ProjectionMode.Continuous,
+			CheckpointsDisabled = false,
+			Epoch = -1,
+			Version = -1,
+			RunAs = SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous),
+			EmitEnabled = false,
+			TrackEmittedStreams = true,
+			CheckpointAfterMs = 1,
+			CheckpointHandledThreshold = 2,
+			CheckpointUnhandledBytesThreshold = 3,
+			PendingEventsThreshold = 4,
+			MaxWriteBatchLength = 5,
+			MaxAllowedWritesInFlight = 6,
+			ProjectionExecutionTimeout = 11
+		};
+
+		public when_updating_projection_config_to_remove_execution_timeout() {
+			AllWritesQueueUp();
+		}
+
+		protected override void Given() {
+			_timeProvider = new FakeTimeProvider();
+			_mp = CreateManagedProjection();
+
+			_mp.InitializeNew(
+				_persistedState,
+				null);
+			_mp.Handle(new CoreProjectionStatusMessage.Prepared(_projectionId, new ProjectionSourceDefinition()));
+			OneWriteCompletes();
+			_mp.Handle(new CoreProjectionStatusMessage.Stopped(_projectionId, ProjectionName, false));
+
+			_updateConfig = new ProjectionManagementMessage.Command.UpdateConfig(
+				new NoopEnvelope(), ProjectionName, _persistedState.EmitEnabled ?? false, _persistedState.TrackEmittedStreams ?? false,
+				_persistedState.CheckpointAfterMs, _persistedState.CheckpointHandledThreshold, _persistedState.CheckpointUnhandledBytesThreshold,
+				_persistedState.PendingEventsThreshold, _persistedState.MaxWriteBatchLength, _persistedState.MaxAllowedWritesInFlight,
+				_persistedState.RunAs,
+				projectionExecutionTimeout: null);
+			_mp.Handle(_updateConfig);
+			OneWriteCompletes();
+
+			_config = GetProjectionConfig(_mp);
+			_persistedStateWrite = _streams[ProjectionStreamId].LastOrDefault();
+
+		}
+
+		[Test]
+		public void config_should_have_null_projection_execution_timeout() {
+			Assert.IsNotNull(_config);
+			Assert.IsNull(_config.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
+		}
+
+		[Test]
+		public void persisted_state_should_have_null_projection_execution_timeout() {
+		Assert.IsNotNull(_persistedStateWrite);
+			var actualState = _persistedStateWrite.Data.ParseJson<ManagedProjection.PersistedState>();
+			Assert.IsNull(actualState.ProjectionExecutionTimeout, "ProjectionExecutionTimeout");
 		}
 	}
 
@@ -129,7 +293,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 		public void persisted_state_is_written() {
 			var writeEvents = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().ToList();
 			Assert.AreEqual(1, writeEvents.Count());
-			Assert.AreEqual("$projections-name", writeEvents[0].EventStreamId);
+			Assert.AreEqual(ProjectionStreamId, writeEvents[0].EventStreamId);
 		}
 
 		[Test]
@@ -235,12 +399,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 	}
 
 	public abstract class projection_config_test_base<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
+		protected const string ProjectionName = "name";
+		protected readonly string ProjectionStreamId = ProjectionNamesBuilder.ProjectionsStreamPrefix + ProjectionName;
 		protected ManagedProjection CreateManagedProjection() {
 			return new ManagedProjection(
 				Guid.NewGuid(),
 				Guid.NewGuid(),
 				1,
-				"name",
+				ProjectionName,
 				true,
 				null,
 				_streamDispatcher,
@@ -264,7 +430,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 
 		protected ProjectionManagementMessage.Command.UpdateConfig CreateConfig() {
 			return new ProjectionManagementMessage.Command.UpdateConfig(
-				new NoopEnvelope(), "name", true, false, 100, 200, 300, 400, 500, 600,
+				new NoopEnvelope(), ProjectionName, true, false, 100, 200, 300, 400, 500, 600,
 				ProjectionManagementMessage.RunAs.Anonymous, ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout);
 		}
 

--- a/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
@@ -39,7 +39,7 @@ public class MultiStreamMultiOutputCheckpointManagerTests {
 		_existingStreams = new ExistingStreamsHelper();
 
 		var projectionConfig = new ProjectionConfig(SystemAccounts.System, 10, 1000, 20, 2,
-			true, true, false, false, false, 10000, 100);
+			true, true, false, false, false, 10000, 100, null);
 		var positionTagger = new FakePositionTagger(ProjectionPhase);
 
 		_sut = new MultiStreamMultiOutputCheckpointManager(

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -344,12 +344,12 @@ namespace EventStore.Projections.Core.Messages {
 				private readonly int _pendingEventsThreshold;
 				private readonly int _maxWriteBatchLength;
 				private readonly int _maxAllowedWritesInFlight;
-				private readonly int _projectionExecutionTimeout;
+				private readonly int? _projectionExecutionTimeout;
 
 				public UpdateConfig(IEnvelope envelope, string name, bool emitEnabled, bool trackEmittedStreams,
 					int checkpointAfterMs,
 					int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold, int pendingEventsThreshold,
-					int maxWriteBatchLength, int maxAllowedWritesInFlight, RunAs runAs, int projectionExecutionTimeout) :
+					int maxWriteBatchLength, int maxAllowedWritesInFlight, RunAs runAs, int? projectionExecutionTimeout) :
 					base(envelope, runAs) {
 					_name = name;
 					_emitEnabled = emitEnabled;
@@ -399,7 +399,7 @@ namespace EventStore.Projections.Core.Messages {
 					get { return _maxAllowedWritesInFlight; }
 				}
 
-				public int ProjectionExecutionTimeout { get => _projectionExecutionTimeout; }
+				public int? ProjectionExecutionTimeout { get => _projectionExecutionTimeout; }
 			}
 
 			[DerivedMessage(ProjectionMessage.Management)]
@@ -801,12 +801,12 @@ namespace EventStore.Projections.Core.Messages {
 			private readonly int _pendingEventsThreshold;
 			private readonly int _maxWriteBatchLength;
 			private readonly int _maxAllowedWritesInFlight;
-			private readonly int _projectionExecutionTimeout;
+			private readonly int? _projectionExecutionTimeout;
 
 			public ProjectionConfig(bool emitEnabled, bool trackEmittedStreams, int checkpointAfterMs,
 				int checkpointHandledThreshold,
 				int checkpointUnhandledBytesThreshold, int pendingEventsThreshold, int maxWriteBatchLength,
-				int maxAllowedWritesInFlight, int projectionExecutionTimeout) {
+				int maxAllowedWritesInFlight, int? projectionExecutionTimeout) {
 				_emitEnabled = emitEnabled;
 				_trackEmittedStreams = trackEmittedStreams;
 				_checkpointAfterMs = checkpointAfterMs;
@@ -850,7 +850,7 @@ namespace EventStore.Projections.Core.Messages {
 				get { return _maxAllowedWritesInFlight; }
 			}
 
-			public int ProjectionExecutionTimeout { get => _projectionExecutionTimeout; }
+			public int? ProjectionExecutionTimeout { get => _projectionExecutionTimeout; }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -53,8 +53,7 @@ namespace EventStore.Projections.Core {
 				projectionsStandardComponents.RunProjections,
 				ioDispatcher,
 				projectionQueryExpiry,
-				projectionTracker,
-				defaultProjectionExecutionTimeout: projectionsStandardComponents.ProjectionExecutionTimeout);
+				projectionTracker);
 
 			SubscribeMainBus(
 				projectionsStandardComponents.LeaderInputBus,

--- a/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
+++ b/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
@@ -221,7 +221,7 @@ namespace EventStore.Projections.Core.Services.Http {
 						return;
 					}
 
-					if (config.ProjectionExecutionTimeout <= 0) {
+					if (config.ProjectionExecutionTimeout is not null && config.ProjectionExecutionTimeout <= 0) {
 						SendBadRequest(o, $"projectionExecutionTimeout should be positive. Found : {config.ProjectionExecutionTimeout}");
 						return;
 					}
@@ -554,8 +554,8 @@ namespace EventStore.Projections.Core.Services.Http {
 						new SendToHttpEnvelope<ProjectionManagementMessage.OperationFailed>(
 							_networkSendQueue,
 							http,
-							OperationFailedFormatter, 
-							OperationFailedConfigurator, 
+							OperationFailedFormatter,
+							OperationFailedConfigurator,
 							new SendToHttpEnvelope<ProjectionSubsystemMessage.InvalidSubsystemRestart>(
 								_networkSendQueue,
 								http,
@@ -602,7 +602,7 @@ namespace EventStore.Projections.Core.Services.Http {
 		private static string DefaultFormatter<T>(ICodec codec, T message) {
 			return codec.To(message);
 		}
-		
+
 		private ResponseConfiguration InvalidSubsystemRestartConfigurator(ICodec codec, ProjectionSubsystemMessage.InvalidSubsystemRestart message) {
 			return new ResponseConfiguration(HttpStatusCode.BadRequest, "Bad Request", "text/plain",
 				Helper.UTF8NoBom);
@@ -657,8 +657,7 @@ namespace EventStore.Projections.Core.Services.Http {
 			public int MaxWriteBatchLength { get; set; }
 			public int MaxAllowedWritesInFlight { get; set; }
 
-			public int ProjectionExecutionTimeout { get; set; } =
-				ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout;
+			public int? ProjectionExecutionTimeout { get; set; }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -34,7 +34,7 @@ namespace EventStore.Projections.Core.Services.Management {
 	}
 
 		/// <summary>
-		/// managed projection controls start/stop/create/update/delete lifecycle of the projection. 
+		/// managed projection controls start/stop/create/update/delete lifecycle of the projection.
 		/// </summary>
 		public class ManagedProjection : IDisposable {
 		public class PersistedState {
@@ -65,8 +65,8 @@ namespace EventStore.Projections.Core.Services.Management {
 			public int MaxWriteBatchLength { get; set; }
 			public int MaxAllowedWritesInFlight { get; set; }
 			public int? ProjectionSubsystemVersion { get; set; }
-			
-			public int ProjectionExecutionTimeout { get; set; }
+
+			public int? ProjectionExecutionTimeout { get; set; }
 
 			public PersistedState() {
 				CheckpointHandledThreshold = ProjectionConsts.CheckpointHandledThreshold;
@@ -75,7 +75,6 @@ namespace EventStore.Projections.Core.Services.Management {
 				PendingEventsThreshold = ProjectionConsts.PendingEventsThreshold;
 				MaxWriteBatchLength = ProjectionConsts.MaxWriteBatchLength;
 				MaxAllowedWritesInFlight = ProjectionConsts.MaxAllowedWritesInFlight;
-				ProjectionExecutionTimeout = ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout;
 			}
 		}
 
@@ -465,8 +464,10 @@ namespace EventStore.Projections.Core.Services.Management {
 					PersistedProjectionState.CheckpointAfterMs,
 					PersistedProjectionState.CheckpointHandledThreshold,
 					PersistedProjectionState.CheckpointUnhandledBytesThreshold,
-					PersistedProjectionState.PendingEventsThreshold, PersistedProjectionState.MaxWriteBatchLength,
-					PersistedProjectionState.MaxAllowedWritesInFlight, PersistedProjectionState.ProjectionExecutionTimeout));
+					PersistedProjectionState.PendingEventsThreshold,
+					PersistedProjectionState.MaxWriteBatchLength,
+					PersistedProjectionState.MaxAllowedWritesInFlight,
+					PersistedProjectionState.ProjectionExecutionTimeout));
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.UpdateConfig message) {
@@ -813,8 +814,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				throw new NotSupportedException("Unsupported error code received");
 		}
 
-		private void Prepare(ProjectionConfig config, Message message) {
-			if (config == null) throw new ArgumentNullException("config");
+		private void Prepare(Message message) {
 			if (_state >= ManagedProjectionState.Preparing) {
 				DisposeCoreProjection();
 				SetState(ManagedProjectionState.Loaded);
@@ -978,7 +978,8 @@ namespace EventStore.Projections.Core.Services.Management {
 				stopOnEof,
 				trackEmittedStreams,
 				checkpointAfterMs,
-				maximumAllowedWritesInFlight, projectionExecutionTimeout);
+				maximumAllowedWritesInFlight,
+				projectionExecutionTimeout);
 			return projectionConfig;
 		}
 
@@ -1030,7 +1031,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				? CreatePreparedMessage(_projectionConfig)
 				: CreateCreateAndPrepareMessage(_projectionConfig);
 
-			Prepare(_projectionConfig, prepareMessage);
+			Prepare(prepareMessage);
 		}
 
 		private void Reply() {

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
@@ -5,7 +5,7 @@ using EventStore.Projections.Core.Services.Interpreted;
 
 namespace EventStore.Projections.Core.Services.Management {
 
-	
+
 	public class ProjectionStateHandlerFactory {
 		private readonly TimeSpan _javascriptCompilationTimeout;
 		private readonly TimeSpan _javascriptExecutionTimeout;
@@ -16,7 +16,8 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 		public IProjectionStateHandler Create(
 			string factoryType, string source,
-			bool enableContentTypeValidation, int projectionExecutionTimeout = ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout,
+			bool enableContentTypeValidation,
+			int? projectionExecutionTimeout,
 			Action<int, Action> cancelCallbackFactory = null,
 			Action<string, object[]> logger = null) {
 			var colonPos = factoryType.IndexOf(':');
@@ -30,9 +31,9 @@ namespace EventStore.Projections.Core.Services.Management {
 			}
 
 			IProjectionStateHandler result;
-			var executionTimeout = projectionExecutionTimeout <= 0
-				? _javascriptExecutionTimeout
-				: TimeSpan.FromMilliseconds(projectionExecutionTimeout);
+			var executionTimeout = projectionExecutionTimeout is > 0
+				? TimeSpan.FromMilliseconds(projectionExecutionTimeout.Value)
+				: _javascriptExecutionTimeout;
 			switch (kind.ToLowerInvariant()) {
 				case "js":
 					result = new JintProjectionStateHandler(source, enableContentTypeValidation,

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -153,7 +153,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					_logger,
 					message.HandlerType,
 					message.Query,
-					message.EnableContentTypeValidation, message.Config.ProjectionExecutionTimeout);
+					message.EnableContentTypeValidation,
+					message.Config.ProjectionExecutionTimeout);
 
 				string name = message.Name;
 				var sourceDefinition = ProjectionSourceDefinition.From(stateHandler.GetSourceDefinition());
@@ -301,11 +302,13 @@ namespace EventStore.Projections.Core.Services.Processing {
 			ILogger logger,
 			string handlerType,
 			string query,
-			bool enableContentTypeValidation, int projectionExecutionTimeout) {
+			bool enableContentTypeValidation,
+			int? projectionExecutionTimeout) {
 			var stateHandler = factory.Create(
 				handlerType,
 				query,
-				enableContentTypeValidation, projectionExecutionTimeout,
+				enableContentTypeValidation,
+				projectionExecutionTimeout,
 				logger: logger.Verbose,
 				cancelCallbackFactory:
 				singletonTimeoutScheduler == null ? null : singletonTimeoutScheduler.Schedule);

--- a/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
@@ -21,7 +21,7 @@ namespace EventStore.Projections.Core.Services {
 		public ProjectionConfig(ClaimsPrincipal runAs, int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold,
 			int pendingEventsThreshold, int maxWriteBatchLength, bool emitEventEnabled, bool checkpointsEnabled,
 			bool createTempStreams, bool stopOnEof, bool trackEmittedStreams,
-			int checkpointAfterMs, int maximumAllowedWritesInFlight, int projectionExecutionTimeout = ClusterVNodeOptions.ProjectionOptions.DefaultProjectionExecutionTimeout) {
+			int checkpointAfterMs, int maximumAllowedWritesInFlight, int? projectionExecutionTimeout) {
 			if (checkpointsEnabled) {
 				if (checkpointHandledThreshold <= 0)
 					throw new ArgumentOutOfRangeException("checkpointHandledThreshold");
@@ -40,7 +40,7 @@ namespace EventStore.Projections.Core.Services {
 					$"The Maximum Number of Allowed Writes in Flight cannot be less than {AllowedWritesInFlight.Unbounded}");
 			}
 
-			if (projectionExecutionTimeout <= 0) {
+			if (projectionExecutionTimeout is not null && projectionExecutionTimeout <= 0) {
 				throw new ArgumentException(
 					$"The projection execution timeout should be positive. Found : {projectionExecutionTimeout}");
 			}
@@ -107,12 +107,7 @@ namespace EventStore.Projections.Core.Services {
 		public int MaximumAllowedWritesInFlight {
 			get { return _maximumAllowedWritesInFlight; }
 		}
-		
-		public int ProjectionExecutionTimeout { get; }
 
-		public static ProjectionConfig GetTest() {
-			return new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000,
-				1);
-		}
+		public int? ProjectionExecutionTimeout { get; }
 	}
 }


### PR DESCRIPTION
Fixed: Don't write the database default `ProjectionExecutionTimeout` in the projection persisted state on creation.

Fixes https://github.com/EventStore/EventStore/issues/4416
Cherry-picked from https://github.com/EventStore/EventStore/pull/4423

This means that projections that have not explicitly set their own `ProjectionExecutionTimeout` will be affected by any changes to the database-level `ProjectionExecutionTimeout`

This does not attempt to fix projections that had the database-level `ProjectionExecutionTimeout` written to the projection's persisted state. Projections that were created on v23.10 will need to be updated to remove the persisted `ProjectionExecutionTimeout` in order for the database-level setting to affect them again.
This update can be done over HTTP or through the admin UI.

