### PR TITLE
[KDB-552] Fix flaky enumerators test

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.CombinationTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.CombinationTests.cs
@@ -850,11 +850,21 @@ public partial class EnumeratorTests {
 				return;
 			}
 
-			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+			var current = await sub.GetNext();
+			Assert.True(
+				current is SubscriptionConfirmation,
+				"Case \"{0}\": Expected SubscriptionConfirmation but was {1}",
+				_testData.TestCase,
+				current.GetType().FullName);
 
 			_nextEventNumber = await ReadExpectedEvents(sub, _nextEventNumber, LastEventNumber);
 
-			Assert.True(await sub.GetNext() is CaughtUp);
+			current = await sub.GetNext();
+			Assert.True(
+				current is CaughtUp,
+				"Case \"{0}\": Expected CaughtUp but was {1}",
+				_testData.TestCase,
+				current.GetType().FullName);
 
 			var (numEventsAdded, softDeleted, hardDeleted, accessRevoked, shouldFallBehindThenCatchup) = await ApplyLiveProperties();
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.CombinationTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.CombinationTests.cs
@@ -673,9 +673,9 @@ public partial class EnumeratorTests {
 		private Task Truncate(long tb) => WriteMetadata(@$"{{""$tb"":{tb}}}");
 		private Task MaxCount(long maxCount) => WriteMetadata(@$"{{""$maxCount"":{maxCount}}}");
 		private async Task ExpiredMaxAge() {
-			// a max age of zero doesn't do anything, so we're forced to introduce a delay of 1 second
-			await WriteMetadata(@"{""$maxAge"": 1 }");
-			await Task.Delay(TimeSpan.FromMilliseconds(1001));
+			// a max age of zero doesn't do anything, so we're forced to introduce a delay of 1 second. Make it 2 to be sure.
+			await WriteMetadata(@"{""$maxAge"": 1 }"); // seconds
+			await Task.Delay(TimeSpan.FromMilliseconds(2000));
 		}
 
 		private Task ApplyTruncation() {


### PR DESCRIPTION
Fixed: Flaky test

Test in question is `EventStore.Core.Tests.Services.Transport.Enumerators.EnumeratorTests+StreamSubscriptionCombinationTests.enumeration_is_correct`

The problem is that we are reading the stream expecting to find no events because they are all expired, but on windows at least, sometimes they are not quite expired. Increasing the delay to reduce the probability of this. Clearly a tactical rather than strategic fix.