### PR TITLE
Remove dependency on CommunityToolkit.HighPerformance

### DIFF
--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -8,7 +8,6 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.2" />
 		<PackageReference Include="EventStore.Plugins" Version="25.2.5" />
 		<PackageReference Include="FluentStorage" Version="5.6.0" />
 		<PackageReference Include="FluentStorage.AWS" Version="5.5.0" />

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
@@ -2,15 +2,13 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
-using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using CommunityToolkit.HighPerformance;
-using CommunityToolkit.HighPerformance.Buffers;
+using DotNext.IO;
 using EventStore.Core.Services.Archive.Storage.Exceptions;
 using Serilog;
 
@@ -22,11 +20,17 @@ public class FileSystemReader : IArchiveStorageReader {
 	private readonly string _archivePath;
 	private readonly Func<int?, int?, string> _getChunkPrefix;
 	private readonly string _archiveCheckpointFile;
+	private readonly FileStreamOptions _fileStreamOptions;
 
 	public FileSystemReader(FileSystemOptions options, Func<int?, int?, string> getChunkPrefix, string archiveCheckpointFile) {
 		_archivePath = options.Path;
 		_getChunkPrefix = getChunkPrefix;
 		_archiveCheckpointFile = archiveCheckpointFile;
+		_fileStreamOptions = new FileStreamOptions {
+			Access = FileAccess.Read,
+			Mode = FileMode.Open,
+			Options = FileOptions.Asynchronous,
+		};
 	}
 
 	public ValueTask<long> GetCheckpoint(CancellationToken ct) {
@@ -47,31 +51,24 @@ public class FileSystemReader : IArchiveStorageReader {
 	public async ValueTask<Stream> GetChunk(string chunkFile, CancellationToken ct) {
 		try {
 			var chunkPath = Path.Combine(_archivePath, chunkFile);
-			return File.OpenRead(chunkPath);
+			return File.Open(chunkPath, _fileStreamOptions);
 		} catch (FileNotFoundException) {
 			throw new ChunkDeletedException();
 		}
 	}
 
 	public async ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct) {
-		var longLength = end - start;
+		var length = end - start;
 
-		if (longLength > int.MaxValue)
-			throw new InvalidOperationException($"Attempted to read too much from chunk {chunkFile}. Start: {start}. End {end}");
-		else if (longLength < 0)
+		if (length < 0)
 			throw new InvalidOperationException($"Attempted to read negative amount from chunk {chunkFile}. Start: {start}. End {end}");
 
-		var length = (int)longLength;
-
-		var chunkPath = Path.Combine(_archivePath, chunkFile);
 		try {
-			using var fileStream = File.OpenRead(chunkPath);
-			fileStream.Position = start;
-
-			var target = MemoryOwner<byte>.Allocate(length, AllocationMode.Default).AsStream();
-			await fileStream.CopyToAsync(target, ct);
-			target.Position = 0;
-			return target;
+			var chunkPath = Path.Combine(_archivePath, chunkFile);
+			var fileStream = File.Open(chunkPath, _fileStreamOptions);
+			var segment = new StreamSegment(fileStream, leaveOpen: false);
+			segment.Adjust(start, length);
+			return segment;
 
 		} catch (FileNotFoundException) {
 			throw new ChunkDeletedException();


### PR DESCRIPTION
Changed: internal changes

The case we added it for is covered by DotNext which we are already using widely
The DotNext StreamSegment class is particularly useful here because it wraps the underlying stream.