### PR TITLE
Adjust log levels of gRPC enumerators

### DIFF
--- a/src/EventStore.ClusterNode/logconfig.json
+++ b/src/EventStore.ClusterNode/logconfig.json
@@ -2,6 +2,7 @@
 	"Logging": {
 		"LogLevel": {
 			"Default": "Debug",
+			"EventStore.Core.Services.Transport.Enumerators": "Information",
 			"System": "Warning",
 			"Microsoft": "Warning",
 			"Grpc": "Warning"

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
@@ -68,7 +68,7 @@ static partial class Enumerator {
 				return ValueTask.CompletedTask;
 			}
 
-			Log.Debug("Subscription {subscriptionId} to $all disposed.", _subscriptionId);
+			Log.Verbose("Subscription {subscriptionId} to $all disposed.", _subscriptionId);
 
 			_disposed = true;
 			Unsubscribe();
@@ -127,7 +127,7 @@ static partial class Enumerator {
 
 		private async Task MainLoop(Position? checkpointPosition, CancellationToken ct) {
 			try {
-				Log.Information("Subscription {subscriptionId} to $all has started at checkpoint {position}",
+				Log.Debug("Subscription {subscriptionId} to $all has started at checkpoint {position}",
 					_subscriptionId, checkpointPosition?.ToString() ?? "Start");
 
 				var confirmationLastPos = await SubscribeToLive();
@@ -153,7 +153,7 @@ static partial class Enumerator {
 					Log.Error(ex, "Subscription {subscriptionId} to $all experienced an error.", _subscriptionId);
 				_channel.Writer.TryComplete(ex);
 			} finally {
-				Log.Information("Subscription {subscriptionId} to $all has ended.", _subscriptionId);
+				Log.Debug("Subscription {subscriptionId} to $all has ended.", _subscriptionId);
 			}
 		}
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -79,7 +79,7 @@ partial class Enumerator {
 				return ValueTask.CompletedTask;
 			}
 
-			Log.Debug("Subscription {subscriptionId} to $all:{eventFilter} disposed.", _subscriptionId, _eventFilter);
+			Log.Verbose("Subscription {subscriptionId} to $all:{eventFilter} disposed.", _subscriptionId, _eventFilter);
 
 			_disposed = true;
 			Unsubscribe();
@@ -155,7 +155,7 @@ partial class Enumerator {
 
 		private async Task MainLoop(Position? checkpointPosition, CancellationToken ct) {
 			try {
-				Log.Information("Subscription {subscriptionId} to $all:{eventFilter} has started at checkpoint {position}",
+				Log.Debug("Subscription {subscriptionId} to $all:{eventFilter} has started at checkpoint {position}",
 					_subscriptionId, _eventFilter, checkpointPosition?.ToString() ?? "Start");
 
 				var confirmationLastPos = await SubscribeToLive();
@@ -182,7 +182,7 @@ partial class Enumerator {
 						_subscriptionId, _eventFilter);
 				_channel.Writer.TryComplete(ex);
 			} finally {
-				Log.Information("Subscription {subscriptionId} to $all:{eventFilter} has ended.",
+				Log.Debug("Subscription {subscriptionId} to $all:{eventFilter} has ended.",
 					_subscriptionId, _eventFilter);
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
@@ -80,7 +80,7 @@ static partial class Enumerator {
 				return ValueTask.CompletedTask;
 			}
 
-			Log.Debug("Subscription {subscriptionId} to {streamName} disposed.", _subscriptionId,
+			Log.Verbose("Subscription {subscriptionId} to {streamName} disposed.", _subscriptionId,
 				_streamName);
 			_disposed = true;
 
@@ -142,7 +142,7 @@ static partial class Enumerator {
 
 		private async Task MainLoop(StreamRevision? checkpointRevision, CancellationToken ct) {
 			try {
-				Log.Information("Subscription {subscriptionId} to {streamName} has started at checkpoint {streamRevision:N0}",
+				Log.Debug("Subscription {subscriptionId} to {streamName} has started at checkpoint {streamRevision:N0}",
 					_subscriptionId, _streamName, checkpointRevision?.ToString() ?? "Start");
 
 				var confirmationLastEventNumber = await SubscribeToLive();
@@ -168,7 +168,7 @@ static partial class Enumerator {
 					Log.Error(ex, "Subscription {subscriptionId} to {streamName} experienced an error.", _subscriptionId, _streamName);
 				_channel.Writer.TryComplete(ex);
 			} finally {
-				Log.Information("Subscription {subscriptionId} to {streamName} has ended.", _subscriptionId, _streamName);
+				Log.Debug("Subscription {subscriptionId} to {streamName} has ended.", _subscriptionId, _streamName);
 			}
 		}
 


### PR DESCRIPTION
Changed: Log levels of the gRPC enumerators to log less

Be less chatty, especially now that these have been in production for a while without causing problems