### PR TITLE
[KDB-437] Adjustments to archive chunk naming infrastructure

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/versioned_pattern_filenaming_strategy.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/versioned_pattern_filenaming_strategy.cs
@@ -180,13 +180,8 @@ public class versioned_pattern_filenaming_strategy : SpecificationWithDirectory 
 	}
 
 	[Test]
-	public void returns_correct_prefix_with_get_prefix_for() {
+	public void returns_correct_prefix() {
 		var strategy = new VersionedPatternFileNamingStrategy(PathName, "chunk-");
-		Assert.AreEqual("chunk-", strategy.GetPrefixFor(null, null));
-		Assert.AreEqual("chunk-000000.", strategy.GetPrefixFor(0, null));
-		Assert.AreEqual("chunk-001337.", strategy.GetPrefixFor(1337, null));
-		Assert.AreEqual("chunk-000000.000000", strategy.GetPrefixFor(0, 0));
-		Assert.AreEqual("chunk-000000.001337", strategy.GetPrefixFor(0, 1337));
-		Assert.AreEqual("chunk-001234.005678", strategy.GetPrefixFor(1234, 5678));
+		Assert.AreEqual("chunk-", strategy.Prefix);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/CustomNamingStrategy.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/CustomNamingStrategy.cs
@@ -26,5 +26,5 @@ internal class CustomNamingStrategy : IVersionedFileNamingStrategy {
 		return int.Parse(fileName[idx..]);
 	}
 
-	public string GetPrefixFor(int? index, int? version) => throw new NotImplementedException();
+	public string Prefix => "chunk-";
 }

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -43,6 +44,8 @@ internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader
 		_onGetChunk = onGetChunk;
 		_chunkGets = new();
 	}
+
+	public IArchiveChunkNamer ChunkNamer => throw new NotImplementedException();
 
 	public IArchiveStorageReader CreateReader() => this;
 	public IArchiveStorageWriter CreateWriter() => this;

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Archiver/ArchiverServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Archiver/ArchiverServiceTests.cs
@@ -298,6 +298,8 @@ internal class FakeUnmerger : IChunkUnmerger {
 }
 
 internal class FakeArchiveChunkNamer : IArchiveChunkNamer {
+	public string Prefix => "";
+
 	public string GetFileNameFor(int logicalChunkNumber) => $"{logicalChunkNumber}-{logicalChunkNumber}.renamed";
 }
 
@@ -318,6 +320,8 @@ internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader
 		_checkpoint = existingCheckpoint;
 		Chunks = new List<string>(existingChunks);
 	}
