### PR TITLE
[KDB-439]: Fix silent sync over async in TFChunk

### DIFF
--- a/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkWriteTransform.cs
+++ b/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkWriteTransform.cs
@@ -28,7 +28,8 @@ public class BitFlipChunkWriteTransform : IChunkWriteTransform {
 
 	public async ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken token) {
 		await _transformedStream.ChunkFileStream.WriteAsync(footer, token);
-		return (int)_transformedStream.ChunkFileStream.Length;
+		await _transformedStream.ChunkFileStream.FlushAsync(token);
+		return (int)_transformedStream.Position;
 	}
 
 	private static int GetAlignedSize(int size, int alignmentSize) {

--- a/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkWriteTransform.cs
+++ b/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkWriteTransform.cs
@@ -29,7 +29,8 @@ public class ByteDupChunkWriteTransform : IChunkWriteTransform {
 
 	public async ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken token) {
 		await _transformedStream.ChunkFileStream.WriteAsync(footer, token);
-		return (int)_transformedStream.ChunkFileStream.Length;
+		await _transformedStream.ChunkFileStream.FlushAsync(token);
+		return (int)_transformedStream.Position;
 	}
 
 	private static int GetAlignedSize(int size, int alignmentSize) {

--- a/src/EventStore.Core.Tests/Transforms/WithHeader/WithHeaderChunkWriteTransform.cs
+++ b/src/EventStore.Core.Tests/Transforms/WithHeader/WithHeaderChunkWriteTransform.cs
@@ -28,7 +28,8 @@ public class WithHeaderChunkWriteTransform(int transformHeaderSize) : IChunkWrit
 
 	public async ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken token) {
 		await _transformedStream.ChunkFileStream.WriteAsync(footer, token);
-		return (int)_transformedStream.ChunkFileStream.Length;
+		await _transformedStream.FlushAsync(token);
+		return (int)_transformedStream.Position;
 	}
 
 	private static int GetAlignedSize(int size, int alignmentSize) {

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -30,9 +30,9 @@
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.452401" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.6" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-		<PackageReference Include="DotNext.IO" Version="5.16.1" />
-		<PackageReference Include="DotNext.Threading" Version="5.16.1" />
-		<PackageReference Include="DotNext.Unsafe" Version="5.16.1" />
+		<PackageReference Include="DotNext.IO" Version="5.17.0" />
+		<PackageReference Include="DotNext.Threading" Version="5.17.0" />
+		<PackageReference Include="DotNext.Unsafe" Version="5.17.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="System.Threading.Channels" Version="9.0.0" />
 		<PackageReference Include="Scrutor" Version="5.0.2" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -30,7 +30,7 @@
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.452401" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.6" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-		<PackageReference Include="DotNext.IO" Version="5.17.0" />
+		<PackageReference Include="DotNext.IO" Version="5.17.1" />
 		<PackageReference Include="DotNext.Threading" Version="5.17.0" />
 		<PackageReference Include="DotNext.Unsafe" Version="5.17.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
@@ -95,9 +95,11 @@ public interface IChunkHandle : IFlushable, IDisposable {
 				bufferCopy.Dispose();
 			}
 
-			// In Release build, the following statement will be removed by the compiler automatically.
-			// We want to be sure that no one will call sync-over-async at least in tests
-			Debug.Fail("Async writes are not allowed");
+			// This synchronous Write implementation exists because it is hard to be sure that it is
+			// never called. Quite a few synchronous stream operations can call synchronous write under
+			// the hood (e.g. SetLength). We want to be sure that these are at least not called
+			// routinely, because it is inefficient.
+			Debug.Fail("Synchronous writes are undesirable");
 		}
 
 
@@ -126,7 +128,8 @@ public interface IChunkHandle : IFlushable, IDisposable {
 				}
 			}
 
