### PR TITLE
[KDB-566]: Async transformation infrastructure

### DIFF
--- a/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkReadStream.cs
+++ b/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkReadStream.cs
@@ -1,17 +1,31 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Tests.Transforms.BitFlip;
 
 public class BitFlipChunkReadStream(ChunkDataReadStream stream)
 	: ChunkDataReadStream(stream.ChunkFileStream) {
-	public override int Read(byte[] buffer, int offset, int count) {
-		int numRead = base.Read(buffer, offset, count);
-		for (int i = 0; i < count; i++)
-			buffer[i + offset] ^= 0xFF;
+	public override int Read(Span<byte> buffer) {
+		var bytesRead = base.Read(buffer);
 
-		return numRead;
+		FlipBits(buffer.Slice(0, bytesRead));
+		return bytesRead;
+	}
+
+	public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken token = default) {
+		var bytesRead = await base.ReadAsync(buffer, token);
+
+		FlipBits(buffer.Span.Slice(0, bytesRead));
+		return bytesRead;
+	}
+
+	private static void FlipBits(Span<byte> buffer) {
+		for (int i = 0; i < buffer.Length; i++)
+			buffer[i] ^= 0xFF;
 	}
 }

--- a/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkTransformFactory.cs
+++ b/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkTransformFactory.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Tests.Transforms.BitFlip;
@@ -10,7 +12,11 @@ namespace EventStore.Core.Tests.Transforms.BitFlip;
 public class BitFlipChunkTransformFactory : IChunkTransformFactory {
 	public TransformType Type => (TransformType) 0xFF;
 	public int TransformDataPosition(int dataPosition) => dataPosition;
-	public ReadOnlyMemory<byte> CreateTransformHeader() => ReadOnlyMemory<byte>.Empty;
-	public ReadOnlyMemory<byte> ReadTransformHeader(Stream stream) => ReadOnlyMemory<byte>.Empty;
-	public IChunkTransform CreateTransform(ReadOnlyMemory<byte> transformHeader) => new BitFlipChunkTransform();
+	public void CreateTransformHeader(Span<byte> transformHeader) => transformHeader.Clear();
+	public ValueTask ReadTransformHeader(Stream stream, Memory<byte> transformHeader, CancellationToken token)
+		=> token.IsCancellationRequested ? ValueTask.FromCanceled(token) : ValueTask.CompletedTask;
+
+	public IChunkTransform CreateTransform(ReadOnlySpan<byte> transformHeader) => new BitFlipChunkTransform();
+
+	public int TransformHeaderLength => 0;
 }

--- a/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkWriteStream.cs
+++ b/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkWriteStream.cs
@@ -1,17 +1,34 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.Buffers;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Tests.Transforms.BitFlip;
 
 public class BitFlipChunkWriteStream(ChunkDataWriteStream stream) :
 	ChunkDataWriteStream(stream.ChunkFileStream, stream.ChecksumAlgorithm) {
-	public override void Write(byte[] buffer, int offset, int count) {
-		var buf = new byte[count];
-		for (int i = 0; i < count; i++)
-			buf[i] = (byte)(buffer[i + offset] ^ 0xFF);
-		ChunkFileStream.Write(buf, 0, buf.Length);
-		ChecksumAlgorithm.TransformBlock(buf, 0, buf.Length, null, 0);
+
+	public override void Write(ReadOnlySpan<byte> buffer) {
+		var tmp = new byte[buffer.Length];
+		FlipBits(buffer, tmp);
+
+		base.Write(tmp);
+	}
+
+	public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token = default) {
+		var tmp = new byte[buffer.Length];
+		FlipBits(buffer.Span, tmp);
+
+		return base.WriteAsync(tmp, token);
+	}
+
+	private static void FlipBits(ReadOnlySpan<byte> source, Span<byte> destination) {
+		for (int i = 0; i < source.Length; i++)
+			destination[i] = (byte)(source[i] ^ 0xFF);
 	}
 }

--- a/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkWriteTransform.cs
+++ b/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkWriteTransform.cs
@@ -2,6 +2,8 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Tests.Transforms.BitFlip;
@@ -14,20 +16,19 @@ public class BitFlipChunkWriteTransform : IChunkWriteTransform {
 		return _transformedStream;
 	}
 
