### PR TITLE
[KDB-625][24.10]Fix double check, avoid possibility of recreating midpoints (#4788)

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -167,7 +167,7 @@ public partial class TFChunk {
 		}
 
 		private Midpoint[] GetOrCreateMidPoints(ReaderWorkItem workItem) {
-			// don't use mipoints when reading from memory
+			// don't use midpoints when reading from memory
 			if (workItem.IsMemory)
 				return null;
 
@@ -184,8 +184,10 @@ public partial class TFChunk {
 				return null;
 
 			lock (_lock) {
-				// guaranteed up to date. we don't want to assign to _midpoints if we aren't supposed to
-				// because the midpoints will take up memory unnecessarily.
+				// guaranteed up to date
+				if (_midpoints is { } midpointsDouble)
+					return midpointsDouble;
+
 				if (!_wantMidpoints)
 					return null;
 


### PR DESCRIPTION
Behaviour was still 'correct', but this could impact performance.

cherry pick of https://github.com/EventStore/EventStore/pull/4788