### PR TITLE
Only use the fallback policy for stream access

### DIFF
--- a/src/EventStore.Core/Authorization/AuthorizationPolicies/AuthorizationPolicySettings.cs
+++ b/src/EventStore.Core/Authorization/AuthorizationPolicies/AuthorizationPolicySettings.cs
@@ -7,7 +7,7 @@ public class AuthorizationPolicySettings {
 	public string StreamAccessPolicyType { get; set; }
 
 	public AuthorizationPolicySettings() {
-		StreamAccessPolicyType = FallbackPolicySelector.FallbackPolicyName;
+		StreamAccessPolicyType = FallbackStreamAccessPolicySelector.FallbackPolicyName;
 	}
 
 	public AuthorizationPolicySettings(string streamAccessPolicyType) {

--- a/src/EventStore.Core/Authorization/AuthorizationPolicies/FallbackStreamAccessPolicySelector.cs
+++ b/src/EventStore.Core/Authorization/AuthorizationPolicies/FallbackStreamAccessPolicySelector.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Authorization.AuthorizationPolicies;
 /// but none of them are valid or can be started.
 /// Only admins have stream access to prevent falling back to a more permissive policy.
 /// </summary>
-public class FallbackPolicySelector : IPolicySelector {
+public class FallbackStreamAccessPolicySelector : IPolicySelector {
 	public const string FallbackPolicyName = "system-fallback";
 	private static readonly Claim[] Admins =
 		{new Claim(ClaimTypes.Role, SystemRoles.Admins), new Claim(ClaimTypes.Name, SystemUsers.Admin)};

--- a/src/EventStore.Core/Authorization/AuthorizationPolicies/StreamBasedAuthorizationPolicyRegistry.cs
+++ b/src/EventStore.Core/Authorization/AuthorizationPolicies/StreamBasedAuthorizationPolicyRegistry.cs
@@ -25,7 +25,7 @@ public class StreamBasedAuthorizationPolicyRegistry :
 	private readonly ILogger _logger = Log.ForContext<StreamBasedAuthorizationPolicyRegistry>();
 	private readonly IPublisher _publisher;
 
-	private readonly FallbackPolicySelector _fallbackPolicySelector = new ();
+	private readonly FallbackStreamAccessPolicySelector _fallbackStreamAccessPolicySelector = new ();
 	private readonly IPolicySelector _legacyPolicySelector;
 	private readonly IPolicySelectorFactory[] _pluginSelectorFactories;
 	private readonly AuthorizationPolicySettings _defaultSettings;
@@ -49,7 +49,7 @@ public class StreamBasedAuthorizationPolicyRegistry :
 		get {
 			return _effectivePolicySelectors.Length != 0
 				? _effectivePolicySelectors.Select(x => x.Select()).ToArray()
-				: [_fallbackPolicySelector.Select()];
+				: [_fallbackStreamAccessPolicySelector.Select(), _legacyPolicySelector.Select()];
 		}
 	}
 
@@ -174,7 +174,7 @@ public class StreamBasedAuthorizationPolicyRegistry :
 
 	private async ValueTask<bool> TryApplyAuthorizationPolicySettings(AuthorizationPolicySettings settings) {
 		switch (settings.StreamAccessPolicyType) {
-			case FallbackPolicySelector.FallbackPolicyName:
+			case FallbackStreamAccessPolicySelector.FallbackPolicyName:
 				await ApplyFallbackPolicySelector();
 				return true;
 			case LegacyPolicySelectorFactory.LegacyPolicySelectorName:


### PR DESCRIPTION
Fixed: Only use the fallback policy for stream access. Revert to the legacy policy for endpoint access.