### PR TITLE
Fix runtime information

### DIFF
--- a/src/EventStore.SystemRuntime.Tests/EventStore.SystemRuntime.Tests.csproj
+++ b/src/EventStore.SystemRuntime.Tests/EventStore.SystemRuntime.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<!-- CVE-2018-8292 -->
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<!-- CVE-2019-0820 -->
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.SystemRuntime\EventStore.SystemRuntime.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/EventStore.SystemRuntime.Tests/RuntimeInformationTests.cs
+++ b/src/EventStore.SystemRuntime.Tests/RuntimeInformationTests.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System.Runtime;
+using Xunit;
+
+namespace EventStore.SystemRuntime.Tests;
+
+public class RuntimeInformationTests {
+	[Fact]
+	public void can_get_runtime_version() {
+		Assert.NotNull(RuntimeInformation.RuntimeVersion);
+	}
+
+	[Fact]
+	public void can_get_runtime_mode() {
+		Assert.True(RuntimeInformation.RuntimeMode > 0);
+	}
+}

--- a/src/EventStore.SystemRuntime/RuntimeInformation.cs
+++ b/src/EventStore.SystemRuntime/RuntimeInformation.cs
@@ -14,99 +14,97 @@ namespace System.Runtime;
 
 [PublicAPI]
 public static class RuntimeInformation {
-    static RuntimeInformation() {
-        if (IsOSPlatform(OSPlatform.OSX)) {
-            OsPlatform = RuntimeOSPlatform.OSX;
-            IsOSX = true;
-        }
-        else if (IsOSPlatform(OSPlatform.Linux)) {
-            OsPlatform = RuntimeOSPlatform.Linux;
-            IsLinux = true;
-        }
-        else if (IsOSPlatform(OSPlatform.Windows)) {
-            OsPlatform = RuntimeOSPlatform.Windows;
-            IsWindows = true;
-        }
-        else if (IsOSPlatform(OSPlatform.FreeBSD)) {
-            OsPlatform = RuntimeOSPlatform.FreeBSD;
-            IsFreeBSD = true;
-        }
-        else
-            OsPlatform = RuntimeOSPlatform.Unknown;
+	static RuntimeInformation() {
+		if (IsOSPlatform(OSPlatform.OSX)) {
+			OsPlatform = RuntimeOSPlatform.OSX;
+			IsOSX = true;
+		} else if (IsOSPlatform(OSPlatform.Linux)) {
+			OsPlatform = RuntimeOSPlatform.Linux;
+			IsLinux = true;
+		} else if (IsOSPlatform(OSPlatform.Windows)) {
+			OsPlatform = RuntimeOSPlatform.Windows;
+			IsWindows = true;
+		} else if (IsOSPlatform(OSPlatform.FreeBSD)) {
+			OsPlatform = RuntimeOSPlatform.FreeBSD;
+			IsFreeBSD = true;
+		} else
+			OsPlatform = RuntimeOSPlatform.Unknown;
 
-        IsUnix = IsLinux || IsFreeBSD || IsOSX;
+		IsUnix = IsLinux || IsFreeBSD || IsOSX;
 
-        IsRunningInContainer  = !IsNullOrEmpty(GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"));
-        IsRunningInKubernetes = !IsNullOrEmpty(GetEnvironmentVariable("KUBERNETES_SERVICE_HOST"));
-        
-        Host = DotNetHostInfo.Collect();
+		IsRunningInContainer = !IsNullOrEmpty(GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"));
+		IsRunningInKubernetes = !IsNullOrEmpty(GetEnvironmentVariable("KUBERNETES_SERVICE_HOST"));
 
-        HomeFolder = GetFolderPath(SpecialFolder.UserProfile);
-    }
+		Host = DotNetHostInfo.Collect();
+		RuntimeVersion = Host.RuntimeVersion;
+		RuntimeMode = Host.Mode;
 
-    /// <summary>
-    /// Indicates if the current process is running in a container.
-    /// </summary>
-    public static readonly bool IsRunningInContainer;
-    
-    /// <summary>
-    /// Indicates if the current process is running in a Kubernetes cluster.
-    /// </summary>
-    public static readonly bool IsRunningInKubernetes;
+		HomeFolder = GetFolderPath(SpecialFolder.UserProfile);
+	}
 
-    /// <summary>
-    /// The operating system platform the current process is running on.
-    /// </summary>
-    public static readonly RuntimeOSPlatform OsPlatform;
+	/// <summary>
+	/// Indicates if the current process is running in a container.
+	/// </summary>
+	public static readonly bool IsRunningInContainer;
 
-    /// <summary>
-    /// Indicates if the current operating system is Linux.
-    /// </summary>
-    public static readonly bool IsLinux;
+	/// <summary>
+	/// Indicates if the current process is running in a Kubernetes cluster.
+	/// </summary>
+	public static readonly bool IsRunningInKubernetes;
 
-    /// <summary>
-    /// Indicates if the current operating system is Windows.
-    /// </summary>
-    public static readonly bool IsWindows;
+	/// <summary>
+	/// The operating system platform the current process is running on.
+	/// </summary>
+	public static readonly RuntimeOSPlatform OsPlatform;
 
-    /// <summary>
-    /// Indicates if the current operating system is macOS.
-    /// </summary>
-    public static readonly bool IsOSX;
+	/// <summary>
+	/// Indicates if the current operating system is Linux.
+	/// </summary>
+	public static readonly bool IsLinux;
 
-    /// <summary>
-    /// Indicates if the current operating system is FreeBSD.
-    /// </summary>
-    public static readonly bool IsFreeBSD;
+	/// <summary>
+	/// Indicates if the current operating system is Windows.
+	/// </summary>
+	public static readonly bool IsWindows;
 
-    /// <summary>
-    /// Indicates if the current operating system is a Unix-based system (Linux, FreeBSD or macOS).
-    /// </summary>
-    public static readonly bool IsUnix;
+	/// <summary>
+	/// Indicates if the current operating system is macOS.
+	/// </summary>
+	public static readonly bool IsOSX;
 
-    /// <summary>
-    /// Information about the .NET host environment.
-    /// This includes details such as the version of the .NET runtime, the architecture, the mode (e.g., 64 for a 64-bit runtime), the commit hash of the .NET runtime, and a custom runtime version of the .NET host.
-    /// </summary>
-    public static readonly DotNetHostInfo Host;
-    
-    /// <summary>
-    /// The user's profile folder.
-    /// </summary>
-    /// <remarks>
-    /// Applications should not create files or folders at this level; they should put their data under the locations referred to by <see cref="F:System.Environment.SpecialFolder.ApplicationData" />.
-    /// </remarks>
-    public static readonly string HomeFolder;
+	/// <summary>
+	/// Indicates if the current operating system is FreeBSD.
+	/// </summary>
+	public static readonly bool IsFreeBSD;
 
-    /// <summary>
-    /// Custom runtime version of the .NET host.
-    /// </summary>
-    public static readonly string RuntimeVersion = Host.RuntimeVersion;
+	/// <summary>
+	/// Indicates if the current operating system is a Unix-based system (Linux, FreeBSD or macOS).
+	/// </summary>
+	public static readonly bool IsUnix;
 
-    /// <summary>
-    /// The mode of the .NET runtime, represented as the size of a pointer (e.g., 64 for a 64-bit runtime).
-    /// </summary>
-    public static readonly int RuntimeMode = Host.Mode;
+	/// <summary>
+	/// Information about the .NET host environment.
+	/// This includes details such as the version of the .NET runtime, the architecture, the mode (e.g., 64 for a 64-bit runtime), the commit hash of the .NET runtime, and a custom runtime version of the .NET host.
+	/// </summary>
+	public static readonly DotNetHostInfo Host;
+
+	/// <summary>
+	/// The user's profile folder.
+	/// </summary>
+	/// <remarks>
+	/// Applications should not create files or folders at this level; they should put their data under the locations referred to by <see cref="F:System.Environment.SpecialFolder.ApplicationData" />.
+	/// </remarks>
+	public static readonly string HomeFolder;
+
+	/// <summary>
+	/// Custom runtime version of the .NET host.
+	/// </summary>
+	public static readonly string RuntimeVersion;
+
+	/// <summary>
+	/// The mode of the .NET runtime, represented as the size of a pointer (e.g., 64 for a 64-bit runtime).
+	/// </summary>
+	public static readonly int RuntimeMode;
 }
 
 /// <summary>
@@ -118,21 +116,21 @@ public static class RuntimeInformation {
 /// <param name="Commit">The commit hash of the .NET runtime.</param>
 /// <param name="RuntimeVersion">Custom runtime version of the .NET host.</param>
 public readonly record struct DotNetHostInfo(string Version, Architecture Architecture, int Mode, string Commit, string RuntimeVersion) {
-    public override string ToString() => RuntimeVersion;
-    
-    public static DotNetHostInfo Collect() {
-        var assemblyVersion = typeof(object).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            ?.InformationalVersion!;
+	public override string ToString() => RuntimeVersion;
 
-        var commit = assemblyVersion.Substring(assemblyVersion.IndexOf('+') + 1, 9);
+	public static DotNetHostInfo Collect() {
+		var assemblyVersion = typeof(object).Assembly
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+			?.InformationalVersion!;
 
-        return new () {
-            Version = Environment.Version.ToString(),
-            Architecture = OSArchitecture,
-            Mode = IntPtr.Size * 8,
-            Commit = commit,
-            RuntimeVersion = $"{FrameworkDescription}/{commit}"
-        };
-    }
+		var commit = assemblyVersion.Substring(assemblyVersion.IndexOf('+') + 1, 9);
+
+		return new() {
+			Version = Environment.Version.ToString(),
+			Architecture = OSArchitecture,
+			Mode = IntPtr.Size * 8,
+			Commit = commit,
+			RuntimeVersion = $"{FrameworkDescription}/{commit}"
+		};
+	}
 }

--- a/src/EventStore.sln
+++ b/src/EventStore.sln
@@ -69,6 +69,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.Licensing", "Eve
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.Licensing.Tests", "EventStore.Licensing.Tests\EventStore.Licensing.Tests.csproj", "{414B49B4-D789-4832-B257-B1F344D57C32}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.SystemRuntime.Tests", "EventStore.SystemRuntime.Tests\EventStore.SystemRuntime.Tests.csproj", "{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -415,6 +417,18 @@ Global
 		{414B49B4-D789-4832-B257-B1F344D57C32}.Release|ARM64.Build.0 = Release|ARM64
 		{414B49B4-D789-4832-B257-B1F344D57C32}.Release|x64.ActiveCfg = Release|x64
 		{414B49B4-D789-4832-B257-B1F344D57C32}.Release|x64.Build.0 = Release|x64
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Debug|ARM64.Build.0 = Debug|ARM64
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Debug|x64.ActiveCfg = Debug|x64
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Debug|x64.Build.0 = Debug|x64
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Release|ARM64.ActiveCfg = Release|ARM64
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Release|ARM64.Build.0 = Release|ARM64
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Release|x64.ActiveCfg = Release|x64
+		{D6FD1EBC-53E8-442C-8E5B-815F6B527B07}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixed: runtime information log on startup

Static field initializers are run before static constructors