### PR TITLE
Only use AuthorizationPolicyRegistryFactory for internal authorization

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -136,18 +136,18 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable {
 			}
 
 			var modifiedOptions = _options;
-			var registryFactory = new AuthorizationPolicyRegistryFactory(_options, configuration, pluginLoader);
-			foreach (var authSubsystem in registryFactory.GetSubsystems()) {
-				modifiedOptions = modifiedOptions.WithPlugableComponent(authSubsystem);
+			if (_options.Auth.AuthorizationType.Equals("internal", StringComparison.InvariantCultureIgnoreCase)) {
+				var registryFactory = new AuthorizationPolicyRegistryFactory(_options, configuration, pluginLoader);
+				foreach (var authSubsystem in registryFactory.GetSubsystems()) {
+					modifiedOptions = modifiedOptions.WithPlugableComponent(authSubsystem);
+				}
+
+				var internalFactory = new AuthorizationProviderFactory(components =>
+					new InternalAuthorizationProviderFactory(registryFactory.Create(components.MainQueue)));
+				return (modifiedOptions, internalFactory);
 			}
 
-			var authorizationTypeToPlugin = new Dictionary<string, AuthorizationProviderFactory> {
-				{
-					"internal", new AuthorizationProviderFactory(components =>
-						new InternalAuthorizationProviderFactory(registryFactory.Create(components.MainQueue))
-					)
-				}
-			};
+			var authorizationTypeToPlugin = new Dictionary<string, AuthorizationProviderFactory> { };
 
 			foreach (var potentialPlugin in pluginLoader.Load<IAuthorizationPlugin>()) {
 				try {
@@ -156,8 +156,9 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable {
 						"Loaded authorization plugin: {plugin} version {version} (Command Line: {commandLine})",
 						potentialPlugin.Name, potentialPlugin.Version, commandLine);
 					authorizationTypeToPlugin.Add(commandLine,
-						new AuthorizationProviderFactory(_ =>
-							potentialPlugin.GetAuthorizationProviderFactory(authorizationConfig)));
+						new AuthorizationProviderFactory(
+							_ => potentialPlugin.GetAuthorizationProviderFactory(authorizationConfig)
+						));
 				} catch (CompositionException ex) {
 					Log.Error(ex, "Error loading authentication plugin.");
 				}


### PR DESCRIPTION
Changed: Only use `AuthorizationPolicyRegistryFactory` when the `internal` authorization plugin is enabled.

This fixes an error when enabling `legacy-authorization-with-stream-authorization-disabled`.