### PR TITLE
[KDB-626] Separate Configuration logic from StartAsync logic

### DIFF
--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.ClientOperations;
 public abstract class specification_with_bare_vnode<TLogFormat, TStreamId> : IPublisher, ISubscriber, IDisposable {
 	private ClusterVNode _node;
 	private readonly List<IDisposable> _disposables = new List<IDisposable>();
-	public void CreateTestNode() {
+	public async ValueTask CreateTestNode() {
 		var logFormatFactory = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory;
 		var options = new ClusterVNodeOptions()
 			.ReduceMemoryUsageForTests()
@@ -43,7 +43,7 @@ public abstract class specification_with_bare_vnode<TLogFormat, TStreamId> : IPu
 		var app = builder.Build();
 		_node.Startup.Configure(app);
 
-		_node.StartAsync(true, CancellationToken.None).Wait();
+		await _node.StartAsync(true, CancellationToken.None);
 	}
 	public void Publish(Message message) {
 		_node.MainQueue.Handle(message);

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Authentication;
 using EventStore.Core.Authentication.InternalAuthentication;
@@ -42,7 +43,7 @@ public abstract class specification_with_bare_vnode<TLogFormat, TStreamId> : IPu
 		var app = builder.Build();
 		_node.Startup.Configure(app);
 
-		_node.StartAsync(true).Wait();
+		_node.StartAsync(true, CancellationToken.None).Wait();
 	}
 	public void Publish(Message message) {
 		_node.MainQueue.Handle(message);

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_request_manager_integration.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_request_manager_integration.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
@@ -25,8 +26,8 @@ public abstract class specification_with_request_manager_integration<TLogFormat,
 	protected abstract Message When();
 
 	[SetUp]
-	public void Setup() {
-		CreateTestNode();
+	public async Task Setup() {
+		await CreateTestNode();
 		Envelope = new FakeEnvelope();
 
 		foreach (var m in WithInitialMessages()) {

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -34,6 +34,7 @@ using EventStore.Plugins.Subsystems;
 using EventStore.TcpUnitTestPlugin;
 using Microsoft.Extensions.Configuration;
 using RuntimeInformation = System.Runtime.RuntimeInformation;
+using System.Threading;
 
 namespace EventStore.Core.Tests.Helpers;
 
@@ -223,7 +224,7 @@ public class MiniClusterNode<TLogFormat, TStreamId> {
 			.Build();
 	}
 
-	public void Start() {
+	public async Task Start() {
 		StartingTime.Start();
 
 		Node.MainBus.Subscribe(
@@ -263,7 +264,7 @@ public class MiniClusterNode<TLogFormat, TStreamId> {
 		}
 
 		_host.Start();
-		Node.Start();
+		await Node.StartAsync(waitUntilReady: false, CancellationToken.None);
 	}
 
 	public HttpClient CreateHttpClient() {

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -291,10 +291,10 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 			Node.MainBus.Unsubscribe(waitForAdminUser);
 		}
 
+		await Node.StartAsync(true, CancellationToken.None).WithTimeout(TimeSpan.FromSeconds(60));
+
 		if (Node.IsShutdown)
 			_started.TrySetResult(true);
-
-		await Node.StartAsync(true, CancellationToken.None).WithTimeout(TimeSpan.FromSeconds(60));
 
 		await Started.WithTimeout();
 

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -38,6 +38,7 @@ using EventStore.Plugins.Transforms;
 using Microsoft.Extensions.DependencyInjection;
 using RuntimeInformation = System.Runtime.RuntimeInformation;
 using EventStore.Core.Tests.Index.Hashers;
+using System.Threading;
 
 namespace EventStore.Core.Tests.Helpers;
 
@@ -293,7 +294,7 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 		if (Node.IsShutdown)
 			_started.TrySetResult(true);
 
-		await Node.StartAsync(true).WithTimeout(TimeSpan.FromSeconds(60));
+		await Node.StartAsync(true, CancellationToken.None).WithTimeout(TimeSpan.FromSeconds(60));
 
 		await Started.WithTimeout();
 

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -291,7 +291,9 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 			Node.MainBus.Unsubscribe(waitForAdminUser);
 		}
 
-		await Node.StartAsync(true, CancellationToken.None).WithTimeout(TimeSpan.FromSeconds(60));
+		using var cts = new CancellationTokenSource();
+		cts.CancelAfter(TimeSpan.FromSeconds(60));
+		await Node.StartAsync(true, cts.Token);
 
 		if (Node.IsShutdown)
 			_started.TrySetResult(true);

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -106,9 +106,9 @@ public abstract class specification_with_cluster<TLogFormat, TStreamId> : Specif
 
 		BeforeNodesStart();
 
-		_nodes[0].Start();
-		_nodes[1].Start();
-		_nodes[2].Start();
+		await _nodes[0].Start();
+		await _nodes[1].Start();
+		await _nodes[2].Start();
 
 		try {
 			await Task.WhenAll(_nodes.Select(x => x.Started)).WithTimeout(TimeSpan.FromSeconds(60));

--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -23,7 +23,7 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 			
 			var node = CreateNode(i % 3, _nodeEndpoints[i % 3],
 				new[] {_nodeEndpoints[(i+1)%3].HttpEndPoint, _nodeEndpoints[(i+2)%3].HttpEndPoint});
-			node.Start();
+			await node.Start();
 			_nodes[i % 3] = node;
 
 			await Task.WhenAll(_nodes.Select(x => x.Started)).WithTimeout(TimeSpan.FromSeconds(30));

--- a/src/EventStore.Core.Tests/Integration/when_node_becomes_leader_with_unindexed_data.cs
+++ b/src/EventStore.Core.Tests/Integration/when_node_becomes_leader_with_unindexed_data.cs
@@ -146,10 +146,9 @@ public class when_node_becomes_leader_with_unindexed_data<TLogFormat, TStreamId>
 		subsystems: Array.Empty<ISubsystem>(), gossipSeeds: gossipSeeds, inMemDb: false,
 		nodePriority: nodePriority, intHostAdvertiseAs: intHostAdvertiseAs);
 
-	private Task StartNode(int i, int priority, string intHostAdvertiseAs = null) {
+	private async Task StartNode(int i, int priority, string intHostAdvertiseAs = null) {
 		_nodes[i] = CreateNode(i, _nodeEndpoints[i], _nodeGossipSeeds[i], priority, intHostAdvertiseAs);
-		_nodes[i].Start();
-		return Task.CompletedTask;
+		await _nodes[i].Start();
 	}
 
 	private async Task<HttpStatusCode> GetLiveStatus(IPEndPoint httpEndPoint){
@@ -227,7 +226,7 @@ public class when_node_becomes_leader_with_unindexed_data<TLogFormat, TStreamId>
 
 		for (int i = 0; i < 3; i++) {
 			_nodes[i] = CreateNode(i, _nodeEndpoints[i], _nodeGossipSeeds[i], 0, null);
-			_nodes[i].Start();
+			await _nodes[i].Start();
 		}
 	}
 

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Authentication;
 using EventStore.Core.Authentication.InternalAuthentication;
@@ -48,7 +49,7 @@ public abstract class SingleNodeScenario<TLogFormat, TStreamId> : SpecificationW
 					options.Application.AllowAnonymousStreamAccess,
 					options.Application.OverrideAnonymousEndpointAccessForGossip).Create(c.MainQueue)]))),
 			certificateProvider: new OptionsCertificateProvider());
-		_node.Start();
+		await _node.StartAsync(waitUntilReady: false, CancellationToken.None);
 	}
 
 	[OneTimeTearDown]
@@ -70,7 +71,7 @@ public abstract class ClusterMemberScenario<TLogFormat, TStreamId> {
 	protected ILogFormatAbstractorFactory<TStreamId> _logFormatFactory;
 
 	[OneTimeSetUp]
-	public virtual void TestFixtureSetUp() {
+	public virtual async Task TestFixtureSetUp() {
 		_logFormatFactory = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory;
 		_quorumSize = _clusterSize / 2 + 1;
 
@@ -89,7 +90,7 @@ public abstract class ClusterMemberScenario<TLogFormat, TStreamId> {
 					_options.Application.AllowAnonymousStreamAccess,
 					_options.Application.OverrideAnonymousEndpointAccessForGossip).Create(c.MainQueue)]))),
 			certificateProvider: new OptionsCertificateProvider());
