### PR TITLE
Add metrics for parked persistent subscription messages

### DIFF
--- a/src/EventStore.ClusterNode/metricsconfig.json
+++ b/src/EventStore.ClusterNode/metricsconfig.json
@@ -49,6 +49,10 @@
 		"ProcessingRequestFromHttpClient": false
 	},
 
+	"PersistentSubscriptions": {
+		"ParkedMessages": true,
+	},
+
 	"Writer": {
 		"FlushSize": true,
 		"FlushDuration": true
@@ -234,9 +238,5 @@
 			"Regex": ".*",
 			"Label": "Other"
 		}
-	],
-
-	"PersistentSubscriptions": {
-		"ParkedMessages": true
-	}
+	]
 }

--- a/src/EventStore.ClusterNode/metricsconfig.json
+++ b/src/EventStore.ClusterNode/metricsconfig.json
@@ -234,5 +234,9 @@
 			"Regex": ".*",
 			"Label": "Other"
 		}
-	]
+	],
+
+	"PersistentSubscriptions": {
+		"ParkedMessages": true
+	}
 }

--- a/src/EventStore.ClusterNode/metricsconfig.json
+++ b/src/EventStore.ClusterNode/metricsconfig.json
@@ -50,7 +50,7 @@
 	},
 
 	"PersistentSubscriptions": {
-		"ParkedMessages": true,
+		"ParkedMessages": true
 	},
 
 	"Writer": {

--- a/src/EventStore.Common/Configuration/MetricsConfiguration.cs
+++ b/src/EventStore.Common/Configuration/MetricsConfiguration.cs
@@ -138,6 +138,10 @@ namespace EventStore.Common.Configuration {
 			Processing,
 		}
 
+		public enum PersistentSubscriptionTracker {
+			ParkedMessages = 1,
+		}
+
 		public class LabelMappingCase {
 			public string Regex { get; set; }
 			public string Label { get; set; }
@@ -173,6 +177,8 @@ namespace EventStore.Common.Configuration {
 		public int ExpectedScrapeIntervalSeconds { get; set; }
 
 		public Dictionary<QueueTracker, bool> Queues { get; set; } = new();
+
+		public Dictionary<PersistentSubscriptionTracker, bool> PersistentSubscriptions { get; set; } = new();
 
 		public LabelMappingCase[] QueueLabels { get; set; } = Array.Empty<LabelMappingCase>();
 

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -189,7 +189,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 				new FakeReadIndex<TLogFormat,TStreamId>(_ => false, new MetaStreamLookup()),
 				ioDispatcher, bus,
 				new PersistentSubscriptionConsumerStrategyRegistry(bus, bus,
-					Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>()));
+					Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>()),
+				new ParkedMessagesTracker.NoOp());
 
 			_sut.Start();
 			_sut.Handle(new SystemMessage.BecomeLeader(correlationId: Guid.NewGuid()));

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/when_an_error_occurs.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/when_an_error_occurs.cs
@@ -34,7 +34,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					new FakeReadIndex<TLogFormat, TStreamId>(_ => false, new MetaStreamLookup()),
 					new IODispatcher(bus, new PublishEnvelope(bus)), bus,
 					new PersistentSubscriptionConsumerStrategyRegistry(bus, bus,
-						Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>()));
+						Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>()),
+					new ParkedMessagesTracker.NoOp());
 				_envelope = new CallbackEnvelope(_replySource.SetResult);
 				_sut.Start();
 			}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1182,7 +1182,7 @@ namespace EventStore.Core {
 			var consumerStrategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry(_mainQueue, _mainBus,
 				additionalPersistentSubscriptionConsumerStrategyFactories);
 			var persistentSubscription = new PersistentSubscriptionService<TStreamId>(perSubscrQueue, readIndex, psubDispatcher,
-				_mainQueue, consumerStrategyRegistry);
+				_mainQueue, consumerStrategyRegistry, trackers.ParkedMessagesTracker);
 			perSubscrBus.Subscribe<SystemMessage.BecomeShuttingDown>(persistentSubscription);
 			perSubscrBus.Subscribe<SystemMessage.BecomeLeader>(persistentSubscription);
 			perSubscrBus.Subscribe<SystemMessage.StateChangeMessage>(persistentSubscription);

