### PR TITLE
Log SLOW QUEUE messages by default again

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Metrics/QueueProcessingTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/QueueProcessingTrackerTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics.Metrics;
+using System.Threading.Tasks;
 using EventStore.Core.Metrics;
+using EventStore.Core.Time;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Metrics {
@@ -48,6 +50,18 @@ namespace EventStore.Core.XUnit.Tests.Metrics {
 							Assert.Equal("the-message-type", t.Value);
 						});
 				});
+		}
+	}
+
+	public class QueueProcessingTrackerNoOpTests {
+		// the noop tracker doesn't track anything but it still needs to return the current time
+		[Fact]
+		public async Task noop_returns_current_time() {
+			var sut = new QueueProcessingTracker.NoOp();
+			var start = Instant.Now;
+			await Task.Delay(1);
+			var end = sut.RecordNow(start, "some message type");
+			Assert.True(start < end);
 		}
 	}
 }

--- a/src/EventStore.Core/Metrics/QueueProcessingTracker.cs
+++ b/src/EventStore.Core/Metrics/QueueProcessingTracker.cs
@@ -3,6 +3,7 @@ using EventStore.Core.Time;
 
 namespace EventStore.Core.Metrics {
 	public interface IQueueProcessingTracker {
+		// returns the current time
 		Instant RecordNow(Instant start, string messageType);
 	}
 
@@ -23,7 +24,7 @@ namespace EventStore.Core.Metrics {
 		}
 
 		public class NoOp : IQueueProcessingTracker {
-			public Instant RecordNow(Instant start, string messageType) => start;
+			public Instant RecordNow(Instant start, string messageType) => Instant.Now;
 		}
 	}
 }


### PR DESCRIPTION
When EventStore:Metrics:Queues:Processing is false (which is it by default), the tracker which is used was not returning the current time when recording. This caused the queues to think that no time had passed while processing the message and prevented slow queue messages from being logged.

Slow BUS messages were still logged