### PR TITLE
Calculate disk stats on linux for correct mount point instead of `/`

### DIFF
--- a/src/EventStore.SystemRuntime/Diagnostics/DriveStats.cs
+++ b/src/EventStore.SystemRuntime/Diagnostics/DriveStats.cs
@@ -6,11 +6,22 @@
 namespace System.Diagnostics;
 
 public static class DriveStats {
-    public static DriveData GetDriveInfo(string path) {
-        var info = new DriveInfo(Directory.GetDirectoryRoot(path));
-        var data = new DriveData(info.Name, info.TotalSize, info.AvailableFreeSpace);
-        return data;
-    }
+	public static DriveData GetDriveInfo(string path) {
+		var info = new DriveInfo(path);
+		var target = info.Name;
+		var diskName = "";
+
+		// info.VolumeLabel looks like what we want but on linux it is just the name again.
+		// so we find the best match in the list of drives.
+		foreach (var candidate in DriveInfo.GetDrives()) {
+			if (target.StartsWith(candidate.Name, StringComparison.InvariantCultureIgnoreCase) &&
+				candidate.Name.StartsWith(diskName, StringComparison.InvariantCultureIgnoreCase)) {
+				diskName = candidate.Name;
+			}
+		}
+
+		return new DriveData(diskName, info.TotalSize, info.AvailableFreeSpace);
+	}
 }
 
 /// <summary>

--- a/src/EventStore.SystemRuntime/Diagnostics/DriveStats.cs
+++ b/src/EventStore.SystemRuntime/Diagnostics/DriveStats.cs
@@ -7,7 +7,7 @@ namespace System.Diagnostics;
 
 public static class DriveStats {
 	public static DriveData GetDriveInfo(string path) {
-		var info = new DriveInfo(path);
+		var info = new DriveInfo(Path.GetFullPath(path));
 		var target = info.Name;
 		var diskName = "";
 


### PR DESCRIPTION
Fixed: Disk stats bug introduced in 24.6.0. On Linux the disk usage/capacity were showing the values for the disk mounted at `/` even if the database was on a different disk

Fixes #4680