### PR TITLE
[KDB-436] Support raw bulk reads of completed chunks that were cached before they were completed

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/tfchunk_get_actual_raw_position_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/tfchunk_get_actual_raw_position_should.cs
@@ -67,7 +67,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		var logPositions = new List<long>();
 		var posMap = new List<PosMap>();
 
-		var chunk = await CreateChunk(
+		using var chunk = await CreateChunk(
 			numEvents: numEvents,
 			completed: false,
 			scavenged: false,
@@ -87,7 +87,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		var logPositions = new List<long>();
 		var posMap = new List<PosMap>();
 
-		var chunk = await CreateChunk(
+		using var chunk = await CreateChunk(
 			numEvents: numEvents,
 			completed: true,
 			scavenged: false,
@@ -107,7 +107,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		var logPositions = new List<long>();
 		var posMap = new List<PosMap>();
 
-		var chunk = await CreateChunk(
+		using var chunk = await CreateChunk(
 			numEvents: numEvents,
 			completed: true,
 			scavenged: true,
@@ -127,7 +127,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		var logPositions = new List<long>();
 		var posMap = new List<PosMap>();
 
-		var chunk = await CreateChunk(
+		using var chunk = await CreateChunk(
 			numEvents: 1,
 			completed: true,
 			scavenged: false,
@@ -148,7 +148,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		var logPositions = new List<long>();
 		var posMap = new List<PosMap>();
 
-		var chunk = await CreateChunk(
+		using var chunk = await CreateChunk(
 			numEvents: 1,
 			completed: true,
 			scavenged: true,
@@ -167,7 +167,7 @@ public class tfchunk_get_actual_raw_position_should<TLogFormat, TStreamId> : Spe
 		var logPositions = new List<long>();
 		var posMap = new List<PosMap>();
 
-		var chunk = await CreateChunk(
+		using var chunk = await CreateChunk(
 			numEvents: 1,
 			completed: false,
 			scavenged: false,

--- a/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
@@ -73,7 +73,7 @@ public class when_closing_the_database<TLogFormat, TStreamId> : SpecificationWit
 	public async Task checkpoints_should_be_flushed_only_when_chunks_are_properly_closed(bool chunksClosed) {
 		if (!chunksClosed) {
 			// acquire a reader to prevent the chunk from being properly closed
-			await _db.Manager.GetChunk(0).AcquireRawReader(CancellationToken.None);
+			await _db.Manager.GetChunk(0).AcquireDataReader(CancellationToken.None);
 		}
 
 		var writer = new TFChunkWriter(_db);
@@ -95,5 +95,8 @@ public class when_closing_the_database<TLogFormat, TStreamId> : SpecificationWit
 			Assert.AreEqual(0L, writerChk.Read());
 			Assert.AreEqual(0L, chaserChk.Read());
 		}
+
+		writerChk.Close(flush: false);
+		chaserChk.Close(flush: false);
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
@@ -17,7 +17,7 @@ public class when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlock
 	public override async Task SetUp() {
 		await base.SetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, 1000);
-		var reader = await _chunk.AcquireRawReader(CancellationToken.None);
+		var reader = await _chunk.AcquireDataReader(CancellationToken.None);
 		_chunk.MarkForDeletion();
 		reader.Release();
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Chunks;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog;
@@ -12,6 +14,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	[Test]
 	public async Task the_file_will_not_be_deleted_until_reader_released() {
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
+		await chunk.Complete(CancellationToken.None);
 		using (var reader = await chunk.AcquireRawReader(CancellationToken.None)) {
 			chunk.MarkForDeletion();
 			var buffer = new byte[1024];
@@ -24,55 +27,76 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	}
 
 	[Test]
-	public async Task a_read_on_new_file_can_be_performed() {
+	public async Task a_raw_read_on_new_file_cannot_be_performed() {
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
+
+		Assert.ThrowsAsync<Exception>(async () => {
+			await chunk.AcquireRawReader(CancellationToken.None);
+		});
+
+		chunk.MarkForDeletion();
+		chunk.WaitForDestroy(5000);
+	}
+
+	[TestCase(false)]
+	[TestCase(true)]
+	public async Task a_raw_read_on_newly_completed_file_can_be_performed(bool cached) {
+		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
+		if (cached)
+			await chunk.CacheInMemory(CancellationToken.None);
+		await chunk.Complete(CancellationToken.None);
 		using (var reader = await chunk.AcquireRawReader(CancellationToken.None)) {
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsFalse(result.IsEOF);
 			Assert.AreEqual(1024, result.BytesRead);
+
+			var header = new ChunkHeader(buffer);
+			Assert.AreEqual(2000, header.ChunkSize);
 		}
 
 		chunk.MarkForDeletion();
 		chunk.WaitForDestroy(5000);
 	}
-/*
-        [Test]
-        public void a_read_on_scavenged_chunk_includes_map()
-        {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("afile"), 200, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
-            chunk.CompleteScavenge(new [] {new PosMap(0, 0), new PosMap(1,1) }, false);
-            using (var reader = chunk.AcquireRawReader())
-            {
-                var buffer = new byte[1024];
-                var result = reader.ReadNextBytes(1024, buffer);
-                Assert.IsFalse(result.IsEOF);
-                Assert.AreEqual(ChunkHeader.Size + ChunkHeader.Size + 2 * PosMap.FullSize, result.BytesRead);
-            }
-            chunk.MarkForDeletion();
-            chunk.WaitForDestroy(5000);
-        }
 
-        [Test]
-        public void a_read_past_end_of_completed_chunk_does_include_header_or_footer()
-        {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("File1"), 300, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
-            chunk.Complete();
-            using (var reader = chunk.AcquireRawReader())
-            {
-                var buffer = new byte[1024];
-                var result = reader.ReadNextBytes(1024, buffer);
-                Assert.IsTrue(result.IsEOF);
-                Assert.AreEqual(ChunkHeader.Size + ChunkFooter.Size, result.BytesRead); //just header + footer = 256
-            }
-            chunk.MarkForDeletion();
-            chunk.WaitForDestroy(5000);
-        }
-*/
+	/*
+			[Test]
+			public void a_read_on_scavenged_chunk_includes_map()
+			{
+				var chunk = TFChunk.CreateNew(GetFilePathFor("afile"), 200, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
+				chunk.CompleteScavenge(new [] {new PosMap(0, 0), new PosMap(1,1) }, false);
+				using (var reader = chunk.AcquireRawReader())
+				{
+					var buffer = new byte[1024];
+					var result = reader.ReadNextBytes(1024, buffer);
+					Assert.IsFalse(result.IsEOF);
+					Assert.AreEqual(ChunkHeader.Size + ChunkHeader.Size + 2 * PosMap.FullSize, result.BytesRead);
+				}
+				chunk.MarkForDeletion();
+				chunk.WaitForDestroy(5000);
+			}
+
+			[Test]
+			public void a_read_past_end_of_completed_chunk_does_include_header_or_footer()
+			{
+				var chunk = TFChunk.CreateNew(GetFilePathFor("File1"), 300, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+				chunk.Complete();
+				using (var reader = chunk.AcquireRawReader())
+				{
+					var buffer = new byte[1024];
+					var result = reader.ReadNextBytes(1024, buffer);
+					Assert.IsTrue(result.IsEOF);
+					Assert.AreEqual(ChunkHeader.Size + ChunkFooter.Size, result.BytesRead); //just header + footer = 256
+				}
+				chunk.MarkForDeletion();
+				chunk.WaitForDestroy(5000);
+			}
+	*/
 
 	[Test]
 	public async Task if_asked_for_more_than_buffer_size_will_only_read_buffer_size() {
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 3000);
+		await chunk.Complete(CancellationToken.None);
 		using (var reader = await chunk.AcquireRawReader(CancellationToken.None)) {
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -87,6 +111,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	[Test]
 	public async Task a_read_past_eof_returns_eof_and_no_footer() {
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
+		await chunk.Complete(CancellationToken.None);
 		using (var reader = await chunk.AcquireRawReader(CancellationToken.None)) {
 			var buffer = new byte[8092];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);

--- a/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
@@ -17,6 +17,7 @@ public class when_unlocking_a_tfchunk_that_has_been_marked_for_deletion : Specif
 	public override async Task SetUp() {
 		await base.SetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, 1000);
+		await _chunk.Complete(CancellationToken.None);
 		var reader = await _chunk.AcquireRawReader(CancellationToken.None);
 		_chunk.MarkForDeletion();
 		reader.Release();


### PR DESCRIPTION
Previously the raw bulk read would have missed the header and any transform because cached data of open chunks do not capture these.