### PR TITLE
[KDB-436] Add retry policy around archive access

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -5,6 +5,9 @@ linter: jetbrains/qodana-dotnet:2024.1
 dotnet:
   solution: src/EventStore.sln
 
+exclude:
+  - name: RedundantTypeArgumentsOfMethod
+
 #
 # License Audit
 #

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkRemoverTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkRemoverTests.cs
@@ -33,8 +33,7 @@ public class ChunkRemoverTests {
 	ChunkRemover<string, ILogRecord> GenSut(
 		int retainDays,
 		long retainBytes,
-		Func<long> readArchiveCheckpoint,
-		int maxAttempts = 1) {
+		Func<long> readArchiveCheckpoint) {
 
 		var sut = new ChunkRemover<string, ILogRecord>(
 			logger: Serilog.Log.Logger,
@@ -42,9 +41,7 @@ public class ChunkRemoverTests {
 			chunkManager: _chunkManager,
 			locatorCodec: new PrefixingLocatorCodec(),
 			retainPeriod: TimeSpan.FromDays(retainDays),
-			retainBytes: retainBytes,
-			maxAttempts: maxAttempts,
-			retryDelayMs: 0);
+			retainBytes: retainBytes);
 		return sut;
 	}
 
@@ -119,40 +116,6 @@ public class ChunkRemoverTests {
 		} else {
 			throw new InvalidOperationException();
 		}
-	}
-
-	[Fact]
-	public async Task when_unexpected_error_accessing_archive() {
-		var minDateInChunk = new DateTime(2024, 1, 1);
-		var maxDateInChunk = new DateTime(2024, 12, 1);
-		_backend.ChunkTimeStampRanges[1] = new(minDateInChunk, maxDateInChunk);
-
-		// chunk 1 contains records with positions 1000-2000
-		var chunk = new FakeChunk(chunkStartNumber: 1, chunkEndNumber: 1, chunkSize: 1_000);
-
-		var attempts = 0;
-
-		var sut = GenSut(
-			retainDays: 10,
-			retainBytes: 1000,
-			readArchiveCheckpoint: () => {
-				attempts++;
-				throw new Exception("something happened");
-			},
-			maxAttempts: 3);
-
-		var removing = await sut.StartRemovingIfNotRetained(
-			scavengePoint: GenScavengePoint(
-				// scavenging > 1000 bytes after the end of the chunk
-				position: chunk.ChunkEndPosition + 1001,
-				// scavenging > 10 days after the last record in the chunk
-				effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
-			concurrentState: _scavengeState,
-			physicalChunk: chunk,
-			CancellationToken.None);
-
-		Assert.False(removing);
-		Assert.Equal(3, attempts);
 	}
 
 	[Fact]

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
@@ -37,8 +37,8 @@ internal class FakeArchiveStorage : IArchiveStorage {
 		_chunkGets = [];
 	}
 
-	public ValueTask<bool> StoreChunk(IChunkBlob chunk, CancellationToken ct) => throw new NotImplementedException();
-	public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct) => throw new NotImplementedException();
+	public ValueTask StoreChunk(IChunkBlob chunk, CancellationToken ct) => throw new NotImplementedException();
+	public ValueTask SetCheckpoint(long checkpoint, CancellationToken ct) => throw new NotImplementedException();
 
 	public ValueTask<long> GetCheckpoint(CancellationToken ct) {
 		return ValueTask.FromResult(_checkpoint);

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Archiver/ArchiverServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Archiver/ArchiverServiceTests.cs
@@ -138,20 +138,20 @@ file sealed class FakeArchiveStorage : IArchiveStorage {
 		StoreChunkEvent = new(initialState: false);
 	}
 
-	public ValueTask<bool> StoreChunk(IChunkBlob chunk, CancellationToken ct) {
+	public ValueTask StoreChunk(IChunkBlob chunk, CancellationToken ct) {
 		Chunks.Add(chunk.ChunkHeader.ChunkStartNumber);
 		Interlocked.Increment(ref NumStores);
 		StoreChunkEvent.Set();
-		return ValueTask.FromResult(true);
+		return ValueTask.CompletedTask;
 	}
 
 	public ValueTask<long> GetCheckpoint(CancellationToken ct) {
 		return ValueTask.FromResult(Checkpoint);
 	}
 
-	public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct) {
+	public ValueTask SetCheckpoint(long checkpoint, CancellationToken ct) {
 		Checkpoint = checkpoint;
-		return ValueTask.FromResult(true);
+		return ValueTask.CompletedTask;
 	}
 
 	public ValueTask<int> ReadAsync(int logicalChunkNumber, Memory<byte> buffer, long offset, CancellationToken ct) {

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTests.cs
@@ -123,7 +123,7 @@ public class ArchiveStorageTests : ArchiveStorageTestsBase<ArchiveStorageTests> 
 	public async Task can_store_a_chunk(StorageType storageType) {
 		var sut = CreateSut(storageType);
 		await using var localChunk = await CreateLocalChunk(0, 0);
-		Assert.True(await sut.StoreChunk(localChunk, CancellationToken.None));
+		await sut.StoreChunk(localChunk, CancellationToken.None);
 
 		var localChunkContent = await localChunk.ReadAllBytes();
 

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/RemoteFileSystemTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/RemoteFileSystemTests.cs
@@ -43,7 +43,7 @@ public sealed class RemoteFileSystemTests : ArchiveStorageTestsBase<RemoteFileSy
 
 		// upload the chunk
 		await using (var localChunk = new FakeChunkBlob(chunkLocalPath, logicalChunkNumber, 0, FileMode.Open)) {
-			Assert.True(await archive.StoreChunk(localChunk, CancellationToken.None));
+			await archive.StoreChunk(localChunk, CancellationToken.None);
 		}
 
 		// read the remote chunk
@@ -90,7 +90,7 @@ public sealed class RemoteFileSystemTests : ArchiveStorageTestsBase<RemoteFileSy
 
 		// upload the chunk
 		await using (var localChunk = new FakeChunkBlob(chunkLocalPath, logicalChunkNumber, 0, FileMode.Open)) {
-			Assert.True(await archive.StoreChunk(localChunk, CancellationToken.None));
+			await archive.StoreChunk(localChunk, CancellationToken.None);
 		}
 
 		// read the remote chunk

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ResilientArchiveStorageTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ResilientArchiveStorageTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Archive.Storage;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using Polly;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
+
+public class ResilientArchiveStorageTests {
+	private readonly IArchiveStorage _sut;
+	private readonly FakeArchiveStorage _wrapped;
+
+	public ResilientArchiveStorageTests() {
+		var pipeline = new ResiliencePipelineBuilder()
+			.AddRetry(new() {
+				MaxRetryAttempts = 1,
+				Delay = TimeSpan.FromSeconds(0),
+			})
+			.Build();
+
+		_wrapped = new FakeArchiveStorage();
+		_sut = new ResilientArchiveStorage(pipeline, _wrapped);
+	}
+
+	[Fact]
+	public async Task can_get_checkpoint() {
+		Assert.Equal(123, await _sut.GetCheckpoint(CancellationToken.None));
+		Assert.Equal(2, _wrapped.Calls);
+	}
+
+	[Fact]
+	public async Task can_get_metadata() {
+		var metadata = await _sut.GetMetadataAsync(1, CancellationToken.None);
+		Assert.Equal(1000, metadata.PhysicalSize);
+		Assert.Equal(2, _wrapped.Calls);
+	}
+
+	[Fact]
+	public async Task can_read() {
+		Assert.Equal(10, await _sut.ReadAsync(1, Memory<byte>.Empty, 0, CancellationToken.None));
+		Assert.Equal(2, _wrapped.Calls);
+	}
+
+	[Fact]
+	public async Task can_set_checkpoint() {
+		await _sut.SetCheckpoint(123, CancellationToken.None);
+		Assert.Equal(2, _wrapped.Calls);
+	}
+
+	[Fact]
+	public async Task can_store_chunk() {
+		await _sut.StoreChunk(null, CancellationToken.None);
+		Assert.Equal(2, _wrapped.Calls);
+	}
+
+	// throws an exception on the first call
+	class FakeArchiveStorage : IArchiveStorage {
+		public int Calls { get; private set; }
+
+		private ValueTask OnCall() =>
+			Calls++ == 0
+				? ValueTask.FromException(new Exception("some exception"))
+				: ValueTask.CompletedTask;
+
+		public async ValueTask<long> GetCheckpoint(CancellationToken ct) {
+			await OnCall();
+			return 123;
+		}
+
+		public async ValueTask<ArchivedChunkMetadata> GetMetadataAsync(int logicalChunkNumber, CancellationToken token) {
+			await OnCall();
+			return new(PhysicalSize: logicalChunkNumber * 1000);
+		}
+
+		public async ValueTask<int> ReadAsync(int logicalChunkNumber, Memory<byte> buffer, long offset, CancellationToken ct) {
+			await OnCall();
+			return logicalChunkNumber * 10;
+		}
+
+		public async ValueTask SetCheckpoint(long checkpoint, CancellationToken ct) {
+			await OnCall();
+		}
+
+		public async ValueTask StoreChunk(IChunkBlob chunk, CancellationToken ct) {
+			await OnCall();
+		}
+	}
+}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -21,6 +21,7 @@
 		<PackageReference Include="Microsoft.FASTER.Core" Version="1.9.16" />
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.1" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.1" />
+		<PackageReference Include="Polly.Core" Version="8.5.1" />
 		<PackageReference Include="Quickenshtein" Version="1.5.1" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />

--- a/src/EventStore.Core/Resilience/PipelineExecutor.cs
+++ b/src/EventStore.Core/Resilience/PipelineExecutor.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Polly;
+using Serilog;
+
+namespace EventStore.Core.Resilience;
+
+// Executes a ResiliencePipeline in the context of an operation * logger
+public class PipelineExecutor(ResiliencePipeline pipeline, string operationPrefix, ILogger logger) {
+	private ResilienceContext GetContext(string operation, CancellationToken ct) {
+		var context = ResilienceContextPool.Shared.Get($"{operationPrefix}.{operation}", ct);
+		context.Properties.Set(ResilienceKeys.Logger, logger);
+		return context;
+	}
+
+	private static void Return(ResilienceContext context) =>
+		ResilienceContextPool.Shared.Return(context);
+
+	public async ValueTask ExecuteAsync<TState>(
+		Func<ResilienceContext, TState, ValueTask> func,
+		TState state,
+		CancellationToken ct,
+		[CallerMemberName] string memberName = "") {
+
+		var context = GetContext(memberName, ct);
+		try {
+			await pipeline.ExecuteAsync(func, context, state);
+		} finally {
+			Return(context);
+		}
+	}
+
+	public async ValueTask<TResult> ExecuteAsync<TResult, TState>(
+		Func<ResilienceContext, TState, ValueTask<TResult>> func,
+		TState state,
+		CancellationToken ct,
+		[CallerMemberName] string memberName = "") {
+
+		var context = GetContext(memberName, ct);
+		try {
+			return await pipeline.ExecuteAsync(func, context, state);
+		} finally {
+			Return(context);
+		}
+	}
+}
+

--- a/src/EventStore.Core/Resilience/ResilienceKeys.cs
+++ b/src/EventStore.Core/Resilience/ResilienceKeys.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using Polly;
+using Serilog;
+
+namespace EventStore.Core.Resilience;
+
+public static class ResilienceKeys {
+	public static ResiliencePropertyKey<ILogger> Logger { get; } = new("logger");
+}

--- a/src/EventStore.Core/Resilience/ResiliencePipelines.cs
+++ b/src/EventStore.Core/Resilience/ResiliencePipelines.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Threading.Tasks;
+using Polly;
+using Serilog;
+
+namespace EventStore.Core.Resilience;
+
+public static class ResiliencePipelines {
+	public static ResiliencePipeline RetrySlow { get; } = BuildRetryPipeline(maxRetryAttempts: 5);
+
+	public static ResiliencePipeline RetryForever { get; } = BuildRetryPipeline(maxRetryAttempts: int.MaxValue);
+
+	private static ResiliencePipeline BuildRetryPipeline(int maxRetryAttempts) =>
+		new ResiliencePipelineBuilder()
+			.AddRetry(new() {
+				BackoffType = DelayBackoffType.Exponential,
+				Delay = TimeSpan.FromSeconds(1),
+				MaxDelay = TimeSpan.FromSeconds(60),
+				MaxRetryAttempts = maxRetryAttempts,
+				OnRetry = args => {
+					var logger = args.Context.Properties.TryGetValue(ResilienceKeys.Logger, out var log)
+						? log
+						: Log.Logger;
+
+					logger.Warning(
+						"Retrying {Operation}. Attempt {Attempt}. Duration {Duration}. Delay {Delay}. " +
+						"Error: {ExceptionMessage} ({ExceptionType})",
+						args.Context.OperationKey,
+						args.AttemptNumber,
+						args.Duration,
+						args.RetryDelay,
+						args.Outcome.Exception?.Message,
+						args.Outcome.Exception?.GetType().Name);
+
+					return ValueTask.CompletedTask;
+				},
+			})
+			.Build();
+}

--- a/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
+++ b/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
@@ -75,7 +75,7 @@ public class ArchivePlugableComponent : IPlugableComponent {
 			services.AddSingleton<IChunkUnmerger, ChunkUnmerger>();
 			services.AddSingleton<ArchiverService>(s => {
 				var archiveStorage = s.GetRequiredService<IArchiveStorage>();
-				return new ArchiverService(
+				return new(
 					mainBus: s.GetRequiredService<ISubscriber>(),
 					archiveStorage: new ResilientArchiveStorage(ResiliencePipelines.RetryForever, archiveStorage),
 					chunkManager: s.GetRequiredService<IChunkRegistry<IChunkBlob>>());

--- a/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
+++ b/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
@@ -3,11 +3,15 @@
 
 using System;
 using System.Collections.Generic;
+using EventStore.Core.Bus;
 using EventStore.Core.Configuration.Sources;
+using EventStore.Core.Resilience;
 using EventStore.Core.Services.Archive.Archiver;
-using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.Services.Archive.Archiver.Unmerger;
 using EventStore.Core.Services.Archive.Naming;
+using EventStore.Core.Services.Archive.Storage;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Plugins;
 using EventStore.Plugins.Licensing;
 using Microsoft.AspNetCore.Builder;
@@ -69,7 +73,13 @@ public class ArchivePlugableComponent : IPlugableComponent {
 
 		if (_isArchiver) {
 			services.AddSingleton<IChunkUnmerger, ChunkUnmerger>();
-			services.AddSingleton<ArchiverService>();
+			services.AddSingleton<ArchiverService>(s => {
+				var archiveStorage = s.GetRequiredService<IArchiveStorage>();
+				return new ArchiverService(
+					mainBus: s.GetRequiredService<ISubscriber>(),
+					archiveStorage: new ResilientArchiveStorage(ResiliencePipelines.RetryForever, archiveStorage),
+					chunkManager: s.GetRequiredService<IChunkRegistry<IChunkBlob>>());
+			});
 		}
 	}
 
@@ -88,7 +98,9 @@ public class ArchivePlugableComponent : IPlugableComponent {
 			chaserCheckpoint: standardComponents.DbConfig.ChaserCheckpoint,
 			epochCheckpoint: standardComponents.DbConfig.EpochCheckpoint,
 			chunkSize: standardComponents.DbConfig.ChunkSize,
-			serviceProvider.GetRequiredService<IArchiveStorage>(),
+			new ResilientArchiveStorage(
+				ResiliencePipelines.RetryForever,
+				serviceProvider.GetRequiredService<IArchiveStorage>()),
 			serviceProvider.GetRequiredService<IArchiveChunkNameResolver>()));
 
 		return newStartupTasks;

--- a/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
@@ -60,9 +60,6 @@ public class ArchiveStorage(
 		try {
 			BinaryPrimitives.WriteInt64LittleEndian(buffer.Span, checkpoint);
 			await blobStorage.StoreAsync(stream, archiveCheckpointFile, ct);
-		} catch (Exception ex) when (ex is not OperationCanceledException) {
-			Log.Error(ex, "Error while setting checkpoint to: {checkpoint} (0x{checkpoint:X})",
-				checkpoint, checkpoint);
 		} finally {
 			await stream.DisposeAsync();
 			buffer.Dispose();

--- a/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
@@ -22,8 +22,6 @@ public class ArchiveStorage(
 	string archiveCheckpointFile)
 	: IArchiveStorage {
 
-	private static readonly ILogger Log = Serilog.Log.ForContext<ArchiveStorage>();
-
 	public async ValueTask<long> GetCheckpoint(CancellationToken ct) {
 		try {
 			using var buffer = Memory.AllocateExactly<byte>(sizeof(long));

--- a/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
@@ -54,24 +54,22 @@ public class ArchiveStorage(
 		}
 	}
 
-	public async ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct) {
+	public async ValueTask SetCheckpoint(long checkpoint, CancellationToken ct) {
 		var buffer = Memory.AllocateExactly<byte>(sizeof(long));
 		var stream = StreamSource.AsStream(buffer.Memory);
 		try {
 			BinaryPrimitives.WriteInt64LittleEndian(buffer.Span, checkpoint);
 			await blobStorage.StoreAsync(stream, archiveCheckpointFile, ct);
-			return true;
 		} catch (Exception ex) when (ex is not OperationCanceledException) {
 			Log.Error(ex, "Error while setting checkpoint to: {checkpoint} (0x{checkpoint:X})",
 				checkpoint, checkpoint);
-			return false;
 		} finally {
 			await stream.DisposeAsync();
 			buffer.Dispose();
 		}
 	}
 
-	public async ValueTask<bool> StoreChunk(IChunkBlob chunk, CancellationToken ct) {
+	public async ValueTask StoreChunk(IChunkBlob chunk, CancellationToken ct) {
 		// process single chunk
 		if (chunk.ChunkHeader.IsSingleLogicalChunk) {
 			await StoreAsync(chunk, ct);
@@ -83,8 +81,6 @@ public class ArchiveStorage(
 				}
 			}
 		}
-
-		return true;
 	}
 
 	private async ValueTask StoreAsync(IChunkBlob chunk, CancellationToken ct) {

--- a/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchiveStorage.cs
@@ -12,7 +12,6 @@ using DotNext.IO;
 using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage.Exceptions;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
-using Serilog;
 
 namespace EventStore.Core.Services.Archive.Storage;
 

--- a/src/EventStore.Core/Services/Archive/Storage/IArchiveStorage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/IArchiveStorage.cs
@@ -3,26 +3,14 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using EventStore.Core.Services.Archive.Storage.Exceptions;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 
 namespace EventStore.Core.Services.Archive.Storage;
 
 public interface IArchiveStorage : IArchiveStorageReader {
 	/// <summary>Sets the position in the transaction log up to which all chunks have been archived</summary>
-	/// <returns>
-	/// <see langword="true"/> if the checkpoint was set<br/>
-	/// <see langword="false"/> if the operation failed and the caller needs to retry after some time
-	/// </returns>
-	public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct);
+	public ValueTask SetCheckpoint(long checkpoint, CancellationToken ct);
 
 	/// <summary>Stores a chunk in the archive</summary>
-	/// <param name="chunk">The chunk to be stored</param>
-	/// <param name="ct"></param>
-	/// <exception cref="ChunkDeletedException">Thrown if the chunk file is deleted while being archived</exception>
-	/// <returns>
-	/// <see langword="true"/> if the chunk was successfully archived<br/>
-	/// <see langword="false"/> if the operation failed and the caller needs to retry after some time
-	/// </returns>
-	public ValueTask<bool> StoreChunk(IChunkBlob chunk, CancellationToken ct);
+	public ValueTask StoreChunk(IChunkBlob chunk, CancellationToken ct);
 }

--- a/src/EventStore.Core/Services/Archive/Storage/ResilientArchiveStorage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ResilientArchiveStorage.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Resilience;
-using EventStore.Core.Services.Archive.Archiver;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using Polly;
 using Serilog;
@@ -13,7 +12,7 @@ using Serilog;
 namespace EventStore.Core.Services.Archive.Storage;
 
 public class ResilientArchiveStorage(ResiliencePipeline pipeline, IArchiveStorage wrapped) : IArchiveStorage {
-	private static readonly ILogger Log = Serilog.Log.ForContext<ArchiverService>();
+	private static readonly ILogger Log = Serilog.Log.ForContext<ResilientArchiveStorage>();
 	private readonly PipelineExecutor _executor = new(pipeline, nameof(ResilientArchiveStorage), Log);
 
 	public ValueTask SetCheckpoint(long checkpoint, CancellationToken ct) =>

--- a/src/EventStore.Core/Services/Archive/Storage/ResilientArchiveStorage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ResilientArchiveStorage.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Resilience;
+using EventStore.Core.Services.Archive.Archiver;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using Polly;
+using Serilog;
+
+namespace EventStore.Core.Services.Archive.Storage;
+
+public class ResilientArchiveStorage(ResiliencePipeline pipeline, IArchiveStorage wrapped) : IArchiveStorage {
+	private static readonly ILogger Log = Serilog.Log.ForContext<ArchiverService>();
+	private readonly PipelineExecutor _executor = new(pipeline, nameof(ResilientArchiveStorage), Log);
+
+	public ValueTask SetCheckpoint(long checkpoint, CancellationToken ct) =>
+		_executor.ExecuteAsync(
+			static (context, state) => 
+				state.wrapped.SetCheckpoint(state.checkpoint, context.CancellationToken),
+			(wrapped, checkpoint),
+			ct);
+
+	public ValueTask StoreChunk(IChunkBlob chunk, CancellationToken ct) =>
+		_executor.ExecuteAsync(
+			static (context, state) => state.wrapped.StoreChunk(state.chunk, context.CancellationToken),
+			(wrapped, chunk),
+			ct);
+
+	public ValueTask<long> GetCheckpoint(CancellationToken ct) =>
+		_executor.ExecuteAsync(
+			static (context, wrapped) => wrapped.GetCheckpoint(context.CancellationToken),
+			wrapped,
+			ct);
+
+	public ValueTask<int> ReadAsync(int logicalChunkNumber, Memory<byte> buffer, long offset, CancellationToken ct) =>
+		_executor.ExecuteAsync(
+			static (context, state) => state.wrapped.ReadAsync(state.logicalChunkNumber, state.buffer, state.offset, context.CancellationToken),
+			(wrapped, logicalChunkNumber, buffer, offset),
+			ct);
+
+	public ValueTask<ArchivedChunkMetadata> GetMetadataAsync(int logicalChunkNumber, CancellationToken ct) =>
+		_executor.ExecuteAsync(
+			static (context, state) => state.wrapped.GetMetadataAsync(state.logicalChunkNumber, context.CancellationToken),
+			(wrapped, logicalChunkNumber),
+			ct);
+}


### PR DESCRIPTION
ArchiveCatchup and ArchiverService use infinite retries.
Others (such as scavenge) retry a few times and give up.

On retrying we log a message including the operation we are attempting, using an appropriate logger (not baked into the policy itself)

```
[16324,13,15:48:38.611,WRN] ResilientArchiveStorage Retrying ResilientArchiveStorage.GetCheckpoint. Attempt 0. Duration 00:00:00.2339772. Delay 00:00:01. Error: The specified bucket does not exist (AmazonS3Exception)
[16324, 9,15:48:39.637,WRN] ResilientArchiveStorage Retrying ResilientArchiveStorage.GetCheckpoint. Attempt 1. Duration 00:00:00.0259347. Delay 00:00:02. Error: The specified bucket does not exist (AmazonS3Exception)
[16324, 7,15:48:41.664,WRN] ResilientArchiveStorage Retrying ResilientArchiveStorage.GetCheckpoint. Attempt 2. Duration 00:00:00.0283828. Delay 00:00:04. Error: The specified bucket does not exist (AmazonS3Exception)
[16324, 9,15:48:45.695,WRN] ResilientArchiveStorage Retrying ResilientArchiveStorage.GetCheckpoint. Attempt 3. Duration 00:00:00.0307512. Delay 00:00:08. Error: The specified bucket does not exist (AmazonS3Exception)
```