### PR TITLE
Add error to /license endpoint

### DIFF
--- a/src/EventStore.Licensing.Tests/LicensingPluginTests.cs
+++ b/src/EventStore.Licensing.Tests/LicensingPluginTests.cs
@@ -103,7 +103,7 @@ public class LicensingPluginTests : IAsyncLifetime {
 		// then
 		Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
 		var responseString = await result.Content.ReadAsStringAsync();
-		Assert.Equal("", responseString);
+		Assert.Equal("\"license is expired, say\"", responseString);
 	}
 
 	[Fact]


### PR DESCRIPTION
Added: license error to /license endpoint

Endpoint can now return
```
200 with license (as before)
404 with no reason - indicates no error, because no license key was provided
404 with a reason - which is the error
```