### PR TITLE
Correct the connector deletion endpoint

### DIFF
--- a/docs/server/features/connectors/manage.md
+++ b/docs/server/features/connectors/manage.md
@@ -387,7 +387,7 @@ before attempting to reconfigure it.
 ## Delete
 
 Delete a connector by sending a `DELETE` request to
-`/connectors/{connector_id}/delete`, where `{connector_id}` is the unique
+`/connectors/{connector_id}`, where `{connector_id}` is the unique
 identifier used when the connector was created.
 
 ::: tabs


### PR DESCRIPTION
This PR corrects the connector deletion endpoint mentioned in our documentation. It was mentioned that to delete a connector, a DELETE request must be sent to /connectors/{connector_id}/delete endpoint, however, the DELETE request must be sent to /connectors/{connector_id} endpoint. https://developers.eventstore.com/server/v24.10/features/connectors/manage.html#delete