### PR TITLE
[KDB-554] Get up to 100 entitlements

### DIFF
--- a/src/EventStore.Licensing.Tests/Keygen/KeygenSimulator.Should.cs
+++ b/src/EventStore.Licensing.Tests/Keygen/KeygenSimulator.Should.cs
@@ -29,7 +29,7 @@ partial class KeygenSimulator {
 
 	public async Task ShouldReceive_EntitlementRequest() {
 		var request = await Receive();
-		Assert.Equal("https://mock-key-gen/licenses/the-license-id/entitlements", $"{request.RequestUri}");
+		Assert.Equal("https://mock-key-gen/licenses/the-license-id/entitlements?limit=100", $"{request.RequestUri}");
 		Assert.Equal(HttpMethod.Get, request.Method);
 	}
 

--- a/src/EventStore.Licensing/Keygen/KeygenClient.cs
+++ b/src/EventStore.Licensing/Keygen/KeygenClient.cs
@@ -114,6 +114,7 @@ public sealed class KeygenClient : IDisposable {
 
 	public async Task<RestResponse<EntitlementsResponse>> GetEntitlements(string licenseId) {
 		var request = new RestRequest($"licenses/{licenseId}/entitlements");
+		request.AddQueryParameter("limit", 100); // only gets 10 entitlements by default
 		var response = await _client.ExecuteGetAsync<EntitlementsResponse>(request);
 		return response;
 	}


### PR DESCRIPTION
Fixed: Bug where only first 10 license entitlements were retrieved

https://keygen.sh/docs/api/entitlements/#entitlements-list