### PR TITLE
[DBX-79-1] Timeout cherry picks

### DIFF
--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -30,7 +30,7 @@
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="YamlDotnet" Version="13.7.1" />
-		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-8g4q-xg66-9fp4 -->
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-447r-wph3-92pm -->
 		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />

--- a/src/EventStore.Core/Helpers/IODispatcher.cs
+++ b/src/EventStore.Core/Helpers/IODispatcher.cs
@@ -271,7 +271,8 @@ public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<
 		bool resolveLinks,
 		ClaimsPrincipal principal,
 		Action<ClientMessage.ReadStreamEventsBackwardCompleted> action,
-		Guid? corrId = null) {
+		Guid? corrId = null,
+		DateTime? expires = null) {
 		if (!corrId.HasValue)
 			corrId = Guid.NewGuid();
 
@@ -286,7 +287,8 @@ public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<
 					resolveLinks,
 					false,
 					null,
-					principal),
+					principal,
+					expires: expires),
 			new ReadStreamEventsBackwardHandlers.Optimistic(action));
 	}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1167,7 +1167,7 @@ public class PersistentSubscriptionService<TStreamId> :
 
 	private void LoadConfiguration(Action continueWith) {
 		_ioDispatcher.ReadBackward(SystemStreams.PersistentSubscriptionConfig, -1, 1, false,
-			SystemAccounts.System, x => HandleLoadCompleted(continueWith, x));
+			SystemAccounts.System, x => HandleLoadCompleted(continueWith, x), expires: DateTime.MaxValue);
 	}
 
 	private void HandleLoadCompleted(Action continueWith,

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -633,7 +633,8 @@ public static class PersistedStateExtensions {
 				corrId, corrId, _readDispatcher.Envelope, ProjectionNamesBuilder.ProjectionsStreamPrefix + name, -1,
 				1,
 				resolveLinkTos: false, requireLeader: false, validationStreamVersion: null,
-				user: SystemAccounts.System),
+				user: SystemAccounts.System,
+				expires: DateTime.MaxValue),
 			new ReadStreamEventsBackwardHandlers.Optimistic(PersistedStateReadCompleted));
 	}
 

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -732,7 +732,8 @@ public class ProjectionManager
 				requireLeader: false,
 				validationStreamVersion: null,
 				user: SystemAccounts.System,
-				replyOnExpired: false),
+				replyOnExpired: false,
+				expires: DateTime.MaxValue),
 			m => OnProjectionsListReadCompleted(m, registeredProjections, from, completedAction));
 	}
 
@@ -1074,7 +1075,8 @@ public class ProjectionManager
 				resolveLinkTos: false,
 				requireLeader: false,
 				validationStreamVersion: null,
-				user: SystemAccounts.System),
+				user: SystemAccounts.System,
+				expires: DateTime.MaxValue),
 			new ReadStreamEventsBackwardHandlers.Optimistic(onComplete));
 	}
 


### PR DESCRIPTION
Fixed: Don't timeout Projection or Persistent Subscription startup reads

Cherry picked from:
https://github.com/EventStore/EventStore/pull/4559
https://github.com/EventStore/EventStore/pull/4557