### PR TITLE
PoC: Remove BinaryWriter dependency from TFChunk

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/prepare_log_record_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/prepare_log_record_should.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using DotNext.Buffers;
 using EventStore.Core.LogAbstraction;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
@@ -145,15 +146,14 @@ public class prepare_log_record_should<TLogFormat, TStreamId> {
 			return;
 		}
 
-		var memStream = new MemoryStream();
-		var binaryWriter = new BinaryWriter(memStream);
+		var binaryWriter = new BufferWriterSlim<byte>();
 
 		const int dataSize = 10000;
 		var eventTypeId = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
 		var prepare = LogRecord.Prepare(_recordFactory, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, _streamId, 0,
 			PrepareFlags.IsRedacted, eventTypeId, new byte[dataSize], null,  DateTime.UtcNow);
 
-		prepare.WriteTo(binaryWriter);
-		Assert.True(memStream.Length >= dataSize);
+		prepare.WriteTo(ref binaryWriter);
+		Assert.True(binaryWriter.WrittenCount >= dataSize);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
@@ -5,10 +5,10 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
-		<PackageReference Include="xunit" Version="2.6.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
@@ -116,21 +116,21 @@ public class PartitionManagerTests {
 	}
 
 	[Fact]
-	public void throws_on_unexpected_log_record_type() {
+	public async Task throws_on_unexpected_log_record_type() {
 		var reader = new FakeReader(UnexpectedLogRecord);
 
 		IPartitionManager partitionManager = new PartitionManager(reader, new FakeWriter(), new LogV3RecordFactory());
 
-		Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => partitionManager.Initialize(CancellationToken.None).AsTask());
+		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => partitionManager.Initialize(CancellationToken.None).AsTask());
 	}
 
 	[Fact]
