### PR TITLE
Fix config reloading

### DIFF
--- a/src/EventStore.Common.Tests/Configuration/SectionTests.cs
+++ b/src/EventStore.Common.Tests/Configuration/SectionTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System.Reflection;
 using EventStore.Common.Configuration;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
 
 namespace EventStore.Common.Tests.Configuration;
 
@@ -42,5 +44,14 @@ public class SectionTests {
 		Assert.Equal("v section2:sub:b", config.GetSection("section2").GetSection("sub")["b"]);
 
 		Assert.Equal("v section3:a", config.GetSection("section3")["a"]);
+
+		// SectionProvider reloads when mounted section changes
+		var memConfigProvider = config
+			.Providers.OfType<SectionProvider>().First()
+			.Providers.OfType<MemoryConfigurationProvider>().First();
+		memConfigProvider.Add("new", "v section2:new");
+		typeof(ConfigurationProvider).GetMethod("OnReload", BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(memConfigProvider, null);
+
+		Assert.Equal("v section2:new", config.GetSection("section2")["new"]);
 	}
 }

--- a/src/EventStore.Common.Tests/Configuration/SectionTests.cs
+++ b/src/EventStore.Common.Tests/Configuration/SectionTests.cs
@@ -46,12 +46,17 @@ public class SectionTests {
 		Assert.Equal("v section3:a", config.GetSection("section3")["a"]);
 
 		// SectionProvider reloads when mounted section changes
-		var memConfigProvider = config
-			.Providers.OfType<SectionProvider>().First()
-			.Providers.OfType<MemoryConfigurationProvider>().First();
+		var sectionProvider = config.Providers.OfType<SectionProvider>().First();
+		var memConfigProvider = sectionProvider.Providers.OfType<MemoryConfigurationProvider>().First();
 		memConfigProvider.Add("new", "v section2:new");
 		typeof(ConfigurationProvider).GetMethod("OnReload", BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(memConfigProvider, null);
 
 		Assert.Equal("v section2:new", config.GetSection("section2")["new"]);
+
+		// can get the provider for a key
+		Assert.True(sectionProvider.TryGet("section2:a", out var value));
+		Assert.Equal("v section2:a2", value);
+		Assert.True(sectionProvider.TryGetProviderFor("section2:a", out var provider));
+		Assert.IsType<MemoryConfigurationProvider>(provider);
 	}
 }

--- a/src/EventStore.Common/Configuration/SectionProvider.cs
+++ b/src/EventStore.Common/Configuration/SectionProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 
@@ -22,6 +23,22 @@ public sealed class SectionProvider : ConfigurationProvider, IDisposable {
 	}
 
 	public IEnumerable<IConfigurationProvider> Providers => _configuration.Providers;
+
+	public bool TryGetProviderFor(string key, out IConfigurationProvider provider) {
+		var prefix = _sectionName + ":";
+		if (key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) {
+			key = key[prefix.Length..];
+			foreach (var candidate in Providers) {
+				if (candidate.TryGet(key, out _)) {
+					provider = candidate;
+					return true;
+				}
+			}
+		}
+
+		provider = default;
+		return false;
+	}
 
 	public void Dispose() {
 		_registration.Dispose();

--- a/src/EventStore.Common/Configuration/SectionProvider.cs
+++ b/src/EventStore.Common/Configuration/SectionProvider.cs
@@ -1,22 +1,38 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
 
 namespace EventStore.Common.Configuration;
 
-public class SectionProvider : ConfigurationProvider {
-	private readonly IConfiguration _configuration;
+public sealed class SectionProvider : ConfigurationProvider, IDisposable {
+	private readonly IConfigurationRoot _configuration;
 	private readonly string _sectionName;
+	private readonly IDisposable _registration;
 
-	public SectionProvider(string sectionName, IConfiguration configuration) {
+	public SectionProvider(string sectionName, IConfigurationRoot configuration) {
 		_configuration = configuration;
 		_sectionName = sectionName;
+		_registration = ChangeToken.OnChange(
+			configuration.GetReloadToken,
+			Load);
+	}
+
+	public IEnumerable<IConfigurationProvider> Providers => _configuration.Providers;
+
+	public void Dispose() {
+		_registration.Dispose();
 	}
 
 	public override void Load() {
+		var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		foreach (var kvp in _configuration.AsEnumerable()) {
-			Data[_sectionName + ":" + kvp.Key] = kvp.Value;
+			data[_sectionName + ":" + kvp.Key] = kvp.Value;
 		}
+		Data = data;
+		OnReload();
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -116,9 +116,9 @@ public class ClusterVNodeOptionsTests {
 		var result = options.CheckForEnvironmentOnlyOptions();
 
 		result.Should().BeEquivalentTo(
-			"Provided by: Command Line. " +
+			"\"DefaultAdminPassword\" Provided by: Command Line. " +
 			"The Admin user password can only be set using Environment Variables" + Environment.NewLine +
-			"Provided by: Command Line. " +
+			"\"DefaultOpsPassword\" Provided by: Command Line. " +
 			"The Ops user password can only be set using Environment Variables" + Environment.NewLine);
 	}
 

--- a/src/EventStore.Core/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Core/Configuration/ConfigurationRootExtensions.cs
@@ -38,13 +38,13 @@ public static class ConfigurationRootExtensions {
 				from key in provider.GetChildKeys()
 				from property in environmentOptionsOnly
 				where string.Equals(property.Name, key, StringComparison.CurrentCultureIgnoreCase)
-				select property.GetCustomAttribute<EnvironmentOnlyAttribute>()?.Message;
+				select (key, property.GetCustomAttribute<EnvironmentOnlyAttribute>()?.Message);
 
 			errorBuilder.Append(
 				errorDescriptions
 					.Aggregate(
 						new StringBuilder(),
-						(sb, err) => sb.AppendLine($"Provided by: {ClusterVNodeOptions.GetSourceDisplayName(provider.GetType())}. {err}")
+						(sb, pair) => sb.AppendLine($"\"{pair.key}\" Provided by: {ClusterVNodeOptions.GetSourceDisplayName(EventStoreConfigurationKeys.Prefix + ":" + pair.key, provider)}. {pair.Message}")
 					)
 			);
 		}


### PR DESCRIPTION
Fixed: Config hot reload (bug introduced since the previous release)

SectionProvider wasn't monitoring the wrapped provider for changes.