### PR TITLE
Calculate days remaining when querying /license endpoint

### DIFF
--- a/src/EventStore.Licensing.Tests/Keygen/KeygenLicenseProviderTests.cs
+++ b/src/EventStore.Licensing.Tests/Keygen/KeygenLicenseProviderTests.cs
@@ -35,14 +35,14 @@ public class KeygenLicenseProviderTests {
 		Assert.True(esdbLicense.HasEntitlement("FUTURE_TECH_3"));
 
 		var endpointInfo = LicenseSummary.SelectForEndpoint(esdbLicense);
-		Assert.Equal(9, endpointInfo.Count());
+		Assert.Equal(9, endpointInfo.Count);
 		Assert.Equal("license id", endpointInfo["licenseId"]);
 		Assert.Equal("acme", endpointInfo["company"]);
 		Assert.Equal("false", endpointInfo["isTrial"]);
 		Assert.Equal("false", endpointInfo["isExpired"]);
 		Assert.Equal("true", endpointInfo["isValid"]);
 		Assert.Equal("true", endpointInfo["isFloating"]);
-		Assert.Equal("2", endpointInfo["daysRemaining"]);
+		Assert.Equal("2.04", endpointInfo["daysRemaining"]);
 		Assert.Equal("0", endpointInfo["startDate"]);
 		Assert.Equal("is lookin good", endpointInfo["notes"]);
 
@@ -78,6 +78,7 @@ public class KeygenLicenseProviderTests {
 
 	[Fact]
 	public async Task inconclusive() {
+		var expectedDaysRemaining = (DateTimeOffset.MaxValue - DateTimeOffset.Now).TotalDays;
 		var licenses = new Subject<LicenseInfo>();
 		var sut = new KeygenLicenseProvider(
 			licenses);
@@ -91,19 +92,19 @@ public class KeygenLicenseProviderTests {
 
 		var endpointInfo = LicenseSummary.SelectForEndpoint(esdbLicense);
 		Assert.Equal(9, endpointInfo.Count());
-		Assert.Equal("Fallback", endpointInfo["licenseId"]);
+		Assert.Equal("Temporary License", endpointInfo["licenseId"]);
 		Assert.Equal("EventStore Ltd", endpointInfo["company"]);
 		Assert.Equal("false", endpointInfo["isTrial"]);
 		Assert.Equal("false", endpointInfo["isExpired"]);
 		Assert.Equal("false", endpointInfo["isValid"]);
-		Assert.Equal("false", endpointInfo["isFloating"]);
-		Assert.Equal("0", endpointInfo["daysRemaining"]);
+		Assert.Equal("true", endpointInfo["isFloating"]);
+		Assert.Equal($"{expectedDaysRemaining:N2}", endpointInfo["daysRemaining"]);
 		Assert.Equal("0", endpointInfo["startDate"]);
 		Assert.Equal("License could not be validated. Please contact EventStore support.", endpointInfo["notes"]);
 
 		var telemetryInfo = LicenseSummary.SelectForTelemetry(esdbLicense);
 		Assert.Equal(4, telemetryInfo.Count());
-		Assert.Equal("Fallback", telemetryInfo["licenseId"]);
+		Assert.Equal("Temporary License", telemetryInfo["licenseId"]);
 		Assert.Equal(false, telemetryInfo["isTrial"]);
 		Assert.Equal(false, telemetryInfo["isExpired"]);
 		Assert.Equal(false, telemetryInfo["isValid"]);

--- a/src/EventStore.Licensing.Tests/Keygen/KeygenLifecycleServiceTests.cs
+++ b/src/EventStore.Licensing.Tests/Keygen/KeygenLifecycleServiceTests.cs
@@ -187,6 +187,7 @@ public sealed class KeygenLifecycleServiceTests : IDisposable {
 	[Theory]
 	[InlineData("LICENSE_INVALID", true)]
 	[InlineData("LICENSE_SUSPENDED", true)]
+	[InlineData("LICENSE_EXPIRED", true)]
 	[InlineData("something_we_didnt_anticipate", false)]
 	public async Task when_license_validation_fails(string code, bool conclusive) {
 		await _sut.StartAsync(CancellationToken.None);

--- a/src/EventStore.Licensing.Tests/LicenseSummaryTests.cs
+++ b/src/EventStore.Licensing.Tests/LicenseSummaryTests.cs
@@ -15,7 +15,6 @@ public class LicenseSummaryTests {
 			licenseId: "license123",
 			company: "company",
 			isTrial: r.Next(2) == 0,
-			isExpired: r.Next(2) == 0,
 			expiry: DateTimeOffset.Now + TimeSpan.FromHours(1),
 			isValid: r.Next(2) == 0,
 			notes: "some notes");
@@ -23,12 +22,11 @@ public class LicenseSummaryTests {
 		var exported = new Dictionary<string, object>();
 		sut.ExportClaims(exported);
 
-		Assert.Equal(7, exported.Keys.Count);
+		Assert.Equal(6, exported.Keys.Count);
 
 		Assert.Equal(sut.LicenseId, exported["licenseId"]);
 		Assert.Equal(sut.Company, exported["company"]);
 		Assert.Equal(sut.IsTrial, exported["isTrial"]);
-		Assert.Equal(sut.IsExpired, exported["isExpired"]);
 		Assert.Equal(sut.ExpiryUnixTimeSeconds, exported["expiryUnixTimeSeconds"]);
 		Assert.Equal(sut.IsValid, exported["isValid"]);
 		Assert.Equal(sut.Notes, exported["notes"]);
@@ -38,12 +36,11 @@ public class LicenseSummaryTests {
 	public void exposes_properties() {
 		var props = LicenseSummary.Properties;
 
-		Assert.Equal(7, props.Count);
+		Assert.Equal(6, props.Count);
 
 		Assert.Contains("licenseId", props);
 		Assert.Contains("company", props);
 		Assert.Contains("isTrial", props);
-		Assert.Contains("isExpired", props);
 		Assert.Contains("expiryUnixTimeSeconds", props);
 		Assert.Contains("isValid", props);
 		Assert.Contains("notes", props);

--- a/src/EventStore.Licensing.Tests/LicenseSummaryTests.cs
+++ b/src/EventStore.Licensing.Tests/LicenseSummaryTests.cs
@@ -9,32 +9,28 @@ namespace EventStore.Licensing.Tests;
 
 public class LicenseSummaryTests {
 	[Fact]
-	public void can_export() {
+	public void can_export_claims() {
 		var r = Random.Shared;
 		var sut = new LicenseSummary(
 			licenseId: "license123",
 			company: "company",
 			isTrial: r.Next(2) == 0,
 			isExpired: r.Next(2) == 0,
+			expiry: DateTimeOffset.Now + TimeSpan.FromHours(1),
 			isValid: r.Next(2) == 0,
-			isFloating: r.Next(2) == 0,
-			daysRemaining: r.Next(123),
-			startDate: new DateTime(2024, 4, 15),
 			notes: "some notes");
 
 		var exported = new Dictionary<string, object>();
-		sut.Export(exported);
+		sut.ExportClaims(exported);
 
-		Assert.Equal(9, exported.Keys.Count);
+		Assert.Equal(7, exported.Keys.Count);
 
 		Assert.Equal(sut.LicenseId, exported["licenseId"]);
 		Assert.Equal(sut.Company, exported["company"]);
 		Assert.Equal(sut.IsTrial, exported["isTrial"]);
 		Assert.Equal(sut.IsExpired, exported["isExpired"]);
+		Assert.Equal(sut.ExpiryUnixTimeSeconds, exported["expiryUnixTimeSeconds"]);
 		Assert.Equal(sut.IsValid, exported["isValid"]);
-		Assert.Equal(sut.IsFloating, exported["isFloating"]);
-		Assert.Equal(sut.DaysRemaining, exported["daysRemaining"]);
-		Assert.Equal(sut.StartDate, exported["startDate"]);
 		Assert.Equal(sut.Notes, exported["notes"]);
 	}
 
@@ -42,16 +38,14 @@ public class LicenseSummaryTests {
 	public void exposes_properties() {
 		var props = LicenseSummary.Properties;
 
-		Assert.Equal(9, props.Count);
+		Assert.Equal(7, props.Count);
 
 		Assert.Contains("licenseId", props);
 		Assert.Contains("company", props);
 		Assert.Contains("isTrial", props);
 		Assert.Contains("isExpired", props);
+		Assert.Contains("expiryUnixTimeSeconds", props);
 		Assert.Contains("isValid", props);
-		Assert.Contains("isFloating", props);
-		Assert.Contains("daysRemaining", props);
-		Assert.Contains("startDate", props);
 		Assert.Contains("notes", props);
 	}
 }

--- a/src/EventStore.Licensing.Tests/LicensingPluginTests.cs
+++ b/src/EventStore.Licensing.Tests/LicensingPluginTests.cs
@@ -55,8 +55,15 @@ public class LicensingPluginTests : IAsyncLifetime {
 			{"another_claim", "another_value" } // excluded from endpoint
 		};
 
-		new LicenseSummary("license123", "the_company", true, true, true, true, 4, new DateTime(2024, 4, 15), "somenotes")
-			.Export(claims);
+		new LicenseSummary(
+			licenseId: "license123",
+			company: "the_company",
+			isTrial: true,
+			isExpired: true,
+			expiry: new DateTimeOffset(1970, 1, 1, 0, 0, 55, default),
+			isValid: true,
+			notes: "somenotes")
+			.ExportClaims(claims);
 
 		var sut = await CreateLicensedSutAsync(claims);
 		_server = await InitializeServerAsync(sut);
@@ -71,15 +78,15 @@ public class LicensingPluginTests : IAsyncLifetime {
 		Assert.DoesNotContain("another", responseString);
 		Assert.Equal("""
 			{
+			  "isExpired": "true",
 			  "licenseId": "license123",
 			  "company": "the_company",
 			  "isTrial": "true",
-			  "isExpired": "true",
+			  "daysRemaining": "0.00",
 			  "isValid": "true",
+			  "notes": "somenotes",
 			  "isFloating": "true",
-			  "daysRemaining": "4",
-			  "startDate": "1713139200",
-			  "notes": "somenotes"
+			  "startDate": "0"
 			}
 			""".Replace(" ", "").Replace(Environment.NewLine, ""),
 			responseString);

--- a/src/EventStore.Licensing.Tests/LicensingPluginTests.cs
+++ b/src/EventStore.Licensing.Tests/LicensingPluginTests.cs
@@ -59,7 +59,6 @@ public class LicensingPluginTests : IAsyncLifetime {
 			licenseId: "license123",
 			company: "the_company",
 			isTrial: true,
-			isExpired: true,
 			expiry: new DateTimeOffset(1970, 1, 1, 0, 0, 55, default),
 			isValid: true,
 			notes: "somenotes")

--- a/src/EventStore.Licensing/Keygen/KeygenLicenseProvider.cs
+++ b/src/EventStore.Licensing/Keygen/KeygenLicenseProvider.cs
@@ -49,7 +49,6 @@ public class KeygenLicenseProvider : ILicenseProvider {
 			LicenseId: "Temporary License",
 			Company: "EventStore Ltd",
 			IsTrial: false,
-			IsExpired: false,
 			ExpiryUnixTimeSeconds: DateTimeOffset.MaxValue.ToUnixTimeSeconds(),
 			IsValid: false,
 			Notes: "License could not be validated. Please contact EventStore support.");
@@ -67,7 +66,7 @@ public class KeygenLicenseProvider : ILicenseProvider {
 			licenseInfo.Name,
 			licenseInfo.Valid, licenseInfo.Trial, licenseInfo.Expiry);
 
-		if (licenseInfo.Expired)
+		if (licenseInfo.Expiry < DateTimeOffset.UtcNow)
 			Log.Warning($"The license expired at {licenseInfo.Expiry}");
 
 		// whether an expired license is valid or not is up to the policy in keygen
@@ -81,7 +80,6 @@ public class KeygenLicenseProvider : ILicenseProvider {
 			LicenseId: licenseInfo.LicenseId,
 			Company: licenseInfo.Name, // todo: name may not necessarily be the company name, depends what we do in the keygen dashboard
 			IsTrial: licenseInfo.Trial,
-			IsExpired: licenseInfo.Expired,
 			ExpiryUnixTimeSeconds: (licenseInfo.Expiry ?? DateTimeOffset.MaxValue).ToUnixTimeSeconds(),
 			IsValid: licenseInfo.Valid,
 			Notes: licenseInfo.Detail);

--- a/src/EventStore.Licensing/Keygen/KeygenLifecycleService.cs
+++ b/src/EventStore.Licensing/Keygen/KeygenLifecycleService.cs
@@ -250,6 +250,7 @@ public sealed class KeygenLifecycleService : IHostedService, IDisposable {
 
 static class ErrorExtensions {
 	static readonly string[] _conclusiveErrors = [
+		"LICENSE_EXPIRED",
 		"LICENSE_INVALID",
 		"LICENSE_SUSPENDED",
 		"MACHINE_CORE_LIMIT_EXCEEDED",

--- a/src/EventStore.Licensing/Keygen/LicenseInfo.cs
+++ b/src/EventStore.Licensing/Keygen/LicenseInfo.cs
@@ -14,8 +14,6 @@ public record LicenseInfo {
 		DateTimeOffset? Expiry,
 		string[] Entitlements) : LicenseInfo {
 
-		public bool Expired => Expiry < DateTimeOffset.UtcNow;
-
 		public static Conclusive FromError(string error) => new(
 			LicenseId: "Unknown",
 			Name: "Unknown",

--- a/src/EventStore.Licensing/LicenseSummary.cs
+++ b/src/EventStore.Licensing/LicenseSummary.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Security.Claims;
 using EventStore.Plugins.Licensing;
 
 namespace EventStore.Licensing;
@@ -71,7 +70,7 @@ public record LicenseSummary(
 		AddString(nameof(LicenseId), license, dict);
 		AddBool(nameof(IsTrial), license, dict);
 
-		if (TryGet(ExpiryUnixTimeSecondsName, license, out var key, out var value)) {
+		if (TryGet(ExpiryUnixTimeSecondsName, license, out var _, out var value)) {
 			dict[IsExpiredName] = CalcDaysRemaining(value) <= 0;
 		}
 


### PR DESCRIPTION
Don't use the snapshot from when validation occurred