-	public void throws_on_unexpected_system_log_record_type() {
+	public async Task throws_on_unexpected_system_log_record_type() {
 		var reader = new FakeReader(UnexpectedSystemLogRecord);
 
 		IPartitionManager partitionManager = new PartitionManager(reader, new FakeWriter(), new LogV3RecordFactory());
 
-		Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => partitionManager.Initialize(CancellationToken.None).AsTask());
+		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => partitionManager.Initialize(CancellationToken.None).AsTask());
 	}
 
 	private LogV3StreamRecord UnexpectedLogRecord => new LogV3StreamRecord(

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PrepareLogRecordViewTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PrepareLogRecordViewTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Text;
+using DotNext.Buffers;
 using EventStore.Core.TransactionLog.LogRecords;
 using Xunit;
 
@@ -66,5 +67,17 @@ public class PrepareLogRecordViewTests {
 		Assert.True(_prepare.Data.SequenceEqual(_data));
 		Assert.True(_prepare.Metadata.SequenceEqual(_metadata));
 		Assert.Equal(Version, _prepare.Version);
+	}
+}
+
+public static class LogRecordExtensions {
+	public static void WriteTo(this ILogRecord record, BinaryWriter writer) {
+		var localWriter = new BufferWriterSlim<byte>();
+		try {
+			record.WriteTo(ref localWriter);
+			writer.Write(localWriter.WrittenSpan);
+		} finally {
+			localWriter.Dispose();
+		}
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/SizeOnDiskTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/SizeOnDiskTests.cs
@@ -2,7 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
-using System.IO;
+using DotNext.Buffers;
 using EventStore.Core.TransactionLog.LogRecords;
 using Xunit;
 
@@ -34,15 +34,14 @@ public class SizeOnDiskTests {
 			metadata: new byte[] { 0XC0, 0xDE },
 			prepareRecordVersion: 1);
 
-		using var memoryStream = new MemoryStream();
-		var writer = new BinaryWriter(memoryStream);
+		var writer = new BufferWriterSlim<byte>();
 		var length = 111;
 
-		writer.Write(length);
-		prepare.WriteTo(writer);
-		writer.Write(length);
+		writer.WriteLittleEndian(length);
+		prepare.WriteTo(ref writer);
+		writer.WriteLittleEndian(length);
 
-		var recordLen = (int)memoryStream.Length;
+		var recordLen = writer.WrittenCount;
 
 		Assert.Equal(recordLen, prepare.SizeOnDisk);
 	}

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/SizeOnDiskTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/SizeOnDiskTests.cs
@@ -34,15 +34,19 @@ public class SizeOnDiskTests {
 			metadata: new byte[] { 0XC0, 0xDE },
 			prepareRecordVersion: 1);
 
-		var writer = new BufferWriterSlim<byte>();
-		var length = 111;
+		var writer = new BufferWriterSlim<byte>(prepare.GetSizeWithLengthPrefixAndSuffix());
+		try {
+			const int dummyLength = 111;
 
-		writer.WriteLittleEndian(length);
-		prepare.WriteTo(ref writer);
-		writer.WriteLittleEndian(length);
+			writer.WriteLittleEndian(dummyLength);
+			prepare.WriteTo(ref writer);
+			writer.WriteLittleEndian(dummyLength);
 
-		var recordLen = writer.WrittenCount;
+			var recordLen = writer.WrittenCount;
 
-		Assert.Equal(recordLen, prepare.SizeOnDisk);
+			Assert.Equal(recordLen, prepare.SizeOnDisk);
+		} finally {
+			writer.Dispose();
+		}
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/SizeOnDiskTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/SizeOnDiskTests.cs
@@ -68,9 +68,6 @@ public class SizeOnDiskTests {
 			writer.WriteLittleEndian(dummyLength);
 
 			Assert.Equal(writer.WrittenCount, record.GetSizeWithLengthPrefixAndSuffix());
-
-			if (record is IPrepareLogRecord prepare)
-				Assert.Equal(writer.WrittenCount, prepare.SizeOnDisk);
 		} finally {
 			writer.Dispose();
 		}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -32,12 +32,11 @@
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.452401" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.6" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-		<PackageReference Include="DotNext" Version="5.14.0" />
-		<PackageReference Include="DotNext.IO" Version="5.14.0" />
-		<PackageReference Include="DotNext.Threading" Version="5.15.0" />
-		<PackageReference Include="DotNext.Unsafe" Version="5.14.0" />
+		<PackageReference Include="DotNext.IO" Version="5.16.1" />
+		<PackageReference Include="DotNext.Threading" Version="5.16.1" />
+		<PackageReference Include="DotNext.Unsafe" Version="5.16.1" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageReference Include="System.Threading.Channels" Version="9.0.0-rc.2.24473.5" />
+		<PackageReference Include="System.Threading.Channels" Version="9.0.0" />
 		<PackageReference Include="Scrutor" Version="5.0.2" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -32,12 +32,12 @@
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.452401" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.6" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-		<PackageReference Include="DotNext" Version="5.16.0" />
-		<PackageReference Include="DotNext.IO" Version="5.16.0" />
-		<PackageReference Include="DotNext.Threading" Version="5.16.0" />
-		<PackageReference Include="DotNext.Unsafe" Version="5.16.0" />
+		<PackageReference Include="DotNext" Version="5.14.0" />
+		<PackageReference Include="DotNext.IO" Version="5.14.0" />
+		<PackageReference Include="DotNext.Threading" Version="5.15.0" />
+		<PackageReference Include="DotNext.Unsafe" Version="5.14.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageReference Include="System.Threading.Channels" Version="9.0.0" />
+		<PackageReference Include="System.Threading.Channels" Version="9.0.0-rc.2.24473.5" />
 		<PackageReference Include="Scrutor" Version="5.0.2" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -32,10 +32,10 @@
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.452401" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.6" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-		<PackageReference Include="DotNext" Version="5.14.0" />
-		<PackageReference Include="DotNext.IO" Version="5.14.0" />
-		<PackageReference Include="DotNext.Threading" Version="5.15.0" />
-		<PackageReference Include="DotNext.Unsafe" Version="5.14.0" />
+		<PackageReference Include="DotNext" Version="5.16.0" />
+		<PackageReference Include="DotNext.IO" Version="5.16.0" />
+		<PackageReference Include="DotNext.Threading" Version="5.16.0" />
+		<PackageReference Include="DotNext.Unsafe" Version="5.16.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="System.Threading.Channels" Version="9.0.0" />
 		<PackageReference Include="Scrutor" Version="5.0.2" />

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
@@ -48,11 +48,19 @@ public struct PosMap : IBinaryFormattable<PosMap> {
 		return new(logPos, actualPos);
 	}
 
+	public readonly void Write(BinaryWriter writer) {
+		Span<byte> buffer = stackalloc byte[FullSize];
+		Format(buffer);
+		writer.Write(buffer);
+	}
+
 	public readonly void Format(Span<byte> destination){
 		SpanWriter<byte> writer = new(destination);
 		writer.WriteLittleEndian(ActualPos);
 		writer.WriteLittleEndian(LogPos);
 	}
 
-	public readonly override string ToString() => $"LogPos: {LogPos}, ActualPos: {ActualPos}";
+	public readonly override string ToString() {
+		return string.Format("LogPos: {0}, ActualPos: {1}", LogPos, ActualPos);
+	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
@@ -48,19 +48,11 @@ public struct PosMap : IBinaryFormattable<PosMap> {
 		return new(logPos, actualPos);
 	}
 
-	public readonly void Write(BinaryWriter writer) {
-		Span<byte> buffer = stackalloc byte[FullSize];
-		Format(buffer);
-		writer.Write(buffer);
-	}
-
 	public readonly void Format(Span<byte> destination){
 		SpanWriter<byte> writer = new(destination);
 		writer.WriteLittleEndian(ActualPos);
 		writer.WriteLittleEndian(LogPos);
 	}
 
-	public readonly override string ToString() {
-		return string.Format("LogPos: {0}, ActualPos: {1}", LogPos, ActualPos);
-	}
+	public readonly override string ToString() => $"LogPos: {LogPos}, ActualPos: {ActualPos}";
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -854,7 +854,7 @@ public partial class TFChunk : IDisposable {
 		return RecordWriteResult.Successful(oldPosition, _physicalDataSize);
 
 		static MemoryOwner<byte> SerializeLogRecord(ILogRecord record, out int recordLength) {
-			var writer = new BufferWriterSlim<byte>(WriterWorkItem.BufferSize);
+			var writer = new BufferWriterSlim<byte>(record.GetSizeWithLengthPrefixAndSuffix());
 			writer.Advance(sizeof(int)); // reserved for length prefix
 			record.WriteTo(ref writer);
 
@@ -862,6 +862,7 @@ public partial class TFChunk : IDisposable {
 			writer.WriteLittleEndian(recordLength); // length suffix
 
 			var buffer = writer.DetachOrCopyBuffer();
+			Debug.Assert(record.GetSizeWithLengthPrefixAndSuffix() == buffer.Length);
 
 			// write length prefix
 			BinaryPrimitives.WriteInt32LittleEndian(buffer.Span, recordLength);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -961,8 +961,8 @@ public partial class TFChunk : IDisposable {
 			mapSize = mapping.Count * PosMap.FullSize;
 
 			using var buffer = Memory.AllocateAtLeast<byte>(mapSize);
-			var bytesWritten = WriteMapping(buffer.Span, mapping);
-			await workItem.AppendData(buffer.Memory.Slice(0, bytesWritten), token);
+			mapSize = WriteMapping(buffer.Span, mapping);
+			await workItem.AppendData(buffer.Memory.Slice(0, mapSize), token);
 		}
 
 		workItem.FlushToDisk();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -960,9 +960,9 @@ public partial class TFChunk : IDisposable {
 
 			mapSize = mapping.Count * PosMap.FullSize;
 
-			using var buffer = Memory.AllocateAtLeast<byte>(mapSize);
-			mapSize = WriteMapping(buffer.Span, mapping);
-			await workItem.AppendData(buffer.Memory.Slice(0, mapSize), token);
+			using var buffer = Memory.AllocateExactly<byte>(mapSize);
+			WriteMapping(buffer.Span, mapping);
+			await workItem.AppendData(buffer.Memory, token);
 		}
 
 		workItem.FlushToDisk();
@@ -1000,13 +1000,11 @@ public partial class TFChunk : IDisposable {
 		_fileSize = fileSize;
 		return footerWithHash;
 
-		static int WriteMapping(Span<byte> buffer, IReadOnlyCollection<PosMap> mapping) {
+		static void WriteMapping(Span<byte> buffer, IReadOnlyCollection<PosMap> mapping) {
 			var writer = new SpanWriter<byte>(buffer);
 			foreach (var map in mapping) {
 				writer.Write(map);
 			}
-
-			return writer.WrittenCount;
 		}
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -960,14 +960,9 @@ public partial class TFChunk : IDisposable {
 
 			mapSize = mapping.Count * PosMap.FullSize;
 
-			var buffer = workItem.BufferWriter.BaseStream;
-			buffer.SetLength(mapSize);
-			buffer.Position = 0;
-			foreach (var map in mapping) {
-				map.Write(workItem.BufferWriter);
-			}
-
-			await workItem.DrainBufferAsync(token);
+			using var buffer = Memory.AllocateAtLeast<byte>(mapSize);
+			var bytesWritten = WriteMapping(buffer.Span, mapping);
+			await workItem.AppendData(buffer.Memory.Slice(0, bytesWritten), token);
 		}
 
 		workItem.FlushToDisk();
@@ -1004,6 +999,15 @@ public partial class TFChunk : IDisposable {
 
 		_fileSize = fileSize;
 		return footerWithHash;
+
+		static int WriteMapping(Span<byte> buffer, IReadOnlyCollection<PosMap> mapping) {
+			var writer = new SpanWriter<byte>(buffer);
+			foreach (var map in mapping) {
+				writer.Write(map);
+			}
+
+			return writer.WrittenCount;
+		}
 	}
 
 	public void Dispose() => TryClose();

--- a/src/EventStore.Core/TransactionLog/LogRecords/CommitLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/CommitLogRecord.cs
@@ -85,6 +85,16 @@ public class CommitLogRecord : LogRecord, IEquatable<CommitLogRecord> {
 		writer.WriteLittleEndian(TimeStamp.Ticks);
 	}
 
+	public override int GetSizeWithLengthPrefixAndSuffix() {
+		return sizeof(int) * 2													/* Length prefix & suffix */
+		+ sizeof(long)															/* TransactionPosition */
+		+ Version is LogRecordVersion.LogRecordV0 ? sizeof(int) : sizeof(long)	/* Version */
+		+ sizeof(long)															/* SortKey */
+		+ 16																	/* CorrelationId */
+		+ sizeof(long)															/* TimeStamp */
+		+ BaseSize;
+	}
+
 	public bool Equals(CommitLogRecord other) {
 		if (ReferenceEquals(null, other)) return false;
 		if (ReferenceEquals(this, other)) return true;

--- a/src/EventStore.Core/TransactionLog/LogRecords/CommitLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/CommitLogRecord.cs
@@ -66,23 +66,23 @@ public sealed class CommitLogRecord : LogRecord, IEquatable<CommitLogRecord> {
 	}
 
 	public override void WriteTo(ref BufferWriterSlim<byte> writer) {
-		base.WriteTo(ref writer); // 10 + 8 = 18
+		base.WriteTo(ref writer);
 
-		writer.WriteLittleEndian(TransactionPosition); // 18 + 8 = 26
+		writer.WriteLittleEndian(TransactionPosition);
 		if (Version is LogRecordVersion.LogRecordV0) {
 			int firstEventNumber = FirstEventNumber is long.MaxValue ? int.MaxValue : (int)FirstEventNumber;
 			writer.WriteLittleEndian(firstEventNumber);
 		} else {
-			writer.WriteLittleEndian(FirstEventNumber); // 26 + 8 = 34
+			writer.WriteLittleEndian(FirstEventNumber);
 		}
 
-		writer.WriteLittleEndian(SortKey); // 34 + 8 = 42
+		writer.WriteLittleEndian(SortKey);
 
 		Span<byte> correlationIdBuffer = writer.GetSpan(16);
 		CorrelationId.TryWriteBytes(correlationIdBuffer);
-		writer.Advance(16); // 42 + 16 = 58
+		writer.Advance(16);
 
-		writer.WriteLittleEndian(TimeStamp.Ticks); // 58 + 8 = 66
+		writer.WriteLittleEndian(TimeStamp.Ticks);
 	}
 
 	public override int GetSizeWithLengthPrefixAndSuffix() {

--- a/src/EventStore.Core/TransactionLog/LogRecords/ILogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/ILogRecord.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
 using System.IO;
+using DotNext.Buffers;
 using EventStore.LogCommon;
 
 namespace EventStore.Core.TransactionLog.LogRecords;
@@ -10,7 +12,7 @@ public interface ILogRecord {
 	LogRecordType RecordType { get; }
 	byte Version { get; }
 	public long LogPosition { get; }
-	void WriteTo(BinaryWriter writer);
+	void WriteTo(ref BufferWriterSlim<byte> writer);
 	long GetNextLogPosition(long logicalPosition, int length);
 	long GetPrevLogPosition(long logicalPosition, int length);
 	int GetSizeWithLengthPrefixAndSuffix();

--- a/src/EventStore.Core/TransactionLog/LogRecords/IPrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/IPrepareLogRecord.cs
@@ -9,7 +9,6 @@ namespace EventStore.Core.TransactionLog.LogRecords;
 // in order to handle a prepare (i.e. data) record.
 // The V2 prepare implements it trivially
 public interface IPrepareLogRecord : ILogRecord {
-	int SizeOnDisk { get; }
 	PrepareFlags Flags { get; }
 	long TransactionPosition { get; }
 	int TransactionOffset { get; }
@@ -24,6 +23,6 @@ public interface IPrepareLogRecord : ILogRecord {
 public interface IPrepareLogRecord<TStreamId> : IPrepareLogRecord {
 	TStreamId EventStreamId { get; }
 	TStreamId EventType { get; }
-	
+
 	IPrepareLogRecord<TStreamId> CopyForRetry(long logPosition, long transactionPosition);
 }

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogV3Record.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogV3Record.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using DotNext.Buffers;
 using EventStore.LogCommon;
 using EventStore.LogV3;
 
@@ -33,7 +34,7 @@ public class LogV3Record<TRecordView> : ILogRecord where TRecordView : IRecordVi
 	public LogV3Record() {
 	}
 
-	public void WriteTo(BinaryWriter writer) {
+	public void WriteTo(ref BufferWriterSlim<byte> writer) {
 		writer.Write(Record.Bytes.Span);
 	}
 

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -51,7 +51,7 @@ public static class PrepareFlagsExtensions {
 	}
 }
 
-public class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, IPrepareLogRecord<string> {
+public sealed class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, IPrepareLogRecord<string> {
 	public const byte PrepareRecordVersion = 1;
 
 	public PrepareFlags Flags { get; private init; }

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -101,9 +101,7 @@ public class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, IPrepar
 
 			_sizeOnDisk =
 				2 * sizeof(int) /* Length prefix & suffix */
-				+ sizeof(byte) /* Record Type */
-				+ sizeof(byte) /* Version */
-				+ sizeof(long) /* Log Position */
+				+ BaseSize
 				+ sizeof(ushort) /* Flags */
 				+ sizeof(long) /* TransactionPosition */
 				+ sizeof(int) /* TransactionOffset */
@@ -272,6 +270,8 @@ public class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, IPrepar
 		writer.Write(_dataOnDisk.Span, LengthFormat.LittleEndian);
 		writer.Write(Metadata.Span, LengthFormat.LittleEndian);
 	}
+
+	public override int GetSizeWithLengthPrefixAndSuffix() => SizeOnDisk;
 
 	public bool Equals(PrepareLogRecord other) {
 		if (ReferenceEquals(null, other)) return false;

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -93,8 +93,8 @@ public sealed class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, 
 
 	// including length and suffix
 	private int ComputeSizeOnDisk() {
-		_eventStreamIdSize ??= Encoding.UTF8.GetByteCount(EventStreamId);
-		_eventTypeSize ??= Encoding.UTF8.GetByteCount(EventType);
+		int eventStreamIdSize = _eventStreamIdSize ??= Encoding.UTF8.GetByteCount(EventStreamId);
+		int eventTypeSize = _eventTypeSize ??= Encoding.UTF8.GetByteCount(EventType);
 
 		return
 			2 * sizeof(int) /* Length prefix & suffix */
@@ -102,12 +102,12 @@ public sealed class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, 
 			+ sizeof(ushort) /* Flags */
 			+ sizeof(long) /* TransactionPosition */
 			+ sizeof(int) /* TransactionOffset */
-			+ (Version == LogRecordVersion.LogRecordV0 ? sizeof(int) : sizeof(long)) /* ExpectedVersion */
-			+ StringSizeWithLengthPrefix(_eventStreamIdSize.Value) /* EventStreamId */
+			+ (Version is LogRecordVersion.LogRecordV0 ? sizeof(int) : sizeof(long)) /* ExpectedVersion */
+			+ StringSizeWithLengthPrefix(eventStreamIdSize) /* EventStreamId */
 			+ 16 /* EventId */
 			+ 16 /* CorrelationId */
 			+ sizeof(long) /* TimeStamp */
-			+ StringSizeWithLengthPrefix(_eventTypeSize.Value) /* EventType */
+			+ StringSizeWithLengthPrefix(eventTypeSize) /* EventType */
 			+ sizeof(int) /* Data length */
 			+ _dataOnDisk.Length /* Data */
 			+ sizeof(int) /* Metadata length */

--- a/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using DotNext.Buffers;
 using DotNext.IO;
 using EventStore.Common.Utils;
 using EventStore.Core.Util;
@@ -89,20 +90,19 @@ public class SystemLogRecord : LogRecord, IEquatable<SystemLogRecord>, ISystemLo
 			}
 			default:
 				throw new ArgumentOutOfRangeException(
-					string.Format("Unexpected SystemRecordSerialization type: {0}", SystemRecordSerialization),
+					$"Unexpected SystemRecordSerialization type: {SystemRecordSerialization}",
 					"SystemRecordSerialization");
 		}
 	}
 
-	public override void WriteTo(BinaryWriter writer) {
-		base.WriteTo(writer);
+	public override void WriteTo(ref BufferWriterSlim<byte> writer) {
+		base.WriteTo(ref writer);
 
-		writer.Write(TimeStamp.Ticks);
-		writer.Write((byte)SystemRecordType);
-		writer.Write((byte)SystemRecordSerialization);
-		writer.Write(Reserved);
-		writer.Write(Data.Length);
-		writer.Write(Data.Span);
+		writer.WriteLittleEndian(TimeStamp.Ticks);
+		writer.Add((byte)SystemRecordType);
+		writer.Add((byte)SystemRecordSerialization);
+		writer.WriteLittleEndian(Reserved);
+		writer.Write(Data.Span, LengthFormat.LittleEndian);
 	}
 
 	public bool Equals(SystemLogRecord other) {

--- a/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
@@ -25,7 +25,7 @@ public enum SystemRecordSerialization : byte {
 	Bson = 3
 }
 
-public class SystemLogRecord : LogRecord, IEquatable<SystemLogRecord>, ISystemLogRecord {
+public sealed class SystemLogRecord : LogRecord, IEquatable<SystemLogRecord>, ISystemLogRecord {
 	public const byte SystemRecordVersion = 0;
 
 	public DateTime TimeStamp { get; private init; }

--- a/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
@@ -105,6 +105,17 @@ public class SystemLogRecord : LogRecord, IEquatable<SystemLogRecord>, ISystemLo
 		writer.Write(Data.Span, LengthFormat.LittleEndian);
 	}
 
+	public override int GetSizeWithLengthPrefixAndSuffix() {
+		return sizeof(int) * 2	/* Length prefix & suffix */
+		       + sizeof(long)	/* TimeStamp */
+		       + sizeof(byte)	/* SystemRecordType */
+		       + sizeof(byte)	/* SystemRecordSerialization */
+		       + sizeof(long)	/* Reserved */
+		       + sizeof(int)	/* Data.Length */
+		       + Data.Length	/* Data */
+		       + BaseSize;
+	}
+
 	public bool Equals(SystemLogRecord other) {
 		if (ReferenceEquals(null, other)) return false;
 		if (ReferenceEquals(this, other)) return true;


### PR DESCRIPTION
Changed: removed presence of `BinaryWriter` in Gen2 as well as underlying memory stream + utilize memory pooling.

Depends on #4662.