### PR TITLE
[KDB-580] Apply labels to PRs based on the changed directories

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+# Add 'documentation' label if all changes are in the docs directory or to the README file
+documentation:
+  - all:
+    - changed-files:
+      - all-globs-to-all-files:
+        - docs/*
+        - README.md
+
+# Add 'ignore-for-release' label if all changes are:
+#    - changes to workflows, codeowners, etc (.github)
+#    - changes to tests (*.Tests)
+ignore-for-release:
+  - all:
+    - changed-files:
+      - all-globs-to-all-files:
+        - .github/*
+        - src/*.Tests/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
Uses the [labeler](https://github.com/actions/labeler) action to label PRs based on which directories have changed. This is mostly for the automated release notes.

The current configuration should:
- label the PR `documentation` if all changes are in the `docs` directory or to the `README.md` file.
- label the PR `ignore-for-release` if all changes are in the `.github` directory.
- label the PR `ignore-for-release` if all changes are in a `*.Tests` directory.
