### PR TITLE
[KDB-615] Fix bug in ticks conversion: Stopwatch.Frequency is not necessarily a multiple of TimeSpan.TicksPerSecond

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Metrics/InstantTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/InstantTests.cs
@@ -9,10 +9,27 @@ namespace EventStore.Core.XUnit.Tests.Metrics;
 
 public class InstantTests {
 	[Fact]
-	public void can_measure_elapsed() {
+	public void can_measure_elapsed_seconds() {
 		var x = Instant.FromSeconds(4);
 		var y = Instant.FromSeconds(6);
 		Assert.Equal(2, y.ElapsedSecondsSince(x));
+	}
+
+	[Theory]
+	[InlineData(4, 4, 0)]
+	[InlineData(4, 6, 2_000_000)]
+	[InlineData(123, 1_000_000_000, 999_999_877_000_000)]
+	public void can_measure_elapsed_time(int startSecs, int endSecs, long elapsedMicroseconds) {
+		var x = Instant.FromSeconds(startSecs);
+		var y = Instant.FromSeconds(endSecs);
+		Assert.Equal(elapsedMicroseconds, y.ElapsedTimeSince(x).TotalMicroseconds);
+	}
+
+	[Fact]
+	public void rounds_up_elapsed_time() {
+		var x = Instant.Now;
+		var y = new Instant(x.Ticks + 1);
+		Assert.True(y.ElapsedTimeSince(x).Ticks > 0);
 	}
 
 	[Fact]

--- a/src/EventStore.Core/Time/Instant.cs
+++ b/src/EventStore.Core/Time/Instant.cs
@@ -11,17 +11,12 @@ namespace EventStore.Core.Time;
 public struct Instant : IEquatable<Instant> {
 	public static readonly long TicksPerSecond;
 	private static readonly double SecondsPerTick;
-	private static readonly long TicksPerTimeSpanTick;
+	private static readonly double TicksPerTimeSpanTick;
 
 	static Instant() {
 		TicksPerSecond = Stopwatch.Frequency;
 		SecondsPerTick =  1 / (double)TicksPerSecond;
-
-		if (TicksPerSecond % TimeSpan.TicksPerSecond != 0)
-			throw new Exception($"Expected {nameof(TicksPerSecond)} ({TicksPerSecond}) to be an exact multiple" +
-			                    $" of {nameof(TimeSpan)}.{nameof(TimeSpan.TicksPerSecond)} ({TimeSpan.TicksPerSecond})");
-
-		TicksPerTimeSpanTick = TicksPerSecond / TimeSpan.TicksPerSecond;
+		TicksPerTimeSpanTick = (double)TicksPerSecond / TimeSpan.TicksPerSecond;
 	}
 
 	public static Instant Now => new(Stopwatch.GetTimestamp());
@@ -39,7 +34,7 @@ public struct Instant : IEquatable<Instant> {
 	private readonly long _ticks;
 
 	// Stopwatch Ticks, not DateTime Ticks - these can be different.
-	private Instant(long stopwatchTicks) {
+	public Instant(long stopwatchTicks) {
 		_ticks = stopwatchTicks;
 	}
 
@@ -68,7 +63,7 @@ public struct Instant : IEquatable<Instant> {
 		var elapsedTicks = ElapsedTicksSince(since);
 		// since we're decreasing the resolution when converting to TimeSpan, we round up to make sure that something
 		// using the TimeSpan doesn't wait for less time than it should.
-		elapsedTicks = (elapsedTicks + TicksPerTimeSpanTick - 1) / TicksPerTimeSpanTick;
+		elapsedTicks = (long) Math.Ceiling(elapsedTicks / TicksPerTimeSpanTick);
 		return new TimeSpan(elapsedTicks);
 	}
 }


### PR DESCRIPTION
Fixed: Fixed bug in ticks conversion: Stopwatch.Frequency is not necessarily a multiple of TimeSpan.TicksPerSecond

Fixes: https://github.com/EventStore/EventStore/issues/4758
Fixes: https://github.com/EventStore/EventStore/issues/4726