### PR TITLE
[KDB-550] Arrange ArchiveStorage tests as derived classes rather than theories

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
-//#define RUN_S3_TESTS // uncomment to run S3 tests, requires AWS CLI to be installed and configured
-
 using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.Services.Archive;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
@@ -11,16 +9,11 @@ using System.Security.Cryptography;
 
 namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
 
-public class ArchiveStorageTestsBase<T> : DirectoryPerTest<T> {
-#if RUN_S3_TESTS
-	protected const string SkipS3 = null;
-#else
-	protected const string SkipS3 = "run manually";
-#endif
-
+public abstract class ArchiveStorageTestsBase<T> : DirectoryPerTest<T> {
 	protected const string ChunkPrefix = "chunk-";
 	protected string ArchivePath => Path.Combine(Fixture.Directory, "archive");
 	protected string DbPath => Path.Combine(Fixture.Directory, "db");
+	protected abstract StorageType StorageType { get; }
 
 	public ArchiveStorageTestsBase() {
 		Directory.CreateDirectory(ArchivePath);

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageWriterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageWriterTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using EventStore.Core.Services.Archive;
 using EventStore.Core.Services.Archive.Storage.Exceptions;
 using FluentStorage.Utils.Extensions;
 using Xunit;
@@ -13,40 +12,34 @@ using Xunit;
 namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
 
 [Collection("ArchiveStorageTests")]
-public class ArchiveStorageWriterTests : ArchiveStorageTestsBase<ArchiveStorageWriterTests> {
-	[Theory]
-	[InlineData(StorageType.FileSystem)]
-	[InlineData(StorageType.S3, Skip = SkipS3)]
-	public async Task can_store_a_chunk(StorageType storageType) {
-		var sut = CreateWriterSut(storageType);
+public abstract class ArchiveStorageWriterTests<T> : ArchiveStorageTestsBase<T> {
+	[Fact]
+	public async Task can_store_a_chunk() {
+		var sut = CreateWriterSut(StorageType);
 		var localChunk = CreateLocalChunk(0, 0);
 		var destinationFile = Path.GetFileName(localChunk);
 		Assert.True(await sut.StoreChunk(localChunk, destinationFile, CancellationToken.None));
 
 		var localChunkContent = await File.ReadAllBytesAsync(localChunk);
-		using var archivedChunkContent = await CreateReaderSut(storageType).GetChunk(destinationFile, CancellationToken.None);
+		using var archivedChunkContent = await CreateReaderSut(StorageType).GetChunk(destinationFile, CancellationToken.None);
 		Assert.Equal(localChunkContent, archivedChunkContent.ToByteArray());
 	}
 
-	[Theory]
-	[InlineData(StorageType.FileSystem)]
-	[InlineData(StorageType.S3, Skip = SkipS3)]
-	public async Task throws_chunk_deleted_exception_if_local_chunk_doesnt_exist(StorageType storageType) {
-		var sut = CreateWriterSut(storageType);
+	[Fact]
+	public async Task throws_chunk_deleted_exception_if_local_chunk_doesnt_exist() {
+		var sut = CreateWriterSut(StorageType);
 		var localChunk = CreateLocalChunk(0, 0);
 		var destinationFile = Path.GetFileName(localChunk);
 		File.Delete(localChunk);
 		await Assert.ThrowsAsync<ChunkDeletedException>(async () => await sut.StoreChunk(localChunk, destinationFile, CancellationToken.None));
 	}
 
-	[Theory]
-	[InlineData(StorageType.FileSystem)]
-	[InlineData(StorageType.S3, Skip = SkipS3)]
-	public async Task can_write_and_read_checkpoint(StorageType storageType) {
+	[Fact]
+	public async Task can_write_and_read_checkpoint() {
 		var checkpoint = Random.Shared.NextInt64();
-		var sut = CreateReaderSut(storageType);
+		var sut = CreateReaderSut(StorageType);
 
-		var writerSut = CreateWriterSut(storageType);
+		var writerSut = CreateWriterSut(StorageType);
 		await writerSut.SetCheckpoint(checkpoint, CancellationToken.None);
 
 		Assert.Equal(checkpoint, await sut.GetCheckpoint(CancellationToken.None));

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/FileSystemTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/FileSystemTests.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using EventStore.Core.Services.Archive;
+
+namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
+
+public class FileSystemReaderTests : ArchiveStorageReaderTests<FileSystemReaderTests> {
+	protected override StorageType StorageType => StorageType.FileSystem;
+}
+
+public class FileSystemWriterTests : ArchiveStorageWriterTests<FileSystemWriterTests> {
+	protected override StorageType StorageType => StorageType.FileSystem;
+}

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/S3Tests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/S3Tests.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+//#define RUN_S3_TESTS // uncomment to run S3 tests, requires AWS CLI to be installed and configured
+
+using EventStore.Core.Services.Archive;
+
+namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
+
+#if RUN_S3_TESTS
+public class S3ReaderTests : ArchiveStorageReaderTests<S3ReaderTests> {
+	protected override StorageType StorageType => StorageType.S3;
+}
+
+public class S3WriterTests : ArchiveStorageWriterTests<S3WriterTests> {
+	protected override StorageType StorageType => StorageType.S3;
+}
+#endif


### PR DESCRIPTION
Changed: unit test changes

Now that they have implementations for all methods