### PR TITLE
Tidy up shutdown

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -222,7 +222,7 @@ internal static class Program {
 
 					exitCodeSource.TrySetResult(0);
 				} catch (Exception ex) {
-					Log.Fatal("Error occurred during setup: {e}", ex);
+					Log.Fatal(ex, "Exiting");
 					exitCodeSource.TrySetResult(1);
 				} finally {
 					signal.Set();

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -78,7 +78,6 @@ using Microsoft.Extensions.DependencyInjection;
 using ILogger = Serilog.ILogger;
 using LogLevel = EventStore.Common.Options.LogLevel;
 using RuntimeInformation = System.Runtime.RuntimeInformation;
-using TimeoutControl = DotNext.Threading.Timeout;
 using EventStore.Core.Services.Archiver;
 using EventStore.Licensing;
 
@@ -1749,7 +1748,7 @@ public class ClusterVNode<TStreamId> :
 			return;
 		}
 
-		_mainQueue.Publish(new ClientMessage.RequestShutdown(exitProcess: false, shutdownHttp: true));
+		_mainQueue.Publish(new ClientMessage.RequestShutdown(false, true));
 
 		try {
 			await _shutdownSource.Task.WaitAsync(timeout ?? DefaultShutdownTimeout, cancellationToken);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -197,7 +197,6 @@ public class ClusterVNode<TStreamId> :
 	private readonly ClusterVNodeStartup<TStreamId> _startup;
 	private readonly INodeHttpClientFactory _nodeHttpClientFactory;
 	private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
-	private readonly ShutdownService _shutdownService;
 
 	private int _stopCalled;
 	private int _reloadingConfig;
@@ -509,10 +508,10 @@ public class ClusterVNode<TStreamId> :
 		_mainQueue = _controller.MainQueue;
 		_mainBus = _controller.MainBus;
 
-		_shutdownService = new ShutdownService(_mainQueue, NodeInfo);
-		_mainBus.Subscribe<SystemMessage.RegisterForGracefulTermination>(_shutdownService);
-		_mainBus.Subscribe<ClientMessage.RequestShutdown>(_shutdownService);
-		_mainBus.Subscribe<SystemMessage.ComponentTerminated>(_shutdownService);
+		var shutdownService = new ShutdownService(_mainQueue, NodeInfo);
+		_mainBus.Subscribe<SystemMessage.RegisterForGracefulTermination>(shutdownService);
+		_mainBus.Subscribe<ClientMessage.RequestShutdown>(shutdownService);
+		_mainBus.Subscribe<SystemMessage.ComponentTerminated>(shutdownService);
 
 		var uriScheme = options.Application.Insecure ? Uri.UriSchemeHttp : Uri.UriSchemeHttps;
 		var clusterDns = options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null;
@@ -1750,27 +1749,22 @@ public class ClusterVNode<TStreamId> :
 			return;
 		}
 
-		// TODO - We might want to increase that value here.
-		timeout ??= TimeSpan.FromSeconds(5);
-		_shutdownService.Shutdown();
+		_mainQueue.Publish(new ClientMessage.RequestShutdown(exitProcess: false, shutdownHttp: true));
 
-		_reloadConfigSignalRegistration?.Dispose();
-		_reloadConfigSignalRegistration = null;
-
-		TimeSpan remainingTime;
-		var timeoutCtl = new TimeoutControl(timeout ?? DefaultShutdownTimeout);
-		foreach (var subsystem in _subsystems ?? []) {
-			timeoutCtl.ThrowIfExpired(out remainingTime);
-			await subsystem.Stop().WaitAsync(remainingTime, cancellationToken);
+		try {
+			await _shutdownSource.Task.WaitAsync(timeout ?? DefaultShutdownTimeout, cancellationToken);
 		}
-
-		timeoutCtl.ThrowIfExpired(out remainingTime);
-		await _shutdownSource.Task.WaitAsync(remainingTime, cancellationToken);
+		catch (Exception) {
+			Log.Error("Graceful shutdown not complete. Forcing shutdown now.");
+			throw;
+		}
 
 		_switchChunksLock?.Dispose();
 	}
 
 	public async ValueTask HandleAsync(SystemMessage.BecomeShuttingDown message, CancellationToken token) {
+		Log.Information("========== [{httpEndPoint}] IS SHUTTING DOWN SUBSYSTEMS...", NodeInfo.HttpEndPoint);
+
 		_reloadConfigSignalRegistration?.Dispose();
 		_reloadConfigSignalRegistration = null;
 


### PR DESCRIPTION
Changed: improved shutdown logging

- Change fatal error message, it spoke of startup but it will be logged on shutdown if the shutdown times out
- No longer call ShutdownService directly, it is single threaded and we were calling from the wrong thread
- Pipe the ExitProcess and ShutdownHttp flags through from the RequestShutdown message to the BecomeShuttingDown message (we used to do this)
- Avoid repeated logging of the same message in two different places "[{httpEndPoint}] IS SHUTTING DOWN.."
- Remove duplicate shutdown of subsystems (this has been here for a long time)