### PR TITLE
Timeout when writing scavengepoint

### DIFF
--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ScavengePointSource.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ScavengePointSource.cs
@@ -116,8 +116,10 @@ public class ScavengePointSource : IScavengePointSource {
 			}
 		);
 
-		using (cancellationToken.Register(() => writeTcs.TrySetCanceled())) {
-			await writeTcs.Task;
+		try {
+			await writeTcs.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+		} catch (TimeoutException ex) {
+			throw new TimeoutException("Timed out while trying to write a scavenge point", ex);
 		}
 
 		_logger.Information("SCAVENGING: Added new scavenge point.");


### PR DESCRIPTION
Fixed: If the scavenge is unable to write a scavenge point it will now error rather than stall

The IO Dispatcher write methods don't accept timeout callbacks (but that will need some more time to look at) So if the WriteEvents message is not replied to with a completed message, then the scavenge will currently stall waiting for it (until the scavenge is stopped) Here we add a timeout, after which the scavenge will fail.