### PR TITLE
[KDB-462] Do not close db and reopen during scavenge tests

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
@@ -429,7 +429,7 @@ public class StreamInfo {
 	}
 }
 
-public class DbResult {
+public sealed class DbResult : IAsyncDisposable {
 	public TFChunkDb Db { get; }
 	public ILogRecord[][] Recs { get; }
 	public HashSet<int> RemoteChunks { get; }
@@ -448,6 +448,10 @@ public class DbResult {
 		Recs = recs;
 		RemoteChunks = remoteChunks;
 		Streams = streams;
+	}
+
+	public async ValueTask DisposeAsync() {
+		await Db.DisposeAsync();
 	}
 }
 

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/CancellationAndContinuationTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/CancellationAndContinuationTests.cs
@@ -322,7 +322,7 @@ public class CancellationAndContinuationTests : SqliteDbPerTest<CancellationAndC
 				var accumulating = Assert.IsType<ScavengeCheckpoint.Accumulating>(checkpoint);
 				Assert.Equal(0, accumulating.DoneLogicalChunkNumber);
 			})
-			.RunAsync();
+			.RunAndKeepDbAsync();
 
 		// now complete the scavenge
 		await new Scenario<LogFormat.V2, string>()
@@ -468,7 +468,7 @@ public class CancellationAndContinuationTests : SqliteDbPerTest<CancellationAndC
 				var calculating = Assert.IsType<ScavengeCheckpoint.Calculating<string>>(checkpoint);
 				Assert.Equal("None", calculating.DoneStreamHandle.ToString());
 			})
-			.RunAsync();
+			.RunAndKeepDbAsync();
 
 		// now complete the scavenge
 		await new Scenario<LogFormat.V2, string>()
@@ -602,7 +602,7 @@ public class CancellationAndContinuationTests : SqliteDbPerTest<CancellationAndC
 				var executing = Assert.IsType<ScavengeCheckpoint.ExecutingChunks>(checkpoint);
 				Assert.Equal(0, executing.DoneLogicalChunkNumber);
 			})
-			.RunAsync();
+			.RunAndKeepDbAsync();
 
 		// now complete the scavenge
 		await new Scenario<LogFormat.V2, string>()
@@ -740,7 +740,7 @@ public class CancellationAndContinuationTests : SqliteDbPerTest<CancellationAndC
 				Assert.True(state.TryGetCheckpoint(out var checkpoint));
 				var executing = Assert.IsType<ScavengeCheckpoint.ExecutingIndex>(checkpoint);
 			})
-			.RunAsync();
+			.RunAndKeepDbAsync();
 
 		// now complete the scavenge
 		await new Scenario<LogFormat.V2, string>()
@@ -803,7 +803,7 @@ public class CancellationAndContinuationTests : SqliteDbPerTest<CancellationAndC
 				Assert.True(state.TryGetCheckpoint(out var checkpoint));
 				var executing = Assert.IsType<ScavengeCheckpoint.Cleaning>(checkpoint);
 			})
-			.RunAsync();
+			.RunAndKeepDbAsync();
 
 		// now complete the scavenge
 		await new Scenario<LogFormat.V2, string>()

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/SoftDeleteTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/SoftDeleteTests.cs
@@ -130,7 +130,7 @@ public class SoftDeleteTests : SqliteDbPerTest<SoftDeleteTests> {
 				Assert.False(state.TryGetOriginalStreamData("ab-1", out _));
 				Assert.False(state.TryGetMetastreamData("$$ab-1", out _));
 			})
-			.RunAsync(
+			.RunAndKeepDbAsync(
 				x => new[] {
 					x.Recs[0].KeepIndexes(2, 3),
 					x.Recs[1],

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/UnsafeIgnoreHardDeletesTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/UnsafeIgnoreHardDeletesTests.cs
@@ -63,7 +63,7 @@ public class UnsafeIgnoreHardDeletesTests : SqliteDbPerTest<UnsafeIgnoreHardDele
 						eventNumber: 0),
 					doneLogicalChunkNumber: null));
 			})
-			.RunAsync(x => new[] {
+			.RunAndKeepDbAsync(x => new[] {
 				x.Recs[0].KeepIndexes(3), // only the tombstone is kept
 				x.Recs[1],
 				x.Recs[2],
@@ -118,7 +118,7 @@ public class UnsafeIgnoreHardDeletesTests : SqliteDbPerTest<UnsafeIgnoreHardDele
 				Tracer.Line("Accumulating from checkpoint: Accumulating SP-0 done None"),
 				Tracer.AnythingElse)
 			// result of scavenging SP-0
-			.RunAsync(x => new[] {
+			.RunAndKeepDbAsync(x => new[] {
 				x.Recs[0].KeepIndexes(0, 2),
 				x.Recs[1],
 				x.Recs[2],


### PR DESCRIPTION
Closing the db is idempotent and so it will no be closed properly the second time Resulted in tests taking longer while they try and fail to clean up the directory.