-	public void CompleteData(int footerSize, int alignmentSize) {
+	public ValueTask CompleteData(int footerSize, int alignmentSize, CancellationToken token = default) {
 		var chunkHeaderAndDataSize = (int)_transformedStream.ChunkFileStream.Position;
 		var alignedSize = GetAlignedSize(chunkHeaderAndDataSize + footerSize, alignmentSize);
 		var paddingSize = alignedSize - chunkHeaderAndDataSize - footerSize;
-		if (paddingSize > 0) {
-			var padding = new byte[paddingSize];
-			_transformedStream.ChunkFileStream.Write(padding);
-			_transformedStream.ChecksumAlgorithm.TransformBlock(padding, 0, padding.Length, null, 0);
-		}
+
+		return paddingSize > 0
+			? _transformedStream.WriteAsync(new byte[paddingSize], token)
+			: ValueTask.CompletedTask;
 	}
 
-	public void WriteFooter(ReadOnlySpan<byte> footer, out int fileSize) {
-		_transformedStream.ChunkFileStream.Write(footer);
-		fileSize = (int)_transformedStream.ChunkFileStream.Length;
+	public async ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken token) {
+		await _transformedStream.ChunkFileStream.WriteAsync(footer, token);
+		return (int)_transformedStream.ChunkFileStream.Length;
 	}
 
 	private static int GetAlignedSize(int size, int alignmentSize) {

--- a/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkReadStream.cs
+++ b/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkReadStream.cs
@@ -2,7 +2,10 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Tests.Transforms.ByteDup;
@@ -11,17 +14,34 @@ public class ByteDupChunkReadStream(ChunkDataReadStream stream)
 	: ChunkDataReadStream(stream.ChunkFileStream) {
 	private const int HeaderSize = 128;
 
-	public override int Read(byte[] buffer, int offset, int count) {
-		var buf = new byte[count * 2];
-		int numRead = base.Read(buf, 0, buf.Length);
-		for (int i = 0; i < count; i++)
-			buffer[i + offset] = buf[i * 2];
+	public override int Read(Span<byte> buffer) {
+		var buf = new byte[buffer.Length * 2];
+		int numRead = base.Read(buf);
+
+		if (int.IsOddInteger(numRead))
+			Debugger.Break();
+
+		for (int i = 0; i < buffer.Length; i++)
+			buffer[i] = buf[i * 2];
+
+		return numRead / 2;
+	}
+
+	public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken token = default) {
+		var buf = new byte[buffer.Length * 2];
+		int numRead = await base.ReadAsync(buf, token);
+
+		if (int.IsOddInteger(numRead))
+			Debugger.Break();
+
+		for (int i = 0; i < buffer.Length; i++)
+			buffer.Span[i] = buf[i * 2];
 
 		return numRead / 2;
 	}
 
 	public override long Seek(long offset, SeekOrigin origin) {
-		if (origin != SeekOrigin.Begin)
+		if (origin is not SeekOrigin.Begin)
 			throw new NotSupportedException();
 
 		Position = offset;

--- a/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkReadStream.cs
+++ b/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkReadStream.cs
@@ -18,9 +18,6 @@ public class ByteDupChunkReadStream(ChunkDataReadStream stream)
 		var buf = new byte[buffer.Length * 2];
 		int numRead = base.Read(buf);
 
-		if (int.IsOddInteger(numRead))
-			Debugger.Break();
-
 		for (int i = 0; i < buffer.Length; i++)
 			buffer[i] = buf[i * 2];
 
@@ -30,9 +27,6 @@ public class ByteDupChunkReadStream(ChunkDataReadStream stream)
 	public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken token = default) {
 		var buf = new byte[buffer.Length * 2];
 		int numRead = await base.ReadAsync(buf, token);
-
-		if (int.IsOddInteger(numRead))
-			Debugger.Break();
 
 		for (int i = 0; i < buffer.Length; i++)
 			buffer.Span[i] = buf[i * 2];

--- a/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkTransformFactory.cs
+++ b/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkTransformFactory.cs
@@ -3,13 +3,19 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Tests.Transforms.ByteDup;
 public class ByteDupChunkTransformFactory : IChunkTransformFactory {
 	public TransformType Type => (TransformType) 0xFE;
 	public int TransformDataPosition(int dataPosition) => dataPosition * 2;
-	public ReadOnlyMemory<byte> CreateTransformHeader() => ReadOnlyMemory<byte>.Empty;
-	public ReadOnlyMemory<byte> ReadTransformHeader(Stream stream) => ReadOnlyMemory<byte>.Empty;
-	public IChunkTransform CreateTransform(ReadOnlyMemory<byte> transformHeader) => new ByteDupChunkTransform();
+	public void CreateTransformHeader(Span<byte> transformHeader) => transformHeader.Clear();
+	public ValueTask ReadTransformHeader(Stream stream, Memory<byte> transformHeader, CancellationToken token)
+		=> token.IsCancellationRequested ? ValueTask.FromCanceled(token) : ValueTask.CompletedTask;
+
+	public IChunkTransform CreateTransform(ReadOnlySpan<byte> transformHeader) => new ByteDupChunkTransform();
+
+	public int TransformHeaderLength => 0;
 }

--- a/src/EventStore.Core.Tests/Transforms/WithHeader/WithHeaderChunkWriteTransform.cs
+++ b/src/EventStore.Core.Tests/Transforms/WithHeader/WithHeaderChunkWriteTransform.cs
@@ -2,6 +2,8 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Tests.Transforms.WithHeader;
@@ -13,20 +15,20 @@ public class WithHeaderChunkWriteTransform(int transformHeaderSize) : IChunkWrit
 		return _transformedStream;
 	}
 
-	public void CompleteData(int footerSize, int alignmentSize) {
+	public async ValueTask CompleteData(int footerSize, int alignmentSize, CancellationToken token) {
 		var chunkHeaderAndDataSize = (int)_transformedStream.ChunkFileStream.Position;
 		var alignedSize = GetAlignedSize(chunkHeaderAndDataSize + footerSize, alignmentSize);
 		var paddingSize = alignedSize - chunkHeaderAndDataSize - footerSize;
 		if (paddingSize > 0) {
 			var padding = new byte[paddingSize];
-			_transformedStream.ChunkFileStream.Write(padding);
-			_transformedStream.ChecksumAlgorithm.TransformBlock(padding, 0, padding.Length, null, 0);
+			await _transformedStream.ChunkFileStream.WriteAsync(padding, token);
+			_transformedStream.ChecksumAlgorithm.AppendData(padding);
 		}
 	}
 
-	public void WriteFooter(ReadOnlySpan<byte> footer, out int fileSize) {
-		_transformedStream.ChunkFileStream.Write(footer);
-		fileSize = (int)_transformedStream.ChunkFileStream.Length;
+	public async ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken token) {
+		await _transformedStream.ChunkFileStream.WriteAsync(footer, token);
+		return (int)_transformedStream.ChunkFileStream.Length;
 	}
 
 	private static int GetAlignedSize(int size, int alignmentSize) {

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -725,6 +725,12 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 				transformType: header.TransformType);
 
 			var transformFactory = db.TransformManager.GetFactoryForExistingChunk(header.TransformType);
+
+			var transformHeader = transformFactory.TransformHeaderLength > 0
+				? new byte[transformFactory.TransformHeaderLength]
+				: [];
+
+			transformFactory.CreateTransformHeader(transformHeader);
 			var newChunk = await TFChunk.CreateWithHeader(
 				filename: $"{chunk.FileName}.tmp",
 				header: newChunkHeader,
@@ -735,7 +741,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 				reduceFileCachePressure: false,
 				tracker: new TFChunkTracker.NoOp(),
 				transformFactory: transformFactory,
-				transformHeader: transformFactory.CreateTransformHeader(),
+				transformHeader: transformHeader,
 				token);
 
 			await newChunk.CompleteScavenge(null, token);

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -9,7 +9,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.2" />
-		<PackageReference Include="EventStore.Plugins" Version="24.10.6" />
+		<PackageReference Include="EventStore.Plugins" Version="25.2.5" />
 		<PackageReference Include="FluentStorage" Version="5.6.0" />
 		<PackageReference Include="FluentStorage.AWS" Version="5.5.0" />
 		<PackageReference Include="Google.Protobuf" Version="3.27.2" />

--- a/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
@@ -11,6 +11,7 @@ using DotNext.IO;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,17 +37,12 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 
 	public ReadOnlySpan<byte> MD5Hash {
 		get => _checksum;
-		init
-		{
-			ArgumentOutOfRangeException.ThrowIfNotEqual(value.Length, ChecksumSize);
-
-			value.CopyTo(_checksum);
-		}
+		init => value.CopyTo(_checksum);
 	}
 
 	public readonly int MapCount; // calculated, not stored
 
-	public ChunkFooter(bool isCompleted, bool isMap12Bytes, int physicalDataSize, long logicalDataSize, int mapSize) {
+	public ChunkFooter(bool isCompleted, bool isMap12Bytes, int physicalDataSize, long logicalDataSize, int mapSize, IncrementalHash hash = null) {
 		Ensure.Nonnegative(physicalDataSize, nameof(physicalDataSize));
 		Ensure.Nonnegative(logicalDataSize, nameof(logicalDataSize));
 		if (logicalDataSize < physicalDataSize)
@@ -62,6 +58,7 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 		MapSize = mapSize;
 
 		Unsafe.SkipInit(out _checksum); // fix for Qodana false positive about init of readonly field
+		hash?.TryGetHashAndReset(_checksum, out _);
 
 		var posMapSize = isMap12Bytes ? PosMap.FullSize : PosMap.DeprecatedSize;
 		if (MapSize % posMapSize is not 0)

--- a/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ChunkFooter.cs
@@ -57,6 +57,7 @@ public sealed class ChunkFooter : IBinaryFormattable<ChunkFooter> {
 		LogicalDataSize = logicalDataSize;
 		MapSize = mapSize;
 
+		Debug.Assert(hash is null || hash.HashLengthInBytes is ChecksumSize);
 		Unsafe.SkipInit(out _checksum); // fix for Qodana false positive about init of readonly field
 		hash?.TryGetHashAndReset(_checksum, out _);
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using DotNext;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -610,10 +610,11 @@ public partial class TFChunk : IDisposable {
 
 		static void VerifyHash(ReadOnlySpan<byte> expected, IncrementalHash actual) {
 			Span<byte> buffer = stackalloc byte[ChunkFooter.ChecksumSize];
+			var bytesWritten = actual.GetCurrentHash(buffer);
+			Debug.Assert(bytesWritten is ChunkFooter.ChecksumSize);
 
 			// Perf: use hardware accelerated byte array comparison
-			if (!actual.TryGetCurrentHash(buffer, out var bytesWritten)
-			    || !expected.SequenceEqual(buffer.Slice(0, bytesWritten)))
+			if (!expected.SequenceEqual(buffer.Slice(0, bytesWritten)))
 				throw new HashValidationException();
 		}
 	}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -22,28 +22,28 @@ internal sealed class WriterWorkItem : Disposable {
 
 	private readonly Stream _fileStream;
 	private Stream _memStream;
-	public readonly HashAlgorithm MD5;
+	public readonly IncrementalHash MD5;
 
-	public unsafe WriterWorkItem(nint memoryPtr, int length, HashAlgorithm md5,
+	public unsafe WriterWorkItem(nint memoryPtr, int length, IncrementalHash md5,
 		IChunkWriteTransform chunkWriteTransform, int initialStreamPosition) {
 		var memStream = new UnmanagedMemoryStream((byte*)memoryPtr, length, length, FileAccess.ReadWrite) {
 			Position = initialStreamPosition,
 		};
 
-		var chunkDataWriteStream = new ChunkDataWriteStream(memStream, md5);
-		WorkingStream = _memStream = chunkWriteTransform.TransformData(chunkDataWriteStream);
+		// var chunkDataWriteStream = new ChunkDataWriteStream(memStream, md5);
+		WorkingStream = _memStream = memStream; // chunkWriteTransform.TransformData(chunkDataWriteStream);
 		MD5 = md5;
 	}
 
-	public WriterWorkItem(SafeFileHandle handle, HashAlgorithm md5, bool unbuffered,
+	public WriterWorkItem(SafeFileHandle handle, IncrementalHash md5, bool unbuffered,
 		IChunkWriteTransform chunkWriteTransform, int initialStreamPosition) {
 		var fileStream = unbuffered
 			? handle.AsUnbufferedStream(FileAccess.ReadWrite)
 			: new BufferedStream(handle.AsUnbufferedStream(FileAccess.ReadWrite), BufferSize);
 		fileStream.Position = initialStreamPosition;
-		var chunkDataWriteStream = new ChunkDataWriteStream(fileStream, md5);
+		// var chunkDataWriteStream = new ChunkDataWriteStream(fileStream, md5);
 
-		WorkingStream = _fileStream = chunkWriteTransform.TransformData(chunkDataWriteStream);
+		WorkingStream = _fileStream = fileStream; // = chunkWriteTransform.TransformData(chunkDataWriteStream);
 		MD5 = md5;
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -4,13 +4,11 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext;
 using DotNext.IO;
 using EventStore.Plugins.Transforms;
-using Microsoft.IO;
 using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -30,8 +28,8 @@ internal sealed class WriterWorkItem : Disposable {
 			Position = initialStreamPosition,
 		};
 
-		// var chunkDataWriteStream = new ChunkDataWriteStream(memStream, md5);
-		WorkingStream = _memStream = memStream; // chunkWriteTransform.TransformData(chunkDataWriteStream);
+		var chunkDataWriteStream = new ChunkDataWriteStream(memStream, md5);
+		WorkingStream = _memStream = chunkWriteTransform.TransformData(chunkDataWriteStream);
 		MD5 = md5;
 	}
 
@@ -41,9 +39,9 @@ internal sealed class WriterWorkItem : Disposable {
 			? handle.AsUnbufferedStream(FileAccess.ReadWrite)
 			: new BufferedStream(handle.AsUnbufferedStream(FileAccess.ReadWrite), BufferSize);
 		fileStream.Position = initialStreamPosition;
-		// var chunkDataWriteStream = new ChunkDataWriteStream(fileStream, md5);
+		var chunkDataWriteStream = new ChunkDataWriteStream(fileStream, md5);
 
-		WorkingStream = _fileStream = fileStream; // = chunkWriteTransform.TransformData(chunkDataWriteStream);
+		WorkingStream = _fileStream = chunkWriteTransform.TransformData(chunkDataWriteStream);
 		MD5 = md5;
 	}
 

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkTransformFactory.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkTransformFactory.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Transforms.Identity;
@@ -10,7 +12,12 @@ namespace EventStore.Core.Transforms.Identity;
 public sealed class IdentityChunkTransformFactory : IChunkTransformFactory {
 	public TransformType Type => TransformType.Identity;
 	public int TransformDataPosition(int dataPosition) => dataPosition;
-	public ReadOnlyMemory<byte> CreateTransformHeader() => ReadOnlyMemory<byte>.Empty;
-	public ReadOnlyMemory<byte> ReadTransformHeader(Stream stream) => ReadOnlyMemory<byte>.Empty;
-	public IChunkTransform CreateTransform(ReadOnlyMemory<byte> transformHeader) => new IdentityChunkTransform();
+	public void CreateTransformHeader(Span<byte> transformHeader) => transformHeader.Clear();
+
+	public ValueTask ReadTransformHeader(Stream stream, Memory<byte> transformHeader, CancellationToken token)
+		=> token.IsCancellationRequested ? ValueTask.FromCanceled(token) : ValueTask.CompletedTask;
+
+	public IChunkTransform CreateTransform(ReadOnlySpan<byte> transformHeader) => new IdentityChunkTransform();
+
+	public int TransformHeaderLength => 0;
 }

--- a/src/EventStore.Core/Transforms/Identity/IdentityChunkWriteTransform.cs
+++ b/src/EventStore.Core/Transforms/Identity/IdentityChunkWriteTransform.cs
@@ -2,6 +2,9 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.Buffers;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Transforms.Identity;
@@ -14,21 +17,29 @@ public sealed class IdentityChunkWriteTransform : IChunkWriteTransform {
 		return _stream;
 	}
 
-	public void CompleteData(int footerSize, int alignmentSize) {
+	public ValueTask CompleteData(int footerSize, int alignmentSize, CancellationToken token) {
 		var chunkHeaderAndDataSize = (int)_stream.Position;
 		var alignedSize = GetAlignedSize(chunkHeaderAndDataSize + footerSize, alignmentSize);
 		var paddingSize = alignedSize - chunkHeaderAndDataSize - footerSize;
-		if (paddingSize > 0)
-			_stream.Write(new byte[paddingSize]);
+		return paddingSize > 0
+			? WritePaddingAsync(_stream, paddingSize, token)
+			: ValueTask.CompletedTask;
+
+		static async ValueTask WritePaddingAsync(ChunkDataWriteStream stream, int paddingSize, CancellationToken token) {
+			using var buffer = Memory.AllocateExactly<byte>(paddingSize);
+			buffer.Span.Clear(); // ensure that the padding is zeroed
+			await stream.WriteAsync(buffer.Memory, token);
+		}
 	}
 
-	public void WriteFooter(ReadOnlySpan<byte> footer, out int fileSize) {
-		_stream.ChunkFileStream.Write(footer);
-		fileSize = (int)_stream.Length;
+	public async ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken token) {
+		await _stream.ChunkFileStream.WriteAsync(footer, token);
+		return (int)_stream.Length;
 	}
 
 	private static int GetAlignedSize(int size, int alignmentSize) {
-		if (size % alignmentSize == 0) return size;
-		return (size / alignmentSize + 1) * alignmentSize;
+		var quotient = Math.DivRem(size, alignmentSize, out var remainder);
+
+		return remainder is 0 ? size : (quotient + 1) * alignmentSize;
 	}
 }


### PR DESCRIPTION
Changed: migration to span-friendly `IncrementalHash` class + transformation infrastructure compatible with async code.