### PR TITLE
Don't time out projection manager reads

### DIFF
--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -628,7 +628,8 @@ namespace EventStore.Projections.Core.Services.Management {
 					corrId, corrId, _readDispatcher.Envelope, ProjectionNamesBuilder.ProjectionsStreamPrefix + name, -1,
 					1,
 					resolveLinkTos: false, requireLeader: false, validationStreamVersion: null,
-					user: SystemAccounts.System),
+					user: SystemAccounts.System,
+					expires: DateTime.MaxValue),
 				new ReadStreamEventsBackwardHandlers.Optimistic(PersistedStateReadCompleted));
 		}
 

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -710,7 +710,8 @@ namespace EventStore.Projections.Core.Services.Management {
 					requireLeader: false,
 					validationStreamVersion: null,
 					user: SystemAccounts.System,
-					replyOnExpired: false),
+					replyOnExpired: false,
+					expires: DateTime.MaxValue),
 				m => OnProjectionsListReadCompleted(m, registeredProjections, from, completedAction));
 		}
 
@@ -1052,7 +1053,8 @@ namespace EventStore.Projections.Core.Services.Management {
 					resolveLinkTos: false,
 					requireLeader: false,
 					validationStreamVersion: null,
-					user: SystemAccounts.System),
+					user: SystemAccounts.System,
+					expires: DateTime.MaxValue),
 				new ReadStreamEventsBackwardHandlers.Optimistic(onComplete));
 		}
 

--- a/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -1,3 +1,4 @@
+using System;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Projections.Core.Messages;
@@ -47,7 +48,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 				new ClientMessage.ReadStreamEventsBackward(
 					msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
 					msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
-					msg.ValidationStreamVersion, msg.User));
+					msg.ValidationStreamVersion, msg.User,
+					expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
 		}
 
 		public void Handle(ClientMessage.ReadStreamEventsForward msg) {
@@ -55,7 +57,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 				new ClientMessage.ReadStreamEventsForward(
 					msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
 					msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
-					msg.ValidationStreamVersion, msg.User, replyOnExpired: false));
+					msg.ValidationStreamVersion, msg.User, replyOnExpired: false,
+					expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
 		}
 
 		public void Handle(ClientMessage.ReadAllEventsForward msg) {


### PR DESCRIPTION
Fixed: Don't time out projection manager reads

Fixes https://github.com/EventStore/EventStore/issues/4492
Fixes https://github.com/EventStore/EventStore/issues/2469

If these reads time out, the subsystem cannot start up correctly.

I'm concerned that passing the `expires` value through in the `RequestResponseQueueForwarder` may have unintended consequences, since it's effectively resetting the message timeout whenever it publishes a read message. Which is why I'm only passing `expires` if it's set to `DateTime.MaxValue`.