### PR TITLE
[KDB-518] Use github automatically generated release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'kind/bug report'
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: kind/enhancement
+labels: enhancement
 assignees: ''
 
 ---

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Added
+      labels:
+        - enhancement
+    - title: Fixed
+      labels:
+        - bug
+    - title: Changed
+      labels:
+        - "*"
+    - title: Deprecated
+      labels:
+        - deprecated
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: Documentation
+      labels:
+        - documentation


### PR DESCRIPTION
Use the [github automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) instead of our custom changelog action

We may want to consider adding some automation to label PRs that affect certain subdirectories (like docs).

PRs with these labels would be added to the following sections in the release notes:
- `ignore-for-release` -> Excluded from the changelog
- `enhancement` -> Added
- `bug` -> Fixed
- `deprecated` -> Deprecated
- `breaking` -> Breaking Changes
- `documentation` -> Documentation
- All other changes -> `Changed`

Additionally:
- Update issue templates to use `bug` and `enhancement` instead of `kind/bug` and `kind/enhancement`