-		_node.Start();
+		await _node.StartAsync(waitUntilReady: false, CancellationToken.None);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/ArchiveCatchupTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/ArchiveCatchupTests.cs
@@ -100,7 +100,7 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests> {
 	public async Task doesnt_catch_up_if_db_is_ahead_or_in_sync_with_archive(long dbCheckpoint, long archiveCheckpoint) {
 		var sut = CreateSut(dbCheckpoint: dbCheckpoint, archiveCheckpoint: archiveCheckpoint);
 
-		await sut.Catchup.Run();
+		await sut.Catchup.Run(CancellationToken.None);
 
 		Assert.Empty(sut.Archive.ChunkGets);
 		Assert.Equal(dbCheckpoint, sut.WriterCheckpoint.Read());
@@ -122,7 +122,7 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests> {
 			dbCheckpoint: dbCheckpoint,
 			archiveCheckpoint: archiveCheckpoint);
 
-		await sut.Catchup.Run();
+		await sut.Catchup.Run(CancellationToken.None);
 
 		var chunksToGet = new List<int>();
 		for (var i = (int)(dbCheckpoint / ChunkSize); i < (int)(archiveCheckpoint / ChunkSize); i++)
@@ -152,7 +152,7 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests> {
 			archiveCheckpoint: archiveCheckpoint,
 			dbChunks: dbChunks);
 
-		await sut.Catchup.Run();
+		await sut.Catchup.Run(CancellationToken.None);
 		await VerifyCatchUp(sut, dbCheckpoint, archiveCheckpoint, expectedChunksToFetch, expectedChunksToBackup);
 	}
 
@@ -168,7 +168,7 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests> {
 			archiveCheckpoint: 2000L,
 			onGetChunk: OnGetChunk);
 
-		await sut.Catchup.Run();
+		await sut.Catchup.Run(CancellationToken.None);
 
 		Assert.Equal(2000L, sut.WriterCheckpoint.Read());
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -133,8 +133,7 @@ public abstract class ClusterVNode {
 	abstract public bool EnableUnixSocket { get; }
 	abstract public bool IsShutdown { get; }
 
-	abstract public void Start();
-	abstract public Task<ClusterVNode> StartAsync(bool waitUntilRead);
+	abstract public Task<ClusterVNode> StartAsync(bool waitUntilReady, CancellationToken token);
 	abstract public Task StopAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 }
 
@@ -203,6 +202,7 @@ public class ClusterVNode<TStreamId> :
 	private readonly CertificateDelegates.ServerCertificateValidator _externalServerCertificateValidator;
 	private readonly CertificateProvider _certificateProvider;
 	private readonly ClusterVNodeStartup<TStreamId> _startup;
+	private readonly Func<CancellationToken, ValueTask> _start;
 	private readonly INodeHttpClientFactory _nodeHttpClientFactory;
 	private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
 
@@ -1601,6 +1601,8 @@ public class ClusterVNode<TStreamId> :
 			return services;
 		}
 
