### PR TITLE
Treat MACHINE_LIMIT_EXCEEDED as a conclusive license validation error

### DIFF
--- a/src/EventStore.Licensing.Tests/Keygen/KeygenLifecycleServiceTests.cs
+++ b/src/EventStore.Licensing.Tests/Keygen/KeygenLifecycleServiceTests.cs
@@ -109,6 +109,7 @@ public sealed class KeygenLifecycleServiceTests : IDisposable {
 	}
 
 	[Theory]
+	[InlineData("MACHINE_LIMIT_EXCEEDED", true)]
 	[InlineData("MACHINE_CORE_LIMIT_EXCEEDED", true)]
 	[InlineData("something_we_didnt_anticipate", false)]
 	public async Task when_license_validation_requires_machine_activation_which_fails(string code, bool conclusive) {


### PR DESCRIPTION
Changed: Treat MACHINE_LIMIT_EXCEEDED as a conclusive license validation error
