### PR TITLE
Revert default gRPC log level to Fatal

### DIFF
--- a/src/EventStore.ClusterNode/logconfig.json
+++ b/src/EventStore.ClusterNode/logconfig.json
@@ -4,7 +4,7 @@
 			"Default": "Debug",
 			"System": "Warning",
 			"Microsoft": "Warning",
-			"Grpc": "Warning"
+			"Grpc": "Fatal"
 		}
 	}
 }


### PR DESCRIPTION
Changed: gRPC log level to fatal (actually keeping the same behaviour as previous versions)

Otherwise we get exception logs when connections drop with open calls, calls time out, etc