### PR TITLE
[KDB-462] Skip scavenge execution of remote chunks

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ArrayExtensions.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ArrayExtensions.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace EventStore.Core.XUnit.Tests.Scavenge;
 
 public static class ArrayExtensions {
+	// keep records at the specified indexes in the chunk
 	public static T[] KeepIndexes<T>(this T[] self, params int[] indexes) {
 		foreach (var i in indexes) {
 			Assert.True(i < self.Length, $"error in test: index {i} does not exist");
@@ -16,7 +17,7 @@ public static class ArrayExtensions {
 		return self.Where((x, i) => indexes.Contains(i)).ToArray();
 	}
 
-	public static T[] KeepNone<T>(this T[] self) => Array.Empty<T>();
+	public static T[] KeepNone<T>(this T[] _) => [];
 
 	public static T[] KeepAll<T>(this T[] self) => self;
 }

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -193,6 +193,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 		return this;
 	}
 
+	// if getExpectedKeptIndexEntries is null then it is the same as getExpectedKeptRecords
 	public async Task<DbResult> RunAsync(
 		Func<DbResult, ILogRecord[][]> getExpectedKeptRecords = null,
 		Func<DbResult, ILogRecord[][]> getExpectedKeptIndexEntries = null) {
@@ -416,6 +417,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 						dbResult.Db.Manager,
 						dbConfig,
 						dbTransformManager),
+					dbResult.RemoteChunks,
 					Tracer),
 				chunkSize: dbConfig.ChunkSize,
 				unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes,

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TracingChunkManagerForChunkExecutor.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TracingChunkManagerForChunkExecutor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog.Scavenging;
@@ -11,12 +12,16 @@ public class TracingChunkManagerForChunkExecutor<TStreamId, TRecord> :
 	IChunkManagerForChunkExecutor<TStreamId, TRecord> {
 
 	private readonly IChunkManagerForChunkExecutor<TStreamId, TRecord> _wrapped;
+	private readonly HashSet<int> _remoteChunks;
 	private readonly Tracer _tracer;
 
 	public TracingChunkManagerForChunkExecutor(
-		IChunkManagerForChunkExecutor<TStreamId, TRecord> wrapped, Tracer tracer) {
+		IChunkManagerForChunkExecutor<TStreamId, TRecord> wrapped,
+		HashSet<int> remoteChunks,
+		Tracer tracer) {
 
 		_wrapped = wrapped;
+		_remoteChunks = remoteChunks;
 		_tracer = tracer;
 	}
 
@@ -31,6 +36,7 @@ public class TracingChunkManagerForChunkExecutor<TStreamId, TRecord> :
 
 	public IChunkReaderForExecutor<TStreamId, TRecord> GetChunkReaderFor(long position) {
 		var reader = _wrapped.GetChunkReaderFor(position);
-		return new TrackingChunkReaderForExecutor<TStreamId, TRecord>(reader, _tracer);
+		var isRemote = _remoteChunks.Contains(reader.ChunkStartNumber);
+		return new TrackingChunkReaderForExecutor<TStreamId, TRecord>(reader, isRemote, _tracer);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TrackingChunkReaderForExecutor.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TrackingChunkReaderForExecutor.cs
@@ -11,13 +11,16 @@ public class TrackingChunkReaderForExecutor<TStreamId, TRecord> :
 	IChunkReaderForExecutor<TStreamId, TRecord> {
 
 	private readonly IChunkReaderForExecutor<TStreamId, TRecord> _wrapped;
+	private readonly bool _isRemote;
 	private readonly Tracer _tracer;
 
 	public TrackingChunkReaderForExecutor(
 		IChunkReaderForExecutor<TStreamId, TRecord> wrapped,
+		bool isRemote,
 		Tracer tracer) {
 
 		_wrapped = wrapped;
+		_isRemote = isRemote;
 		_tracer = tracer;
 	}
 
@@ -30,6 +33,8 @@ public class TrackingChunkReaderForExecutor<TStreamId, TRecord> :
 	public int ChunkEndNumber => _wrapped.ChunkEndNumber;
 
 	public bool IsReadOnly => _wrapped.IsReadOnly;
+
+	public bool IsRemote => _isRemote;
 
 	public long ChunkStartPosition => _wrapped.ChunkStartPosition;
 

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/RemoteChunkTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/RemoteChunkTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Threading.Tasks;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.XUnit.Tests.Scavenge.Sqlite;
+using Xunit;
+using static EventStore.Core.XUnit.Tests.Scavenge.StreamMetadatas;
+
+namespace EventStore.Core.XUnit.Tests.Scavenge;
+
+public class RemoteChunkTests : SqliteDbPerTest<RemoteChunkTests> {
+	[Fact]
+	public async Task remote_chunks_are_not_executed() {
+		var t = 0;
+		await new Scenario<LogFormat.V2, string>()
+			.WithDbPath(Fixture.Directory)
+			.WithDb(x => x
+				.RemoteChunk(
+					Rec.Write(t++, "ab-1"),
+					Rec.Write(t++, "ab-1"))
+				.Chunk(
+					Rec.Write(t++, "ab-1"),
+					Rec.Write(t++, "ab-1"),
+					Rec.Write(t++, "$$ab-1", "$metadata", metadata: MaxCount1))
+				.Chunk(
+					ScavengePointRec(t++)))
+			.WithState(x => x.WithConnectionPool(Fixture.DbConnectionPool))
+			.RunAsync(
+				x => [
+					x.Recs[0], // remote chunk still has its records
+					x.Recs[1].KeepIndexes(1, 2),
+					x.Recs[2],
+				],
+				x => [
+					x.Recs[0].KeepNone(), // index entries for remote chunk are still removed
+					x.Recs[1].KeepIndexes(1, 2),
+					x.Recs[2],
+				]);
+	}
+}

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -18,6 +18,7 @@ using Serilog;
 namespace EventStore.Core.Services.Storage;
 
 // This tracks the current scavenge and starts/stops/creates it according to the client instructions
+// It works for both old and new scavenge, determined by ScavengerFactory
 public class StorageScavenger :
 	IHandle<ClientMessage.ScavengeDatabase>,
 	IHandle<ClientMessage.StopDatabaseScavenge>,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -52,6 +52,8 @@ public partial class TFChunk : IDisposable {
 		get { return _cacheStatus is CacheStatus.Cached; }
 	}
 
+	public bool IsRemote => false;
+
 	// the logical size of (untransformed) data (could be > PhysicalDataSize if scavenged chunk)
 	public long LogicalDataSize {
 		get { return Interlocked.Read(ref _logicalDataSize); }

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkReaderForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkReaderForExecutor.cs
@@ -27,6 +27,8 @@ public class ChunkReaderForExecutor<TStreamId> : IChunkReaderForExecutor<TStream
 
 	public bool IsReadOnly => _chunk.IsReadOnly;
 
+	public bool IsRemote => _chunk.IsRemote;
+
 	public long ChunkStartPosition => _chunk.ChunkHeader.ChunkStartPosition;
 
 	public long ChunkEndPosition => _chunk.ChunkHeader.ChunkEndPosition;

--- a/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
@@ -31,6 +31,7 @@ public interface IChunkReaderForExecutor<TStreamId, TRecord> {
 	int ChunkStartNumber { get; }
 	int ChunkEndNumber { get; }
 	bool IsReadOnly { get; }
+	bool IsRemote { get; }
 	long ChunkStartPosition { get; }
 	long ChunkEndPosition { get; }
 	IAsyncEnumerable<bool> ReadInto(


### PR DESCRIPTION
Changed: Disable scavenge execution of chunks in the archive

- For Archiver node this is temporary (until the necessary logic is implemented)
- For other nodes this is permanent (because the archiver node is the only one to scavenge the archive)