### PR TITLE
Fix support for gossip seeds provided as an array

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -159,6 +159,23 @@ public class ClusterVNodeOptionsTests {
 		options.Cluster.GossipSeed.Should().BeEquivalentTo(endpoints);
 	}
 
+	[Fact]
+	public void can_set_gossip_seed_values_via_array() {
+		var config = new ConfigurationBuilder()
+			.AddInMemoryCollection([
+				new("EventStore:GossipSeed:0", "127.0.0.1:1113"),
+				new("EventStore:GossipSeed:1", "some-host:1114"),
+			])
+			.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Cluster.GossipSeed.Should().BeEquivalentTo(new EndPoint[] {
+			new IPEndPoint(IPAddress.Loopback, 1113),
+			new DnsEndPoint("some-host", 1114),
+		});
+	}
+
 	[Theory]
 	[InlineData("127.0.0.1", "You must specify the ports in the gossip seed.")]
 	[InlineData("127.0.0.1:3.1415", "Invalid format for gossip seed port: 3.1415.")]
@@ -190,6 +207,17 @@ public class ClusterVNodeOptionsTests {
 		Assert.Equal(
 			"Failed to convert configuration value at 'EventStore:NodeIp' to type 'System.Net.IPAddress'. " + expectedError,
 			ex.Message);
+	}
+
+	[Fact]
+	public void can_set_node_ip() {
+		var config = new ConfigurationBuilder()
+			.AddEventStoreEnvironmentVariables(("EVENTSTORE_NODE_IP", "192.168.0.1"))
+			.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Interface.NodeIp.Should().Be(IPAddress.Parse("192.168.0.1"));
 	}
 
 	[Fact]

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -65,6 +65,7 @@ public partial record ClusterVNodeOptions {
 		// required because of a bug in the configuration system that
 		// is not reading the attribute from the property itself
 		TypeDescriptor.AddAttributes(typeof(EndPoint[]), new TypeConverterAttribute(typeof(GossipSeedConverter)));
+		TypeDescriptor.AddAttributes(typeof(EndPoint), new TypeConverterAttribute(typeof(GossipEndPointConverter)));
 		TypeDescriptor.AddAttributes(typeof(IPAddress), new TypeConverterAttribute(typeof(IPAddressConverter)));
 
 		// with full keys we would not even need to do all these binds, just a single one


### PR DESCRIPTION
Fixed: bug introduced since previous release

Regression introduced in https://github.com/EventStore/EventStore/pull/4470

The yaml processor that we removed had special handling to flatten arrays into comma separated strings, which were then handled by the GossipSeedConverter

The new general purpose yaml processor (sensibly) does not do this, so we need to register the GossipEndPointConverter directly so it can be applied to individual endpoints directly