### PR TITLE
[KDB-442] Skip verifying chunk hashes when remote

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -51,6 +51,8 @@ public sealed class ChunkLocalFileSystem : IChunkFileSystem {
 		return task;
 	}
 
+	public bool IsRemote(string locator) => false;
+
 	public ValueTask SetReadOnlyAsync(string fileName, bool value, CancellationToken token) {
 		ValueTask task;
 		if (token.IsCancellationRequested) {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/FileSystemWithArchive.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/FileSystemWithArchive.cs
@@ -38,6 +38,9 @@ public sealed class FileSystemWithArchive : IChunkFileSystem {
 			: _localFileSystem.OpenForReadAsync(fileName, hint, token);
 	}
 
+	public bool IsRemote(string locator) =>
+		_locatorCodec.Decode(locator, out _, out _);
+
 	public ValueTask SetReadOnlyAsync(string locator, bool value, CancellationToken token) {
 		return _locatorCodec.Decode(locator, out _, out var fileName)
 			? ValueTask.CompletedTask

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkFileSystem.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DotNext.Buffers;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using Serilog;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
@@ -14,11 +15,15 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 // one implementation of this interface. That implementation can compose more than one implementation
 // of IBlobFileSystem interface and act as a proxy
 public interface IChunkFileSystem {
-	ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint hint, CancellationToken token);
+	ValueTask<IChunkHandle> OpenForReadAsync(string locator, ReadOptimizationHint hint, CancellationToken token);
 
-	ValueTask SetReadOnlyAsync(string fileName, bool value, CancellationToken token);
+	ValueTask SetReadOnlyAsync(string locator, bool value, CancellationToken token);
 
 	IVersionedFileNamingStrategy NamingStrategy { get; }
+
+	// Remote means not local. It could be in any remote tier of storage, not necessarily the archive.
+	// (although at the moment the archive is the only remote tier)
+	bool IsRemote(string locator);
 
 	IChunkEnumerable GetChunks();
 
@@ -36,7 +41,11 @@ public interface IChunkFileSystem {
 }
 
 public static class ChunkFileSystem {
+	private static readonly ILogger Logger = Log.ForContext(typeof(ChunkFileSystem));
 	public static async ValueTask<ChunkHeader> ReadHeaderAsync(this IChunkFileSystem fileSystem, string fileName, CancellationToken token) {
+		if (fileSystem.IsRemote(fileName))
+			Logger.Warning("Reading remote chunk header. This is OK but should be uncommon");
+
 		using var handle = await fileSystem.OpenForReadAsync(fileName, IChunkFileSystem.ReadOptimizationHint.None, token);
 
 		var length = handle.Length;
@@ -51,6 +60,9 @@ public static class ChunkFileSystem {
 	}
 
 	public static async ValueTask<ChunkFooter> ReadFooterAsync(this IChunkFileSystem fileSystem, string fileName, CancellationToken token) {
+		if (fileSystem.IsRemote(fileName))
+			Logger.Warning("Reading remote chunk footer. This is OK but should be uncommon");
+
 		using var handle = await fileSystem.OpenForReadAsync(fileName, IChunkFileSystem.ReadOptimizationHint.None, token);
 
 		var length = handle.Length;


### PR DESCRIPTION
Because it is expensive, and remote storage such as S3 is rather robust. In the future we could make this configurable, perhaps dependent on the storage implementation

We also log warnings when reading the header/footer of a chunk outside of TFChunk itself. These methods are called on lots of chunks at once (e.g. on startup) but ought not to be called for many remote chunks. We want to be warned about it because it will be slow.