### PR TITLE
[KDB-578][release/v24.10] Support paging in persistent subscriptions

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/FakeReadIndex.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/FakeReadIndex.cs
@@ -13,13 +13,13 @@ using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.Tests.TransactionLog;
 
-internal class FakeReadIndex<TLogFormat, TStreamId> : IReadIndex<TStreamId> {
+public class FakeReadIndex<TLogFormat, TStreamId> : IReadIndex<TStreamId> {
 	private readonly IMetastreamLookup<TStreamId> _metastreams;
 
 	public long LastIndexedPosition {
 		get { return 0; }
 	}
-	
+
 	public IIndexWriter<TStreamId> IndexWriter {
 		get { throw new NotImplementedException(); }
 	}

--- a/src/EventStore.Core.XUnit.Tests/Services/PersistentSubscriptions/GetAllPersistentSubscriptionStatsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/PersistentSubscriptions/GetAllPersistentSubscriptionStatsTests.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.LogV2;
+using EventStore.Core.Messages;
+using EventStore.Core.Metrics;
+using EventStore.Core.Services;
+using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.LogRecords;
+using Xunit;
+using OperationStatus = EventStore.Core.Messages.MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus;
+
+namespace EventStore.Core.XUnit.Tests.Services.PersistentSubscriptions;
+
+public class GetAllPersistentSubscriptionStatsTests {
+	private readonly FakePublisher _publisher = new();
+	private readonly FakeTimeProvider _timeProvider = new ();
+	private readonly IODispatcher _ioDispatcher;
+
+	public GetAllPersistentSubscriptionStatsTests() {
+		var bus = new SynchronousScheduler();
+		_ioDispatcher = new IODispatcher(_publisher, bus);
+		bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+	}
+
+	private PersistentSubscriptionService<string> CreateSut() {
+		_publisher.Messages.Clear();
+		var subscriber = new SynchronousScheduler();
+		var queuedHandler =
+			new QueuedHandlerThreadPool(subscriber, "test", new QueueStatsManager(), new QueueTrackers());
+		var index = new FakeReadIndex<LogFormat.V2, string>(_ => false, new LogV2SystemStreams());
+		var strategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry(_publisher, subscriber,
+			Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>());
+		return new PersistentSubscriptionService<string>(
+			queuedHandler, index, _ioDispatcher, _publisher, strategyRegistry, IPersistentSubscriptionTracker.NoOp);
+	}
+
+	[Fact]
+	public void when_not_ready() {
+		var responseEnvelope = new FakeEnvelope();
+		var sut = CreateSut();
+
+		sut.Handle(new MonitoringMessage.GetAllPersistentSubscriptionStats(responseEnvelope));
+		Assert.Single(responseEnvelope.Replies);
+		var response =
+			responseEnvelope.Replies.FirstOrDefault() as MonitoringMessage.GetPersistentSubscriptionStatsCompleted;
+		Assert.NotNull(response);
+		Assert.Equal(OperationStatus.NotReady, response.Result);
+		Assert.Equal(0, response.Total);
+	}
+
+	[Fact]
+	public void when_there_are_no_persistent_subscriptions() {
+		// Arrange
+		var responseEnvelope = new FakeEnvelope();
+		var sut = CreateSut();
+		sut.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+		// Get the read request and give an empty response
+		var read = _publisher.Messages.OfType<ClientMessage.ReadStreamEventsBackward>().FirstOrDefault();
+		Assert.NotNull(read);
+		read.Envelope.ReplyWith(new ClientMessage.ReadStreamEventsBackwardCompleted(read.CorrelationId,
+			read.EventStreamId, read.FromEventNumber, read.MaxCount, ReadStreamResult.NoStream, [],
+			new StreamMetadata(), true, "", -1, -1, true, 1000));
+
+		// Act
+		sut.Handle(new MonitoringMessage.GetAllPersistentSubscriptionStats(responseEnvelope));
+		var response = responseEnvelope.Replies.OfType<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>()
+			.FirstOrDefault();
+
+		// Assert
+		Assert.NotNull(response);
+		Assert.Equal(OperationStatus.Success, response.Result);
+		Assert.Empty(response.SubscriptionStats);
+		Assert.Equal(0, response.Total);
+	}
+
+	[Fact]
+	public void when_a_persistent_subscription_exists() {
+		// Arrange
+		var responseEnvelope = new FakeEnvelope();
+		var sut = CreateSut();
+		var psubEntry = new PersistentSubscriptionEntry{
+			Group = "test-group",
+			Stream = "test-stream",
+			HistoryBufferSize = 20,
+			LiveBufferSize = 20,
+			ReadBatchSize = 10,
+			NamedConsumerStrategy = SystemConsumerStrategies.RoundRobin
+		};
+		var psubConfig = new PersistentSubscriptionConfig {
+			Version = "2",
+			Updated = _timeProvider.UtcNow,
+			UpdatedBy = "admin",
+			Entries = [psubEntry]
+		};
+
+		sut.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+		// Get the read request and respond with the config
+		var read = _publisher.Messages.OfType<ClientMessage.ReadStreamEventsBackward>().FirstOrDefault();
+		Assert.NotNull(read);
+		read.Envelope.ReplyWith(ReadPersistentSubscriptionConfigCompleted(read, psubConfig));
+
+		// Act
+		sut.Handle(new MonitoringMessage.GetAllPersistentSubscriptionStats(responseEnvelope));
+		var response = responseEnvelope.Replies.OfType<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>()
+			.FirstOrDefault();
+
+		// Assert
+		Assert.NotNull(response);
+		Assert.Equal(OperationStatus.Success, response.Result);
+		Assert.Single(response.SubscriptionStats);
+		Assert.Equal(0, response.RequestedOffset);
+		Assert.Equal(1, response.Total);
+		var responseEntry = response.SubscriptionStats[0];
+		Assert.Equal(psubEntry.Group, responseEntry.GroupName);
+		Assert.Equal(psubEntry.Stream, responseEntry.EventSource);
+		Assert.Equal(psubEntry.NamedConsumerStrategy, responseEntry.NamedConsumerStrategy);
+		Assert.Empty(responseEntry.Connections);
+	}
+
+	[Theory]
+	[InlineData(0, 0, new string[] { })]
+	[InlineData(10, 0, new string[] { })]
+	[InlineData(0, 2, new[] { "stream-1", "stream-2" })]
+	[InlineData(2, 2, new[] { "stream-3", "stream-4" })]
+	[InlineData(3, 2, new[] { "stream-4" })]
+	[InlineData(4, 2, new string[] { })]
+	public void when_getting_all_stats_from_multiple_subscriptions_paged(int offset, int count, string[] expectedTopics) {
+		// Arrange
+		var responseEnvelope = new FakeEnvelope();
+		var sut = CreateSut();
+		var psubs = new List<PersistentSubscriptionEntry>();
+		var topics = new int[] { 3, 2, 0, 1 }; // no particular order
+		foreach (var topic in topics) {
+			for (var group = 0; group < 2; group++) {
+				psubs.Add(new PersistentSubscriptionEntry {
+					Group = $"{group + 1}",
+					Stream = $"stream-{topic + 1}",
+					HistoryBufferSize = 20,
+					LiveBufferSize = 20,
+					ReadBatchSize = 10,
+					NamedConsumerStrategy = SystemConsumerStrategies.RoundRobin
+				});
+			}
+		}
+
+		var psubConfig = new PersistentSubscriptionConfig {
+			Version = "2",
+			Updated = _timeProvider.UtcNow,
+			UpdatedBy = "admin",
+			Entries = psubs
+		};
+
+		sut.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+		// Get the read request and respond with the config
+		var read = _publisher.Messages.OfType<ClientMessage.ReadStreamEventsBackward>().FirstOrDefault();
+		Assert.NotNull(read);
+		read.Envelope.ReplyWith(ReadPersistentSubscriptionConfigCompleted(read, psubConfig));
+
+		// Act
+		sut.Handle(new MonitoringMessage.GetAllPersistentSubscriptionStats(responseEnvelope, offset, count));
+		var response = responseEnvelope.Replies.OfType<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>()
+			.SingleOrDefault();
+
+		// Assert
+		Assert.NotNull(response);
+		Assert.Equal(OperationStatus.Success, response.Result);
+		Assert.Equal(offset, response.RequestedOffset);
+		Assert.Equal(4, response.Total);
+
+		var actualTopics = response.SubscriptionStats
+			.GroupBy(x => x.EventSource)
+			.Select(x => x.Key)
+			.Order();
+		Assert.Equal(expectedTopics, actualTopics);
+	}
+
+	private ClientMessage.ReadStreamEventsBackwardCompleted ReadPersistentSubscriptionConfigCompleted(
+		ClientMessage.ReadStreamEventsBackward message, PersistentSubscriptionConfig config) {
+		var streamId = SystemStreams.PersistentSubscriptionConfig;
+		var eventType = SystemEventTypes.PersistentSubscriptionConfig;
+		var eventData = config.GetSerializedForm();
+
+		var record = new EventRecord(0, LogRecord.Prepare(
+				LogFormatHelper<LogFormat.V2, string>.RecordFactory,
+				100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, streamId, -1,
+				PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+				eventType, eventData, Array.Empty<byte>(), _timeProvider.UtcNow), streamId, eventType);
+
+		return new ClientMessage.ReadStreamEventsBackwardCompleted(message.CorrelationId, message.EventStreamId,
+			message.FromEventNumber, message.MaxCount, ReadStreamResult.Success,
+			[ResolvedEvent.ForUnresolvedEvent(record, 100)], new StreamMetadata(),
+			true, "", 1, 0, true, 1000);
+	}
+}

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -13,10 +13,21 @@ public static partial class MonitoringMessage {
 	[DerivedMessage(CoreMessage.Monitoring)]
 	public partial class GetAllPersistentSubscriptionStats : Message {
 		public readonly IEnvelope Envelope;
+		public readonly int Offset;
+		public readonly int Count;
 
 		public GetAllPersistentSubscriptionStats(IEnvelope envelope) {
 			Ensure.NotNull(envelope, "envelope");
 			Envelope = envelope;
+			Offset = 0;
+			Count = int.MaxValue;
+		}
+
+		public GetAllPersistentSubscriptionStats(IEnvelope envelope, int offset, int count) {
+			Ensure.NotNull(envelope, "envelope");
+			Envelope = envelope;
+			Offset = offset;
+			Count = count;
 		}
 	}
 
@@ -63,12 +74,25 @@ public static partial class MonitoringMessage {
 		public readonly OperationStatus Result;
 		public readonly List<PersistentSubscriptionInfo> SubscriptionStats;
 		public string ErrorString;
+		public readonly int RequestedOffset;
+		public readonly int RequestedCount;
+		public readonly int Total;
 
 		public GetPersistentSubscriptionStatsCompleted(OperationStatus result,
 			List<PersistentSubscriptionInfo> subscriptionStats, string errorString = "") {
 			Result = result;
 			SubscriptionStats = subscriptionStats;
 			ErrorString = errorString;
+		}
+
+		public GetPersistentSubscriptionStatsCompleted(OperationStatus result,
+			List<PersistentSubscriptionInfo> subscriptionStats, int requestedOffset, int requestedCount, int total, string errorString = "") {
+			Result = result;
+			SubscriptionStats = subscriptionStats;
+			ErrorString = errorString;
+			RequestedOffset = requestedOffset;
+			RequestedCount = requestedCount;
+			Total = total;
 		}
 
 		public enum OperationStatus {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -54,7 +54,10 @@ public class PersistentSubscriptionService<TStreamId> :
 	IHandle<MonitoringMessage.GetPersistentSubscriptionStats>,
 	IHandle<MonitoringMessage.GetStreamPersistentSubscriptionStats> {
 
+	// for constant time lookups in ProcessEventCommited
 	private Dictionary<string, List<PersistentSubscription>> _subscriptionTopics;
+	// for quick indexing into stable pages of topics
+	private SortedList<string, List<PersistentSubscription>> _sortedSubscriptionTopics;
 	private Dictionary<string, PersistentSubscription> _subscriptionsById;
 
 	private readonly IQueuedHandler _queuedHandler;
@@ -113,6 +116,7 @@ public class PersistentSubscriptionService<TStreamId> :
 	public void InitToEmpty() {
 		_handleTick = false;
 		_subscriptionTopics = new Dictionary<string, List<PersistentSubscription>>();
+		_sortedSubscriptionTopics = new SortedList<string, List<PersistentSubscription>>();
 		_subscriptionsById = new Dictionary<string, PersistentSubscription>();
 	}
 
@@ -872,6 +876,7 @@ public class PersistentSubscriptionService<TStreamId> :
 		if (!_subscriptionTopics.TryGetValue(eventSource, out var subscribers)) {
 			subscribers = new List<PersistentSubscription>();
 			_subscriptionTopics.Add(eventSource, subscribers);
+			_sortedSubscriptionTopics.Add(eventSource, subscribers);
 		}
 
 		// shut down any existing subscription
@@ -1248,7 +1253,7 @@ public class PersistentSubscriptionService<TStreamId> :
 	private void SaveConfiguration(Action continueWith) {
 		Log.Debug("Saving persistent subscription configuration");
 		var data = _config.GetSerializedForm();
-		var ev = new Event(Guid.NewGuid(), "$PersistentConfig", true, data, new byte[0]);
+		var ev = new Event(Guid.NewGuid(), SystemEventTypes.PersistentSubscriptionConfig, true, data, new byte[0]);
 		var metadata = new StreamMetadata(maxCount: 2);
 		Lazy<StreamMetadata> streamMetadata = new Lazy<StreamMetadata>(() => metadata);
 		Event[] events = new Event[] {ev};
@@ -1341,12 +1346,23 @@ public class PersistentSubscriptionService<TStreamId> :
 			return;
 		}
 
-		var stats = (from subscription in _subscriptionTopics.Values
+		var total = _sortedSubscriptionTopics.Count;
+		var pageOffset = Math.Clamp(message.Offset, 0, total);
+		var pageLength = Math.Clamp(message.Count, 0, total - pageOffset);
+		var topics = new List<PersistentSubscription>[pageLength];
+		for (var i = 0; i < pageLength; i++) {
+			topics[i] = _sortedSubscriptionTopics.Values[i + pageOffset];
+		}
+
+		var stats = (from subscription in topics
 			from sub in subscription
 			select sub.GetStatistics()).ToList();
 		message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats)
-		);
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success,
+			stats,
+			requestedOffset: message.Offset,
+			requestedCount: message.Count,
+			total: total));
 	}
 
 	public void Handle(SubscriptionMessage.PersistentSubscriptionTimerTick message) {

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -102,6 +102,7 @@ public static class SystemEventTypes {
 	public const string ScavengePoint = "$scavengePoint";
 
 	public const string AuthorizationPolicyChanged = "$authorization-policy-changed";
+	public const string PersistentSubscriptionConfig = "$PersistentConfig";
 
 	public static string StreamReferenceEventToStreamId(string eventType, ReadOnlyMemory<byte> data) {
 		string streamId = null;

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -42,7 +42,7 @@ public abstract class CommunicationController : IHttpController {
 		httpEntityManager.ReplyContent(Encoding.ASCII.GetBytes(reason), HttpStatusCode.BadRequest,
 			"Bad Request",type: "text/plain", headers:null,
 			e => Log.Debug("Error while closing HTTP connection (bad request): {e}.", e.Message));
- 
+
 		return new RequestParams(done: true);
 	}
 
@@ -100,6 +100,13 @@ public abstract class CommunicationController : IHttpController {
 		if (path.Length > 0 && path[0] == '/') path = path.Substring(1);
 		var hostUri = http.ResponseUrl;
 		var builder = new UriBuilder(hostUri.Scheme, hostUri.Host, hostUri.Port, hostUri.LocalPath + path);
+		return builder.Uri.AbsoluteUri;
+	}
+
+	protected static string MakeUrl(HttpEntityManager http, string path, string query) {
+		if (path.Length > 0 && path[0] == '/') path = path.Substring(1);
+		var hostUri = http.ResponseUrl;
+		var builder = new UriBuilder(hostUri.Scheme, hostUri.Host, hostUri.Port, hostUri.LocalPath + path, query);
 		return builder.Uri.AbsoluteUri;
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -43,7 +43,7 @@ public class PersistentSubscriptionController : CommunicationController {
 	}
 
 	protected override void SubscribeCore(IHttpService service) {
-		Register(service, "/subscriptions", HttpMethod.Get, GetAllSubscriptionInfo, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
+		Register(service, "/subscriptions?offset={offset}&count={count}", HttpMethod.Get, GetAllSubscriptionInfo, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
 		Register(service, "/subscriptions/restart", HttpMethod.Post, RestartPersistentSubscriptions, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Restart));
 		Register(service, "/subscriptions/{stream}", HttpMethod.Get, GetSubscriptionInfoForStream, Codec.NoCodecs,
 			DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
@@ -62,11 +62,11 @@ public class PersistentSubscriptionController : CommunicationController {
 			Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/replayParked?stopAt={stopAt}", HttpMethod.Post,
 			WithParameters(Operations.Subscriptions.ReplayParked), ReplayParkedMessages);
-		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack/{messageid}", HttpMethod.Post, 
+		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack/{messageid}", HttpMethod.Post,
 			WithParameters(Operations.Subscriptions.ProcessMessages), AckMessage);
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/nack/{messageid}?action={action}",
 			HttpMethod.Post, WithParameters(Operations.Subscriptions.ProcessMessages), NackMessage);
-		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack?ids={messageids}", HttpMethod.Post, 
+		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack?ids={messageids}", HttpMethod.Post,
 			WithParameters(Operations.Subscriptions.ProcessMessages), AckMessages);
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/nack?ids={messageids}&action={action}",
 			HttpMethod.Post, WithParameters(Operations.Subscriptions.ProcessMessages), NackMessages);
@@ -194,13 +194,13 @@ public class PersistentSubscriptionController : CommunicationController {
 	}
 	private bool GetRequireLeader(HttpEntityManager manager, out bool requireLeader) {
 		requireLeader = false;
-		
+
 		var onlyLeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireLeader);
 		var onlyMaster = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireMaster);
-		
+
 		if (StringValues.IsNullOrEmpty(onlyLeader) && StringValues.IsNullOrEmpty(onlyMaster))
 			return true;
-	
+
 		if (string.Equals(onlyLeader, "True", StringComparison.OrdinalIgnoreCase) ||
 		    string.Equals(onlyMaster, "True", StringComparison.OrdinalIgnoreCase)) {
 			requireLeader = true;
@@ -393,7 +393,7 @@ public class PersistentSubscriptionController : CommunicationController {
 		Publish(cmd);
 		http.ReplyStatus(HttpStatusCode.Accepted, "", exception => { });
 	}
-	
+
 	private void ReplayParkedMessages(HttpEntityManager http, UriTemplateMatch match) {
 		if (_httpForwarder.ForwardRequest(http))
 			return;
@@ -425,7 +425,7 @@ public class PersistentSubscriptionController : CommunicationController {
 		var groupname = match.BoundVariables["subscription"];
 		var stream = match.BoundVariables["stream"];
 		var stopAtStr = match.BoundVariables["stopAt"];
-		
+
 		long? stopAt;
 		// if stopAt is declared...
 		if (stopAtStr != null) {
@@ -706,7 +706,7 @@ public class PersistentSubscriptionController : CommunicationController {
 			groupname, http.User);
 		Publish(cmd);
 	}
-	
+
 	private void RestartPersistentSubscriptions(HttpEntityManager http, UriTemplateMatch match) {
 		if (_httpForwarder.ForwardRequest(http))
 			return;
@@ -729,14 +729,54 @@ public class PersistentSubscriptionController : CommunicationController {
 	private void GetAllSubscriptionInfo(HttpEntityManager http, UriTemplateMatch match) {
 		if (_httpForwarder.ForwardRequest(http))
 			return;
-		var envelope = new SendToHttpEnvelope(
-			_networkSendQueue, http,
-			(args, message) =>
-				http.ResponseCodec.To(ToSummaryDto(http,
-					message as MonitoringMessage.GetPersistentSubscriptionStatsCompleted).ToArray()),
-			(args, message) => StatsConfiguration(http, message));
-		var cmd = new MonitoringMessage.GetAllPersistentSubscriptionStats(envelope);
-		Publish(cmd);
+		var offsetParam = match.BoundVariables["offset"];
+		var countParam = match.BoundVariables["count"];
+		if (offsetParam is null && countParam is null) {
+			GetSubscriptionInfoUnpaged(http);
+		} else {
+			GetSubscriptionInfoPaged(http, offsetParam, countParam);
+		}
+
+		// old api for backwards compatibility: just returns the list of persistent subscriptions
+		void GetSubscriptionInfoUnpaged(HttpEntityManager http) {
+			var envelope = new SendToHttpEnvelope(
+				_networkSendQueue, http,
+				(args, message) =>
+					http.ResponseCodec.To(ToSummaryDto(http,
+						message as MonitoringMessage.GetPersistentSubscriptionStatsCompleted).ToArray()),
+				(args, message) => StatsConfiguration(http, message));
+			var cmd = new MonitoringMessage.GetAllPersistentSubscriptionStats(envelope);
+			Publish(cmd);
+		}
+
+		// new api: returns the list (page) of persistent subscriptions with paging info.
+		// count must be provided
+		void GetSubscriptionInfoPaged(HttpEntityManager http, string offsetParam, string countParam) {
+			int offset = offsetParam is null
+				? 0
+				: int.TryParse(offsetParam, out var off)
+					? off
+					: -1;
+
+			if (offset < 0) {
+				SendBadRequest(http, $"Offset \"{offsetParam}\" must be a non-negative integer");
+				return;
+			}
+
+			if (!int.TryParse(countParam, out var count) || count < 1) {
+				SendBadRequest(http, $"Count \"{countParam}\" must be a positive integer");
+				return;
+			}
+
+			var envelope = new SendToHttpEnvelope(
+				_networkSendQueue, http,
+				(_, message) =>
+					http.ResponseCodec.To(ToPagedSummaryDto(
+						http, message as MonitoringMessage.GetPersistentSubscriptionStatsCompleted)),
+				(_, message) => StatsConfiguration(http, message));
+			var cmd = new MonitoringMessage.GetAllPersistentSubscriptionStats(envelope, offset, count);
+			Publish(cmd);
+		}
 	}
 
 	private void GetSubscriptionInfoForStream(HttpEntityManager http, UriTemplateMatch match) {
@@ -768,7 +808,7 @@ public class PersistentSubscriptionController : CommunicationController {
 		var cmd = new MonitoringMessage.GetPersistentSubscriptionStats(envelope, stream, groupName);
 		Publish(cmd);
 	}
-	
+
 	private IEnvelope CreateErrorEnvelope(HttpEntityManager http) {
 		return new SendToHttpEnvelope<SubscriptionMessage.InvalidPersistentSubscriptionsRestart>(
 			_networkSendQueue,
@@ -977,6 +1017,37 @@ public class PersistentSubscriptionController : CommunicationController {
 		}
 	}
 
+	private PagedSubscriptionInfo ToPagedSummaryDto(HttpEntityManager manager,
+		MonitoringMessage.GetPersistentSubscriptionStatsCompleted message) {
+
+		if (message is null || message.SubscriptionStats is null) {
+			return new PagedSubscriptionInfo();
+		}
+
+		var stats = ToSummaryDto(manager, message).ToArray();
+		var offset = message.RequestedOffset;
+		var count = message.RequestedCount;
+		var links = new List<RelLink> {
+			new(MakeUrl(manager, "/subscriptions", $"?offset={offset}&count={count}"), "self"),
+			new(MakeUrl(manager, "/subscriptions", $"?offset=0&count={count}"), "first"),
+		};
+		if (offset > 0) {
+			var prevOffset = Math.Max(0, offset - count);
+			links.Add(new RelLink(MakeUrl(manager, "/subscriptions", $"?offset={prevOffset}&count={count}"), "previous"));
+		}
+		if (offset + count < message.Total) {
+			var nextOffset = offset + count;
+			links.Add(new RelLink(MakeUrl(manager, "/subscriptions", $"?offset={nextOffset}&count={count}"), "next"));
+		}
+		return new PagedSubscriptionInfo {
+			Links = links,
+			Offset = offset,
+			Count = count,
+			Total = message.Total,
+			Subscriptions = stats,
+		};
+	}
+
 	private IEnumerable<SubscriptionSummary> ToSummaryDto(HttpEntityManager manager,
 		MonitoringMessage.GetPersistentSubscriptionStatsCompleted message) {
 		if (message == null) yield break;
@@ -1054,6 +1125,14 @@ public class PersistentSubscriptionController : CommunicationController {
 			LiveBufferSize = 500;
 			ReadBatchSize = 20;
 		}
+	}
+
+	public class PagedSubscriptionInfo {
+		public List<RelLink> Links { get; set; }
+		public int Offset { get; set; }
+		public int Count { get; set; }
+		public int Total { get; set; }
+		public IReadOnlyList<SubscriptionSummary> Subscriptions { get; set; }
 	}
 
 	public class SubscriptionSummary {


### PR DESCRIPTION
Cherry-pick https://github.com/EventStore/EventStore/pull/4762 to v24.10

A count and offset can now be specified when getting all persistent subscription stats through the HTTP API: `/subscriptions?count={count}&offset={offset}`.

The response of `/subscriptions` (without the query string) is unchanged.

Example request and response:

```
Request:
curl -i http://localhost:2113/subscriptions?count=5&offset=10"

Response:

{
  "links": [
    {
      "href": "http://localhost:2113/subscriptions?count=5&offset=10",
      "rel": "self"
    },
    {
      "href": "http://localhost:2113/subscriptions?count=5&offset=15",
      "rel": "next"
    },
    {
      "href": "http://localhost:2113/subscriptions?count=5&offset=5",
      "rel": "previous"
    }
  ],
  "offset": 10,
  "count": 5,
  "total": 31,
  "subscriptions": [
      // truncated
  ]
}
```