-			Debug.Fail("Async reads are not allowed");
+			// see comment on other Debug.Fail call
+			Debug.Fail("Synchronous writes are undesirable");
 			return bytesRead;
 		}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,6 +94,10 @@ public interface IChunkHandle : IFlushable, IDisposable {
 				ResetTimeout();
 				bufferCopy.Dispose();
 			}
+
+			// In Release build, the following statement will be removed by the compiler automatically.
+			// We want to be sure that no one will call sync-over-async at least in tests
+			Debug.Fail("Async writes are not allowed");
 		}
 
 
@@ -121,6 +126,7 @@ public interface IChunkHandle : IFlushable, IDisposable {
 				}
 			}
 
+			Debug.Fail("Async reads are not allowed");
 			return bytesRead;
 		}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.IO;
 using DotNext;
-using DotNext.IO;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -40,7 +39,7 @@ internal sealed class ReaderWorkItem : Disposable {
 
 	private static ChunkDataReadStream CreateTransformedFileStream(IChunkHandle handle,
 		IChunkReadTransform chunkReadTransform) {
-		var fileStream = new PoolingBufferedStream(handle.CreateStream()) { MaxBufferSize = BufferSize };
+		var fileStream = new BufferedStream(handle.CreateStream(), BufferSize);
 		return chunkReadTransform.TransformData(new ChunkDataReadStream(fileStream));
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -1,27 +1,39 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using DotNext;
+using DotNext.Buffers;
 using DotNext.IO;
 using EventStore.Plugins.Transforms;
+using static DotNext.Runtime.Intrinsics;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
 internal sealed class ReaderWorkItem : Disposable {
-	private const int BufferSize = 512;
+	private const int BufferSize = 4096;
 
 	// if item was taken from the pool, the field contains position within the array (>= 0)
 	private readonly int _positionInPool = -1;
 	public readonly ChunkDataReadStream BaseStream;
 	private readonly bool _leaveOpen;
+	private readonly IBufferedReader _cachedReader;
 
 	private ReaderWorkItem(ChunkDataReadStream stream, bool leaveOpen) {
 		Debug.Assert(stream is not null);
 
 		_leaveOpen = leaveOpen;
 		BaseStream = stream;
+
+		// Access to the internal buffer of 'PoolingBufferedStream' is only allowed
+		// when the top-level stream doesn't perform any transformations. Otherwise,
+		// the buffer contains untransformed bytes that cannot be accessed directly.
+		_cachedReader = IsExactTypeOf<ChunkDataReadStream>(stream)
+		                && stream.ChunkFileStream is PoolingBufferedStream bufferedStream
+			? bufferedStream
+			: null;
 	}
 
 	public ReaderWorkItem(Stream sharedStream, IChunkReadTransform chunkReadTransform)
@@ -53,6 +65,17 @@ internal sealed class ReaderWorkItem : Disposable {
 
 			_positionInPool = value;
 		}
+	}
+
+	internal IBufferedReader TryGetBufferedReader(int length, out ReadOnlyMemory<byte> buffer) {
+		if (_cachedReader is { } reader) {
+			buffer = reader.Buffer.TrimLength(length);
+		} else {
+			buffer = ReadOnlyMemory<byte>.Empty;
+			reader = null;
+		}
+
+		return buffer.Length >= length ? reader : null;
 	}
 
 	protected override void Dispose(bool disposing) {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.IO;
 using DotNext;
+using DotNext.IO;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -39,7 +40,7 @@ internal sealed class ReaderWorkItem : Disposable {
 
 	private static ChunkDataReadStream CreateTransformedFileStream(IChunkHandle handle,
 		IChunkReadTransform chunkReadTransform) {
-		var fileStream = new BufferedStream(handle.CreateStream(), BufferSize);
+		var fileStream = new PoolingBufferedStream(handle.CreateStream()) { MaxBufferSize = BufferSize };
 		return chunkReadTransform.TransformData(new ChunkDataReadStream(fileStream));
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -14,10 +14,10 @@ internal sealed class ReaderWorkItem : Disposable {
 
 	// if item was taken from the pool, the field contains position within the array (>= 0)
 	private readonly int _positionInPool = -1;
-	public readonly Stream BaseStream;
+	public readonly ChunkDataReadStream BaseStream;
 	private readonly bool _leaveOpen;
 
-	private ReaderWorkItem(Stream stream, bool leaveOpen) {
+	private ReaderWorkItem(ChunkDataReadStream stream, bool leaveOpen) {
 		Debug.Assert(stream is not null);
 
 		_leaveOpen = leaveOpen;
@@ -34,7 +34,7 @@ internal sealed class ReaderWorkItem : Disposable {
 		IsMemory = false;
 	}
 
-	private static Stream CreateTransformedMemoryStream(Stream memStream, IChunkReadTransform chunkReadTransform) {
+	private static ChunkDataReadStream CreateTransformedMemoryStream(Stream memStream, IChunkReadTransform chunkReadTransform) {
 		return chunkReadTransform.TransformData(new ChunkDataReadStream(memStream));
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -951,15 +951,18 @@ public partial class TFChunk : IDisposable {
 		if (mapping is null) {
 			mapSize = 0;
 			bufferFromPool = ArrayPool<byte>.Shared.Rent(ChunkFooter.Size);
-		} else if (_inMem) {
-			throw new InvalidOperationException(
-				"Cannot write an in-memory chunk with a PosMap. " +
-				"Scavenge is not supported on in-memory databases");
-		} else if (_cacheStatus is not CacheStatus.Uncached) {
-			throw new InvalidOperationException("Trying to write mapping while chunk is cached. "
-			                                    + "You probably are writing scavenged chunk as cached. "
-			                                    + "Do not do this.");
 		} else {
+			if (_inMem)
+				throw new InvalidOperationException(
+					"Cannot write an in-memory chunk with a PosMap. " +
+					"Scavenge is not supported on in-memory databases");
+
+			if (_cacheStatus is not CacheStatus.Uncached) {
+				throw new InvalidOperationException("Trying to write mapping while chunk is cached. "
+				                                    + "You probably are writing scavenged chunk as cached. "
+				                                    + "Do not do this.");
+			}
+
 			mapSize = mapping.Count * PosMap.FullSize;
 
 			bufferFromPool = ArrayPool<byte>.Shared.Rent(Math.Max(mapSize, ChunkFooter.Size));

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -951,18 +951,15 @@ public partial class TFChunk : IDisposable {
 		if (mapping is null) {
 			mapSize = 0;
 			bufferFromPool = ArrayPool<byte>.Shared.Rent(ChunkFooter.Size);
+		} else if (_inMem) {
+			throw new InvalidOperationException(
+				"Cannot write an in-memory chunk with a PosMap. " +
+				"Scavenge is not supported on in-memory databases");
+		} else if (_cacheStatus is not CacheStatus.Uncached) {
+			throw new InvalidOperationException("Trying to write mapping while chunk is cached. "
+			                                    + "You probably are writing scavenged chunk as cached. "
+			                                    + "Do not do this.");
 		} else {
-			if (_inMem)
-				throw new InvalidOperationException(
-					"Cannot write an in-memory chunk with a PosMap. " +
-					"Scavenge is not supported on in-memory databases");
-
-			if (_cacheStatus is not CacheStatus.Uncached) {
-				throw new InvalidOperationException("Trying to write mapping while chunk is cached. "
-				                                    + "You probably are writing scavenged chunk as cached. "
-				                                    + "Do not do this.");
-			}
-
 			mapSize = mapping.Count * PosMap.FullSize;
 
 			bufferFromPool = ArrayPool<byte>.Shared.Rent(Math.Max(mapSize, ChunkFooter.Size));

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -955,7 +955,7 @@ public partial class TFChunk : IDisposable {
 
 	private async ValueTask<ChunkFooter> WriteFooter(IReadOnlyCollection<PosMap> mapping, CancellationToken token) {
 		var workItem = _writerWorkItem;
-		workItem.ResizeStream((int)workItem.WorkingStream.Position);
+		workItem.ResizeStream(workItem.WorkingStream.Position);
 
 		int mapSize;
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -993,7 +993,7 @@ public partial class TFChunk : IDisposable {
 
 		// at this point in code, 'WorkingStream` should not contain buffered bytes because SeLength
 		// can cause sync-over-async write. This fact is checked within `IChunkHandle.UnbufferedStream` class
-		workItem.WorkingStream.SetLength(fileSize);
+		workItem.ResizeStream(fileSize);
 
 		_fileSize = fileSize;
 		return footerWithHash;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -977,7 +977,7 @@ public partial class TFChunk : IDisposable {
 			alignmentSize: _chunkHeader.Version >= (byte)ChunkVersions.Aligned ? AlignmentSize : 1,
 			token);
 
-		await Flush(token);
+		await workItem.FlushToDisk(token);
 
 		int fileSize;
 		ChunkFooter footerWithHash;
@@ -998,7 +998,7 @@ public partial class TFChunk : IDisposable {
 			ArrayPool<byte>.Shared.Return(bufferFromPool);
 		}
 
-		await Flush(token);
+		await workItem.FlushToDisk(token);
 
 		_fileSize = fileSize;
 		return footerWithHash;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using DotNext;
 using DotNext.Buffers;
 using DotNext.Threading;
 using DotNext.IO;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -559,7 +559,7 @@ public partial class TFChunk {
 				buffer.Dispose();
 			}
 
-			// log record payload + lenght suffix
+			// log record payload + length suffix
 			var lengthWithSuffix = length + sizeof(int);
 			ILogRecord record;
 			IBufferedReader bufferedReader = null;
@@ -567,7 +567,7 @@ public partial class TFChunk {
 				// Perf: if buffered stream contains necessary amount of buffered bytes, we can omit expensive buffer
 				// rental and copy
 				if ((bufferedReader = workItem.TryGetBufferedReader(lengthWithSuffix, out var input)) is null) {
-					buffer = Memory.AllocateExactly<byte>(length + sizeof(int));
+					buffer = Memory.AllocateExactly<byte>(lengthWithSuffix);
 					await workItem.BaseStream.ReadExactlyAsync(buffer.Memory, token);
 					input = buffer.Memory;
 				} else {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using DotNext;
 using DotNext.Buffers;
 using DotNext.Threading;
 using DotNext.IO;
@@ -548,32 +550,45 @@ public partial class TFChunk {
 				return (null, -1);
 
 			int length;
-			MemoryOwner<byte> buffer;
+			var buffer = Memory.AllocateAtLeast<byte>(sizeof(int));
 
-			using (buffer = Memory.AllocateAtLeast<byte>(sizeof(int))) {
+			// Perf: use 'try-catch' instead of 'using' to avoid defensive copy of 'buffer' caused by the compiler
+			try {
 				length = await workItem.BaseStream.ReadLittleEndianAsync<int>(buffer.Memory, token);
 				ValidateRecordLength(length, actualPosition);
+			} finally {
+				buffer.Dispose();
 			}
 
+			// log record payload + lenght suffix
+			var lengthWithSuffix = length + sizeof(int);
 			ILogRecord record;
+			IBufferedReader bufferedReader = null;
 			try {
-				// log record payload + lenght suffix
-				buffer = Memory.AllocateExactly<byte>(length + sizeof(int));
-				await workItem.BaseStream.ReadExactlyAsync(buffer.Memory, token);
+				// Perf: if buffered stream contains necessary amount of buffered bytes, we can omit expensive buffer
+				// rental and copy
+				if ((bufferedReader = workItem.TryGetBufferedReader(lengthWithSuffix, out var input)) is null) {
+					buffer = Memory.AllocateExactly<byte>(length + sizeof(int));
+					await workItem.BaseStream.ReadExactlyAsync(buffer.Memory, token);
+					input = buffer.Memory;
+				} else {
+					Debug.Assert(buffer.IsEmpty);
+				}
 
-				var reader = new SequenceReader(new(buffer.Memory[..length]));
+				var reader = new SequenceReader(new(input[..length]));
 				record = LogRecord.ReadFrom(ref reader);
 
 				_tracker.OnRead(record);
 
 				int suffixLength =
-					BinaryPrimitives.ReadInt32LittleEndian(buffer.Span[^sizeof(int)..]);
+					BinaryPrimitives.ReadInt32LittleEndian(input.Span[^sizeof(int)..]);
 
 				ValidatePrefixSuffixLength(length, suffixLength, actualPosition, "pre-position");
 			} catch (Exception exc) {
 				throw new InvalidReadException(
 					$"Error while reading log record forwards at actual position {actualPosition}. {exc.Message}");
 			} finally {
+				bufferedReader?.Consume(lengthWithSuffix);
 				buffer.Dispose();
 			}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -17,7 +17,7 @@ internal sealed class WriterWorkItem : Disposable {
 
 	public Stream WorkingStream { get; private set; }
 
-	private readonly Stream _fileStream;
+	private readonly ChunkDataWriteStream _fileStream;
 	private Stream _memStream;
 	public readonly IncrementalHash MD5;
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -7,7 +7,6 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext;
-using DotNext.IO;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -37,7 +36,7 @@ internal sealed class WriterWorkItem : Disposable {
 		var chunkStream = handle.CreateStream();
 		var fileStream = unbuffered
 			? chunkStream
-			: new PoolingBufferedStream(chunkStream) { MaxBufferSize = BufferSize };
+			: new BufferedStream(chunkStream, BufferSize);
 		fileStream.Position = initialStreamPosition;
 		var chunkDataWriteStream = new ChunkDataWriteStream(fileStream, md5);
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -74,6 +74,13 @@ internal sealed class WriterWorkItem : Disposable {
 		base.Dispose(disposing);
 	}
 
+	public ValueTask FlushToDisk(CancellationToken token) {
+		// in-mem stream doesn't require async call
+		_memStream.Flush();
+
+		return new(_fileStream is not null ? _fileStream.FlushAsync(token) : Task.CompletedTask);
+	}
+
 	public void FlushToDisk() {
 		_fileStream?.Flush();
 		_memStream?.Flush();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -76,7 +76,7 @@ internal sealed class WriterWorkItem : Disposable {
 
 	public ValueTask FlushToDisk(CancellationToken token) {
 		// in-mem stream doesn't require async call
-		_memStream.Flush();
+		_memStream?.Flush();
 
 		return new(_fileStream is not null ? _fileStream.FlushAsync(token) : Task.CompletedTask);
 	}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -59,7 +59,7 @@ internal sealed class WriterWorkItem : Disposable {
 		return _fileStream?.WriteAsync(buf, token) ?? ValueTask.CompletedTask;
 	}
 
-	public void ResizeStream(int fileSize) {
+	public void ResizeStream(long fileSize) {
 		_fileStream?.SetLength(fileSize);
 		_memStream?.SetLength(fileSize);
 	}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext;
+using DotNext.IO;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -36,7 +37,7 @@ internal sealed class WriterWorkItem : Disposable {
 		var chunkStream = handle.CreateStream();
 		var fileStream = unbuffered
 			? chunkStream
-			: new BufferedStream(chunkStream, BufferSize);
+			: new PoolingBufferedStream(chunkStream) { MaxBufferSize = BufferSize };
 		fileStream.Position = initialStreamPosition;
 		var chunkDataWriteStream = new ChunkDataWriteStream(fileStream, md5);
 


### PR DESCRIPTION
Changed: Fix silent sync over async in TFChunk

`TFChunk` implicitly uses sync-over-async because the buffered stream keeps buffered data when some callers invoke `SetLength` or `Position` setter. Those calls trigger synchronous writer to the underlying stream.