### PR TITLE
[KDB-457] Archive: Map logical chunk numbers to archive chunk file names

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
@@ -48,7 +48,6 @@ internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader
 	public IArchiveStorageWriter CreateWriter() => this;
 
 	public ValueTask<bool> StoreChunk(string chunkPath, CancellationToken ct) => throw new NotImplementedException();
-	public ValueTask<bool> RemoveChunks(int chunkStartNumber, int chunkEndNumber, string exceptChunk, CancellationToken ct) => throw new NotImplementedException();
 	public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct) => throw new NotImplementedException();
 	public ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct) => throw new NotImplementedException();
 

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
@@ -47,7 +47,7 @@ internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader
 	public IArchiveStorageReader CreateReader() => this;
 	public IArchiveStorageWriter CreateWriter() => this;
 
-	public ValueTask<bool> StoreChunk(string chunkPath, CancellationToken ct) => throw new NotImplementedException();
+	public ValueTask<bool> StoreChunk(string chunkPath, string destinationFile, CancellationToken ct) => throw new NotImplementedException();
 	public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct) => throw new NotImplementedException();
 	public ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct) => throw new NotImplementedException();
 

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Naming/ArchiveChunkNamerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Naming/ArchiveChunkNamerTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using EventStore.Core.Services.Archive.Naming;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Archive.Naming;
+
+public class ArchiveChunkNamerTests {
+	private ArchiveChunkNamer CreateSut() {
+		var namingStrategy = new VersionedPatternFileNamingStrategy(string.Empty, "chunk-");
+		return new ArchiveChunkNamer(namingStrategy);
+	}
+
+	[Theory]
+	[InlineData(0, "chunk-000000.000001")]
+	[InlineData(1, "chunk-000001.000001")]
+	[InlineData(1000, "chunk-001000.000001")]
+	public void returns_correct_file_name(int logicalChunkNumber, string expectedFileName) {
+		var sut = CreateSut();
+		Assert.Equal(expectedFileName, sut.GetFileNameFor(logicalChunkNumber));
+	}
+
+	[Fact]
+	public void throws_if_chunk_number_is_negative() {
+		var sut = CreateSut();
+		Assert.Throws<ArgumentOutOfRangeException>(() => sut.GetFileNameFor(-1));
+		Assert.Throws<ArgumentOutOfRangeException>(() => sut.GetFileNameFor(-2));
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
@@ -24,7 +24,7 @@ public class ArchiveStorageReaderTests : ArchiveStorageTestsBase<ArchiveStorageR
 		// create a chunk and upload it
 		var chunkPath = CreateLocalChunk(0, 0);
 		var chunkFile = Path.GetFileName(chunkPath);
-		await CreateWriterSut(storageType).StoreChunk(chunkPath, CancellationToken.None);
+		await CreateWriterSut(storageType).StoreChunk(chunkPath, chunkFile, CancellationToken.None);
 
 		// read the local chunk
 		var localContent = await File.ReadAllBytesAsync(chunkPath);
@@ -46,7 +46,7 @@ public class ArchiveStorageReaderTests : ArchiveStorageTestsBase<ArchiveStorageR
 		// create a chunk and upload it
 		var chunkPath = CreateLocalChunk(0, 0);
 		var chunkFile = Path.GetFileName(chunkPath);
-		await CreateWriterSut(storageType).StoreChunk(chunkPath, CancellationToken.None);
+		await CreateWriterSut(storageType).StoreChunk(chunkPath, chunkFile, CancellationToken.None);
 
 		// read the local chunk
 		var localContent = await File.ReadAllBytesAsync(chunkPath);

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageWriterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageWriterTests.cs
@@ -21,10 +21,11 @@ public class ArchiveStorageWriterTests : ArchiveStorageTestsBase<ArchiveStorageW
 	public async Task can_store_a_chunk(StorageType storageType) {
 		var sut = CreateWriterSut(storageType);
 		var localChunk = CreateLocalChunk(0, 0);
-		Assert.True(await sut.StoreChunk(localChunk, CancellationToken.None));
+		var destinationFile = Path.GetFileName(localChunk);
+		Assert.True(await sut.StoreChunk(localChunk, destinationFile, CancellationToken.None));
 
 		var localChunkContent = await File.ReadAllBytesAsync(localChunk);
-		using var archivedChunkContent = await CreateReaderSut(storageType).GetChunk(Path.GetFileName(localChunk), CancellationToken.None);
+		using var archivedChunkContent = await CreateReaderSut(storageType).GetChunk(destinationFile, CancellationToken.None);
 		Assert.Equal(localChunkContent, archivedChunkContent.ToByteArray());
 	}
 
@@ -34,7 +35,8 @@ public class ArchiveStorageWriterTests : ArchiveStorageTestsBase<ArchiveStorageW
 	public async Task throws_chunk_deleted_exception_if_local_chunk_doesnt_exist(StorageType storageType) {
 		var sut = CreateWriterSut(storageType);
 		var localChunk = CreateLocalChunk(0, 0);
+		var destinationFile = Path.GetFileName(localChunk);
 		File.Delete(localChunk);
-		await Assert.ThrowsAsync<ChunkDeletedException>(async () => await sut.StoreChunk(localChunk, CancellationToken.None));
+		await Assert.ThrowsAsync<ChunkDeletedException>(async () => await sut.StoreChunk(localChunk, destinationFile, CancellationToken.None));
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageWriterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageWriterTests.cs
@@ -37,21 +37,4 @@ public class ArchiveStorageWriterTests : ArchiveStorageTestsBase<ArchiveStorageW
 		File.Delete(localChunk);
 		await Assert.ThrowsAsync<ChunkDeletedException>(async () => await sut.StoreChunk(localChunk, CancellationToken.None));
 	}
-
-	[Theory]
-	[InlineData(StorageType.FileSystem)]
-	public async Task can_remove_chunks(StorageType storageType) {
-		var sut = CreateWriterSut(storageType);
-
-		CreateArchiveChunk(0, 0);
-		CreateArchiveChunk(1, 0);
-		CreateArchiveChunk(2, 0);
-
-		Assert.True(await sut.RemoveChunks(0, 2, "chunk-000001.000000", CancellationToken.None));
-
-		var archivedChunks = Directory
-			.EnumerateFiles(ArchivePath)
-			.Select(Path.GetFileName);
-		Assert.Equal(["chunk-000001.000000"], archivedChunks);
-	}
 }

--- a/src/EventStore.Core/Services/Archive/ArchiveCatchup/ArchiveCatchup.cs
+++ b/src/EventStore.Core/Services/Archive/ArchiveCatchup/ArchiveCatchup.cs
@@ -23,6 +23,9 @@ namespace EventStore.Core.Services.Archive.ArchiveCatchup;
 //     data was restored from a backup, we can end up in a situation where the leader-to-be is behind the archive.
 //     in this case, we still want all nodes to catch up with the archive *before* joining the cluster to maintain
 //     consistency between the data that's in the cluster and in the archive.
+//
+// Note: This class has been designed in such a way that it can also handle chunks that are merged in the archive.
+// However, chunks are now unmerged before being archived. This does not affect the correctness of this implementation.
 
 public class ArchiveCatchup : IClusterVNodeStartupTask {
 	private readonly string _dbPath;

--- a/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
+++ b/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using EventStore.Core.Services.Archive.Archiver;
 using EventStore.Core.Services.Archive.Storage;
+using EventStore.Core.Services.Archive.Archiver.Unmerger;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Plugins;
 using EventStore.Plugins.Licensing;
@@ -61,8 +62,10 @@ public class ArchivePlugableComponent : IPlugableComponent {
 		services.AddScoped<IArchiveStorageFactory, ArchiveStorageFactory>();
 		services.Decorate<IReadOnlyList<IClusterVNodeStartupTask>>(AddArchiveCatchupTask);
 
-		if (_isArchiver)
+		if (_isArchiver) {
+			services.AddSingleton<IChunkUnmerger, ChunkUnmerger>();
 			services.AddSingleton<ArchiverService>();
+		}
 	}
 
 	private static IReadOnlyList<IClusterVNodeStartupTask> AddArchiveCatchupTask(

--- a/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
+++ b/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using EventStore.Core.Services.Archive.Archiver;
 using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.Services.Archive.Archiver.Unmerger;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Plugins;
 using EventStore.Plugins.Licensing;
@@ -61,6 +62,7 @@ public class ArchivePlugableComponent : IPlugableComponent {
 		services.AddSingleton(options);
 		services.AddScoped<IArchiveStorageFactory, ArchiveStorageFactory>();
 		services.Decorate<IReadOnlyList<IClusterVNodeStartupTask>>(AddArchiveCatchupTask);
+		services.AddSingleton<IArchiveChunkNamer, ArchiveChunkNamer>();
 
 		if (_isArchiver) {
 			services.AddSingleton<IChunkUnmerger, ChunkUnmerger>();

--- a/src/EventStore.Core/Services/Archive/Archiver/Unmerger/ChunkUnmerger.cs
+++ b/src/EventStore.Core/Services/Archive/Archiver/Unmerger/ChunkUnmerger.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+
+namespace EventStore.Core.Services.Archive.Archiver.Unmerger;
+
+public class ChunkUnmerger : IChunkUnmerger {
+	public IAsyncEnumerable<string> Unmerge(string chunkPath, int chunkStartNumber, int chunkEndNumber) {
+		throw new NotImplementedException();
+	}
+}

--- a/src/EventStore.Core/Services/Archive/Archiver/Unmerger/IChunkUnmerger.cs
+++ b/src/EventStore.Core/Services/Archive/Archiver/Unmerger/IChunkUnmerger.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System.Collections.Generic;
+
+namespace EventStore.Core.Services.Archive.Archiver.Unmerger;
+
+public interface IChunkUnmerger {
+	IAsyncEnumerable<string> Unmerge(string chunkPath, int chunkStartNumber, int chunkEndNumber);
+}

--- a/src/EventStore.Core/Services/Archive/Naming/ArchiveChunkNamer.cs
+++ b/src/EventStore.Core/Services/Archive/Naming/ArchiveChunkNamer.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.IO;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+
+namespace EventStore.Core.Services.Archive.Naming;
+
+public class ArchiveChunkNamer : IArchiveChunkNamer {
+	private readonly IVersionedFileNamingStrategy _namingStrategy;
+
+	public ArchiveChunkNamer(IVersionedFileNamingStrategy namingStrategy) {
+		_namingStrategy = namingStrategy;
+	}
+
+	public string GetFileNameFor(int logicalChunkNumber) {
+		ArgumentOutOfRangeException.ThrowIfNegative(logicalChunkNumber);
+
+		var filePath = _namingStrategy.GetFilenameFor(logicalChunkNumber, version: 1);
+		return Path.GetFileName(filePath);
+	}
+}

--- a/src/EventStore.Core/Services/Archive/Naming/IArchiveChunkNamer.cs
+++ b/src/EventStore.Core/Services/Archive/Naming/IArchiveChunkNamer.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+namespace EventStore.Core.Services.Archive.Naming;
+
+public interface IArchiveChunkNamer {
+	string GetFileNameFor(int logicalChunkNumber);
+}

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
@@ -89,27 +89,4 @@ public class FileSystemWriter : IArchiveStorageWriter {
 			return false;
 		}
 	}
-
-	public ValueTask<bool> RemoveChunks(int chunkStartNumber, int chunkEndNumber, string exceptChunk, CancellationToken ct) {
-		try {
-			var directoryInfo = new DirectoryInfo(_archivePath);
-			for (var chunkNumber = chunkStartNumber; chunkNumber <= chunkEndNumber; chunkNumber++) {
-				var chunkPrefix = _getChunkPrefix(chunkNumber, null);
-				foreach (var file in directoryInfo.EnumerateFiles($"{chunkPrefix}*")) {
-					if (file.Name == exceptChunk)
-						continue;
-
-					File.Delete(file.FullName);
-				}
-			}
-		} catch (OperationCanceledException) {
-			throw;
-		} catch (Exception ex) {
-			Log.Error(ex, "Error while removing chunks in range: {chunkStartNumber}-{chunkEndNumber} (except {chunk})",
-				chunkStartNumber, chunkEndNumber, exceptChunk);
-			return ValueTask.FromResult(false);
-		}
-
-		return ValueTask.FromResult(true);
-	}
 }

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
@@ -42,13 +42,10 @@ public class FileSystemWriter : IArchiveStorageWriter {
 		}
 	}
 
-	public async ValueTask<bool> StoreChunk(string chunkPath, CancellationToken ct) {
+	public async ValueTask<bool> StoreChunk(string chunkPath, string destinationFile, CancellationToken ct) {
 		try {
-			var destinationPath = Path.Combine(_archivePath, Path.GetFileName(chunkPath));
+			var destinationPath = Path.Combine(_archivePath, destinationFile);
 			var tempPath = $"{destinationPath}.tmp";
-
-			if (File.Exists(destinationPath))
-				File.Delete(destinationPath);
 
 			if (File.Exists(tempPath))
 				File.Delete(tempPath);
@@ -76,7 +73,7 @@ public class FileSystemWriter : IArchiveStorageWriter {
 				await source.CopyToAsync(destination, ct);
 			}
 
-			File.Move(tempPath, destinationPath);
+			File.Move(tempPath, destinationPath, overwrite: true);
 
 			return true;
 		} catch (OperationCanceledException) {

--- a/src/EventStore.Core/Services/Archive/Storage/FluentWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FluentWriter.cs
@@ -19,18 +19,16 @@ public abstract class FluentWriter {
 		throw new NotImplementedException();
 	}
 
-	public async ValueTask<bool> StoreChunk(string chunkPath, CancellationToken ct) {
-		var fileName = "unknown";
+	public async ValueTask<bool> StoreChunk(string chunkPath, string destinationFile, CancellationToken ct) {
 		try {
-			fileName = Path.GetFileName(chunkPath);
-			await BlobStorage.WriteFileAsync(fileName, filePath: chunkPath, ct);
+			await BlobStorage.WriteFileAsync(destinationFile, filePath: chunkPath, ct);
 			return true;
 		} catch (FileNotFoundException) {
 			throw new ChunkDeletedException();
 		} catch (OperationCanceledException) {
 			throw;
 		} catch (Exception ex) {
-			Log.Error(ex, "Error while storing chunk: {ChunkFile}", fileName);
+			Log.Error(ex, "Error while storing chunk: {chunkFile}", destinationFile);
 			return false;
 		}
 	}

--- a/src/EventStore.Core/Services/Archive/Storage/FluentWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FluentWriter.cs
@@ -34,13 +34,4 @@ public abstract class FluentWriter {
 			return false;
 		}
 	}
-
-	public ValueTask<bool> RemoveChunks(
-		int chunkStartNumber,
-		int chunkEndNumber,
-		string exceptChunk,
-		CancellationToken ct) {
-
-		throw new NotImplementedException();
-	}
 }

--- a/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageWriter.cs
@@ -23,14 +23,4 @@ public interface IArchiveStorageWriter {
 	/// <see langword="false"/> if the operation failed and the caller needs to retry after some time
 	/// </returns>
 	public ValueTask<bool> StoreChunk(string chunkPath, CancellationToken ct);
-
-	/// <summary>Removes all chunks within the specified chunk number range from the archive, except the specified one</summary>
-	/// <param name="chunkStartNumber">The chunk start number</param>
-	/// <param name="chunkEndNumber">The chunk end number</param>
-	/// <param name="exceptChunk">The file name of the chunk that must not be removed from the archive</param>
-	/// <returns>
-	/// <see langword="true"/> if the operation was successful<br/>
-	/// <see langword="false"/> if the operation failed and the caller needs to retry after some time
-	/// </returns>
-	public ValueTask<bool> RemoveChunks(int chunkStartNumber, int chunkEndNumber, string exceptChunk, CancellationToken ct);
 }

--- a/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageWriter.cs
@@ -17,10 +17,11 @@ public interface IArchiveStorageWriter {
 
 	/// <summary>Stores a chunk in the archive</summary>
 	/// <param name="chunkPath">The path of the chunk to archive</param>
+	/// <param name="destinationFile">The destination file name in the archive</param>
 	/// <exception cref="ChunkDeletedException">Thrown if the chunk file is deleted while being archived</exception>
 	/// <returns>
 	/// <see langword="true"/> if the chunk was successfully archived<br/>
 	/// <see langword="false"/> if the operation failed and the caller needs to retry after some time
 	/// </returns>
-	public ValueTask<bool> StoreChunk(string chunkPath, CancellationToken ct);
+	public ValueTask<bool> StoreChunk(string chunkPath, string destinationFile, CancellationToken ct);
 }


### PR DESCRIPTION
Added: Infrastructure to map logical positions to archived chunks

This works by making the filename of the chunks in the archive deterministic by 1. not merging them together and 2. not changing the filename when the version changes