### PR TITLE
[DBX-76] Allow extra data to be added to telemetry from configuration

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
@@ -128,7 +128,7 @@ public sealed class TelemetryServiceTests : IAsyncLifetime {
 		Assert.NotNull(_sink.Data["fakeComponent"]);
 		Assert.Equal("""
 			{
-			  "foo": "bar"
+			  "baz": "qux"
 			}
 			""",
 			_sink.Data["fakeComponent"].ToString());
@@ -191,14 +191,14 @@ public sealed class TelemetryServiceTests : IAsyncLifetime {
 		Assert.NotNull(_sink.Data["fakeComponent"]);
 	}
 
-	class FakePlugableComponent(string name = "fakeComponent") : Plugin(name) {
+	class FakePlugableComponent(string name = "FakeComponent") : Plugin(name) {
 		public void PublishSomeTelemetry() {
 			PublishDiagnosticsData(new() {
 				["enabled"] = Enabled
 			}, Snapshot);
 
 			PublishDiagnosticsData(new() {
-				["foo"] = "bar"
+				["Baz"] = "qux"
 			}, Snapshot);
 		}
 	}

--- a/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
@@ -9,7 +9,7 @@ using EventStore.Plugins.Authentication;
 
 namespace EventStore.Core.Authentication.PassthroughAuthentication;
 
-public class PassthroughAuthenticationProvider() : AuthenticationProviderBase(name: "insecure")  {
+public class PassthroughAuthenticationProvider() : AuthenticationProviderBase(name: "insecure", diagnosticsName: "PassthroughAuthentication") {
 	public override void Authenticate(AuthenticationRequest authenticationRequest) =>
 		authenticationRequest.Authenticated(SystemAccounts.System);
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1419,6 +1419,7 @@ public class ClusterVNode<TStreamId> :
 		var telemetryService = new TelemetryService(
 			Db.Manager,
 			modifiedOptions,
+			configuration,
 			_mainQueue,
 			new TelemetrySink(options.Application.TelemetryOptout),
 			Db.Config.WriterCheckpoint.AsReadOnly(),


### PR DESCRIPTION
Added: telemetry configuration section to telemetry that is sent

Values from the `EventStore:Telemetry` configuration section will be added to the telemetry.

e.g. in `eventstore.conf`
```
Telemetry:
  Foo: ABC
```

comes out as

```
"telemetry": {
  "foo": "ABC"
},
```