+		IReadOnlyList<IClusterVNodeStartupTask> startupTasks = [];
+
 		void ConfigureNode(IApplicationBuilder app) {
 			var dbTransforms = app.ApplicationServices.GetService<IReadOnlyList<IDbTransform>>();
 			Db.TransformManager.LoadTransforms(dbTransforms);
@@ -1608,11 +1610,13 @@ public class ClusterVNode<TStreamId> :
 			if (!Db.TransformManager.TrySetActiveTransform(options.Database.Transform))
 				throw new InvalidConfigurationException(
 					$"Unknown {nameof(options.Database.Transform)} specified: {options.Database.Transform}");
+
+			startupTasks = app.ApplicationServices.GetRequiredService<IReadOnlyList<IClusterVNodeStartupTask>>();
 		}
 
-		void StartNodeUnwrapException(IApplicationBuilder app) {
+		async ValueTask StartNodeUnwrapException(CancellationToken token) {
 			try {
-				StartNode(app);
+				await StartNode(token);
 			} catch (AggregateException aggEx) when (aggEx.InnerException is { } innerEx) {
 				// We only really care that *something* is wrong - throw the first inner exception.
 				// keeping its original stack
@@ -1620,7 +1624,7 @@ public class ClusterVNode<TStreamId> :
 			}
 		}
 
-		void StartNode(IApplicationBuilder app) {
+		async ValueTask StartNode(CancellationToken token) {
 			// TRUNCATE IF NECESSARY
 			var truncPos = Db.Config.TruncateCheckpoint.Read();
 			if (truncPos != -1) {
@@ -1629,42 +1633,35 @@ public class ClusterVNode<TStreamId> :
 					truncPos, truncPos, writerCheckpoint, writerCheckpoint, chaserCheckpoint, chaserCheckpoint,
 					epochCheckpoint, epochCheckpoint);
 				var truncator = new TFChunkDbTruncator(Db.Config, Db.Manager.FileSystem, type => Db.TransformManager.GetFactoryForExistingChunk(type));
-				using (var task = truncator.TruncateDb(truncPos, CancellationToken.None).AsTask()) {
-					task.Wait(DefaultShutdownTimeout);
-				}
+				await truncator.TruncateDb(truncPos, CancellationToken.None);
 
 				// The truncator has moved the checkpoints but it is possible that other components in the startup have
 				// already read the old values. If we ensure all checkpoint reads are performed after the truncation
 				// then we can remove this extra restart
 				Log.Information("Truncation successful. Shutting down.");
 				var shutdownGuid = Guid.NewGuid();
-				using (var task = HandleAsync(
-					       new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
-					       CancellationToken.None).AsTask()) {
-					task.Wait(DefaultShutdownTimeout);
-				}
+				await HandleAsync(
+						new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
+						token)
+					.AsTask()
+					.WaitAsync(DefaultShutdownTimeout, token);
 
 				Handle(new SystemMessage.BecomeShutdown(shutdownGuid));
 				Application.Exit(0, "Shutting down after successful truncation.");
 				return;
 			}
 
-			var startupTasks = (app.ApplicationServices.GetRequiredService<IReadOnlyList<IClusterVNodeStartupTask>>())
-				.Select(x => x.Run())
-				.ToArray();
-			Task.WaitAll(startupTasks); // No timeout or cancellation, this is intended
+			foreach (var x in startupTasks) {
+				await x.Run(token);
+			}
 
 			// start the main queue as we publish messages to it while opening the db
 			AddTask(_controller.Start());
 
-			using (var task = Db.Open(!options.Database.SkipDbVerify, threads: options.Database.InitializationThreads,
-				       createNewChunks: false).AsTask()) {
-				task.Wait(); // No timeout or cancellation, this is intended
-			}
+			await Db.Open(!options.Database.SkipDbVerify, threads: options.Database.InitializationThreads,
+				createNewChunks: false, token: token);
 
-			using (var task = epochManager.Init(CancellationToken.None).AsTask()) {
-				task.Wait(); // No timeout or cancellation, this is intended
-			}
+			await epochManager.Init(token);
 
 			storageWriter.Start();
 			AddTasks(storageWriter.Tasks);
@@ -1677,6 +1674,7 @@ public class ClusterVNode<TStreamId> :
 
 			dynamicCacheManager.Start();
 		}
+		_start = StartNodeUnwrapException;
 
 		_startup = new ClusterVNodeStartup<TStreamId>(
 			modifiedOptions.PlugableComponents,
@@ -1690,8 +1688,7 @@ public class ClusterVNode<TStreamId> :
 			trackers,
 			options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null,
 			ConfigureNodeServices,
-			ConfigureNode,
-			StartNodeUnwrapException);
+			ConfigureNode);
 
 		_mainBus.Subscribe<SystemMessage.SystemReady>(_startup);
 		_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_startup);