--- a/src/EventStore.Core/Metrics/ParkedMessagesMetrics.cs
+++ b/src/EventStore.Core/Metrics/ParkedMessagesMetrics.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace EventStore.Core.Metrics;
+
+public class ParkedMessagesMetrics {
+	private readonly CounterSubMetric _parkedByClient;
+	private readonly CounterSubMetric _parkedMaxRetries;
+	private readonly CounterSubMetric _parkedReplays;
+
+	public ParkedMessagesMetrics(Meter meter, string name) {
+		var counterMetric = new CounterMetric(meter, name);
+
+		_parkedByClient = new CounterSubMetric(counterMetric, new [] {
+			new KeyValuePair<string, object>("op", "park-message"),
+			new KeyValuePair<string, object>("reason", "client-nak")
+		});
+
+		_parkedMaxRetries = new CounterSubMetric(counterMetric, new [] {
+			new KeyValuePair<string, object>("op", "park-message"),
+			new KeyValuePair<string, object>("reason", "max-retries")
+		});
+
+		_parkedReplays = new CounterSubMetric(counterMetric, new [] {
+			new KeyValuePair<string, object>("op", "replay-parked-messages")
+		});
+	}
+
+	public void OnParkedMessageByClient() => _parkedByClient.Add(1);
+	public void OnParkedMessageDueToMaxRetries() => _parkedMaxRetries.Add(1);
+	public void OnParkedMessagesReplayed() => _parkedReplays.Add(1);
+}

--- a/src/EventStore.Core/Metrics/ParkedMessagesMetrics.cs
+++ b/src/EventStore.Core/Metrics/ParkedMessagesMetrics.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 
 namespace EventStore.Core.Metrics;
 
