### PR TITLE
[KDB-597] Change log messages and default usernames from EventStore to KurrentDB

### DIFF
--- a/src/EventStore.Common/DevCertificates/CertificateManager.cs
+++ b/src/EventStore.Common/DevCertificates/CertificateManager.cs
@@ -20,7 +20,7 @@ namespace EventStore.Common.DevCertificates;
 public abstract class CertificateManager {
 	internal const int CurrentCertificateVersion = 2;
 	internal const string EventStoreDbHttpsOid = "1.3.6.1.4.1.43941.1.1.1";
-	internal const string EventStoreHttpsOidFriendlyName = "Event Store HTTPS development certificate";
+	internal const string EventStoreHttpsOidFriendlyName = "Kurrent HTTPS development certificate";
 
 	private const string ServerAuthenticationEnhancedKeyUsageOid = "1.3.6.1.5.5.7.3.1";
 	private const string ServerAuthenticationEnhancedKeyUsageOidFriendlyName = "Server Authentication";
@@ -37,7 +37,7 @@ public abstract class CertificateManager {
                 ? new MacOSCertificateManager() as CertificateManager
                 : new UnixCertificateManager();
 #pragma warning restore CA1416 // Validate platform compatibility
-        
+
 	public static CertificateManagerEventSource Log { get; set; } = new CertificateManagerEventSource();
 
 	// Setting to 0 means we don't append the version byte,
@@ -679,9 +679,9 @@ public abstract class CertificateManager {
 	}
 
 	internal static string GetDescription(X509Certificate2 c) =>
-		$"{c.Thumbprint} - {c.Subject} - Valid from {c.NotBefore:u} to {c.NotAfter:u} - IsEventStoreDevelopmentCertificate: {IsHttpsDevelopmentCertificate(c).ToString().ToLowerInvariant()} - IsExportable: {Instance.IsExportable(c).ToString().ToLowerInvariant()}";
+		$"{c.Thumbprint} - {c.Subject} - Valid from {c.NotBefore:u} to {c.NotAfter:u} - IsKurrentDevelopmentCertificate: {IsHttpsDevelopmentCertificate(c).ToString().ToLowerInvariant()} - IsExportable: {Instance.IsExportable(c).ToString().ToLowerInvariant()}";
 
-	[EventSource(Name = "eventstore-dev-certs")]
+	[EventSource(Name = "kurrentdb-dev-certs")]
 	public sealed class CertificateManagerEventSource : EventSource {
 		[Event(1, Level = EventLevel.Verbose, Message = "Listing certificates from {0}\\{1}")]
 		[UnconditionalSuppressMessage("Trimming", "IL2026",
@@ -885,7 +885,7 @@ public abstract class CertificateManager {
 		internal void LoadCertificateError(string error) => WriteEvent(63, error);
 
 		[Event(64, Level = EventLevel.Error,
-			Message = "The provided certificate '{0}' is not a valid Event Store HTTPS development certificate.")]
+			Message = "The provided certificate '{0}' is not a valid Kurrent HTTPS development certificate.")]
 		internal void NoHttpsDevelopmentCertificate(string description) => WriteEvent(64, description);
 	}
 

--- a/src/EventStore.Common/Utils/VersionInfo.cs
+++ b/src/EventStore.Common/Utils/VersionInfo.cs
@@ -24,7 +24,7 @@ public static class VersionInfo {
 	public static string CommitSha { get; private set; } = ThisAssembly.Git.Commit;
 	public static string Timestamp { get; private set; } = ThisAssembly.Git.CommitDate;
 
-	public static string Text => $"EventStoreDB version {Version} {Edition} ({BuildId}/{CommitSha})";
+	public static string Text => $"KurrentDB version {Version} {Edition} ({BuildId}/{CommitSha})";
 
 	static VersionInfo() {
 		// the official release assemblies contain the version prefix (4 part number)

--- a/src/EventStore.Core.Tests/ClientAPI/UserManagement/get_current_user.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/UserManagement/get_current_user.cs
@@ -15,6 +15,6 @@ public class get_current_user<TLogFormat, TStreamId> : TestWithNode<TLogFormat, 
 	public async Task returns_the_current_user() {
 		var x = await _manager.GetCurrentUserAsync(new UserCredentials("admin", "changeit"));
 		Assert.AreEqual("admin", x.LoginName);
-		Assert.AreEqual("Event Store Administrator", x.FullName);
+		Assert.AreEqual("KurrentDB Administrator", x.FullName);
 	}
 }

--- a/src/EventStore.Core.Tests/ClientAPI/UserManagement/list_users.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/UserManagement/list_users.cs
@@ -17,9 +17,9 @@ public class list_users<TLogFormat, TStreamId> : TestWithNode<TLogFormat, TStrea
 		var x = await _manager.ListAllAsync(new UserCredentials("admin", "changeit"));
 		Assert.AreEqual(3, x.Count);
 		Assert.AreEqual("admin", x[0].LoginName);
-		Assert.AreEqual("Event Store Administrator", x[0].FullName);
+		Assert.AreEqual("KurrentDB Administrator", x[0].FullName);
 		Assert.AreEqual("ops", x[1].LoginName);
-		Assert.AreEqual("Event Store Operations", x[1].FullName);
+		Assert.AreEqual("KurrentDB Operations", x[1].FullName);
 		Assert.AreEqual("ouro", x[2].LoginName);
 		Assert.AreEqual("ourofull", x[2].FullName);
 	}

--- a/src/EventStore.Core.Tests/Services/PeriodicLogs/PeriodicallyLoggingServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/PeriodicLogs/PeriodicallyLoggingServiceTests.cs
@@ -24,15 +24,15 @@ public class PeriodicallyLoggingServiceTests {
 		_logger = new FakeLogger();
 		_esVersion = "0.0.0.0";
 	}
-	
+
 	[Test]
 	public void on_start() {
 		// given
 		var sut = new PeriodicallyLoggingService(_publisher, _esVersion, _logger);
-		
+
 		// when
 		sut.Handle(new SystemMessage.SystemStart());
-		
+
 		// then
 		Assert.IsInstanceOf<MonitoringMessage.CheckEsVersion>(_publisher.Messages.Single());
 		Assert.IsEmpty(_logger.LogMessages);
@@ -42,17 +42,17 @@ public class PeriodicallyLoggingServiceTests {
 	public void log_es_version_periodically() {
 		// given
 		var sut = new PeriodicallyLoggingService(_publisher, _esVersion, _logger);
-		
+
 		// when
 		sut.Handle(new MonitoringMessage.CheckEsVersion());
-		
+
 		// then
 		var schedule = (TimerMessage.Schedule)_publisher.Messages.Single();
 		Assert.AreEqual(TimeSpan.FromHours(12), schedule.TriggerAfter);
 		Assert.IsInstanceOf<MonitoringMessage.CheckEsVersion>(schedule.ReplyMessage);
 
 		var logMessage = _logger.LogMessages.Single();
-		Assert.AreEqual($"Current version of Event Store is : \"0.0.0.0\" ", logMessage.RenderMessage());
-	} 
+		Assert.AreEqual($"Current version of KurrentDB is : \"0.0.0.0\" ", logMessage.RenderMessage());
+	}
 
 }

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -354,7 +354,7 @@ public class ClusterVNodeOptionsTests {
 
 		var options = ClusterVNodeOptions.FromConfiguration(config);
 		options.GetDeprecationWarnings().Should().Be(
-			"The EnableHistograms setting has been deprecated as of version 24.10.0 and currently has no effect. Please contact EventStore if this feature is of interest to you." +
+			"The EnableHistograms setting has been deprecated as of version 24.10.0 and currently has no effect. Please contact Kurrent if this feature is of interest to you." +
 			Environment.NewLine +
 			"AtomPub over HTTP Interface has been deprecated as of version 20.6.0. It is recommended to use gRPC instead" +
 			Environment.NewLine);

--- a/src/EventStore.Core/Authentication/InternalAuthentication/UserManagementService.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/UserManagementService.cs
@@ -464,7 +464,7 @@ public class UserManagementService :
 	void CreateAdminUser() {
 		var userData = CreateUserData(
 			SystemUsers.Admin,
-			"Event Store Administrator",
+			"KurrentDB Administrator",
 			[SystemRoles.Admins],
 			_defaultUserOptions.DefaultAdminPassword
 		);
@@ -515,7 +515,7 @@ public class UserManagementService :
 	void CreateOperationsUser() {
 		var userData = CreateUserData(
 			SystemUsers.Operations,
-			"Event Store Operations",
+			"KurrentDB Operations",
 			[SystemRoles.Operations],
 			_defaultUserOptions.DefaultOpsPassword
 		);

--- a/src/EventStore.Core/Cluster/ClientClusterInfo.cs
+++ b/src/EventStore.Core/Cluster/ClientClusterInfo.cs
@@ -59,7 +59,7 @@ public class ClientClusterInfo {
 
 		public int NodePriority { get; set; }
 		public bool IsReadOnlyReplica { get; set; }
-		
+
 		public string ESVersion { get; set; }
 
 		public ClientMemberInfo() {
@@ -123,7 +123,7 @@ public class ClientClusterInfo {
 				$"HttpEndPointIp: {HttpEndPointIp}, HttpEndPointPort: {HttpEndPointPort}, " +
 				$"LastCommitPosition: {LastCommitPosition}, WriterCheckpoint: {WriterCheckpoint}, ChaserCheckpoint: {ChaserCheckpoint}, " +
 				$"EpochPosition: {EpochPosition}, EpochNumber: {EpochNumber}, EpochId: {EpochId:B}, NodePriority: {NodePriority}, " +
-				$"IsReadOnlyReplica: {IsReadOnlyReplica}, ESVersion: ${ESVersion}";
+				$"IsReadOnlyReplica: {IsReadOnlyReplica}, DBVersion: ${ESVersion}";
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -384,7 +384,7 @@ public class ClusterVNode<TStreamId> :
 				} catch (UnauthorizedAccessException) {
 					if (dbPath == Locations.DefaultDataDirectory) {
 						Log.Information(
-							"Access to path {dbPath} denied. The Event Store database will be created in {fallbackDefaultDataDirectory}",
+							"Access to path {dbPath} denied. The KurrentDB database will be created in {fallbackDefaultDataDirectory}",
 							dbPath, Locations.FallbackDefaultDataDirectory);
 						dbPath = Locations.FallbackDefaultDataDirectory;
 						Log.Information("Defaulting DB Path to {dbPath}", dbPath);

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -104,10 +104,10 @@ public partial record ClusterVNodeOptions {
 
 	[Description("Dev Mode Options")]
 	public record DevModeOptions {
-		[Description("Runs EventStoreDB in dev mode. This will create and add dev certificates to your certificate store, enable atompub over http, and run standard projections.")]
+		[Description("Runs KurrentDB in dev mode. This will create and add dev certificates to your certificate store, enable atompub over http, and run standard projections.")]
 		public bool Dev { get; init; } = false;
 
-		[Description("Removes any dev certificates installed on this computer without starting EventStoreDB.")]
+		[Description("Removes any dev certificates installed on this computer without starting KurrentDB.")]
 		public bool RemoveDevCerts { get; init; } = false;
 	}
 
@@ -123,7 +123,7 @@ public partial record ClusterVNodeOptions {
 		[Description("Print effective configuration to console and then exit.")]
 		public bool WhatIf { get; init; } = false;
 
-		[Description("Allows EventStoreDB to run with unknown configuration options present.")]
+		[Description("Allows KurrentDB to run with unknown configuration options present.")]
 		public bool AllowUnknownOptions { get; init; } = false;
 
 		[Description("Disable HTTP caching.")] public bool DisableHttpCaching { get; init; } = false;
@@ -138,7 +138,7 @@ public partial record ClusterVNodeOptions {
 		[Description("Enables the tracking of various histograms in the backend, " +
 		             "typically only used for debugging, etc.")]
 		[Deprecated("The EnableHistograms setting has been deprecated as of version 24.10.0 and currently has no effect. " +
-					"Please contact EventStore if this feature is of interest to you.")]
+					"Please contact Kurrent if this feature is of interest to you.")]
 		public bool EnableHistograms { get; init; } = false;
 
 		[Description("Log Http Requests and Responses before processing them.")]
@@ -243,7 +243,7 @@ public partial record ClusterVNodeOptions {
 		public string? TrustedRootCertificatesPath { get; init; } =
 			Locations.DefaultTrustedRootCertificateDirectory;
 
-		[Description("The pattern the CN (Common Name) of a connecting EventStoreDB node must match to be authenticated. A wildcard FQDN can be specified if using wildcard certificates or if the CN is not the same on all nodes. Leave empty to automatically use the CN of this node's certificate.")]
+		[Description("The pattern the CN (Common Name) of a connecting KurrentDB node must match to be authenticated. A wildcard FQDN can be specified if using wildcard certificates or if the CN is not the same on all nodes. Leave empty to automatically use the CN of this node's certificate.")]
 		public string CertificateReservedNodeCommonName { get; init; } = string.Empty;
 	}
 
@@ -384,7 +384,7 @@ public partial record ClusterVNodeOptions {
 		[Description("Enables Unbuffered/DirectIO when writing to the file system, this bypasses filesystem " +
 		             "caches.")]
 		[Deprecated("The Unbuffered setting has been deprecated as of version 24.6.0 and currently has no effect. " +
-		            "Please contact EventStore if this feature is of interest to you.")]
+		            "Please contact Kurrent if this feature is of interest to you.")]
 		public bool Unbuffered { get; init; } = false;
 
 		[Description("The initial number of readers to start when opening a TFChunk.")]

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -71,7 +71,7 @@ public static class ClusterVNodeOptionsValidator {
 
 		if (options.Database.Db.StartsWith("~")) {
 			throw new ApplicationInitializationException(
-				"The given database path starts with a '~'. Event Store does not expand '~'.");
+				"The given database path starts with a '~'. KurrentDB does not expand '~'.");
 		}
 
 		if (options.Database.Index != null && options.Database.Db != null) {

--- a/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
@@ -64,7 +64,7 @@ public class EventStoreLoggerConfiguration {
 
 		if (logsDirectory.StartsWith("~")) {
 			throw new ApplicationInitializationException(
-				"The given log path starts with a '~'. Event Store does not expand '~'.");
+				"The given log path starts with a '~'. KurrentDB does not expand '~'.");
 		}
 
 		var configurationRoot = new ConfigurationBuilder()
@@ -75,7 +75,7 @@ public class EventStoreLoggerConfiguration {
 
 		Serilog.Log.Logger = (configurationRoot.GetSection("Serilog").Exists()
 				? new LoggerConfiguration()
-					.Enrich.WithProperty(Constants.SourceContextPropertyName, "EventStore")
+					.Enrich.WithProperty(Constants.SourceContextPropertyName, "KurrentDB")
 					.ReadFrom.Configuration(configurationRoot)
 				: Default(logsDirectory, componentName, configurationRoot, logConsoleFormat, logFileInterval,
 					logFileSize, logFileRetentionCount, disableLogFile))
@@ -204,7 +204,7 @@ public class EventStoreLoggerConfiguration {
 
 	private static LoggerConfiguration StandardLoggerConfiguration =>
 		new LoggerConfiguration()
-			.Enrich.WithProperty(Constants.SourceContextPropertyName, "EventStore")
+			.Enrich.WithProperty(Constants.SourceContextPropertyName, "KurrentDB")
 			.Enrich.WithProcessId()
 			.Enrich.WithThreadId()
 			.Enrich.FromLogContext();

--- a/src/EventStore.Core/Log/SerilogEventListener.cs
+++ b/src/EventStore.Core/Log/SerilogEventListener.cs
@@ -10,7 +10,7 @@ namespace EventStore.Common.Log;
 
 public class SerilogEventListener : EventListener {
 	private readonly Dictionary<string, LogEventLevel> _eventSources = new() {
-		{ "eventstore-dev-certs", LogEventLevel.Verbose }
+		{ "kurrentdb-dev-certs", LogEventLevel.Verbose }
 	};
 
 	protected override void OnEventSourceCreated(EventSource eventSource) {

--- a/src/EventStore.Core/Services/Gossip/ClusterMultipleVersionsLogger.cs
+++ b/src/EventStore.Core/Services/Gossip/ClusterMultipleVersionsLogger.cs
@@ -24,7 +24,7 @@ public class ClusterMultipleVersionsLogger : IHandle<GossipMessage.GossipUpdated
 		Dictionary<EndPoint, string> ipAddressVsVersion = GetIPAddressVsVersion(updatedCluster, out int numDistinctKnownVersions);
 		if (numDistinctKnownVersions > 1) {
 			IEnumerable<string> ipAndVersion = ipAddressVsVersion.Select(keyvalue => $"({keyvalue.Key},{keyvalue.Value})");
-			Log.Warning($"MULTIPLE ES VERSIONS ON CLUSTER NODES FOUND [ {string.Join(", ", ipAndVersion)} ]");
+			Log.Warning($"MULTIPLE DB VERSIONS ON CLUSTER NODES FOUND [ {string.Join(", ", ipAndVersion)} ]");
 		}
 	}
 

--- a/src/EventStore.Core/Services/PeriodicLogs/PeriodicallyLoggingService.cs
+++ b/src/EventStore.Core/Services/PeriodicLogs/PeriodicallyLoggingService.cs
@@ -10,12 +10,12 @@ using Serilog;
 
 namespace EventStore.Core.Services.PeriodicLogs;
 
-public class PeriodicallyLoggingService : 
+public class PeriodicallyLoggingService :
 	IHandle<SystemMessage.SystemStart>,
 	IHandle<MonitoringMessage.CheckEsVersion> {
 
 	private static readonly TimeSpan _interval = TimeSpan.FromHours(12);
-	
+
 	private readonly IPublisher _publisher;
 	private readonly string _esVersion;
 	private readonly ILogger _logger;
@@ -37,8 +37,8 @@ public class PeriodicallyLoggingService :
 	}
 
 	public void Handle(MonitoringMessage.CheckEsVersion message) {
-		_logger.Information("Current version of Event Store is : {esVersion} ", _esVersion);
+		_logger.Information("Current version of KurrentDB is : {dbVersion} ", _esVersion);
 		_publisher.Publish(_esVersionScheduleLog);
 	}
-	
+
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -54,6 +54,7 @@ public class InfoController : IHttpController, IHandle<SystemMessage.StateChange
 		entity.ReplyTextContent(
 			Codec.Json.To(
 				new {
+					DBVersion = VersionInfo.Version,
 					ESVersion = VersionInfo.Version,
 					State = _currentState.ToString().ToLower(),
 					Features = _features,

--- a/src/EventStore.Core/Telemetry/TelemetrySink.cs
+++ b/src/EventStore.Core/Telemetry/TelemetrySink.cs
@@ -57,11 +57,11 @@ public class TelemetrySink : ITelemetrySink {
 		sb.AppendLine("---------");
 
 		if (_optout) {
-			sb.AppendLine("You have opted out of sending telemetry by setting the EVENTSTORE_TELEMETRY_OPTOUT environment variable to true.");
+			sb.AppendLine("You have opted out of sending telemetry by setting the KURRENTDB_TELEMETRY_OPTOUT environment variable to true.");
 		} else {
-			sb.Append("EventStoreDB collects usage data in order to improve your experience. ");
-			sb.AppendLine("The data is anonymous and collected by Event Store Ltd.");
-			sb.AppendLine("You can opt out of sending telemetry by setting the EVENTSTORE_TELEMETRY_OPTOUT environment variable to true.");
+			sb.Append("KurrentDB collects usage data in order to improve your experience. ");
+			sb.AppendLine("The data is anonymous and collected by Kurrent, Inc.");
+			sb.AppendLine("You can opt out of sending telemetry by setting the KURRENTDB_TELEMETRY_OPTOUT environment variable to true.");
 		}
 
 		sb.AppendLine("For more information visit https://eventstore.com/telemetry");

--- a/src/EventStore.Licensing.Tests/Keygen/KeygenLicenseProviderTests.cs
+++ b/src/EventStore.Licensing.Tests/Keygen/KeygenLicenseProviderTests.cs
@@ -135,14 +135,14 @@ public class KeygenLicenseProviderTests {
 		var endpointInfo = LicenseSummary.SelectForEndpoint(esdbLicense);
 		Assert.Equal(9, endpointInfo.Count);
 		Assert.Equal("Temporary License", endpointInfo["licenseId"]);
-		Assert.Equal("EventStore Ltd", endpointInfo["company"]);
+		Assert.Equal("Kurrent, Inc", endpointInfo["company"]);
 		Assert.Equal("false", endpointInfo["isTrial"]);
 		Assert.Equal("false", endpointInfo["isExpired"]);
 		Assert.Equal("false", endpointInfo["isValid"]);
 		Assert.Equal("true", endpointInfo["isFloating"]);
 		Assert.Equal($"{expectedDaysRemaining:N2}", endpointInfo["daysRemaining"]);
 		Assert.Equal("0", endpointInfo["startDate"]);
-		Assert.Equal("License could not be validated. Please contact EventStore support.", endpointInfo["notes"]);
+		Assert.Equal("License could not be validated. Please contact Kurrent support.", endpointInfo["notes"]);
 
 		var telemetryInfo = LicenseSummary.SelectForTelemetry(esdbLicense);
 		Assert.Equal(4, telemetryInfo.Count);

--- a/src/EventStore.Licensing/Keygen/KeygenLicenseProvider.cs
+++ b/src/EventStore.Licensing/Keygen/KeygenLicenseProvider.cs
@@ -43,15 +43,15 @@ public class KeygenLicenseProvider : ILicenseProvider {
 	// technical problems taking down production deployments.
 	// The primary means of protection against license tampering is the license agreement
 	static License CreateLicense(LicenseInfo.Inconclusive licenseInfo) {
-		Log.Warning("License could not be validated. Please contact EventStore support.");
+		Log.Warning("License could not be validated. Please contact Kurrent support.");
 
 		var summary = new LicenseSummary(
 			LicenseId: "Temporary License",
-			Company: "EventStore Ltd",
+			Company: "Kurrent, Inc",
 			IsTrial: false,
 			ExpiryUnixTimeSeconds: DateTimeOffset.MaxValue.ToUnixTimeSeconds(),
 			IsValid: false,
-			Notes: "License could not be validated. Please contact EventStore support.");
+			Notes: "License could not be validated. Please contact Kurrent support.");
 
 		return CreateLicense(summary, ["ALL"]);
 	}

--- a/src/EventStore.Licensing/LicensingPlugin.cs
+++ b/src/EventStore.Licensing/LicensingPlugin.cs
@@ -65,7 +65,7 @@ public class LicensingPlugin : Plugin {
 		var clientOptions = configuration.GetSection("KurrentDB").Get<KeygenClientOptions>() ?? new();
 		if (clientOptions.Licensing.BaseUrl is not null) {
 			baseUrl = clientOptions.Licensing.BaseUrl;
-			Log.Information("Using custom licensing URL: {Url}. This requires permission from EventStore Ltd.", baseUrl);
+			Log.Information("Using custom licensing URL: {Url}. This requires permission from Kurrent, Inc.", baseUrl);
 		}
 
 		IObservable<LicenseInfo> licenses;

--- a/src/EventStore.Transport.Http/Atom/AtomSpecs.cs
+++ b/src/EventStore.Transport.Http/Atom/AtomSpecs.cs
@@ -6,7 +6,7 @@ namespace EventStore.Transport.Http.Atom;
 public class AtomSpecs {
 	public const int FeedPageSize = 20;
 
-	public const string Author = "EventStore";
+	public const string Author = "Kurrent";
 
 	public const string AtomV1Namespace = "http://www.w3.org/2005/Atom";
 	public const string AtomPubV1Namespace = "http://www.w3.org/2007/app";

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -366,19 +366,19 @@ public class TcpConnection : TcpConnectionBase, ITcpConnection {
 
 		if (_verbose) {
 			Log.Information(
-				"ES {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Received bytes: {totalBytesReceived}, Sent bytes: {totalBytesSent}",
+				"DB {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Received bytes: {totalBytesReceived}, Sent bytes: {totalBytesSent}",
 				GetType().Name, DateTime.UtcNow, RemoteEndPoint, LocalEndPoint, _connectionId,
 				TotalBytesReceived, TotalBytesSent);
 			Log.Information(
-				"ES {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Send calls: {sendCalls}, callbacks: {sendCallbacks}",
+				"DB {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Send calls: {sendCalls}, callbacks: {sendCallbacks}",
 				GetType().Name, DateTime.UtcNow, RemoteEndPoint, LocalEndPoint, _connectionId,
 				SendCalls, SendCallbacks);
 			Log.Information(
-				"ES {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Receive calls: {receiveCalls}, callbacks: {receiveCallbacks}",
+				"DB {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Receive calls: {receiveCalls}, callbacks: {receiveCallbacks}",
 				GetType().Name, DateTime.UtcNow, RemoteEndPoint, LocalEndPoint, _connectionId,
 				ReceiveCalls, ReceiveCallbacks);
 			Log.Information(
-				"ES {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Close reason: [{socketError}] {reason}",
+				"DB {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Close reason: [{socketError}] {reason}",
 				GetType().Name, DateTime.UtcNow, RemoteEndPoint, LocalEndPoint, _connectionId,
 				socketError, reason);
 		}

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -270,7 +270,7 @@ public class TcpConnectionSsl : TcpConnectionBase, ITcpConnection {
 		}
 	}
 
-	// The following method is invoked by the RemoteCertificateValidationDelegate. 
+	// The following method is invoked by the RemoteCertificateValidationDelegate.
 	public bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain,
 		SslPolicyErrors sslPolicyErrors) {
 		var (isValid, error) = _serverCertValidator(certificate, chain, sslPolicyErrors, _otherNames);
@@ -573,19 +573,19 @@ public class TcpConnectionSsl : TcpConnectionBase, ITcpConnection {
 
 		if (_verbose) {
 			Log.Information(
-				"ES {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Received bytes: {totalBytesReceived}, Sent bytes: {totalBytesSent}",
+				"DB {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Received bytes: {totalBytesReceived}, Sent bytes: {totalBytesSent}",
 				GetType().Name, DateTime.UtcNow, RemoteEndPoint, LocalEndPoint, _connectionId,
 				TotalBytesReceived, TotalBytesSent);
 			Log.Information(
-				"ES {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Send calls: {sendCalls}, callbacks: {sendCallbacks}",
+				"DB {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Send calls: {sendCalls}, callbacks: {sendCallbacks}",
 				GetType().Name, DateTime.UtcNow, RemoteEndPoint, LocalEndPoint, _connectionId,
 				SendCalls, SendCallbacks);
 			Log.Information(
-				"ES {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Receive calls: {receiveCalls}, callbacks: {receiveCallbacks}",
+				"DB {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Receive calls: {receiveCalls}, callbacks: {receiveCallbacks}",
 				GetType().Name, DateTime.UtcNow, RemoteEndPoint, LocalEndPoint, _connectionId,
 				ReceiveCalls, ReceiveCallbacks);
 			Log.Information(
-				"ES {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Close reason: [{e}] {reason}",
+				"DB {connectionType} closed [{dateTime:HH:mm:ss.fff}: N{remoteEndPoint}, L{localEndPoint}, {connectionId:B}]:Close reason: [{e}] {reason}",
 				GetType().Name, DateTime.UtcNow, RemoteEndPoint, LocalEndPoint, _connectionId,
 				socketError, reason);
 		}

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -64,14 +64,14 @@ internal static class Program {
 			}
 
 			if (options.DevMode.RemoveDevCerts) {
-				Log.Information("Removing EventStoreDB dev certs.");
+				Log.Information("Removing KurrentDB dev certs.");
 				CertificateManager.Instance.CleanupHttpsCertificates();
 				Log.Information("Dev certs removed. Exiting.");
 				return 0;
 			}
 
 			Log.Information(
-                    "{description,-25} {version} {edition} ({buildId}/{commitSha}, {timestamp})", "ES VERSION:",
+                    "{description,-25} {version} {edition} ({buildId}/{commitSha}, {timestamp})", "DB VERSION:",
 				VersionInfo.Version, VersionInfo.Edition, VersionInfo.BuildId, VersionInfo.CommitSha, VersionInfo.Timestamp
                 );
 
@@ -100,7 +100,7 @@ internal static class Program {
 			if (options.UnknownOptionsDetected && !options.Application.AllowUnknownOptions) {
 				Log.Fatal(
 					$"Found unknown options. To continue anyway, set {nameof(ClusterVNodeOptions.ApplicationOptions.AllowUnknownOptions)} to true.");
-				Log.Information("Use the --help option in the command line to see the full list of EventStoreDB configuration options.");
+				Log.Information("Use the --help option in the command line to see the full list of KurrentDB configuration options.");
 				return 1;
 			}
 


### PR DESCRIPTION
- Change instances of `EventStore` to `KurrentDB` or `Kurrent, Inc`.
- Change default log source from `EventStore` to `KurrentDB`.
- Change instances of `ESVersion` in the logs to `DBVersion`.
- Add `DBVersion` to `/info` response, we can consider `ESVersion` deprecated from the next release.
- Rename admin and ops users' full names.

Do we want the startup version log to say `DB VERSION` or `KURRENTDB VERSION` instead of `ES VERSION`?
```
[10664, 1,14:59:20.976,INF] KurrentDB         DB VERSION:        0.0.0-prerelease local (/ca67321bf, 2025-01-20T14:39:37+01:00)
```