+
+	public IArchiveChunkNamer ChunkNamer => throw new NotImplementedException();
 
 	public IArchiveStorageReader CreateReader() => this;
 	public IArchiveStorageWriter CreateWriter() => this;

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Naming/ArchiveChunkNamerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Naming/ArchiveChunkNamerTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace EventStore.Core.XUnit.Tests.Services.Archive.Naming;
 
 public class ArchiveChunkNamerTests {
-	private ArchiveChunkNamer CreateSut() {
+	private static ArchiveChunkNamer CreateSut() {
 		var namingStrategy = new VersionedPatternFileNamingStrategy(string.Empty, "chunk-");
 		return new ArchiveChunkNamer(namingStrategy);
 	}
@@ -28,5 +28,11 @@ public class ArchiveChunkNamerTests {
 		var sut = CreateSut();
 		Assert.Throws<ArgumentOutOfRangeException>(() => sut.GetFileNameFor(-1));
 		Assert.Throws<ArgumentOutOfRangeException>(() => sut.GetFileNameFor(-2));
+	}
+
+	[Fact]
+	public void returns_correct_prefix() {
+		var sut = CreateSut();
+		Assert.Equal("chunk-", sut.Prefix);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
-using EventStore.Core.Services.Archive.Storage;
-using EventStore.Core.Services.Archive;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
 using System.IO;
 using System.Security.Cryptography;
+using EventStore.Core.Services.Archive;
+using EventStore.Core.Services.Archive.Naming;
+using EventStore.Core.Services.Archive.Storage;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
 
 namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
 
@@ -21,7 +22,7 @@ public abstract class ArchiveStorageTestsBase<T> : DirectoryPerTest<T> {
 	}
 
 	protected IArchiveStorageFactory CreateSutFactory(StorageType storageType) {
-		var namingStrategy = new VersionedPatternFileNamingStrategy(ArchivePath, ChunkPrefix);
+		var namingStrategy = new ArchiveChunkNamer(new VersionedPatternFileNamingStrategy(ArchivePath, ChunkPrefix));
 		var factory = new ArchiveStorageFactory(
 				new() {
 					StorageType = storageType,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -60,6 +60,8 @@ using EventStore.Core.Caching;
 using EventStore.Core.Certificates;
 using EventStore.Core.Cluster;
 using EventStore.Core.Services.Archive;
+using EventStore.Core.Services.Archive.Naming;
+using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.PeriodicLogs;
 using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
@@ -82,7 +84,6 @@ using ILogger = Serilog.ILogger;
 using LogLevel = EventStore.Common.Options.LogLevel;
 using RuntimeInformation = System.Runtime.RuntimeInformation;
 using EventStore.Licensing;
-using EventStore.Core.Services.Archive.Storage;
 
 namespace EventStore.Core;
 public abstract class ClusterVNode {
@@ -1298,7 +1299,10 @@ public class ClusterVNode<TStreamId> :
 			var chunkDeleter = IChunkDeleter<TStreamId, ILogRecord>.NoOp;
 			if (archiveOptions.Enabled) {
 				// todo: consider if we can/should reuse the same reader elsewhere
-				var archiveReader = new ArchiveStorageFactory(archiveOptions, Db.Manager.FileSystem.NamingStrategy).CreateReader();
+				var archiveReader = new ArchiveStorageFactory(
+						archiveOptions,
+						new ArchiveChunkNamer(Db.Manager.FileSystem.NamingStrategy))
+					.CreateReader();
 				chunkDeleter = new ChunkDeleter<TStreamId, ILogRecord>(
 					logger: logger,
 					archiveCheckpoint: new AdvancingCheckpoint(archiveReader.GetCheckpoint),

--- a/src/EventStore.Core/Services/Archive/Naming/ArchiveChunkNamer.cs
+++ b/src/EventStore.Core/Services/Archive/Naming/ArchiveChunkNamer.cs
@@ -14,6 +14,8 @@ public class ArchiveChunkNamer : IArchiveChunkNamer {
 		_namingStrategy = namingStrategy;
 	}
 
+	public string Prefix => _namingStrategy.Prefix;
+
 	public string GetFileNameFor(int logicalChunkNumber) {
 		ArgumentOutOfRangeException.ThrowIfNegative(logicalChunkNumber);
 

--- a/src/EventStore.Core/Services/Archive/Naming/IArchiveChunkNamer.cs
+++ b/src/EventStore.Core/Services/Archive/Naming/IArchiveChunkNamer.cs
@@ -4,5 +4,8 @@
 namespace EventStore.Core.Services.Archive.Naming;
 
 public interface IArchiveChunkNamer {
+	// The prefix that is applied to all chunks
+	string Prefix { get; }
+
 	string GetFileNameFor(int logicalChunkNumber);
 }

--- a/src/EventStore.Core/Services/Archive/Storage/ArchiveStorageFactory.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchiveStorageFactory.cs
@@ -2,20 +2,21 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Services.Archive.Naming;
 
 namespace EventStore.Core.Services.Archive.Storage;
 
 public class ArchiveStorageFactory(
 	ArchiveOptions options,
-	IVersionedFileNamingStrategy fileNamingStrategy) : IArchiveStorageFactory {
+	IArchiveChunkNamer chunkNamer) : IArchiveStorageFactory {
+
 	private const string ArchiveCheckpointFile = "archive.chk";
 
 	public IArchiveStorageReader CreateReader() {
 		return options.StorageType switch {
 			StorageType.Unspecified => throw new InvalidOperationException("Please specify an Archive StorageType"),
-			StorageType.FileSystem => new FileSystemReader(options.FileSystem, fileNamingStrategy.GetPrefixFor, ArchiveCheckpointFile),
-			StorageType.S3 => new S3Reader(options.S3, fileNamingStrategy.GetPrefixFor, ArchiveCheckpointFile),
+			StorageType.FileSystem => new FileSystemReader(options.FileSystem, chunkNamer, ArchiveCheckpointFile),
+			StorageType.S3 => new S3Reader(options.S3, chunkNamer, ArchiveCheckpointFile),
 			_ => throw new ArgumentOutOfRangeException(nameof(options.StorageType))
 		};
 	}
@@ -25,8 +26,8 @@ public class ArchiveStorageFactory(
 		// we use our own implementation instead (todo: consider if it could be an IBlobStorage)
 		return options.StorageType switch {
 			StorageType.Unspecified => throw new InvalidOperationException("Please specify an Archive StorageType"),
-			StorageType.FileSystem => new FileSystemWriter(options.FileSystem, fileNamingStrategy.GetPrefixFor, ArchiveCheckpointFile),
-			StorageType.S3 => new S3Writer(options.S3, fileNamingStrategy.GetPrefixFor, ArchiveCheckpointFile),
+			StorageType.FileSystem => new FileSystemWriter(options.FileSystem, ArchiveCheckpointFile),
+			StorageType.S3 => new S3Writer(options.S3, ArchiveCheckpointFile),
 			_ => throw new ArgumentOutOfRangeException(nameof(options.StorageType))
 		};
 	}

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
@@ -17,11 +17,9 @@ public class FileSystemWriter : IArchiveStorageWriter {
 
 	private readonly string _archivePath;
 	private readonly string _archiveCheckpointFile;
-	private readonly Func<int?, int?, string> _getChunkPrefix;
 
-	public FileSystemWriter(FileSystemOptions options, Func<int?, int?, string> getChunkPrefix, string archiveCheckpointFile) {
+	public FileSystemWriter(FileSystemOptions options, string archiveCheckpointFile) {
 		_archivePath = options.Path;
-		_getChunkPrefix = getChunkPrefix;
 		_archiveCheckpointFile = archiveCheckpointFile;
 	}
 

--- a/src/EventStore.Core/Services/Archive/Storage/FluentReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FluentReader.cs
@@ -1,22 +1,24 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
-using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext.Buffers;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage.Exceptions;
 using FluentStorage.Blobs;
 using Serilog;
 
 namespace EventStore.Core.Services.Archive.Storage;
 
-public abstract class FluentReader(string archiveCheckpointFile) {
+public abstract class FluentReader(IArchiveChunkNamer chunkNamer, string archiveCheckpointFile) {
 	protected abstract ILogger Log { get; }
 	protected abstract IBlobStorage BlobStorage { get; }
+
+	public IArchiveChunkNamer ChunkNamer => chunkNamer;
 
 	public async ValueTask<long> GetCheckpoint(CancellationToken ct) {
 		await using var stream = await BlobStorage.OpenReadAsync(archiveCheckpointFile, ct);

--- a/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageReader.cs
@@ -5,10 +5,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.Services.Archive.Naming;
 
 namespace EventStore.Core.Services.Archive.Storage;
 
 public interface IArchiveStorageReader {
+	public IArchiveChunkNamer ChunkNamer { get; }
+
 	/// <returns>A position in the transaction log up to which all chunks have been archived</returns>
 	public ValueTask<long> GetCheckpoint(CancellationToken ct);
 

--- a/src/EventStore.Core/Services/Archive/Storage/S3Writer.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Writer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
-using System;
 using FluentStorage;
 using FluentStorage.Blobs;
 using Serilog;
@@ -9,7 +8,7 @@ using Serilog;
 namespace EventStore.Core.Services.Archive.Storage;
 
 public class S3Writer : FluentWriter, IArchiveStorageWriter {
-	public S3Writer(S3Options options, Func<int?, int?, string> getChunkPrefix, string archiveCheckpointFile)
+	public S3Writer(S3Options options, string archiveCheckpointFile)
 		: base(archiveCheckpointFile) {
 		BlobStorage = StorageFactory.Blobs.AwsS3(
 			awsCliProfileName: options.AwsCliProfileName,

--- a/src/EventStore.Core/TransactionLog/FileNamingStrategy/IVersionedFileNamingStrategy.cs
+++ b/src/EventStore.Core/TransactionLog/FileNamingStrategy/IVersionedFileNamingStrategy.cs
@@ -7,12 +7,12 @@ namespace EventStore.Core.TransactionLog.FileNamingStrategy;
 // chunk versions, to chunk files in storage. Strictly it is more than a naming strategy
 // because it also reads the storage to list the chunks.
 public interface IVersionedFileNamingStrategy {
-	// Pure naming strategy methods
+	// Pure naming strategy
+	string Prefix { get; }
 	string GetFilenameFor(int index, int version);
 	string CreateTempFilename();
 	int GetIndexFor(string fileName);
 	int GetVersionFor(string fileName);
-	string GetPrefixFor(int? index, int? version);
 
 	// Methods that rely on the state of the storage
 	string[] GetAllVersionsFor(int index);

--- a/src/EventStore.Core/TransactionLog/FileNamingStrategy/VersionedPatternFileNamingStrategy.cs
+++ b/src/EventStore.Core/TransactionLog/FileNamingStrategy/VersionedPatternFileNamingStrategy.cs
@@ -97,14 +97,4 @@ public class VersionedPatternFileNamingStrategy : IVersionedFileNamingStrategy {
 	public string[] GetAllTempFiles() {
 		return Directory.GetFiles(_path, "*.tmp");
 	}
-
-	public string GetPrefixFor(int? index, int? version) {
-		if (index is null)
-			return _prefix;
-
-		if (version is null)
-			return $"{_prefix}{index:000000}.";
-
-		return $"{_prefix}{index:000000}.{version:000000}";
-	}
 }


### PR DESCRIPTION
Changed: internal changes

- Add Prefix property to IArchiveChunkNamer, it is up to it to 'see through' to the underlying naming strategy if appropriate
- Add ChunkNamer property to IArchiveStorageReader (groundwork)
- Simplify IVersionedFileNamingStrategy.GetPrefixFor to just a Prefix getter now that it doesn't need to be so powerful