### PR TITLE
[ESDB-169-8]: Move GetActualRawPosition to async

### DIFF
--- a/src/EventStore.Core.Tests/Services/RedactionService/EventPositionTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/EventPositionTests.cs
@@ -27,7 +27,7 @@ public class EventPositionTests<TLogFormat, TStreamId> : RedactionServiceTestFix
 			_positions[eventNumber] = new();
 
 		var chunk = Db.Manager.GetChunkFor(eventRecord.LogPosition);
-		var eventOffset = chunk.GetActualRawPosition(eventRecord.LogPosition);
+		var eventOffset = await chunk.GetActualRawPosition(eventRecord.LogPosition, token);
 		var eventPosition = new EventPosition(
 			eventRecord.LogPosition, Path.GetFileName(chunk.FileName), chunk.ChunkHeader.MinCompatibleVersion, chunk.IsReadOnly, (uint)eventOffset);
 		_positions[eventNumber].Add(eventPosition);

--- a/src/EventStore.Core.Tests/TransactionLog/tfchunk_get_actual_raw_position_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/tfchunk_get_actual_raw_position_should.cs
@@ -76,7 +76,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 
 		Assert.AreEqual(numEvents, logPositions.Count);
 		foreach(var logPos in logPositions)
-			Assert.AreEqual(ChunkHeader.Size + logPos, chunk.GetActualRawPosition(logPos));
+			Assert.AreEqual(ChunkHeader.Size + logPos, await chunk.GetActualRawPosition(logPos, CancellationToken.None));
 		Assert.IsEmpty(posMap);
 	}
 
@@ -96,7 +96,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 
 		Assert.AreEqual(numEvents, logPositions.Count);
 		foreach(var logPos in logPositions)
-			Assert.AreEqual(ChunkHeader.Size + logPos, chunk.GetActualRawPosition(logPos));
+			Assert.AreEqual(ChunkHeader.Size + logPos, await chunk.GetActualRawPosition(logPos, CancellationToken.None));
 		Assert.IsEmpty(posMap);
 	}
 
@@ -118,7 +118,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		Assert.AreEqual(numEvents, posMap.Count);
 		for (int i = 0; i < numEvents; i++) {
 			Assert.AreEqual(posMap[i].LogPos, logPositions[i]);
-			Assert.AreEqual(ChunkHeader.Size + posMap[i].ActualPos, chunk.GetActualRawPosition(logPositions[i]));
+			Assert.AreEqual(ChunkHeader.Size + posMap[i].ActualPos, await chunk.GetActualRawPosition(logPositions[i], CancellationToken.None));
 		}
 	}
 
@@ -138,9 +138,9 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		Assert.IsEmpty(posMap);
 
 		Assert.AreEqual(chunk.LogicalDataSize, chunk.PhysicalDataSize);
-		Assert.AreEqual(ChunkHeader.Size + chunk.LogicalDataSize - 1, chunk.GetActualRawPosition(chunk.LogicalDataSize - 1));
-		Assert.AreEqual(-1, chunk.GetActualRawPosition(chunk.LogicalDataSize));
-		Assert.AreEqual(-1, chunk.GetActualRawPosition(chunk.LogicalDataSize + 1));
+		Assert.AreEqual(ChunkHeader.Size + chunk.LogicalDataSize - 1, await chunk.GetActualRawPosition(chunk.LogicalDataSize - 1, CancellationToken.None));
+		Assert.AreEqual(-1, await chunk.GetActualRawPosition(chunk.LogicalDataSize, CancellationToken.None));
+		Assert.AreEqual(-1, await chunk.GetActualRawPosition(chunk.LogicalDataSize + 1, CancellationToken.None));
 	}
 
 	[Test]
@@ -158,8 +158,8 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		Assert.AreEqual(1, logPositions.Count);
 		Assert.AreEqual(1, posMap.Count);
 
-		Assert.AreEqual(ChunkHeader.Size + posMap[0].ActualPos, chunk.GetActualRawPosition(logPositions[0]));
-		Assert.AreEqual(-1, chunk.GetActualRawPosition(logPositions[0] + 1));
+		Assert.AreEqual(ChunkHeader.Size + posMap[0].ActualPos, await chunk.GetActualRawPosition(logPositions[0], CancellationToken.None));
+		Assert.AreEqual(-1, await chunk.GetActualRawPosition(logPositions[0] + 1, CancellationToken.None));
 	}
 
 	[Test]
@@ -174,6 +174,6 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 			logPositions,
 			posMap);
 
-		Assert.Throws<ArgumentOutOfRangeException>(() => chunk.GetActualRawPosition(-1));
+		Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await chunk.GetActualRawPosition(-1, CancellationToken.None));
 	}
 }

--- a/src/EventStore.Core/Services/RedactionService.cs
+++ b/src/EventStore.Core/Services/RedactionService.cs
@@ -78,7 +78,7 @@ public class RedactionService<TStreamId> :
 			var logPos = eventInfo.LogPosition;
 			var chunk = _db.Manager.GetChunkFor(logPos);
 			var localPosition = chunk.ChunkHeader.GetLocalLogPosition(logPos);
-			var chunkEventOffset = chunk.GetActualRawPosition(localPosition);
+			var chunkEventOffset = await chunk.GetActualRawPosition(localPosition, token);
 
 			// all the events returned by ReadEventInfo_KeepDuplicates() must exist in the log
 			// since the log record was read from the chunk to check for hash collisions.

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -608,9 +608,10 @@ public partial class TFChunk : IDisposable {
 	// (d) raw (byte offset in file, which is actual - header size)
 	//
 	// this method takes (b) and returns (d)
-	public long GetActualRawPosition(long logicalPosition) {
+	public async ValueTask<long> GetActualRawPosition(long logicalPosition, CancellationToken token) {
 		ArgumentOutOfRangeException.ThrowIfNegative(logicalPosition);
 
+		token.ThrowIfCancellationRequested();
 		var actualPosition = _readSide.GetActualPosition(logicalPosition);
 
 		if (actualPosition < 0)


### PR DESCRIPTION
Changed: `TFChunk.GetActualRawPosition` converted to async method

Depends on #4579.