### PR TITLE
[KDB-402]: Move log record read operation to async

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/LengthPrefixSuffixFramer.cs
+++ b/src/EventStore.Core.Tests/Helpers/LengthPrefixSuffixFramer.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext;
+using DotNext.IO;
 using EventStore.Core.Helpers;
 using NUnit.Framework;
 
@@ -52,10 +53,10 @@ public class length_prefix_suffix_framer_should {
 	public async Task unframe_record_when_provided_exactly_enough_data_in_one_call() {
 		int unframedCnt = 0;
 		var framer = new LengthPrefixSuffixFramer();
-		framer.RegisterMessageArrivedCallback(new Action<BinaryReader>(r => {
+		framer.RegisterMessageArrivedCallback(async (r, token) => {
 			unframedCnt += 1;
-			Assert.AreEqual(new byte[] {0x07, 0x17, 0x27}, ReadAll(r));
-		}).ToAsync());
+			Assert.AreEqual(new byte[] {0x07, 0x17, 0x27}, await ReadAll(r, token));
+		});
 
 		await framer.UnFrameData(new ArraySegment<byte>([
 			0x03, 0x00, 0x00, 0x00,
@@ -70,10 +71,10 @@ public class length_prefix_suffix_framer_should {
 	public async Task unframe_record_when_provided_with_small_chunks_of_data_at_a_time() {
 		int unframedCnt = 0;
 		var framer = new LengthPrefixSuffixFramer();
-		framer.RegisterMessageArrivedCallback(new Action<BinaryReader>(r => {
+		framer.RegisterMessageArrivedCallback(async (r, token) => {
 			unframedCnt += 1;
-			Assert.AreEqual(new byte[] { 0x07, 0x17, 0x27 }, ReadAll(r));
-		}).ToAsync());
+			Assert.AreEqual(new byte[] { 0x07, 0x17, 0x27 }, await ReadAll(r, token));
+		});
 
 		await framer.UnFrameData(new ArraySegment<byte>(new byte[] {0x03, 0x00}), CancellationToken.None);
 		await framer.UnFrameData(new ArraySegment<byte>(new byte[] {0x00, 0x00}), CancellationToken.None);
@@ -89,16 +90,16 @@ public class length_prefix_suffix_framer_should {
 	public async Task unframe_two_consecutive_records() {
 		int unframedCnt = 0;
 		var framer = new LengthPrefixSuffixFramer();
-		framer.RegisterMessageArrivedCallback(new Action<BinaryReader>(r => {
+		framer.RegisterMessageArrivedCallback(async (r, token) => {
 			if (unframedCnt == 0)
-				Assert.AreEqual(new byte[] {0x07, 0x17, 0x27}, ReadAll(r));
+				Assert.AreEqual(new byte[] {0x07, 0x17, 0x27}, await ReadAll(r, token));
 			else if (unframedCnt == 1)
-				Assert.AreEqual(new byte[] {0x05, 0x15}, ReadAll(r));
+				Assert.AreEqual(new byte[] {0x05, 0x15}, await ReadAll(r, token));
 			else
 				Assert.Fail();
 
 			unframedCnt += 1;
-		}).ToAsync());
+		});
 
 		await framer.UnFrameData(new ArraySegment<byte>([
 			0x03, 0x00, 0x00, 0x00,
@@ -124,16 +125,16 @@ public class length_prefix_suffix_framer_should {
 	public async Task discard_data_when_reset_and_continue_unframing_from_blank_slate() {
 		int unframedCnt = 0;
 		var framer = new LengthPrefixSuffixFramer();
-		framer.RegisterMessageArrivedCallback(new Action<BinaryReader>(r => {
+		framer.RegisterMessageArrivedCallback(async (r, token) => {
 			if (unframedCnt == 0)
-				Assert.AreEqual(new byte[] {0x07, 0x17, 0x27}, ReadAll(r));
+				Assert.AreEqual(new byte[] {0x07, 0x17, 0x27}, await ReadAll(r, token));
 			else if (unframedCnt == 1)
-				Assert.AreEqual(new byte[] {0x05, 0x15}, ReadAll(r));
+				Assert.AreEqual(new byte[] {0x05, 0x15}, await ReadAll(r, token));
 			else
 				Assert.Fail();
 
 			unframedCnt += 1;
-		}).ToAsync());
+		});
 
 		await framer.UnFrameData(new ArraySegment<byte>([
 			0x03, 0x00, 0x00, 0x00,
@@ -157,12 +158,10 @@ public class length_prefix_suffix_framer_should {
 		Assert.AreEqual(2, unframedCnt);
 	}
 
-	private byte[] ReadAll(BinaryReader br) {
-		var buf = new byte[100000];
-		int read = br.Read(buf, 0, buf.Length);
-
-		var res = new byte[read];
-		Buffer.BlockCopy(buf, 0, res, 0, read);
-		return res;
+	private static async ValueTask<byte[]> ReadAll(IAsyncBinaryReader br, CancellationToken token) {
+		Assert.True(br.TryGetRemainingBytesCount(out var bytesCount));
+		var result = new byte[bytesCount];
+		await br.ReadAsync(result, token);
+		return result;
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateScenario.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Services.Storage;
 using EventStore.Core.TransactionLog.Chunks;
@@ -35,7 +36,7 @@ public abstract class TruncateScenario<TLogFormat, TStreamId> : ReadIndexTestSce
 		await Db.DisposeAsync();
 
 		var truncator = new TFChunkDbTruncator(Db.Config, _ => new IdentityChunkTransformFactory());
-		truncator.TruncateDb(TruncateCheckpoint);
+		await truncator.TruncateDb(TruncateCheckpoint, CancellationToken.None);
 	}
 
 	protected virtual void OnBeforeTruncating() {

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
@@ -36,18 +37,18 @@ public class when_truncating_against_max_truncation_config : SpecificationWithDi
 
 	[Test]
 	public void truncate_above_max_throws_exception() {
-		Assert.Throws<Exception>(() => {
+		Assert.ThrowsAsync<Exception>(async () => {
 			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-			truncator.TruncateDb(0);
+			await truncator.TruncateDb(0, CancellationToken.None);
 		});
 	}
 
 	[Test]
 	public void truncate_within_max_does_not_throw_exception() {
 
-		Assert.DoesNotThrow(() => {
+		Assert.DoesNotThrowAsync(async () => {
 			var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-			truncator.TruncateDb(4800);
+			await truncator.TruncateDb(4800 ,CancellationToken.None);
 		});
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
@@ -40,7 +41,7 @@ public class when_truncating_into_the_middle_of_completed_chunk : SpecificationW
 		DbUtil.CreateSingleChunk(_config, 3, GetFilePathFor("chunk-000003.000000"));
 
 		var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-		truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		await truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed(), CancellationToken.None);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
@@ -35,7 +36,7 @@ public class when_truncating_into_the_middle_of_multichunk : SpecificationWithDi
 		DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
 
 		var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-		truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		await truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed(), CancellationToken.None);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
@@ -38,7 +39,7 @@ public class when_truncating_into_the_middle_of_ongoing_chunk : SpecificationWit
 		DbUtil.CreateOngoingChunk(_config, 1, GetFilePathFor("chunk-000001.000002"), contents: _file2Contents);
 
 		var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-		truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		await truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed(), CancellationToken.None);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
@@ -32,7 +33,7 @@ public class when_truncating_right_at_the_end_of_multichunk : SpecificationWithD
 		DbUtil.CreateOngoingChunk(_config, 13, GetFilePathFor("chunk-000013.000000"));
 
 		var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-		truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		await truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed(), CancellationToken.None);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_data_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_data_chunk_boundary.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
@@ -31,7 +32,7 @@ public class when_truncating_to_a_data_chunk_boundary : SpecificationWithDirecto
 		DbUtil.CreateOngoingChunk(_config, 5, GetFilePathFor("chunk-000005.000000"));
 
 		var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-		truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		await truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed(), CancellationToken.None);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_scavenged_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_a_scavenged_chunk_boundary.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Chunks;
@@ -31,7 +32,7 @@ public class when_truncating_to_a_scavenged_chunk_boundary : SpecificationWithDi
 		DbUtil.CreateOngoingChunk(_config, 5, GetFilePathFor("chunk-000005.000000"));
 
 		var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-		truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		await truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed(), CancellationToken.None);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
@@ -31,7 +32,7 @@ public class when_truncating_to_the_very_beginning_of_multichunk_db : Specificat
 		DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
 
 		var truncator = new TFChunkDbTruncator(_config, _ => new IdentityChunkTransformFactory());
-		truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
+		await truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed(), CancellationToken.None);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System.Threading;
 using System.Threading.Tasks;
-using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog;
@@ -16,7 +15,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 		using (var reader = chunk.AcquireRawReader()) {
 			chunk.MarkForDeletion();
 			var buffer = new byte[1024];
-			var result = reader.ReadNextBytes(1024, buffer);
+			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsFalse(result.IsEOF);
 			Assert.AreEqual(1024, result.BytesRead);
 		}
@@ -29,7 +28,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
 		using (var reader = chunk.AcquireRawReader()) {
 			var buffer = new byte[1024];
-			var result = reader.ReadNextBytes(1024, buffer);
+			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsFalse(result.IsEOF);
 			Assert.AreEqual(1024, result.BytesRead);
 		}
@@ -76,7 +75,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 3000);
 		using (var reader = chunk.AcquireRawReader()) {
 			var buffer = new byte[1024];
-			var result = reader.ReadNextBytes(3000, buffer);
+			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsFalse(result.IsEOF);
 			Assert.AreEqual(1024, result.BytesRead);
 		}
@@ -90,7 +89,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
 		using (var reader = chunk.AcquireRawReader()) {
 			var buffer = new byte[8092];
-			var result = reader.ReadNextBytes(8092, buffer);
+			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsTrue(result.IsEOF);
 			Assert.AreEqual(4096, result.BytesRead); //does not includes header and footer space
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using DotNext.IO;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -26,7 +27,8 @@ public class when_writing_an_existing_chunked_transaction_file_with_checksum<TLo
 	[Test]
 	public async Task a_record_can_be_written() {
 		var filename = GetFilePathFor("chunk-000000.000000");
-		var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, TFChunk.CurrentChunkVersion, 10000, 0, 0, false, chunkId: Guid.NewGuid(), TransformType.Identity);
+		var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, TFChunk.CurrentChunkVersion, 10000, 0, 0, false,
+			chunkId: Guid.NewGuid(), TransformType.Identity);
 		var chunkBytes = chunkHeader.AsByteArray();
 		var bytes = new byte[ChunkHeader.Size + 10000 + ChunkFooter.Size];
 		Buffer.BlockCopy(chunkBytes, 0, bytes, 0, chunkBytes.Length);
@@ -54,8 +56,8 @@ public class when_writing_an_existing_chunked_transaction_file_with_checksum<TLo
 			timeStamp: new DateTime(2012, 12, 21),
 			flags: PrepareFlags.None,
 			eventType: eventTypeId,
-			data: new byte[] {1, 2, 3, 4, 5},
-			metadata: new byte[] {7, 17});
+			data: new byte[] { 1, 2, 3, 4, 5 },
+			metadata: new byte[] { 7, 17 });
 
 		await tf.Write(record, CancellationToken.None);
 		await tf.DisposeAsync();
@@ -63,11 +65,13 @@ public class when_writing_an_existing_chunked_transaction_file_with_checksum<TLo
 
 		Assert.AreEqual(record.GetSizeWithLengthPrefixAndSuffix() + 137,
 			_checkpoint.Read()); //137 is fluff assigned to beginning of checkpoint
-		using (var filestream = File.Open(filename, FileMode.Open, FileAccess.Read)) {
-			filestream.Seek(ChunkHeader.Size + 137 + sizeof(int), SeekOrigin.Begin);
-			var reader = new BinaryReader(filestream);
-			var read = LogRecord.ReadFrom(reader, (int)reader.BaseStream.Length);
-			Assert.AreEqual(record, read);
-		}
+		await using var filestream = File.Open(filename, new FileStreamOptions
+			{ Mode = FileMode.Open, Access = FileAccess.Read, Options = FileOptions.Asynchronous });
+		filestream.Seek(ChunkHeader.Size + 137 + sizeof(int), SeekOrigin.Begin);
+		var reader = IAsyncBinaryReader.Create(filestream, new byte[128]);
+
+		Assert.True(reader.TryGetRemainingBytesCount(out var recordLength));
+		var read = await LogRecord.ReadFrom(reader, (int)recordLength, CancellationToken.None);
+		Assert.AreEqual(record, read);
 	}
 }

--- a/src/EventStore.Core/Services/RedactionService.cs
+++ b/src/EventStore.Core/Services/RedactionService.cs
@@ -223,13 +223,15 @@ public class RedactionService<TStreamId> :
 		ChunkHeader newChunkHeader;
 		ChunkFooter newChunkFooter;
 		try {
-			using var fs = new FileStream(newChunkPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+			var fs = new FileStream(newChunkPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 128, FileOptions.Asynchronous);
 			try {
-				newChunkHeader = ChunkHeader.FromStream(fs);
+				newChunkHeader = await ChunkHeader.FromStream(fs, token);
 				fs.Seek(-ChunkFooter.Size, SeekOrigin.End);
-				newChunkFooter = ChunkFooter.FromStream(fs);
+				newChunkFooter = await ChunkFooter.FromStream(fs, token);
 			} catch {
 				return new(SwitchChunkResult.NewChunkHeaderOrFooterInvalid);
+			} finally {
+				await fs.DisposeAsync();
 			}
 		} catch {
 			return new(SwitchChunkResult.NewChunkOpenFailed);

--- a/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
@@ -2,9 +2,11 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using EventStore.Cluster;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
@@ -103,12 +105,9 @@ public class InternalTcpDispatcher : ClientWriteTcpDispatcher {
 
 	private ReplicationMessage.CreateChunk UnwrapCreateChunk(TcpPackage package, IEnvelope envelope) {
 		var dto = package.Data.Deserialize<CreateChunk>();
-		ChunkHeader chunkHeader;
-		using (var memStream = new MemoryStream(dto.ChunkHeaderBytes.ToByteArray())) {
-			chunkHeader = ChunkHeader.FromStream(memStream);
-		}
+		ChunkHeader chunkHeader = new(dto.ChunkHeaderBytes.Span);
 
-		return new ReplicationMessage.CreateChunk(new Guid(dto.LeaderId.Span), new Guid(dto.SubscriptionId.Span), chunkHeader,
+		return new(new Guid(dto.LeaderId.Span), new Guid(dto.SubscriptionId.Span), chunkHeader,
 			dto.FileSize, dto.IsScavengedChunk, dto.TransformHeaderBytes.Memory);
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
@@ -7,8 +7,11 @@ using EventStore.Common.Utils;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using DotNext.Buffers;
 using DotNext.Buffers.Binary;
+using DotNext.IO;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.TransactionLog.Chunks;
 
@@ -116,10 +119,8 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 		return array;
 	}
 
-	[SkipLocalsInit]
-	public static ChunkFooter FromStream(Stream stream) {
-		Span<byte> buffer = stackalloc byte[Size];
-		stream.ReadExactly(buffer);
-		return new(buffer);
+	public static async ValueTask<ChunkFooter> FromStream(Stream stream, CancellationToken token) {
+		using var buffer = Memory.AllocateExactly<byte>(Size);
+		return await stream.ReadAsync<ChunkFooter>(buffer.Memory, token);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
@@ -56,6 +56,7 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 		LogicalDataSize = logicalDataSize;
 		MapSize = mapSize;
 
+		Unsafe.SkipInit(out _checksum); // fix for Qodana false positive about init of readonly field
 		md5Hash.CopyTo(_checksum);
 
 		var posMapSize = isMap12Bytes ? PosMap.FullSize : PosMap.DeprecatedSize;

--- a/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
@@ -9,17 +9,19 @@ using DotNext.Buffers;
 using DotNext.Buffers.Binary;
 using DotNext.IO;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace EventStore.Core.TransactionLog.Chunks;
 
-
 // TODO: Consider struct instead of class
 public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 	public const int Size = TFConsts.ChunkFooterSize;
 	public const int ChecksumSize = 16;
+
+	private readonly MD5HashBuffer _checksum;
 
 	// flags within single byte
 	public readonly bool IsCompleted;
@@ -31,22 +33,21 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 		LogicalDataSize; // the size of a logical data size (after scavenge LogicalDataSize can be > physicalDataSize)
 
 	public readonly int MapSize;
-	public readonly byte[] MD5Hash; // TODO: Allocation can be removed with InlineArray
+
+	public ReadOnlySpan<byte> MD5Hash => _checksum;
 
 	public readonly int MapCount; // calculated, not stored
 
 	public ChunkFooter(bool isCompleted, bool isMap12Bytes, int physicalDataSize, long logicalDataSize, int mapSize,
-		byte[] md5Hash) {
-		Ensure.Nonnegative(physicalDataSize, "physicalDataSize");
-		Ensure.Nonnegative(logicalDataSize, "logicalDataSize");
+		ReadOnlySpan<byte> md5Hash) {
+		Ensure.Nonnegative(physicalDataSize, nameof(physicalDataSize));
+		Ensure.Nonnegative(logicalDataSize, nameof(logicalDataSize));
 		if (logicalDataSize < physicalDataSize)
-			throw new ArgumentOutOfRangeException("logicalDataSize",
-				string.Format("LogicalDataSize {0} is less than PhysicalDataSize {1}", logicalDataSize,
-					physicalDataSize));
+			throw new ArgumentOutOfRangeException(nameof(logicalDataSize),
+				$"LogicalDataSize {logicalDataSize} is less than PhysicalDataSize {physicalDataSize}");
 		Ensure.Nonnegative(mapSize, "mapSize");
-		Ensure.NotNull(md5Hash, "md5Hash");
 		if (md5Hash.Length != ChecksumSize)
-			throw new ArgumentException("MD5Hash is of wrong length.", "md5Hash");
+			throw new ArgumentException("MD5Hash is of wrong length.", nameof(md5Hash));
 
 		IsCompleted = isCompleted;
 		IsMap12Bytes = isMap12Bytes;
@@ -54,7 +55,8 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 		PhysicalDataSize = physicalDataSize;
 		LogicalDataSize = logicalDataSize;
 		MapSize = mapSize;
-		MD5Hash = md5Hash;
+
+		md5Hash.CopyTo(_checksum);
 
 		var posMapSize = isMap12Bytes ? PosMap.FullSize : PosMap.DeprecatedSize;
 		if (MapSize % posMapSize != 0)
@@ -78,7 +80,7 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 
 		MapSize = reader.ReadLittleEndian<int>();
 		reader.ConsumedCount = Size - ChecksumSize;
-		MD5Hash = reader.ReadToEnd().ToArray();
+		reader.Read(_checksum);
 
 		var posMapSize = IsMap12Bytes ? PosMap.FullSize : PosMap.DeprecatedSize;
 		if (MapSize % posMapSize is not 0) {
@@ -107,7 +109,7 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 
 		writer.WriteLittleEndian(MapSize);
 		writer.WrittenCount = Size - ChecksumSize;
-		writer.Write(MD5Hash);
+		writer.Write(_checksum);
 	}
 
 	static ChunkFooter IBinaryFormattable<ChunkFooter>.Parse(ReadOnlySpan<byte> source)
@@ -122,5 +124,10 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 	public static async ValueTask<ChunkFooter> FromStream(Stream stream, CancellationToken token) {
 		using var buffer = Memory.AllocateExactly<byte>(Size);
 		return await stream.ReadAsync<ChunkFooter>(buffer.Memory, token);
+	}
+
+	[InlineArray(ChecksumSize)]
+	private struct MD5HashBuffer {
+		private byte _element0;
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -1,28 +1,43 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
+using DotNext;
+using DotNext.Buffers;
 using DotNext.IO;
 using EventStore.Plugins.Transforms;
 using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
-internal sealed class ReaderWorkItem : BinaryReader {
-	public const int BufferSize = 8192;
+internal sealed class ReaderWorkItem : Disposable {
+	private const int BufferSize = 512;
 
 	// if item was taken from the pool, the field contains position within the array (>= 0)
 	private readonly int _positionInPool = -1;
+	public readonly Stream BaseStream;
+	public readonly IAsyncBinaryReader Reader;
+	private readonly bool _leaveOpen;
+	private MemoryOwner<byte> _buffer;
 
-	public unsafe ReaderWorkItem(Stream sharedStream, IChunkReadTransform chunkReadTransform)
-		: base(CreateTransformedMemoryStream(sharedStream, chunkReadTransform), Encoding.UTF8, leaveOpen: true) {
+	private ReaderWorkItem(Stream stream, bool leaveOpen, int bufferSize) {
+		Debug.Assert(stream is not null);
+
+		_leaveOpen = leaveOpen;
+		BaseStream = stream;
+		_buffer = Memory.AllocateAtLeast<byte>(bufferSize);
+		Reader = IAsyncBinaryReader.Create(stream, _buffer.Memory);
+	}
+
+	public ReaderWorkItem(Stream sharedStream, IChunkReadTransform chunkReadTransform)
+		: this(CreateTransformedMemoryStream(sharedStream, chunkReadTransform), leaveOpen: true, BufferSize) {
 		IsMemory = true;
 	}
 
 	public ReaderWorkItem(SafeFileHandle handle, IChunkReadTransform chunkReadTransform)
-		: base(CreateTransformedFileStream(handle, chunkReadTransform), Encoding.UTF8, leaveOpen: false) {
+		: this(CreateTransformedFileStream(handle, chunkReadTransform), leaveOpen: false, BufferSize) {
 		IsMemory = false;
 	}
 
@@ -44,5 +59,16 @@ internal sealed class ReaderWorkItem : BinaryReader {
 
 			_positionInPool = value;
 		}
+	}
+
+	protected override void Dispose(bool disposing) {
+		if (disposing) {
+			if (!_leaveOpen)
+				BaseStream.Dispose();
+
+			_buffer.Dispose();
+		}
+
+		base.Dispose(disposing);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -175,6 +175,11 @@ public partial class TFChunk : IDisposable {
 		_reduceFileCachePressure = reduceFileCachePressure;
 		_memStreams = new();
 		_fileStreams = new();
+
+		// Workaround: the lock is used by the finalizer. When the finalizer is called by .NET,
+		// the lock is already finalized (and Dispose is called) and cannot be used. To avoid that situation,
+		// we suppress the finalizer for the lock. Anyway, the lock doesn't hold any unmanaged resources.
+		GC.SuppressFinalize(_cachedDataLock);
 	}
 
 	~TFChunk() {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -425,7 +425,7 @@ public partial class TFChunk : IDisposable {
 		Debug.Assert(_cachedLength > 0);
 
 		ReadOnlyMemory<byte> memoryView = UnmanagedMemory.AsMemory((byte*)_cachedData, _cachedLength);
-		return StreamSource.AsSharedStream(new(memoryView), compatWithAsync: false);
+		return StreamSource.AsSharedStream(new(memoryView), compatWithAsync: true);
 	}
 
 	private FileOptions WritableHandleOptions {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -568,7 +568,7 @@ public partial class TFChunk : IDisposable {
 		}
 
 		// Perf: use hardware accelerated byte array comparison
-		if (!MemoryExtensions.SequenceEqual<byte>(footer.MD5Hash, hash))
+		if (!footer.MD5Hash.SequenceEqual(hash))
 			throw new HashValidationException();
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkDataReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkDataReader.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 
@@ -17,22 +19,16 @@ public sealed class TFChunkBulkDataReader(TFChunk.TFChunk chunk, Stream streamTo
 		Stream.Position = rawPos;
 	}
 
-	public override BulkReadResult ReadNextBytes(int count, byte[] buffer) {
-		Ensure.NotNull(buffer, "buffer");
-		Ensure.Nonnegative(count, "count");
-
-		if (Stream.Position == 0)
+	public override async ValueTask<BulkReadResult> ReadNextBytes(Memory<byte> buffer, CancellationToken token) {
+		if (Stream.Position is 0)
 			Stream.Position = ChunkHeader.Size;
 
-		if (count > buffer.Length)
-			count = buffer.Length;
-
 		var oldPos = (int)Stream.Position - ChunkHeader.Size;
-		var toRead = Math.Min(Chunk.PhysicalDataSize - oldPos, count);
+		var toRead = Math.Min(Chunk.PhysicalDataSize - oldPos, buffer.Length);
 		Debug.Assert(toRead >= 0);
 		Stream.Position = Stream.Position; // flush read buffer
-		int bytesRead = Stream.Read(buffer, 0, toRead);
-		return new BulkReadResult(oldPos,
+		int bytesRead = await Stream.ReadAsync(buffer.Slice(0, toRead), token);
+		return new(oldPos,
 			bytesRead,
 			isEof: Chunk.IsReadOnly && oldPos + bytesRead == Chunk.PhysicalDataSize);
 	}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkRawReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkRawReader.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 
@@ -19,15 +21,9 @@ public sealed class TFChunkBulkRawReader(TFChunk.TFChunk chunk, Stream streamToU
 
 	}
 
-	public override BulkReadResult ReadNextBytes(int count, byte[] buffer) {
-		Ensure.NotNull(buffer, "buffer");
-		Ensure.Nonnegative(count, "count");
-
-		if (count > buffer.Length)
-			count = buffer.Length;
-
+	public override async ValueTask<BulkReadResult> ReadNextBytes(Memory<byte> buffer, CancellationToken token) {
 		var oldPos = (int)Stream.Position;
-		int bytesRead = Stream.Read(buffer, 0, count);
-		return new BulkReadResult(oldPos, bytesRead, isEof: Stream.Length == Stream.Position);
+		int bytesRead = await Stream.ReadAsync(buffer, token);
+		return new(oldPos, bytesRead, isEof: Stream.Length == Stream.Position);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkReader.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 
@@ -20,7 +22,7 @@ public abstract class TFChunkBulkReader : IDisposable {
 	private readonly TFChunk.TFChunk _chunk;
 	private readonly Stream _stream;
 	private bool _disposed;
-	public bool IsMemory { get; init; }
+	public bool IsMemory { get; }
 
 	internal TFChunkBulkReader(TFChunk.TFChunk chunk, Stream streamToUse, bool isMemory) {
 		Ensure.NotNull(chunk, "chunk");
@@ -31,7 +33,7 @@ public abstract class TFChunkBulkReader : IDisposable {
 	}
 
 	public abstract void SetPosition(long position);
-	public abstract BulkReadResult ReadNextBytes(int count, byte[] buffer);
+	public abstract ValueTask<BulkReadResult> ReadNextBytes(Memory<byte> buffer, CancellationToken token);
 
 	~TFChunkBulkReader() {
 		Dispose();

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
@@ -154,12 +154,8 @@ public abstract class LogRecord : ILogRecord {
 		internal readonly LogRecordType Type;
 		internal readonly byte Version;
 
-		internal Header(LogRecordType type, byte version) {
-			Type = type;
-			Version = version;
-		}
-
 		private Header(ReadOnlySpan<byte> input) {
+			// Perf: Read the span from the last element to have just one range check inserted by JIT
 			Version = input[1];
 			Type = (LogRecordType)input[0];
 		}

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
@@ -3,6 +3,11 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.Buffers;
+using DotNext.Buffers.Binary;
+using DotNext.IO;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.LogAbstraction;
@@ -26,42 +31,41 @@ public abstract class LogRecord : ILogRecord {
 		return logicalPosition - length - 2 * sizeof(int);
 	}
 
-	public static ILogRecord ReadFrom(BinaryReader reader, int length) {
-		var recordType = (LogRecordType)reader.ReadByte();
-		var version = reader.ReadByte();
+	public static async ValueTask<ILogRecord> ReadFrom(IAsyncBinaryReader reader, int length, CancellationToken token) {
+		var header = await reader.ReadAsync<Header>(token);
 
-		static long ReadPosition(BinaryReader reader) {
-			var logPosition = reader.ReadInt64();
-			Ensure.Nonnegative(logPosition, "logPosition");
-			return logPosition;
-		}
-
-		switch (recordType) {
+		switch (header.Type) {
 			case LogRecordType.Prepare:
-				return new PrepareLogRecord(reader, version, ReadPosition(reader));
+				var logPosition = await reader.ReadLittleEndianAsync<long>(token);
+				Ensure.Nonnegative(logPosition, nameof(logPosition));
+				return await PrepareLogRecord.ParseAsync(reader, header.Version, logPosition, token);
 			case LogRecordType.Commit:
-				return new CommitLogRecord(reader, version, ReadPosition(reader));
+				logPosition = await reader.ReadLittleEndianAsync<long>(token);
+				Ensure.Nonnegative(logPosition, nameof(logPosition));
+				return await CommitLogRecord.ParseAsync(reader, header.Version, logPosition, token);
 			case LogRecordType.System:
-				if (version > SystemLogRecord.SystemRecordVersion)
-					return new LogV3EpochLogRecord(LogV3Reader.ReadBytes(recordType, version, reader, length));
+				if (header.Version > SystemLogRecord.SystemRecordVersion)
+					return new LogV3EpochLogRecord(await LogV3Reader.ReadBytes(header.Type, header.Version, reader, length, token));
 
-				return new SystemLogRecord(reader, version, ReadPosition(reader));
+				logPosition = await reader.ReadLittleEndianAsync<long>(token);
+				Ensure.Nonnegative(logPosition, nameof(logPosition));
+				return await SystemLogRecord.ParseAsync(reader, header.Version, logPosition, token);
 
 			case LogRecordType.StreamWrite:
-				return new LogV3StreamWriteRecord(LogV3Reader.ReadBytes(recordType, version, reader, length));
+				return new LogV3StreamWriteRecord(await LogV3Reader.ReadBytes(header.Type, header.Version, reader, length, token));
 
 			case LogRecordType.Stream:
-				return new LogV3StreamRecord(LogV3Reader.ReadBytes(recordType, version, reader, length));
+				return new LogV3StreamRecord(await LogV3Reader.ReadBytes(header.Type, header.Version, reader, length, token));
 
 			case LogRecordType.EventType:
-				return new LogV3EventTypeRecord(LogV3Reader.ReadBytes(recordType, version, reader, length));
+				return new LogV3EventTypeRecord(await LogV3Reader.ReadBytes(header.Type, header.Version, reader, length, token));
 
 			case LogRecordType.PartitionType:
-				return new PartitionTypeLogRecord(LogV3Reader.ReadBytes(recordType, version, reader, length));
-			
+				return new PartitionTypeLogRecord(await LogV3Reader.ReadBytes(header.Type, header.Version, reader, length, token));
+
 			case LogRecordType.Partition:
-				return new PartitionLogRecord(LogV3Reader.ReadBytes(recordType, version, reader, length));
-			
+				return new PartitionLogRecord(await LogV3Reader.ReadBytes(header.Type, header.Version, reader, length, token));
+
 			default:
 				throw new ArgumentOutOfRangeException("recordType");
 		}
@@ -143,5 +147,31 @@ public abstract class LogRecord : ILogRecord {
 			WriteTo(new BinaryWriter(memoryStream));
 			return 8 + (int)memoryStream.Length;
 		}
+	}
+
+	private readonly struct Header : IBinaryFormattable<Header> {
+		private const int Size = sizeof(LogRecordType) + sizeof(byte);
+		internal readonly LogRecordType Type;
+		internal readonly byte Version;
+
+		internal Header(LogRecordType type, byte version) {
+			Type = type;
+			Version = version;
+		}
+
+		private Header(ReadOnlySpan<byte> input) {
+			Version = input[1];
+			Type = (LogRecordType)input[0];
+		}
+
+		public void Format(Span<byte> output) {
+			output[1] = Version;
+			output[0] = (byte)Type;
+		}
+
+		static int IBinaryFormattable<Header>.Size => Size;
+
+		static Header IBinaryFormattable<Header>.Parse(ReadOnlySpan<byte> input)
+			=> new(input);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogV3Reader.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogV3Reader.cs
@@ -3,19 +3,22 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.IO;
 using EventStore.LogCommon;
 
 namespace EventStore.Core.TransactionLog.LogRecords;
 
 public static class LogV3Reader {
-	public static byte[] ReadBytes(LogRecordType type, byte version, BinaryReader reader, int recordLength) {
+	public static async ValueTask<byte[]> ReadBytes(LogRecordType type, byte version, IAsyncBinaryReader reader, int recordLength, CancellationToken token) {
 		// todo: if we could get some confidence that we would return to the pool
 		// (e.g. with reference counting) then we could use arraypool here. or just maybe a ring buffer
 		// var bytes = ArrayPool<byte>.Shared.Rent(length);
 		var bytes = new byte[recordLength];
 		bytes[0] = (byte)type;
 		bytes[1] = version;
-		reader.Read(bytes.AsSpan(2..recordLength));
+		await reader.ReadAsync(bytes.AsMemory(2..recordLength), token);
 		return bytes;
 	}
 }

--- a/src/EventStore.Core/Util/AsyncBinaryReader.cs
+++ b/src/EventStore.Core/Util/AsyncBinaryReader.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.IO;
+using DotNext.Text;
+
+namespace EventStore.Core.Util;
+
+internal static class AsyncBinaryReader {
+	public static async ValueTask<string> ReadStringAsync(this IAsyncBinaryReader reader, DecodingContext context, CancellationToken token) {
+		using var owner = await reader.DecodeAsync(context, LengthFormat.Compressed, token: token);
+		return owner.ToString();
+	}
+
+	public static async ValueTask<byte[]> ReadBytesAsync(this IAsyncBinaryReader reader, int length, CancellationToken token) {
+		var array = GC.AllocateUninitializedArray<byte>(length);
+		await reader.ReadAsync(array, token);
+		return array;
+	}
+}

--- a/src/EventStore.Core/Util/MD5Hash.cs
+++ b/src/EventStore.Core/Util/MD5Hash.cs
@@ -2,8 +2,13 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.Buffers;
+using DotNext.Collections.Generic;
 using EventStore.Common.Utils;
 using MD5 = EventStore.Core.Hashing.MD5;
 
@@ -42,6 +47,29 @@ public class MD5Hash {
 
 			md5.TransformBlock(buffer, 0, read, null, 0);
 			toRead -= read;
+		}
+	}
+
+	public static async ValueTask ContinuousHashFor(HashAlgorithm md5, Stream s, int startPosition, long count, CancellationToken token) {
+		Ensure.NotNull(md5, "md5");
+		Ensure.Nonnegative(count, "count");
+
+		if (s.Position != startPosition)
+			s.Position = startPosition;
+
+		var buffer = ArrayPool<byte>.Shared.Rent(4096);
+		try {
+			long toRead = count;
+			while (toRead > 0) {
+				int read = await s.ReadAsync(buffer.AsMemory(0, (int)Math.Min(toRead, buffer.Length)), token);
+				if (read is 0)
+					break;
+
+				md5.TransformBlock(buffer, 0, read, null, 0);
+				toRead -= read;
+			}
+		} finally {
+			ArrayPool<byte>.Shared.Return(buffer);
 		}
 	}
 }


### PR DESCRIPTION
Changed: `TFChunk` read side internal API has moved to async I/O