### PR TITLE
[KDB-610] Handle replayed messages when retrying events

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/StreamBufferTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/StreamBufferTests.cs
@@ -231,6 +231,26 @@ public class StreamBufferTests {
 		Assert.AreEqual(2, buffer.GetLowestRetry().sequenceNumber);
 	}
 
+	[Test]
+	public void can_add_retries_after_replayed_events() {
+		var buffer = new StreamBuffer(10, 10, null, true);
+		// add parked events
+		var parkedEvent = BuildMessageAt(1);
+		buffer.AddRetry(OutstandingMessage.ForParkedEvent(Helper.BuildLinkEvent(Guid.NewGuid(), "$persistentsubscription-foo::group-parked", 0, parkedEvent.ResolvedEvent)));
+
+		// add retried events
+		buffer.AddRetry(BuildMessageAt(4));
+		buffer.AddRetry(BuildMessageAt(2));
+		buffer.AddRetry(BuildMessageAt(3));
+
+		Assert.AreEqual(2, buffer.GetLowestRetry().sequenceNumber);
+		var messagePointers = buffer.Scan().ToArray();
+		Assert.AreEqual(GetEventIdFor(1), messagePointers[0].Message.ResolvedEvent.Event.EventId);
+		Assert.AreEqual(GetEventIdFor(2), messagePointers[1].Message.EventId);
+		Assert.AreEqual(GetEventIdFor(3), messagePointers[2].Message.EventId);
+		Assert.AreEqual(GetEventIdFor(4), messagePointers[3].Message.EventId);
+	}
+
 	private OutstandingMessage BuildMessageAt(int position, Guid? forcedEventId = null) {
 		IPersistentSubscriptionStreamPosition previousEventPosition =
 			position > 0 ? Helper.GetStreamPositionFor(position - 1, _eventSource) : null;

--- a/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
@@ -78,7 +78,7 @@ public class StreamBuffer {
 
 		while (currentNode != null) {
 			var currentEventPosition = currentNode.Value.EventPosition;
-			if (retryEventPosition.CompareTo(currentEventPosition) < 0) {
+			if (currentEventPosition is not null && retryEventPosition.CompareTo(currentEventPosition) < 0) {
 				_retry.AddBefore(currentNode, ev);
 				return;
 			}


### PR DESCRIPTION
This fixes an issue where retried messages may be missed if they are retried after a parked message is already in the buffer. 

This happens because parked messages do not have an event position, so the position comparison in `AddRetry` fails with an `InvalidOperationException`:

```
 Error while processing message EventStore.Core.Messages.SubscriptionMessage+PersistentSubscriptionTimerTick in queued handler 'PersistentSubscriptions'.
System.InvalidOperationException: Operation is not valid due to the current state of the object.
   at EventStore.Core.Services.PersistentSubscription.PersistentSubscriptionSingleStreamPosition.CompareTo(IPersistentSubscriptionStreamPosition other) in D:\a\TrainStation\TrainStation\EventStore\src\EventStore.Core\Services\PersistentSubscription\PersistentSubscriptionSingleStreamPosition.cs:line 26
   at EventStore.Core.Services.PersistentSubscription.PersistentSubscription.RetryMessage(OutstandingMessage message) in D:\a\TrainStation\TrainStation\EventStore\src\EventStore.Core\Services\PersistentSubscription\PersistentSubscription.cs:line 678
   at EventStore.Core.Services.PersistentSubscription.PersistentSubscription.NotifyClockTick(DateTime time) in D:\a\TrainStation\TrainStation\EventStore\src\EventStore.Core\Services\PersistentSubscription\PersistentSubscription.cs:line 657
   at EventStore.Core.Services.PersistentSubscription.PersistentSubscriptionService1.WakeSubscriptions() in D:\\a\\TrainStation\\TrainStation\\EventStore\\src\\EventStore.Core\\Services\\PersistentSubscription\\PersistentSubscriptionService.cs:line 1367    at EventStore.Core.Services.PersistentSubscription.PersistentSubscriptionService1.Handle(PersistentSubscriptionTimerTick message) in D:\a\TrainStation\TrainStation\EventStore\src\EventStore.Core\Services\PersistentSubscription\PersistentSubscriptionService.cs:line 1355
   at EventStore.Core.Bus.IHandle1.EventStore.Core.Bus.IAsyncHandle<T>.HandleAsync(T message, CancellationToken token) in D:\\a\\TrainStation\\TrainStation\\EventStore\\src\\EventStore.Core\\Bus\\IHandle.cs:line 19 --- End of stack trace from previous location ---
   at EventStore.Core.Bus.InMemoryBus.MessageTypeHandler1.InvokeAsync(Message message, CancellationToken token) in D:\a\TrainStation\TrainStation\EventStore\src\EventStore.Core\Bus\InMemoryBus.MessageHierarchy.cs:line 130
   at EventStore.Core.Bus.InMemoryBus.DispatchAndWatchSlowMsg(MessageTypeHandler handlers, Message message, CancellationToken token) in D:\a\TrainStation\TrainStation\EventStore\src\EventStore.Core\Bus\InMemoryBus.cs:line 81
   at EventStore.Core.Bus.QueuedHandlerThreadPool.System.Threading.IThreadPoolWorkItem.Execute() in D:\a\TrainStation\TrainStation\EventStore\src\EventStore.Core\Bus\QueuedHandlerThreadPool.cs:line 157
```