### PR TITLE
[KDB-439]: Convert `TFChunk.MarkForDeletion` to async

### DIFF
--- a/src/EventStore.Core.Tests/Index/IndexV1/PTableReadScenario.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/PTableReadScenario.cs
@@ -33,10 +33,10 @@ public abstract class PTableReadScenario : SpecificationWithFile {
 	}
 
 	[TearDown]
-	public override void TearDown() {
+	public override Task TearDown() {
 		PTable.Dispose();
 
-		base.TearDown();
+		return base.TearDown();
 	}
 
 	protected abstract void AddItemsForScenario(IMemTable memTable);

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_latest_entry_before_position.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_latest_entry_before_position.cs
@@ -64,9 +64,9 @@ public class when_trying_to_get_latest_entry_before_position : SpecificationWith
 	}
 
 	[TearDown]
-	public override void TearDown() {
+	public override Task TearDown() {
 		_pTable?.Dispose();
-		base.TearDown();
+		return base.TearDown();
 	}
 
 	private ISearchTable GetTable(bool memTableOrPTable) => memTableOrPTable ? (ISearchTable) _memTable : _pTable;

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_next_entry.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_next_entry.cs
@@ -58,9 +58,9 @@ public class when_trying_to_get_next_entry : SpecificationWithFile {
 	}
 
 	[TearDown]
-	public override void TearDown() {
+	public override Task TearDown() {
 		_pTable?.Dispose();
-		base.TearDown();
+		return base.TearDown();
 	}
 
 	private ISearchTable GetTable(bool memTableOrPTable) => memTableOrPTable ? (ISearchTable) _memTable : _pTable;

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_previous_entry.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_previous_entry.cs
@@ -58,9 +58,9 @@ public class when_trying_to_get_previous_entry : SpecificationWithFile {
 	}
 
 	[TearDown]
-	public override void TearDown() {
+	public override Task TearDown() {
 		_pTable?.Dispose();
-		base.TearDown();
+		return base.TearDown();
 	}
 
 	private ISearchTable GetTable(bool memTableOrPTable) => memTableOrPTable ? (ISearchTable) _memTable : _pTable;

--- a/src/EventStore.Core.Tests/SpecificationWithFile.cs
+++ b/src/EventStore.Core.Tests/SpecificationWithFile.cs
@@ -19,8 +19,15 @@ public class SpecificationWithFile {
 	}
 
 	[TearDown]
-	public virtual void TearDown() {
-		if (File.Exists(Filename))
-			File.Delete(Filename);
+	public virtual Task TearDown() {
+		var task = Task.CompletedTask;
+		try {
+			if (File.Exists(Filename))
+				File.Delete(Filename);
+		} catch (Exception e) {
+			task = Task.FromException(e);
+		}
+
+		return task;
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -39,9 +39,9 @@ public class scavenged_chunk : SpecificationWithFile {
 
 		var last = await chunk.TryReadLast(CancellationToken.None);
 		Assert.IsTrue(last.Success);
-		Assert.AreEqual(map[map.Count - 1].ActualPos, last.LogRecord.LogPosition);
+		Assert.AreEqual(map[^1].ActualPos, last.LogRecord.LogPosition);
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(1000);
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_appending_past_end_of_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_appending_past_end_of_a_tfchunk.cs
@@ -33,9 +33,9 @@ public class when_appending_past_end_of_a_tfchunk<TLogFormat, TStreamId> : Speci
 	}
 
 	[TearDown]
-	public override void TearDown() {
+	public override Task TearDown() {
 		_chunk.Dispose();
-		base.TearDown();
+		return base.TearDown();
 	}
 
 	[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_tfchunk_from_empty_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_tfchunk_from_empty_file.cs
@@ -22,9 +22,9 @@ public class when_creating_tfchunk_from_empty_file : SpecificationWithFile {
 	}
 
 	[TearDown]
-	public override void TearDown() {
+	public override Task TearDown() {
 		_chunk.Dispose();
-		base.TearDown();
+		return base.TearDown();
 	}
 
 	[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using NUnit.Framework;
@@ -16,7 +17,7 @@ public class when_destroying_a_tfchunk : SpecificationWithFile {
 	public override async Task SetUp() {
 		await base.SetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, 1000);
-		_chunk.MarkForDeletion();
+		await _chunk.MarkForDeletion(CancellationToken.None);
 	}
 
 	[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
@@ -22,15 +22,15 @@ public class when_destroying_a_tfchunk_that_is_locked : SpecificationWithFile {
 		await _chunk.Complete(CancellationToken.None);
 		_chunk.UnCacheFromMemory();
 		_reader = _chunk.AcquireRawReader();
-		_chunk.MarkForDeletion();
+		await _chunk.MarkForDeletion(CancellationToken.None);
 	}
 
 	[TearDown]
-	public override void TearDown() {
+	public override async Task TearDown() {
 		_reader.Release();
-		_chunk.MarkForDeletion();
+		await _chunk.MarkForDeletion(CancellationToken.None);
 		_chunk.WaitForDestroy(2000);
-		base.TearDown();
+		await base.TearDown();
 	}
 
 	[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using NUnit.Framework;
@@ -17,7 +18,7 @@ public class when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlock
 		await base.SetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, 1000);
 		var reader = _chunk.AcquireRawReader();
-		_chunk.MarkForDeletion();
+		await _chunk.MarkForDeletion(CancellationToken.None);
 		reader.Release();
 	}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
@@ -19,7 +19,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 	public async Task the_file_will_not_be_deleted_until_reader_released() {
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
 		using (var reader = chunk.AcquireDataReader()) {
-			chunk.MarkForDeletion();
+			await chunk.MarkForDeletion(CancellationToken.None);
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsFalse(result.IsEOF);
@@ -39,7 +39,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 			Assert.AreEqual(0, result.BytesRead);
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 
@@ -54,7 +54,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 			Assert.AreEqual(0, result.BytesRead);
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 
@@ -69,7 +69,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 			Assert.AreEqual(0, result.BytesRead); //header 128 + footer 128 + map 16
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 
@@ -91,7 +91,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 			Assert.AreEqual(1024, result.BytesRead);
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 
@@ -109,7 +109,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 				"Read wrong number of bytes.");
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 
@@ -130,7 +130,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 				"Read wrong number of bytes.");
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -13,7 +13,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	public async Task the_file_will_not_be_deleted_until_reader_released() {
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
 		using (var reader = chunk.AcquireRawReader()) {
-			chunk.MarkForDeletion();
+			await chunk.MarkForDeletion(CancellationToken.None);
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsFalse(result.IsEOF);
@@ -33,7 +33,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			Assert.AreEqual(1024, result.BytesRead);
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 /*
@@ -80,7 +80,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			Assert.AreEqual(1024, result.BytesRead);
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 
@@ -94,7 +94,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			Assert.AreEqual(4096, result.BytesRead); //does not includes header and footer space
 		}
 
-		chunk.MarkForDeletion();
+		await chunk.MarkForDeletion(CancellationToken.None);
 		chunk.WaitForDestroy(5000);
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using NUnit.Framework;
@@ -17,7 +18,7 @@ public class when_unlocking_a_tfchunk_that_has_been_marked_for_deletion : Specif
 		await base.SetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, 1000);
 		var reader = _chunk.AcquireRawReader();
-		_chunk.MarkForDeletion();
+		await _chunk.MarkForDeletion(CancellationToken.None);
 		reader.Release();
 	}
 

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TracingChunkWriterForExecutor.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TracingChunkWriterForExecutor.cs
@@ -35,7 +35,6 @@ public class TracingChunkWriterForExecutor<TStreamId, TRecord> :
 		return result;
 	}
 
-	public void Abort(bool deleteImmediately) {
-		_wrapped.Abort(deleteImmediately);
-	}
+	public ValueTask Abort(bool deleteImmediately, CancellationToken token)
+		=> _wrapped.Abort(deleteImmediately, token);
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -259,7 +259,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger {
 					+ "\nOld chunk total size: {oldSize}, scavenged chunk size: {newSize}."
 					+ "\nScavenged chunk removed.", oldChunkName, sw.Elapsed, oldSize, newSize);
 
-				newChunk.MarkForDeletion();
+				await newChunk.MarkForDeletion(ct);
 				_scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, "");
 			} else {
 				var positionMapping = new List<PosMap>(filteredCount);
@@ -327,7 +327,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger {
 			_scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, exc.Message);
 		} catch (OperationCanceledException) {
 			_logger.Information("Scavenging cancelled at: {oldChunkName}", oldChunkName);
-			newChunk.MarkForDeletion();
+			await newChunk.MarkForDeletion(CancellationToken.None);
 			_scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, "Scavenge cancelled");
 		} catch (Exception ex) {
 			_logger.Information(
@@ -511,7 +511,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger {
 			logger.Information("Scavenging cancelled at:"
 			         + "\n{oldChunksList}",
 				oldChunksList);
-			newChunk.MarkForDeletion();
+			await newChunk.MarkForDeletion(CancellationToken.None);
 			scavengerLog.ChunksNotMerged(chunkStartNumber, chunkEndNumber, sw.Elapsed, "Scavenge cancelled");
 			return false;
 		} catch (Exception ex) {

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
@@ -105,12 +105,13 @@ public class ChunkWriterForExecutor<TStreamId> : IChunkWriterForExecutor<TStream
 	}
 
 	// tbh not sure why this distinction is important
-	public void Abort(bool deleteImmediately) {
+	public async ValueTask Abort(bool deleteImmediately, CancellationToken token) {
 		if (deleteImmediately) {
+			await _outputChunk.Flush(token);
 			_outputChunk.Dispose();
 			TFChunkScavenger<TStreamId>.DeleteTempChunk(_logger, FileName, TFChunkScavenger.MaxRetryCount);
 		} else {
-			_outputChunk.MarkForDeletion();
+			await _outputChunk.MarkForDeletion(token);
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
@@ -22,7 +22,7 @@ public interface IChunkWriterForExecutor<TStreamId, TRecord> {
 
 	ValueTask<(string NewFileName, long NewFileSize)> Complete(CancellationToken token);
 
-	void Abort(bool deleteImmediately);
+	ValueTask Abort(bool deleteImmediately, CancellationToken token);
 }
 
 public interface IChunkReaderForExecutor<TStreamId, TRecord> {

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
@@ -305,12 +305,12 @@ public class ChunkExecutor<TStreamId, TRecord> : IChunkExecutor<TStreamId> {
 				outputChunk.FileName,
 				exc.Message);
 
-			outputChunk.Abort(deleteImmediately: true);
+			await outputChunk.Abort(deleteImmediately: true, cancellationToken);
 			throw;
 
 		} catch (OperationCanceledException) {
 			_logger.Information("SCAVENGING: Cancelled at: {oldChunkName}", oldChunkName);
-			outputChunk.Abort(deleteImmediately: false);
+			await outputChunk.Abort(deleteImmediately: false, CancellationToken.None);
 			throw;
 
 		} catch (Exception ex) {
@@ -319,7 +319,7 @@ public class ChunkExecutor<TStreamId, TRecord> : IChunkExecutor<TStreamId> {
 				"SCAVENGING: Got exception while scavenging chunk: #{chunkStartNumber}-{chunkEndNumber}.",
 				chunkStartNumber, chunkEndNumber);
 
-			outputChunk.Abort(deleteImmediately: true);
+			await outputChunk.Abort(deleteImmediately: true, cancellationToken);
 			throw;
 		}
 	}


### PR DESCRIPTION
Changed: Convert `TFChunk.MarkForDeletion` to async to avoid sync-over-async when flushing the stream