### PR TITLE
[KDB-442] Rename ArchivedChunkMetadata.Size to ArchivedChunkMetadata.PhysicalSize

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/ArchiveReaderEmptyChunks.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/ArchiveReaderEmptyChunks.cs
@@ -23,7 +23,7 @@ class ArchiveReaderEmptyChunks(long chunkSize, long chunksInArchive) : IArchiveS
 	public ValueTask<long> GetCheckpoint(CancellationToken ct) => new(chunkSize * chunksInArchive);
 
 	public ValueTask<ArchivedChunkMetadata> GetMetadataAsync(int logicalChunkNumber, CancellationToken token) =>
-		ValueTask.FromResult<ArchivedChunkMetadata>(new(Size: FileSize));
+		ValueTask.FromResult<ArchivedChunkMetadata>(new(PhysicalSize: FileSize));
 
 	public ValueTask<int> ReadAsync(int logicalChunkNumber, Memory<byte> buffer, long offset, CancellationToken ct) {
 		if (ct.IsCancellationRequested)

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
@@ -79,6 +79,6 @@ internal class FakeArchiveStorage : IArchiveStorage {
 	}
 
 	public ValueTask<ArchivedChunkMetadata> GetMetadataAsync(int logicalChunkNumber, CancellationToken token) {
-		return ValueTask.FromResult<ArchivedChunkMetadata>(new(Size: _fileSize));
+		return ValueTask.FromResult<ArchivedChunkMetadata>(new(PhysicalSize: _fileSize));
 	}
 }

--- a/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
@@ -47,7 +47,7 @@ public class ArchiveStorage(
 		try {
 			var objectName = chunkNameResolver.ResolveFileName(logicalChunkNumber);
 			var metadata = await blobStorage.GetMetadataAsync(objectName, ct);
-			return new(Size: metadata.Size);
+			return new(PhysicalSize: metadata.Size);
 		} catch (FileNotFoundException) {
 			throw new ChunkDeletedException();
 		}

--- a/src/EventStore.Core/Services/Archive/Storage/ArchivedChunkHandle.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchivedChunkHandle.cs
@@ -27,7 +27,7 @@ internal sealed class ArchivedChunkHandle : IChunkHandle {
 
 	public static async ValueTask<IChunkHandle> OpenForReadAsync(IArchiveStorageReader reader, int logicalChunkNumber, CancellationToken token) {
 		var metadata = await reader.GetMetadataAsync(logicalChunkNumber, token);
-		return new ArchivedChunkHandle(reader, logicalChunkNumber, metadata.Size);
+		return new ArchivedChunkHandle(reader, logicalChunkNumber, metadata.PhysicalSize);
 	}
 
 	void IFlushable.Flush() {

--- a/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageReader.cs
@@ -16,4 +16,4 @@ public interface IArchiveStorageReader {
 	ValueTask<ArchivedChunkMetadata> GetMetadataAsync(int logicalChunkNumber, CancellationToken token);
 }
 
-public readonly record struct ArchivedChunkMetadata(long Size);
+public readonly record struct ArchivedChunkMetadata(long PhysicalSize);


### PR DESCRIPTION
It is the physical size of the file/blob, not the logical size of the chunk