### PR TITLE
[KDB-528] Log SLOW QUEUE messages by default again

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Metrics/QueueProcessingTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/QueueProcessingTrackerTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics.Metrics;
+using System.Threading.Tasks;
 using EventStore.Core.Metrics;
+using EventStore.Core.Time;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Metrics;
@@ -52,5 +54,17 @@ public class QueueProcessingTrackerTests : IDisposable {
 						Assert.Equal("the-message-type", t.Value);
 					});
 			});
+	}
+}
+
+public class QueueProcessingTrackerNoOpTests {
+	// the noop tracker doesn't track anything but it still needs to return the current time
+	[Fact]
+	public async Task noop_returns_current_time() {
+		var sut = new QueueProcessingTracker.NoOp();
+		var start = Instant.Now;
+		await Task.Delay(1);
+		var end = sut.RecordNow(start, "some message type");
+		Assert.True(start < end);
 	}
 }

--- a/src/EventStore.Core/Metrics/QueueProcessingTracker.cs
+++ b/src/EventStore.Core/Metrics/QueueProcessingTracker.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Time;
 namespace EventStore.Core.Metrics;
 
 public interface IQueueProcessingTracker {
+	// returns the current time
 	Instant RecordNow(Instant start, string messageType);
 }
 
@@ -27,6 +28,6 @@ public class QueueProcessingTracker : IQueueProcessingTracker {
 	}
 
 	public class NoOp : IQueueProcessingTracker {
-		public Instant RecordNow(Instant start, string messageType) => start;
+		public Instant RecordNow(Instant start, string messageType) => Instant.Now;
 	}
 }


### PR DESCRIPTION
Fixed: 'slow queue' messages are now enabled by default again

When EventStore:Metrics:Queues:Processing is false (which is it by default), the tracker which is used was not returning the current time when recording. This caused the queues to think that no time had passed while processing the message and prevented slow queue messages from being logged.

Slow BUS messages were still logged