### PR TITLE
[KDB-567] Deal with requested scavenge threads being out of range

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ThreadCountTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ThreadCountTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System.Threading.Tasks;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.XUnit.Tests.Scavenge.Sqlite;
+using Xunit;
+using static EventStore.Core.XUnit.Tests.Scavenge.StreamMetadatas;
+
+namespace EventStore.Core.XUnit.Tests.Scavenge;
+
+public class ThreadCountTests : SqliteDbPerTest<ThreadCountTests> {
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(0)]
+	[InlineData(1)]
+	[InlineData(TFChunkScavenger.MaxThreadCount)]
+	[InlineData(TFChunkScavenger.MaxThreadCount + 1)]
+	public async Task runs_when_thread_count_too_high_or_low(int threads) {
+		var t = 0;
+		await new Scenario<LogFormat.V2, string>()
+			.WithThreads(threads)
+			.WithDbPath(Fixture.Directory)
+			.WithDb(x => x
+				// lots of chunks so there is possibility of parallel execution of them
+				.Chunk(
+					Rec.Write(t++, "ab-1"))
+				.Chunk(
+					Rec.Write(t++, "ab-1"))
+				.Chunk(
+					Rec.Write(t++, "ab-1"))
+				.Chunk(
+					Rec.Write(t++, "ab-1"))
+				.Chunk(
+					Rec.Write(t++, "ab-1"))
+				.Chunk(
+					Rec.Write(t++, "ab-1"))
+				.Chunk(
+					Rec.Write(t++, "$$ab-1", "$metadata", metadata: MaxCount1))
+				.Chunk(
+					ScavengePointRec(t++)))
+			.WithState(x => x.WithConnectionPool(Fixture.DbConnectionPool))
+			.RunAsync(x => [
+				x.Recs[0].KeepNone(),
+				x.Recs[1].KeepNone(),
+				x.Recs[2].KeepNone(),
+				x.Recs[3].KeepNone(),
+				x.Recs[4].KeepNone(),
+				x.Recs[5].KeepIndexes(0),
+				x.Recs[6].KeepIndexes(0),
+				x.Recs[7].KeepIndexes(0),
+			]);
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -28,6 +28,7 @@ using ILogger = Serilog.ILogger;
 namespace EventStore.Core.TransactionLog.Chunks;
 
 public abstract class TFChunkScavenger {
+	public const int MinThreadCount = 1;
 	public const int MaxThreadCount = 4;
 	public const int MaxRetryCount = 5;
 	public const int FlushPageInterval = 32; // max 65536 pages to write resulting in 2048 flushes per chunk

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
@@ -40,7 +40,13 @@ public class ChunkExecutor<TStreamId, TRecord> : IChunkExecutor<TStreamId> {
 		_chunkSize = chunkSize;
 		_unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
 		_cancellationCheckPeriod = cancellationCheckPeriod;
-		_threads = threads;
+
+		if (threads < 1 || threads > TFChunkScavenger.MaxThreadCount) {
+			_logger.Warning("SCAVENGING: Number of threads specified ({SpecifiedThreads}) is too high, clamping to {AdjustedThreads}",
+				threads, TFChunkScavenger.MaxThreadCount);
+		}
+
+		_threads = Math.Clamp(threads, 1, TFChunkScavenger.MaxThreadCount);
 		_throttle = throttle;
 	}
 

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
@@ -40,14 +40,13 @@ public class ChunkExecutor<TStreamId, TRecord> : IChunkExecutor<TStreamId> {
 		_chunkSize = chunkSize;
 		_unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
 		_cancellationCheckPeriod = cancellationCheckPeriod;
-
-		if (threads < 1 || threads > TFChunkScavenger.MaxThreadCount) {
-			_logger.Warning("SCAVENGING: Number of threads specified ({SpecifiedThreads}) is too high, clamping to {AdjustedThreads}",
-				threads, TFChunkScavenger.MaxThreadCount);
-		}
-
-		_threads = Math.Clamp(threads, 1, TFChunkScavenger.MaxThreadCount);
+		_threads = Math.Clamp(threads, TFChunkScavenger.MinThreadCount, TFChunkScavenger.MaxThreadCount);
 		_throttle = throttle;
+
+		if (_threads != threads) {
+			_logger.Warning("SCAVENGING: Number of threads specified ({SpecifiedThreads}) is out of range. Clamping to {AdjustedThreads}",
+				threads, _threads);
+		}
 	}
 
 	public ValueTask Execute(


### PR DESCRIPTION
Fixed: Scavenge no longer fails when requested threads is out of the range 1-4

Previously if you specified more than 4 threads in the scavenge request, the scavenge will proceed until the chunk execution phase and then stop with an error about the pool being empty. The solution is to run the scavenge again with fewer threads (1-4) and it will continue from where it left off. This fix clamps the threads to the valid range, the same as old scavenge does.