### PR TITLE
Drive free memory stat in Linux from MemAvailable rather than MemFree

### DIFF
--- a/src/EventStore.SystemRuntime/Diagnostics/RuntimeStats.cs
+++ b/src/EventStore.SystemRuntime/Diagnostics/RuntimeStats.cs
@@ -53,7 +53,7 @@ public static class RuntimeStats {
         };
 
         static async ValueTask<long> GetFreeMemoryLinux() {
-            var output = await ExecuteShellCommandAsync("grep MemFree /proc/meminfo"); // old code uses MemAvailable
+            var output = await ExecuteShellCommandAsync("grep MemAvailable /proc/meminfo");
             var parts  = output.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             var value  = ToInt64(parts[1]) * 1024; // Convert KB to bytes
             return value;


### PR DESCRIPTION
Fixed: reverted free mem stat to be MemAvailable rather than MemFree on linux

This is also how it was in versions prior to 24.6.

MemAvailable is a better indication of the amount of memory that the system is able to provide for new workloads.

Fixes #4507