### PR TITLE
[DBX-71] Move plugable components out of 'Plugins' in telemetry

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
@@ -125,15 +125,13 @@ public sealed class TelemetryServiceTests : IAsyncLifetime {
 		Assert.NotNull(_sink.Data["foo"]);
 		Assert.Equal(new JsonObject { ["bar"] = 42 }.ToString(), _sink.Data["foo"].ToString());
 
-		Assert.NotNull(_sink.Data["plugins"]);
+		Assert.NotNull(_sink.Data["fakeComponent"]);
 		Assert.Equal("""
 			{
-			  "fakeComponent": {
-			    "foo": "bar"
-			  }
+			  "foo": "bar"
 			}
 			""",
-			_sink.Data["plugins"].ToString());
+			_sink.Data["fakeComponent"].ToString());
 
 		Assert.Equal(_sink.Data["environment"]!["os"]!.ToString(), RuntimeInformation.OSDescription);
 	}
@@ -190,7 +188,7 @@ public sealed class TelemetryServiceTests : IAsyncLifetime {
 		Assert.Equal(Guid.Parse(_sink.Data["cluster"]["leaderId"].ToString()), _replicaStateMessage.Leader.InstanceId);
 		Assert.Equal(Int32.Parse(_sink.Data["database"]["epochNumber"].ToString()), _replicaStateMessage.Leader.EpochNumber);
 
-		Assert.NotNull(_sink.Data["plugins"]);
+		Assert.NotNull(_sink.Data["fakeComponent"]);
 	}
 
 	class FakePlugableComponent(string name = "fakeComponent") : Plugin(name) {

--- a/src/EventStore.Core/Telemetry/TelemetryService.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryService.cs
@@ -208,7 +208,7 @@ public sealed class TelemetryService :
 			.ForEach(evt => {
 				try {
 					var payload = JsonSerializer.SerializeToNode(evt.Data);
-					message.Envelope.ReplyWith(new TelemetryMessage.Response("plugins", evt.Source, payload));
+					message.Envelope.ReplyWith(new TelemetryMessage.Response(evt.Source, payload));
 				}
 				catch (Exception ex) {
 					Logger.Warning(ex, "Failed to collect telemetry from pluggable component {Source}", evt.Source);


### PR DESCRIPTION
Changed: Moved plugable components out of 'Plugins' section in telemetry