@@ -8,22 +7,20 @@ public class ParkedMessagesMetrics {
 	private readonly CounterSubMetric _parkedMaxRetries;
 	private readonly CounterSubMetric _parkedReplays;
 
-	public ParkedMessagesMetrics(Meter meter, string name) {
-		var counterMetric = new CounterMetric(meter, name);
+	public ParkedMessagesMetrics(
+		CounterMetric messagesParked,
+		CounterMetric replaysRequested) {
 
-		_parkedByClient = new CounterSubMetric(counterMetric, new [] {
-			new KeyValuePair<string, object>("op", "park-message"),
+		_parkedByClient = new CounterSubMetric(messagesParked, [
 			new KeyValuePair<string, object>("reason", "client-nak")
-		});
+		]);
 
-		_parkedMaxRetries = new CounterSubMetric(counterMetric, new [] {
-			new KeyValuePair<string, object>("op", "park-message"),
+		_parkedMaxRetries = new CounterSubMetric(messagesParked, [
 			new KeyValuePair<string, object>("reason", "max-retries")
-		});
+		]);
 
-		_parkedReplays = new CounterSubMetric(counterMetric, new [] {
-			new KeyValuePair<string, object>("op", "replay-parked-messages")
-		});
+		_parkedReplays = new CounterSubMetric(replaysRequested, [
+		]);
 	}
 
 	public void OnParkedMessageByClient() => _parkedByClient.Add(1);

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -86,6 +86,8 @@ public static class MetricsBootstrapper {
 		var queueBusyMetric = new AverageMetric(coreMeter, "eventstore-queue-busy", "seconds", label => new("queue", label));
 		var byteMetric = new CounterMetric(coreMeter, "eventstore-io", unit: "bytes");
 		var eventMetric = new CounterMetric(coreMeter, "eventstore-io", unit: "events");
+		var persistentSubscriptionsMessagesParked = new CounterMetric(coreMeter, "eventstore-persistent-subscriptions-messages-parked");
+		var persistentSubscriptionsReplaysRequested = new CounterMetric(coreMeter, "eventstore-persistent-subscriptions-replays-requested");
 
 		// incoming grpc calls
 		var enabledCalls = conf.IncomingGrpcCalls.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToArray();
@@ -233,7 +235,9 @@ public static class MetricsBootstrapper {
 
 		// persistent subscriptions
 		if (conf.PersistentSubscriptions.TryGetValue(Conf.PersistentSubscriptionTracker.ParkedMessages, out var parkedMessages) && parkedMessages) {
-			var parkedMessagesMetrics = new ParkedMessagesMetrics(coreMeter, "eventstore-persistent-subscriptions");
+			var parkedMessagesMetrics = new ParkedMessagesMetrics(
+				persistentSubscriptionsMessagesParked,
+				persistentSubscriptionsReplaysRequested);
 			trackers.ParkedMessagesTracker = new ParkedMessagesTracker(parkedMessagesMetrics);
 		}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/ParkedMessagesTracker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ParkedMessagesTracker.cs
@@ -1,0 +1,38 @@
+using System;
+using EventStore.Core.Metrics;
+
+namespace EventStore.Core.Services.PersistentSubscription;
+
+public enum ParkReason {
+	MaxRetries,
+	ByClient
+}
+
+public interface IParkedMessagesTracker {
+	void OnMessageParked(ParkReason parkReason);
+	void OnParkedMessagesReplayed();
+}
+
+public class ParkedMessagesTracker(ParkedMessagesMetrics metrics) : IParkedMessagesTracker {
+	public void OnMessageParked(ParkReason parkReason) {
+		switch (parkReason) {
+			case ParkReason.MaxRetries:
+				metrics.OnParkedMessageDueToMaxRetries();
+				break;
+			case ParkReason.ByClient:
+				metrics.OnParkedMessageByClient();
+				break;
+			default:
+				throw new ArgumentOutOfRangeException(nameof(parkReason), parkReason, null);
+		}
+	}
+
+	public void OnParkedMessagesReplayed() {
+		metrics.OnParkedMessagesReplayed();
+	}
+
+	public class NoOp : IParkedMessagesTracker {
+		public void OnMessageParked(ParkReason parkReason) { }
+		public void OnParkedMessagesReplayed() { }
+	}
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -24,7 +24,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private readonly IPersistentSubscriptionStreamReader _streamReader;
 		private readonly IPersistentSubscriptionCheckpointReader _checkpointReader;
 		private readonly IPersistentSubscriptionCheckpointWriter _checkpointWriter;
+		private readonly IParkedMessagesTracker _parkedMessagesTracker;
 		private IPersistentSubscriptionMessageParker _messageParker;
+
 
 		public PersistentSubscriptionParams(bool resolveLinkTos, string subscriptionId,
 			IPersistentSubscriptionEventSource eventSource,
@@ -38,7 +40,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			IPersistentSubscriptionStreamReader streamReader,
 			IPersistentSubscriptionCheckpointReader checkpointReader,
 			IPersistentSubscriptionCheckpointWriter checkpointWriter,
-			IPersistentSubscriptionMessageParker messageParker) {
+			IPersistentSubscriptionMessageParker messageParker,
+			IParkedMessagesTracker parkedMessagesTracker) {
 			_resolveLinkTos = resolveLinkTos;
 			_subscriptionId = subscriptionId;
 			_eventSource = eventSource;
@@ -59,6 +62,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			_checkpointReader = checkpointReader;
 			_checkpointWriter = checkpointWriter;
 			_messageParker = messageParker;
+			_parkedMessagesTracker = parkedMessagesTracker;
 		}
 
 		public bool ResolveLinkTos {
@@ -143,6 +147,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		public string ParkedMessageStream {
 			get { return "$persistentsubscription-" + _eventSource + "::" + _groupName + "-parked"; }
+		}
+
+		public IParkedMessagesTracker ParkedMessagesTracker {
+			get { return _parkedMessagesTracker; }
 		}
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
@@ -22,6 +22,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private IPersistentSubscriptionCheckpointReader _checkpointReader;
 		private IPersistentSubscriptionCheckpointWriter _checkpointWriter;
 		private IPersistentSubscriptionMessageParker _messageParker;
+		private IParkedMessagesTracker _parkedMessagesTracker = new ParkedMessagesTracker.NoOp();
 		private TimeSpan _checkPointAfter;
 		private int _minCheckPointCount;
 		private int _maxCheckPointCount;
@@ -76,6 +77,16 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		/// <returns></returns>
 		public PersistentSubscriptionParamsBuilder WithMessageParker(IPersistentSubscriptionMessageParker parker) {
 			_messageParker = parker;
+			return this;
+		}
+		
+		/// <summary>
+		/// Sets the parked message tracker for the instance
+		/// </summary>
+		/// <param name="parkedMessagesTracker"></param>
+		/// <returns></returns>
+		public PersistentSubscriptionParamsBuilder WithParkedMessageTracker(IParkedMessagesTracker parkedMessagesTracker) {
+			_parkedMessagesTracker = parkedMessagesTracker;
 			return this;
 		}
 
@@ -310,7 +321,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				builder._streamReader,
 				builder._checkpointReader,
 				builder._checkpointWriter,
-				builder._messageParker);
+				builder._messageParker,
+				builder._parkedMessagesTracker);
 		}
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1103,9 +1103,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		public void Handle(ClientMessage.ReplayParkedMessages message) {
 			PersistentSubscription subscription;
 			var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}", 
+			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}. Requested by {user}", 
 				key,
-				message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
+				message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)",
+				message.User?.Identity?.Name);
 
 			if (message.StopAt.HasValue && message.StopAt.Value < 0) {
 				message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -57,6 +57,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private readonly IODispatcher _ioDispatcher;
 		private readonly IPublisher _bus;
 		private readonly PersistentSubscriptionConsumerStrategyRegistry _consumerStrategyRegistry;
+		private readonly IParkedMessagesTracker _parkedMessagesTracker;
 		private readonly IPersistentSubscriptionCheckpointReader _checkpointReader;
 		private readonly IPersistentSubscriptionStreamReader _streamReader;
 		private PersistentSubscriptionConfig _config = new PersistentSubscriptionConfig();
@@ -67,16 +68,19 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		public PersistentSubscriptionService(IQueuedHandler queuedHandler, IReadIndex<TStreamId> readIndex,
 			IODispatcher ioDispatcher, IPublisher bus,
-			PersistentSubscriptionConsumerStrategyRegistry consumerStrategyRegistry) {
+			PersistentSubscriptionConsumerStrategyRegistry consumerStrategyRegistry,
+			IParkedMessagesTracker parkedMessagesTracker) {
 			Ensure.NotNull(queuedHandler, "queuedHandler");
 			Ensure.NotNull(readIndex, "readIndex");
 			Ensure.NotNull(ioDispatcher, "ioDispatcher");
+			Ensure.NotNull(parkedMessagesTracker, "parkedMessagesTracker");
 
 			_queuedHandler = queuedHandler;
 			_readIndex = readIndex;
 			_ioDispatcher = ioDispatcher;
 			_bus = bus;
 			_consumerStrategyRegistry = consumerStrategyRegistry;
+			_parkedMessagesTracker = parkedMessagesTracker;
 			_checkpointReader = new PersistentSubscriptionCheckpointReader(_ioDispatcher);
 			_streamReader = new PersistentSubscriptionStreamReader(_ioDispatcher, 100);
 			_timerTickCorrelationId = Guid.NewGuid();
@@ -483,7 +487,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					_streamReader,
 					_checkpointReader,
 					new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
-					new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
+					new PersistentSubscriptionMessageParker(key, _ioDispatcher),
+					_parkedMessagesTracker));
 
 			var updateEntry = new PersistentSubscriptionEntry {
 				Stream = stream, //'Stream' name kept for backward compatibility
@@ -693,8 +698,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					_streamReader,
 					_checkpointReader,
 					new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
-					new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
-			
+					new PersistentSubscriptionMessageParker(key, _ioDispatcher),
+					_parkedMessagesTracker));
+
 			UpdateSubscription(stream, groupName, subscription);
 			return true;
 


### PR DESCRIPTION
Added: Metrics for parked persistent subscription messages

```
# TYPE eventstore_persistent_subscriptions_messages_parked counter
eventstore_persistent_subscriptions_messages_parked{reason="client-nak"} 0 1736938919662
eventstore_persistent_subscriptions_messages_parked{reason="max-retries"} 0 1736938919662

# TYPE eventstore_persistent_subscriptions_replays_requested counter
eventstore_persistent_subscriptions_replays_requested 0 1736938919662
```

Also logs the username of the user who requested parked messages to be replayed.