@@ -1804,10 +1801,6 @@ public class ClusterVNode<TStreamId> :
 		}
 	}
 
-	public override void Start() {
-		_mainQueue.Publish(new SystemMessage.SystemInit());
-	}
-
 	public override async Task StopAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default) {
 		if (Interlocked.Exchange(ref _stopCalled, 1) == 1) {
 			Log.Warning("Stop was already called.");
@@ -1880,7 +1873,7 @@ public class ClusterVNode<TStreamId> :
 #endif
 	}
 
-	public override Task<ClusterVNode> StartAsync(bool waitUntilReady) {
+	public override async Task<ClusterVNode> StartAsync(bool waitUntilReady, CancellationToken token) {
 		var tcs = new TaskCompletionSource<ClusterVNode>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		if (waitUntilReady) {
@@ -1890,12 +1883,13 @@ public class ClusterVNode<TStreamId> :
 			tcs.TrySetResult(this);
 		}
 
-		Start();
+		await _start(token);
+		_mainQueue.Publish(new SystemMessage.SystemInit());
 
 		if (IsShutdown)
 			tcs.TrySetResult(this);
 
-		return tcs.Task;
+		return await tcs.Task;
 	}
 
 	public static ValueTuple<bool, string> ValidateServerCertificate(X509Certificate certificate,

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -56,7 +56,6 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 	private readonly StatusCheck _statusCheck;
 	private readonly Func<IServiceCollection, IServiceCollection> _configureNodeServices;
 	private readonly Action<IApplicationBuilder> _configureNode;
-	private readonly Action<IApplicationBuilder> _startNode;
 
 	private bool _ready;
 	private readonly IAuthorizationProvider _authorizationProvider;
@@ -79,8 +78,7 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 		Trackers trackers,
 		string clusterDns,
 		Func<IServiceCollection, IServiceCollection> configureNodeServices,
-		Action<IApplicationBuilder> configureNode,
-		Action<IApplicationBuilder> startNode) {
+		Action<IApplicationBuilder> configureNode) {
 
 		Ensure.Positive(maxAppendSize, nameof(maxAppendSize));
 
@@ -113,7 +111,6 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 		_clusterDns = clusterDns;
 		_configureNodeServices = configureNodeServices ?? throw new ArgumentNullException(nameof(configureNodeServices));
 		_configureNode = configureNode ?? throw new ArgumentNullException(nameof(configureNode));
-		_startNode = startNode ?? throw new ArgumentNullException(nameof(startNode));
 		_statusCheck = new StatusCheck(this);
 	}
 
@@ -180,8 +177,6 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 						.Build(),
 					_httpService);
 			});
