### PR TITLE
[DBX-65] Add script to remove explicit ProjectionExecutionTimeout settings from projections

### DIFF
--- a/src/Scripts/projections/ProjectionExecutionTimeout/CreateTestProjections.ps1
+++ b/src/Scripts/projections/ProjectionExecutionTimeout/CreateTestProjections.ps1
@@ -1,0 +1,26 @@
+param (
+    $EventStoreAddress,
+    $AdminUsername,
+    [SecureString] $AdminPassword
+)
+
+# Set up basic auth credentials
+$password = ConvertFrom-SecureString $AdminPassword -AsPlainText
+$pair = "${AdminUsername}:${password}"
+$encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
+$basicAuthValue = "Basic $encodedCreds"
+
+$Headers = @{
+    Authorization = $basicAuthValue;
+    Accept = 'application/json';
+    "Content-Type" = 'application/json';
+}
+
+
+For ($i=0; $i -le 50; $i++) {
+    $projectionName = "test-projection-${i}"
+    Write-Host "Creating projection $projectionName"
+
+    $body = "{ fromAll().when() }"
+    Invoke-WebRequest "${EventStoreAddress}/projections/continuous?name=${projectionName}" -Method "POST" -Body $body -Headers $Headers
+}

--- a/src/Scripts/projections/ProjectionExecutionTimeout/README.md
+++ b/src/Scripts/projections/ProjectionExecutionTimeout/README.md
@@ -1,0 +1,21 @@
+# Remove ProjectionExecutionTimeout settings
+
+This script removes the persisted projection-specific `ProjectionExecutionTimeout` setting on all non-transient projections in EventStoreDB, allowing the projection to fall back to the default value configured by the database `ProjectionExecutionTimeout` setting.
+
+This forms part of the fix introduced in [PR#4423](https://github.com/EventStore/EventStore/pull/4423).
+
+## Usage
+
+Example usage for a local test instance:
+
+```
+./RemoveProjectionExecutionTimeout.ps1 -EventStoreAddress "https://localhost:2113" -AdminUsername "admin" -AdminPassword (ConvertTo-SecureString "changeit" -AsPlainText)
+```
+
+### Parameters
+
+| Name                  | Type              | Description |
+|-----------------------|-------------------|-------------|
+| EventStoreAddress     | `String`          | The base address of the EventStoreDB server.  |
+| AdminUsername         | `String`          | The username of a user with admin privileges. |
+| AdminPassword         | `SecureString`    | The password for the admin user.              |

--- a/src/Scripts/projections/ProjectionExecutionTimeout/RemoveProjectionExecutionTimeout.ps1
+++ b/src/Scripts/projections/ProjectionExecutionTimeout/RemoveProjectionExecutionTimeout.ps1
@@ -1,0 +1,131 @@
+param (
+    $EventStoreAddress,
+    $AdminUsername,
+    [SecureString] $AdminPassword
+)
+
+# Set up basic auth credentials
+$password = ConvertFrom-SecureString $AdminPassword -AsPlainText
+$pair = "${AdminUsername}:${password}"
+$encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
+$basicAuthValue = "Basic $encodedCreds"
+
+$Headers = @{
+    Authorization = $basicAuthValue;
+    Accept = 'application/json';
+    "Content-Type" = 'application/json';
+}
+
+function Get-AllProjections {
+    param (
+        $Mode
+    )
+
+    # Projections API doesn't have pagination, so we just need to send the one request
+    $listResponse = Invoke-RestMethod -Uri "${EventStoreAddress}/projections/${Mode}" -Headers $Headers
+    $details = foreach ($projection in $listResponse.Projections) {
+        @{
+            Name = $projection.EffectiveName
+            DisableUri = $projection.DisableCommandUrl
+            EnableUri = $projection.EnableCommandUrl
+            StatusUri = $projection.StatusUrl
+            ConfigUri = "${EventStoreAddress}/projection/$($projection.EffectiveName)/config"
+            Status = $projection.Status
+        }
+    }
+    $details
+}
+
+function Get-ProjectionConfig {
+    param (
+        $ProjectionDetails
+    )
+
+    Write-Host "Getting projection config for $($ProjectionDetails.Name)"
+    Invoke-RestMethod -Uri $ProjectionDetails.ConfigUri -Headers $Headers
+}
+
+function Watch-ProjectionStatus {
+    param (
+        $ProjectionDetails,
+        $ExpectedStatus
+    )
+    Write-Host "Waiting for projection $($projection.Name) to enter status $ExpectedStatus"
+    $complete = $false
+    while ($false -eq $complete) {
+        $status = Invoke-RestMethod -Uri $ProjectionDetails.StatusUri -Headers $Headers
+        if ($ExpectedStatus -eq $status.Status) {
+            $complete = $true
+        } else {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+}
+
+function Disable-Projection {
+    param (
+        $ProjectionDetails
+    )
+
+    Write-Host "Disabling projection $($ProjectionDetails.Name)"
+    Invoke-WebRequest -Uri $ProjectionDetails.DisableUri -Method "POST" -Headers $Headers | Out-Null
+
+    Watch-ProjectionStatus $ProjectionDetails @("Stopped", "Faulted")
+
+    Write-Host "Projection $($ProjectionDetails.Name) has been disabled"
+}
+
+function Enable-Projection {
+    param (
+        $ProjectionDetails
+    )
+
+    Write-Host "Enabling projection $($ProjectionDetails.Name)"
+    Invoke-WebRequest -Uri $ProjectionDetails.EnableUri -Method "POST" -Headers $Headers | Out-Null
+
+    Watch-ProjectionStatus $ProjectionDetails @("Running")
+
+    Write-Host "Projection $($ProjectionDetails.Name) has been enabled"
+}
+
+function Update-ProjectionConfig {
+    param (
+        $ProjectionDetails,
+        $ProjectionConfig
+    )
+    Write-Host "Removing projection execution timeout from projection $($ProjectionDetails.Name)"
+
+    # Remove the ProjectionExecutionTimeout
+    $ProjectionConfig.PSObject.Properties.Remove('projectionExecutionTimeout')
+
+    # Post the config back to the projection
+    $body = ConvertTo-Json $ProjectionConfig
+    Invoke-WebRequest -Uri $ProjectionDetails.ConfigUri -Header $Headers -Method "PUT" -Body $body | Out-Null
+
+    Write-Host "Configuration for projection $($ProjectionDetails.Name) has been updated"
+}
+
+$AllProjections = Get-AllProjections "all-non-transient"
+Write-Host "Found $($AllProjections.Count) projections"
+
+foreach($projection in $AllProjections) {
+    
+    Write-Host "`nChecking projection $($projection.Name)"
+    $projectionConfig = Get-ProjectionConfig $projection
+
+    if ($null -ne $projectionConfig.ProjectionExecutionTimeout) {
+        Write-Host "Fixing projection $($projection.Name)"
+        if ($projection.Status -ne "Stopped" -and $projection.Status -ne "Faulted") {
+            Disable-Projection $projection
+        }
+
+        Update-ProjectionConfig $projection $projectionConfig
+
+        # Only enable the projection if it was running in the first place
+        if ($projection.Status -eq "Running") {
+            Enable-Projection $projection
+        }
+    } else {
+        Write-Host "Projection $($projection.Name) has no projection execution timeout. Skipping."
+    }
+}


### PR DESCRIPTION
This script removes the persisted projection-specific `ProjectionExecutionTimeout` setting on all non-transient projections in EventStoreDB, allowing the projection to fall back to the default value configured by the database `ProjectionExecutionTimeout` setting.

This forms part of the fix introduced in #4423