### PR TITLE
[ESDB-186-1] Add logical chunk read distribution metric

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -19,6 +19,11 @@ csharp_new_line_before_finally = false
 csharp_new_line_before_members_in_anonymous_types = false
 csharp_new_line_before_members_in_object_initializers = false
 csharp_new_line_within_query_expression_clauses = true
+
+# disable hint to use primary constructor
+dotnet_diagnostic.IDE0290.severity = none
+
+# use ValueTasks correctly
 dotnet_diagnostic.CA2012.severity = error
 
 # Indentation preferences

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/ChunkHeaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/ChunkHeaderTests.cs
@@ -12,7 +12,7 @@ public class ChunkHeaderTests {
 	public void can_round_trip(bool isScavenged) {
 		var source = new ChunkHeader(
 			version: (byte)Random.Shared.Next(4, 8),
-			minCompatibleVersion: (byte)Random.Shared.Next(8),
+			minCompatibleVersion: (byte)Random.Shared.Next(4),
 			chunkSize: Random.Shared.Next(500, 600),
 			chunkStartNumber: Random.Shared.Next(500, 600),
 			chunkEndNumber: Random.Shared.Next(700, 800),

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkTrackerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using EventStore.Core.Metrics;
+using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.XUnit.Tests.Metrics;
@@ -11,6 +12,9 @@ using Xunit;
 namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
 
 public class TFChunkTrackerTests : IDisposable {
+	const long WriterCheckpoint = 4_500;
+	const int ChunkSize = 1_000;
+
 	private readonly TFChunkTracker _sut;
 	private readonly TestMeterListener<long> _listener;
 
@@ -19,11 +23,13 @@ public class TFChunkTrackerTests : IDisposable {
 		_listener = new TestMeterListener<long>(meter);
 		var byteMetric = new CounterMetric(meter, "eventstore-io", unit: "bytes");
 		var eventMetric = new CounterMetric(meter, "eventstore-io", unit: "events");
+		var writerCheckpoint = new InMemoryCheckpoint(WriterCheckpoint);
 
 		var readTag = new KeyValuePair<string, object>("activity", "read");
 		_sut = new TFChunkTracker(
-			readBytes: new CounterSubMetric(byteMetric, new[] {readTag}),
-			readEvents: new CounterSubMetric(eventMetric, new[] {readTag}));
+			readDistribution: new LogicalChunkReadDistributionMetric(meter, "chunk-read-distribution", writerCheckpoint, ChunkSize),
+			readBytes: new CounterSubMetric(byteMetric, [readTag]),
+			readEvents: new CounterSubMetric(eventMetric, [readTag]));
 	}
 
 	public void Dispose() {
@@ -63,6 +69,31 @@ public class TFChunkTrackerTests : IDisposable {
 		AssertBytesRead(0);
 	}
 
+	[Theory]
+	[InlineData(5_500, -1)]
+	[InlineData(4_501, 0)]
+	[InlineData(4_500, 0)]
+	[InlineData(4_000, 0)]
+	[InlineData(3_999, 1)]
+	[InlineData(3_000, 1)]
+	[InlineData(2_000, 2)]
+	[InlineData(1_000, 3)]
+	[InlineData(999, 4)]
+	[InlineData(1, 4)]
+	[InlineData(0, 4)]
+	public void records_read_distribution(long logPosition, long expectedChunk) {
+		_sut.OnRead(CreatePrepare(data: new byte[5], meta: new byte[5], logPosition: logPosition));
+
+		_listener.Observe();
+		var actual = _listener.RetrieveMeasurements("chunk-read-distribution");
+		Assert.Collection(
+			actual,
+			m => {
+				Assert.Equal(expectedChunk, m.Value);
+				Assert.Empty(m.Tags);
+			});
+	}
+
 	private void AssertEventsRead(long? expectedEventsRead) =>
 		AssertMeasurements("eventstore-io-events", expectedEventsRead);
 
@@ -87,8 +118,8 @@ public class TFChunkTrackerTests : IDisposable {
 		}
 	}
 
-	private static PrepareLogRecord CreatePrepare(byte[] data, byte[] meta) {
-		return new PrepareLogRecord(42, Guid.NewGuid(), Guid.NewGuid(), 42, 42, "tests", null, 42, DateTime.Now,
+	private static PrepareLogRecord CreatePrepare(byte[] data, byte[] meta, long logPosition = 42) {
+		return new PrepareLogRecord(logPosition, Guid.NewGuid(), Guid.NewGuid(), 42, 42, "tests", null, 42, DateTime.Now,
 			PrepareFlags.Data, "type-test", null, data, meta);
 	}
 

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -213,11 +213,19 @@ namespace EventStore.Core {
 					.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("eventstore"))
 					.AddMeter(metricsConfiguration.Meters)
 					.AddView(i => {
-						if (i.Name.StartsWith("eventstore-") &&
+						if (i.Name == MetricsBootstrapper.LogicalChunkReadDistributionName)
+							// 20 buckets, 0, 1, 2, 4, 8, ...
+							return new ExplicitBucketHistogramConfiguration {
+								Boundaries = [
+									0,
+									.. Enumerable.Range(0, count: 19).Select(x => 1 << x)
+								]
+							};
+						else if (i.Name.StartsWith("eventstore-") &&
 							i.Name.EndsWith("-latency") &&
 							i.Unit == "seconds")
 							return new ExplicitBucketHistogramConfiguration {
-								Boundaries = new double[] {
+								Boundaries = [
 									0.001, //    1 ms
 									0.005, //    5 ms
 									0.01,  //   10 ms
@@ -226,11 +234,11 @@ namespace EventStore.Core {
 									0.5,   //  500 ms
 									1,     // 1000 ms
 									5,     // 5000 ms
-								}
+								]
 							};
 						else if (i.Name.StartsWith("eventstore-") && i.Unit == "seconds")
 							return new ExplicitBucketHistogramConfiguration {
-								Boundaries = new double[] {
+								Boundaries = [
 									0.000_001, // 1 microsecond
 									0.000_01,
 									0.000_1,
@@ -239,7 +247,7 @@ namespace EventStore.Core {
 									0.1,
 									1, // 1 second
 									10,
-								}
+								]
 							};
 						return default;
 					})

--- a/src/EventStore.Core/Metrics/LogicalChunkReadDistributionMetric.cs
+++ b/src/EventStore.Core/Metrics/LogicalChunkReadDistributionMetric.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics.Metrics;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.Metrics;
+
+public class LogicalChunkReadDistributionMetric {
+	private readonly Histogram<long> _histogram;
+	private readonly IReadOnlyCheckpoint _writer;
+	private readonly int _chunkSize;
+
+	public LogicalChunkReadDistributionMetric(Meter meter, string name, IReadOnlyCheckpoint writer, int chunkSize) {
+		_histogram = meter.CreateHistogram<long>(name);
+		_writer = writer;
+		_chunkSize = chunkSize;
+	}
+
+	public void Record(ILogRecord record) {
+		// todo: consider sampling if this turns out to have a performance implication.
+		// in the mean time event read metrics can be turned off in metricsconfig.json
+		var recordLogicalChunk = record.LogPosition / _chunkSize;
+		var currentLogicalChunk = _writer.ReadNonFlushed() / _chunkSize;
+		_histogram.Record(currentLogicalChunk - recordLogicalChunk);
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TransactionFileTracker.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TransactionFileTracker.cs
@@ -5,18 +5,23 @@ using EventStore.Core.TransactionLog.LogRecords;
 namespace EventStore.Core.TransactionLog.Chunks;
 
 public class TFChunkTracker : ITransactionFileTracker {
+	private readonly LogicalChunkReadDistributionMetric _readDistribution;
 	private readonly CounterSubMetric _readBytes;
 	private readonly CounterSubMetric _readEvents;
 
 	public TFChunkTracker(
+		LogicalChunkReadDistributionMetric readDistribution,
 		CounterSubMetric readBytes,
 		CounterSubMetric readEvents) {
 
 		_readBytes = readBytes;
 		_readEvents = readEvents;
+		_readDistribution = readDistribution;
 	}
 
 	public void OnRead(ILogRecord record) {
+		_readDistribution.Record(record);
+
 		if (record is not PrepareLogRecord prepare)
 			return;
 


### PR DESCRIPTION
Added: Chunk read distribution metric

Allows users to see which chunks are commonly being read relative to the tail of the log. Buckets are arranged in powers of 2:
- the most recent chunk
- the most recent 2 chunks
- the most recent 4 chunks
- ... for 20 buckets

This will help with assessing how big the chunk cache should be and how the archive criteria should be set