-
-		_startNode(app);
 	}
 
 	public IServiceProvider ConfigureServices(IServiceCollection services) {

--- a/src/EventStore.Core/IClusterVNodeStartupTask.cs
+++ b/src/EventStore.Core/IClusterVNodeStartupTask.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace EventStore.Core;
 
+// Implementations of this interface are run to completion during startup
 public interface IClusterVNodeStartupTask {
 	ValueTask Run(CancellationToken token);
 }

--- a/src/EventStore.Core/IClusterVNodeStartupTask.cs
+++ b/src/EventStore.Core/IClusterVNodeStartupTask.cs
@@ -1,10 +1,11 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EventStore.Core;
 
 public interface IClusterVNodeStartupTask {
-	Task Run();
+	ValueTask Run(CancellationToken token);
 }

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -83,7 +83,7 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 		var projectionsStarted = _projections.Select(p => SystemProjections.Created(p.LeaderInputBus)).ToArray();
 
 		foreach (var node in _nodes) {
-			node.Start();
+			await node.Start();
 			node.WaitIdle();
 		}
 

--- a/src/KurrentDB/ClusterVNodeHostedService.cs
+++ b/src/KurrentDB/ClusterVNodeHostedService.cs
@@ -312,7 +312,7 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable {
 	}
 
 	public Task StartAsync(CancellationToken cancellationToken) =>
-		_options.Application.WhatIf ? Task.CompletedTask : Node.StartAsync(false);
+		_options.Application.WhatIf ? Task.CompletedTask : Node.StartAsync(waitUntilReady: false, cancellationToken);
 
 	public Task StopAsync(CancellationToken cancellationToken) =>
 		Node.StopAsync(cancellationToken: cancellationToken);

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -238,7 +238,7 @@ internal static class Program {
 
 					exitCodeSource.TrySetResult(0);
 				} catch (OperationCanceledException) {
-					; // no op
+					// no op
 				} catch (Exception ex) {
 					Log.Fatal(ex, "Exiting");
 					exitCodeSource.TrySetResult(1);

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -178,6 +178,7 @@ internal static class Program {
 			}
 
 			using var cts = new CancellationTokenSource();
+			var token = cts.Token;
 			Application.RegisterExitAction(code => {
 				// add a small delay to allow the host to start up in case there's a premature shutdown
 				cts.CancelAfter(TimeSpan.FromSeconds(1));
@@ -234,7 +235,7 @@ internal static class Program {
 						// Allows the subsystems to resolve dependencies out of the DI in Configure() before being started.
 						// Later it may be possible to use constructor injection instead if it fits with the bootstrapping strategy.
 						.ConfigureServices(services => services.AddSingleton<IHostedService>(hostedService))
-						.RunConsoleAsync(x => x.SuppressStatusMessages = true, cts.Token);
+						.RunConsoleAsync(x => x.SuppressStatusMessages = true, token);
 
 					exitCodeSource.TrySetResult(0);
 				} catch (OperationCanceledException) {

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -39,7 +39,6 @@ internal static class Program {
 
 		ThreadPool.SetMaxThreads(1000, 1000);
 		var exitCodeSource = new TaskCompletionSource<int>();
-		var cts = new CancellationTokenSource();
 
 		Log.Logger = EventStoreLoggerConfiguration.ConsoleLog;
 		try {
@@ -178,6 +177,7 @@ internal static class Program {
 				return 0;
 			}
 
+			using var cts = new CancellationTokenSource();
 			Application.RegisterExitAction(code => {
 				// add a small delay to allow the host to start up in case there's a premature shutdown
 				cts.CancelAfter(TimeSpan.FromSeconds(1));

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -237,6 +237,8 @@ internal static class Program {
 						.RunConsoleAsync(x => x.SuppressStatusMessages = true, cts.Token);
 
 					exitCodeSource.TrySetResult(0);
+				} catch (OperationCanceledException) {
+					; // no op
 				} catch (Exception ex) {
 					Log.Fatal(ex, "Exiting");
 					exitCodeSource.TrySetResult(1);


### PR DESCRIPTION
StartAsync is async and can be cancelled. Otherwise ctrl+c doesn't work during this stage. Also removed retry logic from ArchiveCatchup now that it's baked into the ArchiveStorage