### PR TITLE
[KDB-591] Rename custom content types for the HTTP API

### DIFF
--- a/src/EventStore.Core.Tests/Http/Admin/scavenges.cs
+++ b/src/EventStore.Core.Tests/Http/Admin/scavenges.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using EventStore.Transport.Http;
+using NUnit.Framework;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EventStore.Core.Tests.Http.Users.users;
+using HttpStatusCode = System.Net.HttpStatusCode;
+
+namespace EventStore.Core.Tests.Http.Admin {
+	namespace scavenges {
+		[Category("LongRunning")]
+		[TestFixture]
+		public class when_getting_scavenge_stream_without_accept_header : with_admin_user {
+			private JObject _descriptionDocument;
+			private List<JToken> _links;
+
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override async Task When() {
+				_descriptionDocument = await GetJsonWithoutAcceptHeader<JObject>("/streams/$scavenges?embed=body");
+			}
+
+			[Test]
+			public void returns_not_acceptable() {
+				Assert.AreEqual(HttpStatusCode.NotAcceptable, _lastResponse.StatusCode);
+			}
+
+			[Test]
+			public void returns_a_description_document() {
+				Assert.IsNotNull(_descriptionDocument);
+				_links = _descriptionDocument != null ? _descriptionDocument["_links"].ToList() : new List<JToken>();
+				Assert.IsNotNull(_links, "Expected there to be links in the description but _links is null");
+			}
+		}
+
+		[Category("LongRunning")]
+		[TestFixture(ContentType.DescriptionDocJson)]
+		[TestFixture(ContentType.LegacyDescriptionDocJson)]
+		public class when_getting_scavenge_stream_with_description_document_content_type(string contentType) : with_admin_user {
+			private JObject _descriptionDocument;
+			private List<JToken> _links;
+
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override async Task When() {
+				_descriptionDocument = await GetJson<JObject>("/streams/$scavenges?embed=body", contentType, null);
+				_links = _descriptionDocument != null ? _descriptionDocument["_links"].ToList() : new List<JToken>();
+			}
+
+			[Test]
+			public void returns_ok() {
+				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+			}
+
+			[Test]
+			public void returns_a_description_document() {
+				Assert.IsNotNull(_descriptionDocument);
+			}
+
+			[Test]
+			public void contains_the_self_link() {
+				Assert.AreEqual("self", ((JProperty)_links[0]).Name);
+				Assert.AreEqual("/streams/%24scavenges%3Fembed%3Dbody", _descriptionDocument["_links"]["self"]["href"].ToString());
+			}
+
+			[Test]
+			public void self_link_contains_only_the_description_document_content_type() {
+				var supportedContentTypes = _descriptionDocument["_links"]["self"]["supportedContentTypes"]
+					.Values<string>()
+					.ToArray();
+				Assert.AreEqual(1, supportedContentTypes.Length);
+				Assert.AreEqual(contentType, supportedContentTypes[0]);
+			}
+
+			[Test]
+			public void contains_the_stream_link() {
+				Assert.AreEqual("stream", ((JProperty)_links[1]).Name);
+				Assert.AreEqual("/streams/%24scavenges%3Fembed%3Dbody", _descriptionDocument["_links"]["stream"]["href"].ToString());
+			}
+
+			[Test]
+			public void stream_link_contains_supported_stream_content_types() {
+				var supportedContentTypes = _descriptionDocument["_links"]["stream"]["supportedContentTypes"]
+					.Values<string>().ToArray();
+				Assert.AreEqual(3, supportedContentTypes.Length);
+				Assert.Contains(ContentType.Atom, supportedContentTypes);
+				Assert.Contains(ContentType.AtomJson, supportedContentTypes);
+				Assert.Contains(ContentType.LegacyAtomJson, supportedContentTypes);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Http/ArgumentPassing/matching.cs
+++ b/src/EventStore.Core.Tests/Http/ArgumentPassing/matching.cs
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.Http.ArgumentPassing {
 			[TestCase("%20", " ", "2", "2")] // space
 			[TestCase("%25", "%", "2", "2")] // %
 			public async Task returns_ok_status_code(string _a, string _ra, string _b, string _rb) {
-				_response = await GetJson2<JObject>("/test-encoding/" + _a, "b=" + _b);
+				_response = await GetJson<JObject>("/test-encoding/" + _a, extra: "b=" + _b);
 				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
 				HelperExtensions.AssertJson(new { a = _ra, b = _rb }, _response);
 			}
@@ -48,31 +48,6 @@ namespace EventStore.Core.Tests.Http.ArgumentPassing {
 				_response = await GetJson<JObject>("/test-encoding/1", accept: accept);
 				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
 				HelperExtensions.AssertJson(new { a = "1" }, _response);
-			}
-		}
-
-		[Category("LongRunning")]
-		[Ignore("Only demonstrates differences between .NET and Mono")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_matching_against_placeholders_with_reserved_characters<TLogFormat, TStreamId> : HttpBehaviorSpecification<TLogFormat, TStreamId> {
-			private JObject _response;
-
-			protected override Task Given() => Task.CompletedTask;
-			protected override Task When() => Task.CompletedTask;
-
-			[Test]
-			// [TestCase("%24", "$", "2", "2")]
-			// [TestCase("$", "$", "2", "2")]
-			// [TestCase("%3F", "?", "2", "2")] // ?
-			// [TestCase("%2F", "/", "2", "2")] // /
-			// [TestCase("%20", " ", "2", "2")] // space
-			// [TestCase("%25", "%", "2", "2")] // %
-			public async Task returns_ok_status_code(string _a, string _ra, string _b, string _rb) {
-				_response = await GetJson2<JObject>("/test-encoding-reserved-" + _a, "?b=" + _b);
-				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
-				Console.WriteLine(_response.ToString());
-				HelperExtensions.AssertJson(new { a = _ra, b = _rb }, _response);
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
+++ b/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
@@ -4,12 +4,9 @@
 using System;
 using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -18,12 +15,14 @@ using EventStore.Common.Utils;
 using EventStore.Core.Tests.ClientAPI.Helpers;
 using EventStore.Core.Tests.Helpers;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using EventStore.ClientAPI.Transport.Http;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Converters;
+using ContentTypeConstant = EventStore.Transport.Http.ContentType;
 
 namespace EventStore.Core.Tests.Http;
+
+public abstract class HttpBehaviorSpecification : HttpBehaviorSpecification<LogFormat.V2, string>;
 
 public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
 	protected MiniNode<TLogFormat, TStreamId> _node;
@@ -78,8 +77,6 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 	protected virtual MiniNode<TLogFormat, TStreamId> CreateMiniNode() =>
 		new(PathName);
 
-	protected virtual bool GivenSkipInitializeStandardUsersCheck() => false;
-
 	public override async Task TestFixtureTearDown() {
 		_connection.Close();
 		await _node.Shutdown();
@@ -119,7 +116,7 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 			? new Uri(path, UriKind.RelativeOrAbsolute)
 			: new Uri(path + "?" + extra, UriKind.RelativeOrAbsolute);
 
-		if (supplied.IsAbsoluteUri && !supplied.IsFile) // NOTE: is file imporant for mono
+		if (supplied.IsAbsoluteUri && !supplied.IsFile)
 			return supplied;
 
 		var httpEndPoint = _node.HttpEndPoint;
@@ -144,54 +141,15 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 		return GetRequestResponse(request);
 	}
 
-	protected Task<HttpResponseMessage> MakeArrayEventsPost<T>(string path, T body, NetworkCredential credentials = null, string extra = null) {
+	protected Task<HttpResponseMessage> MakeArrayEventsPost<T>(string path, T body, NetworkCredential credentials = null, string extra = null, string contentType = null) {
 		credentials ??= _defaultCredentials;
-		var request = CreateEventsJsonPostRequest(path, "POST", body, credentials, extra);
+		var request = CreateEventsJsonPostRequest(path, "POST", body, credentials, extra, contentType);
 		return GetRequestResponse(request);
 	}
 
 	protected Task<HttpResponseMessage> MakeRawJsonPost<T>(string path, T body, NetworkCredential credentials = null, string extra = null) {
 		credentials ??= _defaultCredentials;
 		var request = CreateRawJsonPostRequest(path, "POST", body, credentials, extra);
-		return GetRequestResponse(request);
-	}
-
-	protected async Task<JObject> MakeJsonPostWithJsonResponse<T>(string path, T body, NetworkCredential credentials = null, string extra = null) {
-		credentials ??= _defaultCredentials;
-		var request = CreateRawJsonPostRequest(path, "POST", body, credentials, extra);
-		_lastResponse = await GetRequestResponse(request);
-		var memoryStream = new MemoryStream();
-		await _lastResponse.Content.CopyToAsync(memoryStream);
-		var bytes = memoryStream.ToArray();
-		_lastResponseBody = Helper.UTF8NoBom.GetString(bytes);
-		try {
-			return _lastResponseBody.ParseJson<JObject>();
-		} catch (JsonException ex) {
-			_lastJsonException = ex;
-			return default;
-		}
-	}
-
-	protected async Task<JObject> MakeJsonEventsPostWithJsonResponse<T>(string path, T body, NetworkCredential credentials = null, string extra = null) {
-		credentials ??= _defaultCredentials;
-		var request = CreateEventsJsonPostRequest(path, "POST", body, credentials, extra);
-		_lastResponse = await GetRequestResponse(request);
-		var memoryStream = new MemoryStream();
-		await _lastResponse.Content.CopyToAsync(memoryStream);
-		var bytes = memoryStream.ToArray();
-		_lastResponseBody = Helper.UTF8NoBom.GetString(bytes);
-		try {
-			return _lastResponseBody.ParseJson<JObject>();
-		} catch (JsonException ex) {
-			_lastJsonException = ex;
-			return default;
-		}
-	}
-
-
-	protected Task<HttpResponseMessage> MakeEventsJsonPut<T>(string path, T body, NetworkCredential credentials, string extra = null) {
-		credentials ??= _defaultCredentials;
-		var request = CreateEventsJsonPostRequest(path, "PUT", body, credentials, extra);
 		return GetRequestResponse(request);
 	}
 
@@ -237,17 +195,6 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 		}
 	}
 
-	protected async Task<T> GetJson2<T>(string path, string extra, string accept = null, NetworkCredential credentials = null) {
-		credentials ??= _defaultCredentials;
-		await Get(path, extra, accept, credentials);
-		try {
-			return _lastResponseBody.ParseJson<T>();
-		} catch (JsonException ex) {
-			_lastJsonException = ex;
-			return default;
-		}
-	}
-
 	protected async Task<T> GetJsonWithoutAcceptHeader<T>(string path) {
 		var request = CreateRequest(path, "", "GET", null);
 		_lastResponse = await GetRequestResponse(request);
@@ -268,7 +215,7 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 		credentials = credentials ?? _defaultCredentials;
 		var request = CreateRequest(path, extra, "GET", null, credentials, headers);
 		if (setAcceptHeader) {
-			request.Headers.Add("accept", accept ?? "application/json");
+			request.Headers.Add("accept", accept ?? ContentTypeConstant.Json);
 		}
 
 		_lastResponse = await GetRequestResponse(request);
@@ -283,32 +230,7 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 		var response = await _client.SendAsync(request);
 		_allResponses.Add(response);
 
-		/*if (_dumpRequest != null) {
-			var bytes = _dumpRequest(request);
-			if (bytes != null)
-				Console.WriteLine(Encoding.ASCII.GetString(bytes, 0, GetBytesLength(bytes)).TrimEnd('\0'));
-		}
-
-		if (_dumpRequest2 != null) {
-			var bytes = _dumpRequest2(request);
-			if (bytes != null)
-				Console.WriteLine(Encoding.ASCII.GetString(bytes, 0, GetBytesLength(bytes)).TrimEnd('\0'));
-		}
-
-		Console.WriteLine();
-		if (_dumpResponse != null) {
-			var bytes = _dumpResponse(response);
-			var len = _dumpResponse2(response);
-			if (bytes != null)
-				Console.WriteLine(Encoding.ASCII.GetString(bytes, 0, len).TrimEnd('\0'));
-		}*/
-
 		return response;
-	}
-
-	private int GetBytesLength(byte[] bytes) {
-		var index = Array.IndexOf(bytes, 0);
-		return index < 0 ? bytes.Length : index;
 	}
 
 	protected readonly JsonSerializerSettings TestJsonSettings = new JsonSerializerSettings {
@@ -327,11 +249,11 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 	}
 
 	protected HttpRequestMessage CreateEventsJsonPostRequest<T>(
-		string path, string method, T body, NetworkCredential credentials = null, string extra = null) {
+		string path, string method, T body, NetworkCredential credentials = null, string extra = null, string contentType = null) {
 		credentials = credentials ?? _defaultCredentials;
-		var request = CreateRequest(path, extra, method, "application/vnd.eventstore.events+json", credentials);
+		var request = CreateRequest(path, extra, method, contentType ?? ContentTypeConstant.EventsJson, credentials);
 		request.Content = new ByteArrayContent(ToJsonBytes(body)) {
-			Headers = { ContentType = new MediaTypeHeaderValue("application/vnd.eventstore.events+json") }
+			Headers = { ContentType = new MediaTypeHeaderValue(contentType ?? ContentTypeConstant.EventsJson) }
 		};
 		return request;
 	}
@@ -339,9 +261,9 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 	protected HttpRequestMessage CreateRawJsonPostRequest<T>(
 		string path, string method, T body, NetworkCredential credentials = null, string extra = null) {
 		credentials ??= _defaultCredentials;
-		var request = CreateRequest(path, extra, method, "application/json", credentials);
+		var request = CreateRequest(path, extra, method, ContentTypeConstant.Json, credentials);
 		request.Content = new ByteArrayContent(ToJsonBytes(body)) {
-			Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+			Headers = { ContentType = new MediaTypeHeaderValue(ContentTypeConstant.Json) }
 		};
 		return request;
 	}
@@ -357,94 +279,4 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 
 	protected abstract Task Given();
 	protected abstract Task When();
-
-	private static Func<HttpResponseMessage, byte[]> CreateDumpResponse() {
-		var r = Expression.Parameter(typeof(HttpResponseMessage), "r");
-		var piCoreResponseData = typeof(HttpResponseMessage).GetProperty(
-			"CoreResponseData",
-			BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy |
-			BindingFlags.Instance);
-		var fim_ConnectStream = piCoreResponseData.PropertyType.GetField("m_ConnectStream",
-			BindingFlags.GetField | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
-		var connectStreamType = AppDomain.CurrentDomain.GetAssemblies()
-			.Select(a => a.GetType("System.Net.ConnectStream")).Where(t => t != null).FirstOrDefault();
-		var fim_ReadBuffer = connectStreamType.GetField("m_ReadBuffer",
-			BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
-		var body = Expression.Field(
-			Expression.Convert(Expression.Field(Expression.Property(r, piCoreResponseData), fim_ConnectStream),
-				connectStreamType), fim_ReadBuffer);
-		var debugExpression = Expression.Lambda<Func<HttpResponseMessage, byte[]>>(body, r);
-		return debugExpression.Compile();
-	}
-
-	private static Func<HttpResponseMessage, int> CreateDumpResponse2() {
-		var r = Expression.Parameter(typeof(HttpResponseMessage), "r");
-		var piCoreResponseData = typeof(HttpResponseMessage).GetProperty(
-			"CoreResponseData",
-			BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy |
-			BindingFlags.Instance);
-		var fim_ConnectStream = piCoreResponseData.PropertyType.GetField("m_ConnectStream",
-			BindingFlags.GetField | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
-		var connectStreamType = AppDomain.CurrentDomain.GetAssemblies()
-			.Select(a => a.GetType("System.Net.ConnectStream")).Where(t => t != null).FirstOrDefault();
-		var fim_ReadOffset = connectStreamType.GetField("m_ReadOffset",
-			BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
-		var fim_ReadBufferSize = connectStreamType.GetField("m_ReadBufferSize",
-			BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
-		var stream =
-			Expression.Convert(Expression.Field(Expression.Property(r, piCoreResponseData), fim_ConnectStream),
-				connectStreamType);
-		var body = Expression.Add(Expression.Field(stream, fim_ReadOffset),
-			Expression.Field(stream, fim_ReadBufferSize));
-		var debugExpression = Expression.Lambda<Func<HttpResponseMessage, int>>(body, r);
-		return debugExpression.Compile();
-	}
-
-	private static Func<HttpRequestMessage, byte[]> CreateDumpRequest() {
-		var r = Expression.Parameter(typeof(HttpRequestMessage), "r");
-		var fi_WriteBuffer = typeof(HttpRequestMessage).GetField("_WriteBuffer",
-			BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy |
-			BindingFlags.Instance);
-		var body = Expression.Field(r, fi_WriteBuffer);
-		var debugExpression = Expression.Lambda<Func<HttpRequestMessage, byte[]>>(body, r);
-		return debugExpression.Compile();
-	}
-
-	private static Func<HttpRequestMessage, byte[]> CreateDumpRequest2() {
-		var r = Expression.Parameter(typeof(HttpRequestMessage), "r");
-		var fi_SubmitWriteStream = typeof(HttpRequestMessage).GetField(
-			"_SubmitWriteStream",
-			BindingFlags.GetField | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy
-			| BindingFlags.Instance);
-		var connectStreamType = AppDomain.CurrentDomain.GetAssemblies()
-			.Select(a => a.GetType("System.Net.ConnectStream")).Where(t => t != null).FirstOrDefault();
-		var piBufferedData = connectStreamType.GetProperty(
-			"BufferedData",
-			BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy
-			| BindingFlags.Instance);
-		var fiheadChunk = piBufferedData.PropertyType.GetField(
-			"headChunk",
-			BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy
-			| BindingFlags.Instance);
-		var piBuffer = fiheadChunk.FieldType.GetField(
-			"Buffer",
-			BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy
-			| BindingFlags.Instance);
-		var submitWriteStreamExpression = Expression.Field(r, fi_SubmitWriteStream);
-		var headChunk =
-			Expression.Condition(
-				Expression.ReferenceNotEqual(submitWriteStreamExpression,
-					Expression.Constant(null, submitWriteStreamExpression.Type)),
-				Expression.Field(
-					Expression.Property(
-						Expression.Convert(submitWriteStreamExpression, connectStreamType), piBufferedData),
-					fiheadChunk),
-				Expression.Constant(null, fiheadChunk.FieldType));
-		var body =
-			Expression.Condition(
-				Expression.ReferenceNotEqual(headChunk, Expression.Constant(null, headChunk.Type)),
-				Expression.Field(headChunk, piBuffer), Expression.Constant(null, piBuffer.FieldType));
-		var debugExpression = Expression.Lambda<Func<HttpRequestMessage, byte[]>>(body, r);
-		return debugExpression.Compile();
-	}
 }

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/ack.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/ack.cs
@@ -1,14 +1,7 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
-using System;
-using System.Net;
-using System.Text.RegularExpressions;
-using EventStore.Core.Tests.Http.Users.users;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 using Newtonsoft.Json.Linq;
 using System.Linq;
 using System.Net.Http;
@@ -20,9 +13,9 @@ using EventStore.Transport.Http;
 
 namespace EventStore.Core.Tests.Http.PersistentSubscription;
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_acking_a_message<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_acking_a_message(string contentType) : with_subscription_having_events {
 	private HttpResponseMessage _response;
 	private string _ackLink;
 
@@ -30,7 +23,7 @@ class when_acking_a_message<TLogFormat, TStreamId> : with_subscription_having_ev
 		await base.Given();
 		var json = await GetJson<JObject>(
 			SubscriptionPath + "/1",
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 		Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
 		_ackLink = json["entries"].Children().First()["links"].Children()
@@ -52,9 +45,9 @@ class when_acking_a_message<TLogFormat, TStreamId> : with_subscription_having_ev
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_acking_messages<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_acking_messages(string contentType) : with_subscription_having_events {
 	private HttpResponseMessage _response;
 	private string _ackAllLink;
 
@@ -62,7 +55,7 @@ class when_acking_messages<TLogFormat, TStreamId> : with_subscription_having_eve
 		await base.Given();
 		var json = await GetJson<JObject>(
 			SubscriptionPath + "/" + Events.Count,
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 		Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
 		_ackAllLink = json["links"].Children().First(x => x.Value<string>("relation") == "ackAll")

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/getting.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/getting.cs
@@ -17,7 +17,7 @@ using EventStore.ClientAPI.Common;
 
 namespace EventStore.Core.Tests.Http.PersistentSubscription;
 
-abstract class with_subscription_having_events<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+abstract class with_subscription_having_events : with_admin_user {
 	protected List<object> Events;
 	protected string SubscriptionPath;
 	protected string GroupName;
@@ -78,9 +78,9 @@ abstract class with_subscription_having_events<TLogFormat, TStreamId> : with_adm
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_without_permission<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_without_permission(string contentType) : with_subscription_having_events {
 	protected override async Task Given() {
 		await base.Given();
 		await SecureStream();
@@ -90,7 +90,7 @@ class when_getting_messages_without_permission<TLogFormat, TStreamId> : with_sub
 		SetDefaultCredentials(null);
 		await GetJson<JObject>(
 			SubscriptionPath,
-			ContentType.CompetingJson);
+			contentType);
 	}
 
 	[Test]
@@ -100,9 +100,9 @@ class when_getting_messages_without_permission<TLogFormat, TStreamId> : with_sub
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_an_empty_subscription<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_an_empty_subscription(string contentType) : with_admin_user {
 	private JObject _response;
 	protected List<object> Events;
 	protected string SubscriptionPath;
@@ -135,7 +135,7 @@ class when_getting_messages_from_an_empty_subscription<TLogFormat, TStreamId> : 
 		//pull all events out.
 		_response = await GetJson<JObject>(
 			SubscriptionPath + "/" + Events.Count,
-			ContentType.CompetingJson, //todo CLC sort out allowed content types
+			contentType,
 			_admin);
 
 		var count = _response["entries"].Count();
@@ -145,7 +145,7 @@ class when_getting_messages_from_an_empty_subscription<TLogFormat, TStreamId> : 
 	protected override async Task When() {
 		_response = await GetJson<JObject>(
 			SubscriptionPath,
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 	}
 
@@ -156,15 +156,15 @@ class when_getting_messages_from_an_empty_subscription<TLogFormat, TStreamId> : 
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_n_messages<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_n_messages(string contentType) : with_subscription_having_events {
 	private JObject _response;
 
 	protected override async Task When() {
 		_response = await GetJson<JObject>(
 			SubscriptionPath + "/" + Events.Count,
-			ContentType.CompetingJson, //todo CLC sort out allowed content types
+			contentType,
 			_admin);
 	}
 
@@ -175,15 +175,15 @@ class when_getting_messages_from_a_subscription_with_n_messages<TLogFormat, TStr
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_more_than_n_messages<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_more_than_n_messages(string contentType) : with_subscription_having_events {
 	private JObject _response;
 
 	protected override async Task When() {
 		_response = await GetJson<JObject>(
 			SubscriptionPath + "/" + (Events.Count - 1),
-			ContentType.CompetingJson, //todo CLC sort out allowed content types
+			contentType,
 			_admin);
 	}
 
@@ -194,15 +194,15 @@ class when_getting_messages_from_a_subscription_with_more_than_n_messages<TLogFo
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_less_than_n_messags<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_less_than_n_messags(string contentType) : with_subscription_having_events {
 	private JObject _response;
 
 	protected override async Task When() {
 		_response = await GetJson<JObject>(
 			SubscriptionPath + "/" + (Events.Count + 1),
-			ContentType.CompetingJson, //todo CLC sort out allowed content types
+			contentType,
 			_admin);
 	}
 
@@ -213,15 +213,15 @@ class when_getting_messages_from_a_subscription_with_less_than_n_messags<TLogFor
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_unspecified_count<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_unspecified_count(string contentType) : with_subscription_having_events {
 	private JObject _response;
 
 	protected override async Task When() {
 		_response = await GetJson<JObject>(
 			SubscriptionPath,
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 	}
 
@@ -232,13 +232,13 @@ class when_getting_messages_from_a_subscription_with_unspecified_count<TLogForma
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_a_negative_count<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_a_negative_count(string contentType) : with_subscription_having_events {
 	protected override Task When() {
 		return Get(SubscriptionPath + "/-1",
 			"",
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 	}
 
@@ -248,13 +248,13 @@ class when_getting_messages_from_a_subscription_with_a_negative_count<TLogFormat
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_a_count_of_0<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_a_count_of_0(string contentType) : with_subscription_having_events {
 	protected override async Task When() {
 		await Get(SubscriptionPath + "/0",
 			"",
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 	}
 
@@ -264,13 +264,13 @@ class when_getting_messages_from_a_subscription_with_a_count_of_0<TLogFormat, TS
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_count_more_than_100<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_count_more_than_100(string contentType) : with_subscription_having_events {
 	protected override async Task When() {
 		await Get(SubscriptionPath + "/101",
 			"",
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 	}
 
@@ -280,13 +280,13 @@ class when_getting_messages_from_a_subscription_with_count_more_than_100<TLogFor
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_count_not_an_integer<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_count_not_an_integer(string contentType) : with_subscription_having_events {
 	protected override Task When() {
 		return Get(SubscriptionPath + "/10.1",
 			"",
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 	}
 
@@ -296,13 +296,13 @@ class when_getting_messages_from_a_subscription_with_count_not_an_integer<TLogFo
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_messages_from_a_subscription_with_count_not_a_number<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_messages_from_a_subscription_with_count_not_a_number(string contentType) : with_subscription_having_events {
 	protected override Task When() {
 		return Get(SubscriptionPath + "/one",
 			"",
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 	}
 

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/nack.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/nack.cs
@@ -13,9 +13,9 @@ using EventStore.Transport.Http;
 
 namespace EventStore.Core.Tests.Http.PersistentSubscription;
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_nacking_a_message<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_nacking_a_message(string contentType) : with_subscription_having_events {
 	private HttpResponseMessage _response;
 	private string _nackLink;
 
@@ -23,7 +23,7 @@ class when_nacking_a_message<TLogFormat, TStreamId> : with_subscription_having_e
 		await base.Given();
 		var json = await GetJson<JObject>(
 			SubscriptionPath + "/1",
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 		Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
 		Assert.DoesNotThrow(() => {
@@ -42,9 +42,9 @@ class when_nacking_a_message<TLogFormat, TStreamId> : with_subscription_having_e
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_nacking_messages<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_nacking_messages(string contentType) : with_subscription_having_events {
 	private HttpResponseMessage _response;
 	private string _nackAllLink;
 
@@ -52,7 +52,7 @@ class when_nacking_messages<TLogFormat, TStreamId> : with_subscription_having_ev
 		await base.Given();
 		var json = await GetJson<JObject>(
 			SubscriptionPath + "/" + Events.Count,
-			ContentType.CompetingJson,
+			contentType,
 			_admin);
 		Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
 		Assert.DoesNotThrow(() => {

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -9,20 +9,18 @@ using EventStore.ClientAPI;
 using EventStore.Transport.Http;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using HttpStatusCode = System.Net.HttpStatusCode;
 using System.Xml.Linq;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Tests.Http.Users.users;
+using HttpStatusCode = System.Net.HttpStatusCode;
 
 namespace EventStore.Core.Tests.Http.PersistentSubscription;
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class
-	when_getting_statistics_for_new_subscription_for_stream_with_existing_events<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture]
+class when_getting_statistics_for_new_subscription_for_stream_with_existing_events : with_subscription_having_events {
 	private JArray _json;
 
 	protected override async Task When() {
@@ -46,9 +44,9 @@ class
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_statistics_for_subscription_with_parked_events<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture(ContentType.CompetingJson)]
+[TestFixture(ContentType.LegacyCompetingJson)]
+class when_getting_statistics_for_subscription_with_parked_events(string contentType) : with_subscription_having_events {
 	private string _nackLink;
 	private JObject _json;
 	private string _streamName;
@@ -71,10 +69,11 @@ class when_getting_statistics_for_subscription_with_parked_events<TLogFormat, TS
 		_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.WritePrepares>(Handle));
 		_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.CommitIndexed>(Handle));
 
-		var json = await GetJson2<JObject>(
-			SubscriptionPath + "/1", "embed=rich",
-			ContentType.CompetingJson,
-			_admin);
+		var json = await GetJson<JObject>(
+			SubscriptionPath + "/1",
+			extra: "embed=rich",
+			accept: contentType,
+			credentials: _admin);
 
 		Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
 		Assert.DoesNotThrow(() =>
@@ -113,9 +112,8 @@ class when_getting_statistics_for_subscription_with_parked_events<TLogFormat, TS
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_all_statistics_in_json<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture]
+class when_getting_all_statistics_in_json : with_subscription_having_events {
 	private JArray _json;
 
 	protected override async Task When() {
@@ -136,9 +134,8 @@ class when_getting_all_statistics_in_json<TLogFormat, TStreamId> : with_subscrip
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_all_statistics_in_xml<TLogFormat, TStreamId> : with_subscription_having_events<TLogFormat, TStreamId> {
+[TestFixture]
+class when_getting_all_statistics_in_xml : with_subscription_having_events {
 	private XDocument _xml;
 
 	protected override async Task When() {
@@ -159,15 +156,14 @@ class when_getting_all_statistics_in_xml<TLogFormat, TStreamId> : with_subscript
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_non_existent_single_statistics<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+[TestFixture]
+class when_getting_non_existent_single_statistics : with_admin_user {
 	private HttpResponseMessage _response;
 
 	protected override Task Given() => Task.CompletedTask;
 
 	protected override async Task When() {
-		var request = CreateRequest("/subscriptions/fu/fubar", null, "GET", "text/xml");
+		var request = CreateRequest("/subscriptions/fu/fubar", null, "GET", ContentType.Xml);
 		_response = await GetRequestResponse(request);
 	}
 
@@ -179,15 +175,14 @@ class when_getting_non_existent_single_statistics<TLogFormat, TStreamId> : with_
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_non_existent_stream_statistics<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+[TestFixture]
+class when_getting_non_existent_stream_statistics : with_admin_user {
 	private HttpResponseMessage _response;
 
 	protected override Task Given() => Task.CompletedTask;
 
 	protected override async Task When() {
-		var request = CreateRequest("/subscriptions/fubar", null, "GET", "text/xml", null);
+		var request = CreateRequest("/subscriptions/fubar", null, "GET", ContentType.Xml, null);
 		_response = await GetRequestResponse(request);
 	}
 
@@ -199,9 +194,8 @@ class when_getting_non_existent_stream_statistics<TLogFormat, TStreamId> : with_
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_subscription_statistics_for_individual<TLogFormat, TStreamId> : SpecificationWithPersistentSubscriptionAndConnections<TLogFormat, TStreamId> {
+[TestFixture]
+class when_getting_subscription_statistics_for_individual : SpecificationWithPersistentSubscriptionAndConnections {
 	private JObject _json;
 
 
@@ -287,9 +281,8 @@ class when_getting_subscription_statistics_for_individual<TLogFormat, TStreamId>
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_subscription_stats_summary<TLogFormat, TStreamId> : SpecificationWithPersistentSubscriptionAndConnections<TLogFormat, TStreamId> {
+[TestFixture]
+class when_getting_subscription_stats_summary : SpecificationWithPersistentSubscriptionAndConnections {
 	private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
 		.DoNotResolveLinkTos()
 		.StartFromCurrent();
@@ -438,9 +431,8 @@ class when_getting_subscription_stats_summary<TLogFormat, TStreamId> : Specifica
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-class when_getting_subscription_statistics_for_stream<TLogFormat, TStreamId> : SpecificationWithPersistentSubscriptionAndConnections<TLogFormat, TStreamId> {
+[TestFixture]
+class when_getting_subscription_statistics_for_stream : SpecificationWithPersistentSubscriptionAndConnections {
 	private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
 		.DoNotResolveLinkTos()
 		.StartFromCurrent();
@@ -566,7 +558,7 @@ class when_getting_subscription_statistics_for_stream<TLogFormat, TStreamId> : S
 	}
 }
 
-public abstract class SpecificationWithPersistentSubscriptionAndConnections<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+public abstract class SpecificationWithPersistentSubscriptionAndConnections : with_admin_user {
 	protected string _streamName = Guid.NewGuid().ToString();
 	protected string _groupName = Guid.NewGuid().ToString();
 	protected IEventStoreConnection _conn;

--- a/src/EventStore.Core.Tests/Http/StreamSecurity/SpecificationWithUsers.cs
+++ b/src/EventStore.Core.Tests/Http/StreamSecurity/SpecificationWithUsers.cs
@@ -23,10 +23,6 @@ abstract class SpecificationWithUsers<TLogFormat, TStreamId>
 
 	protected readonly NetworkCredential _admin = DefaultData.AdminNetworkCredentials;
 
-	protected override bool GivenSkipInitializeStandardUsersCheck() {
-		return false;
-	}
-
 	protected override MiniNode<TLogFormat, TStreamId> CreateMiniNode() {
 		return new MiniNode<TLogFormat, TStreamId>(PathName,
 			enableTrustedAuth: true);

--- a/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
+++ b/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
@@ -9,9 +9,9 @@ using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.Common.Utils;
 using EventStore.Core.Services;
-using EventStore.Core.Tests.Http.Users;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
+using ContentType = EventStore.Transport.Http.ContentType;
 
 namespace EventStore.Core.Tests.Http.StreamSecurity {
 	namespace stream_access {
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Http.StreamSecurity {
 						new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { Some = "Data" } } }
 							.ToJsonBytes()) {
 						Headers = {
-							ContentType = MediaTypeHeaderValue.Parse("application/vnd.eventstore.events+json")
+							ContentType = MediaTypeHeaderValue.Parse(ContentType.EventsJson)
 						}
 					}
 				};

--- a/src/EventStore.Core.Tests/Http/Streams/HttpSpecificationWithLinkToToDeletedEvents.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/HttpSpecificationWithLinkToToDeletedEvents.cs
@@ -11,8 +11,7 @@ using EventStore.Core.Tests.ClientAPI.Helpers;
 
 namespace EventStore.Core.Tests.Http.Streams;
 
-public abstract class HttpSpecificationWithLinkToToDeletedEvents<TLogFormat, TStreamId>
-	: HttpBehaviorSpecification<TLogFormat, TStreamId> {
+public abstract class HttpSpecificationWithLinkToToDeletedEvents : HttpBehaviorSpecification {
 	protected string LinkedStreamName;
 	protected string DeletedStreamName;
 

--- a/src/EventStore.Core.Tests/Http/Streams/HttpSpecificationWithLinkToToEvents.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/HttpSpecificationWithLinkToToEvents.cs
@@ -10,8 +10,7 @@ using EventStore.Core.Tests.ClientAPI.Helpers;
 
 namespace EventStore.Core.Tests.Http.Streams;
 
-public abstract class HttpSpecificationWithLinkToToEvents<TLogFormat, TStreamId>
-	: HttpBehaviorSpecification<TLogFormat, TStreamId> {
+public abstract class HttpSpecificationWithLinkToToEvents : HttpBehaviorSpecification {
 	protected string LinkedStreamName;
 	protected string StreamName;
 	protected string Stream2Name;

--- a/src/EventStore.Core.Tests/Http/Streams/SpecificationWithLinkToToMaxCountDeletedEvents.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/SpecificationWithLinkToToMaxCountDeletedEvents.cs
@@ -11,8 +11,7 @@ using EventStore.Core.Tests.ClientAPI.Helpers;
 
 namespace EventStore.Core.Tests.Http.Streams;
 
-public abstract class SpecificationWithLinkToToMaxCountDeletedEvents<TLogFormat, TStreamId>
-	: HttpBehaviorSpecification<TLogFormat, TStreamId> {
+public abstract class SpecificationWithLinkToToMaxCountDeletedEvents : HttpBehaviorSpecification {
 	protected string LinkedStreamName;
 	protected string DeletedStreamName;
 

--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -29,33 +29,33 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 
 			public Task<HttpResponseMessage> PostEventWithExpectedVersion(long expectedVersion) {
-				var request = CreateRequest(TestStream, "", "POST", "application/json");
+				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
 				request.Headers.Add("ES-EventType", "SomeType");
 				request.Headers.Add("ES-ExpectedVersion", expectedVersion.ToString());
 				request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
 				var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
 				request.Content = new ByteArrayContent(data) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				return GetRequestResponse(request);
 			}
 
 			public Task TombstoneTestStream() {
-				var deleteRequest = CreateRequest(TestStream, "", "DELETE", "application/json");
+				var deleteRequest = CreateRequest(TestStream, "", "DELETE", ContentType.Json);
 				deleteRequest.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
 				deleteRequest.Headers.Add("ES-HardDelete", bool.TrueString);
 				return GetRequestResponse(deleteRequest);
 			}
 
 			public Task SoftDeleteTestStream() {
-				var deleteRequest = CreateRequest(TestMetadataStream, "", "POST", "application/json");
+				var deleteRequest = CreateRequest(TestMetadataStream, "", "POST", ContentType.Json);
 				deleteRequest.Headers.Add("ES-EventType", SystemEventTypes.StreamMetadata);
 				deleteRequest.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
 				deleteRequest.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
 				deleteRequest.Content = new ByteArrayContent(StreamMetadata
 					.Create(truncateBefore: long.MaxValue)
 					.AsJsonBytes()) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				return GetRequestResponse(deleteRequest);
 			}
@@ -112,7 +112,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_bad_request_with_wrong_expected_version() {
 				Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
-				// Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
 			}
 
 			[Test]
@@ -199,7 +198,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_gone_status_code() {
 				Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
-				// Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
 			}
 		}
 
@@ -253,7 +251,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_bad_request_with_wrong_expected_version() {
 				Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
-				//// Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
 			}
 
 			[Test]
@@ -285,7 +282,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_bad_request_with_wrong_expected_version() {
 				Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
-				// Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
 			}
 
 			[Test]
@@ -317,7 +313,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_gone_status_code() {
 				Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
-				// Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
 			}
 		}
 
@@ -338,7 +333,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_gone_status_code() {
 				Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
-				// Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
 			}
 		}
 
@@ -407,13 +401,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 			private List<JToken> _read;
 
 			protected override async Task Given() {
-				var request = CreateRequest(TestMetadataStream, "", "POST", "application/json");
+				var request = CreateRequest(TestMetadataStream, "", "POST", ContentType.Json);
 				request.Headers.Add("ES-EventType", "$user-created");
 				request.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
 				request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
 				var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
 				request.Content = new ByteArrayContent(data) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				await GetRequestResponse(request);
 			}
@@ -452,7 +446,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_bad_request_with_wrong_expected_version() {
 				Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
-				// Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
 			}
 
 
@@ -486,7 +479,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_gone_status_code() {
 				Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
-				// Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
 			}
 		}
 
@@ -508,7 +500,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			[Test]
 			public void should_return_gone_status_code() {
 				Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
-				// Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Http/Streams/description_document.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/description_document.cs
@@ -1,29 +1,21 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
-using System;
-using System.Net;
-using System.Text;
-using EventStore.Core.Tests.ClientAPI;
-using EventStore.Core.Tests.Helpers;
-using EventStore.Core.Tests.Http.Users;
 using EventStore.Transport.Http;
 using NUnit.Framework;
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using HttpStatusCode = System.Net.HttpStatusCode;
-using EventStore.Core.Services.Transport.Http;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Http.Users.users;
+using HttpStatusCode = System.Net.HttpStatusCode;
 
 namespace EventStore.Core.Tests.Http.Streams;
 
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-public class when_getting_a_stream_without_accept_header<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+[TestFixture]
+public class when_getting_a_stream_without_accept_header : with_admin_user {
 	private JObject _descriptionDocument;
 	private List<JToken> _links;
 
@@ -47,16 +39,16 @@ public class when_getting_a_stream_without_accept_header<TLogFormat, TStreamId> 
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-public class when_getting_a_stream_with_description_document_media_type<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+[TestFixture(ContentType.DescriptionDocJson)]
+[TestFixture(ContentType.LegacyDescriptionDocJson)]
+public class when_getting_a_stream_with_description_document_media_type(string contentType) : with_admin_user {
 	private JObject _descriptionDocument;
 	private List<JToken> _links;
 
 	protected override Task Given() => Task.CompletedTask;
 
 	protected override async Task When() {
-		_descriptionDocument = await GetJson<JObject>(TestStream, "application/vnd.eventstore.streamdesc+json", null);
+		_descriptionDocument = await GetJson<JObject>(TestStream, contentType, null);
 	}
 
 	[Test]
@@ -73,16 +65,16 @@ public class when_getting_a_stream_with_description_document_media_type<TLogForm
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-public class when_getting_description_document<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+[TestFixture(ContentType.DescriptionDocJson)]
+[TestFixture(ContentType.LegacyDescriptionDocJson)]
+public class when_getting_description_document(string contentType) : with_admin_user {
 	private JObject _descriptionDocument;
 	private List<JToken> _links;
 
 	protected override Task Given() => Task.CompletedTask;
 
 	protected override async Task When() {
-		_descriptionDocument = await GetJson<JObject>(TestStream, "application/vnd.eventstore.streamdesc+json", null);
+		_descriptionDocument = await GetJson<JObject>(TestStream, contentType, null);
 		_links = _descriptionDocument != null ? _descriptionDocument["_links"].ToList() : new List<JToken>();
 	}
 
@@ -107,7 +99,7 @@ public class when_getting_description_document<TLogFormat, TStreamId> : with_adm
 		var supportedContentTypes = _descriptionDocument["_links"]["self"]["supportedContentTypes"].Values<string>()
 			.ToArray();
 		Assert.AreEqual(1, supportedContentTypes.Length);
-		Assert.AreEqual("application/vnd.eventstore.streamdesc+json", supportedContentTypes[0]);
+		Assert.AreEqual(contentType, supportedContentTypes[0]);
 	}
 
 	[Test]
@@ -120,16 +112,17 @@ public class when_getting_description_document<TLogFormat, TStreamId> : with_adm
 	public void stream_link_contains_supported_stream_content_types() {
 		var supportedContentTypes = _descriptionDocument["_links"]["stream"]["supportedContentTypes"]
 			.Values<string>().ToArray();
-		Assert.AreEqual(2, supportedContentTypes.Length);
-		Assert.Contains("application/atom+xml", supportedContentTypes);
-		Assert.Contains("application/vnd.eventstore.atom+json", supportedContentTypes);
+		Assert.AreEqual(3, supportedContentTypes.Length);
+		Assert.Contains(ContentType.Atom, supportedContentTypes);
+		Assert.Contains(ContentType.AtomJson, supportedContentTypes);
+		Assert.Contains(ContentType.LegacyAtomJson, supportedContentTypes);
 	}
 }
 
 [Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-public class when_getting_description_document_and_subscription_exists_for_stream<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+[TestFixture(ContentType.DescriptionDocJson)]
+[TestFixture(ContentType.LegacyDescriptionDocJson)]
+public class when_getting_description_document_and_subscription_exists_for_stream(string contentType) : with_admin_user {
 	private JObject _descriptionDocument;
 	private List<JToken> _links;
 	private JToken[] _subscriptions;
@@ -145,7 +138,7 @@ public class when_getting_description_document_and_subscription_exists_for_strea
 	}
 
 	protected override async Task When() {
-		_descriptionDocument = await GetJson<JObject>(TestStream, "application/vnd.eventstore.streamdesc+json", null);
+		_descriptionDocument = await GetJson<JObject>(TestStream, contentType, null);
 		_links = _descriptionDocument != null ? _descriptionDocument["_links"].ToList() : new List<JToken>();
 		_subscriptions = _descriptionDocument["_links"]["streamSubscription"].Values<JToken>().ToArray();
 	}
@@ -174,8 +167,9 @@ public class when_getting_description_document_and_subscription_exists_for_strea
 	[Test]
 	public void subscriptions_link_contains_supported_subscription_content_types() {
 		var supportedContentTypes = _subscriptions[0]["supportedContentTypes"].Values<string>().ToArray();
-		Assert.AreEqual(2, supportedContentTypes.Length);
-		Assert.Contains("application/vnd.eventstore.competingatom+xml", supportedContentTypes);
-		Assert.Contains("application/vnd.eventstore.competingatom+json", supportedContentTypes);
+		Assert.AreEqual(3, supportedContentTypes.Length);
+		Assert.Contains(ContentType.Competing, supportedContentTypes);
+		Assert.Contains(ContentType.CompetingJson, supportedContentTypes);
+		Assert.Contains(ContentType.LegacyCompetingJson, supportedContentTypes);
 	}
 }

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,13 +16,12 @@ using EventStore.Core.Tests.Helpers;
 using EventStore.Transport.Http;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
-using HttpStatusCode = System.Net.HttpStatusCode;
 using EventStore.Core.Tests.Http.Users.users;
+using HttpStatusCode = System.Net.HttpStatusCode;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	namespace feed {
-		public abstract class SpecificationWithLongFeed<TLogFormat, TStreamId>
-			: with_admin_user<TLogFormat, TStreamId> {
+		public abstract class SpecificationWithLongFeed : with_admin_user {
 			protected int _numberOfEvents;
 
 			protected override async Task Given() {
@@ -51,27 +49,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_posting_multiple_events<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
-			protected override Task When() {
-				return GetJson<JObject>(TestStream, ContentType.AtomJson);
-			}
-
-			[Test]
-			public void returns_ok_status_code() {
-				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
-			}
-		}
-
-		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_retrieving_feed_head<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyAtomJson)]
+		public class when_retrieving_feed_head(string contentType) : SpecificationWithLongFeed {
 			private JObject _feed;
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>(TestStream, ContentType.AtomJson);
+				_feed = await GetJson<JObject>(TestStream, contentType);
 			}
 
 			[Test]
@@ -111,9 +95,9 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_retrieving_feed_head_with_forwarded_prefix<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyAtomJson)]
+		public class when_retrieving_feed_head_with_forwarded_prefix(string contentType) : SpecificationWithLongFeed {
 			private JObject _feed;
 			private string _prefix;
 
@@ -121,7 +105,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 				_prefix = "testprefix";
 				var headers = new NameValueCollection();
 				headers.Add("X-Forwarded-Prefix", _prefix);
-				_feed = await GetJson<JObject>(TestStream, ContentType.AtomJson, headers: headers);
+				_feed = await GetJson<JObject>(TestStream, contentType, headers: headers);
 			}
 
 			[Test]
@@ -161,21 +145,21 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_retrieving_the_previous_link_of_the_feed_head<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyAtomJson)]
+		public class when_retrieving_the_previous_link_of_the_feed_head(string contentType) : SpecificationWithLongFeed {
 			private JObject _feed;
 			private JObject _head;
 			private string _previous;
 
 			protected override async Task Given() {
 				await base.Given();
-				_head = await GetJson<JObject>(TestStream, ContentType.AtomJson);
+				_head = await GetJson<JObject>(TestStream, contentType);
 				_previous = GetLink(_head, "previous");
 			}
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>(_previous, ContentType.AtomJson);
+				_feed = await GetJson<JObject>(_previous, contentType);
 			}
 
 			[Test]
@@ -227,10 +211,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_reading_a_stream_forward_with_deleted_linktos<TLogFormat, TStreamId>
-			: HttpSpecificationWithLinkToToDeletedEvents<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_forward_with_deleted_linktos : HttpSpecificationWithLinkToToDeletedEvents {
 			private JObject _feed;
 			private List<JToken> _entries;
 
@@ -260,10 +242,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_reading_a_stream_forward_with_linkto<TLogFormat, TStreamId>
-			: HttpSpecificationWithLinkToToEvents<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_forward_with_linkto : HttpSpecificationWithLinkToToEvents {
 			private JObject _feed;
 			private List<JToken> _entries;
 
@@ -308,10 +288,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_reading_a_stream_forward_with_linkto_with_at_sign_in_name<TLogFormat, TStreamId>
-			: HttpBehaviorSpecification<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_forward_with_linkto_with_at_sign_in_name : HttpBehaviorSpecification {
 			protected string LinkedStreamName;
 			protected string StreamName;
 
@@ -388,11 +366,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class
-			when_reading_a_stream_forward_with_maxcount_deleted_linktos<TLogFormat, TStreamId> :
-				SpecificationWithLinkToToMaxCountDeletedEvents<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_forward_with_maxcount_deleted_linktos : SpecificationWithLinkToToMaxCountDeletedEvents {
 			private JObject _feed;
 			private List<JToken> _entries;
 
@@ -408,12 +383,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		[Explicit("Failing test for Greg demonstrating NullReferenceException in Convert.cs")]
-		public class
-			when_reading_a_stream_forward_with_maxcount_deleted_linktos_with_rich_entry<TLogFormat, TStreamId> :
-				SpecificationWithLinkToToMaxCountDeletedEvents<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_forward_with_maxcount_deleted_linktos_with_rich_entry : SpecificationWithLinkToToMaxCountDeletedEvents {
 			private JObject _feed;
 			private List<JToken> _entries;
 
@@ -430,10 +401,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_reading_a_stream_forward_with_deleted_linktos_with_content_enabled_as_xml<TLogFormat, TStreamId> :
-			HttpSpecificationWithLinkToToDeletedEvents<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_forward_with_deleted_linktos_with_content_enabled_as_xml : HttpSpecificationWithLinkToToDeletedEvents {
 			private XDocument _feed;
 			private XElement[] _entries;
 
@@ -461,11 +430,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class
-			when_reading_a_stream_forward_with_deleted_linktos_with_content_enabled<TLogFormat, TStreamId> :
-				HttpSpecificationWithLinkToToDeletedEvents<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_forward_with_deleted_linktos_with_content_enabled : HttpSpecificationWithLinkToToDeletedEvents {
 			private JObject _feed;
 			private List<JToken> _entries;
 
@@ -496,10 +462,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_reading_a_stream_backward_with_deleted_linktos<TLogFormat, TStreamId>
-			: HttpSpecificationWithLinkToToDeletedEvents<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_backward_with_deleted_linktos : HttpSpecificationWithLinkToToDeletedEvents {
 			private JObject _feed;
 			private List<JToken> _entries;
 
@@ -529,11 +493,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class
-			when_reading_a_stream_backward_with_deleted_linktos_and_embed_of_content<TLogFormat, TStreamId> :
-				HttpSpecificationWithLinkToToDeletedEvents<TLogFormat, TStreamId> {
+		[TestFixture]
+		public class when_reading_a_stream_backward_with_deleted_linktos_and_embed_of_content : HttpSpecificationWithLinkToToDeletedEvents {
 			private JObject _feed;
 			private List<JToken> _entries;
 
@@ -564,9 +525,9 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_polling_the_head_forward_and_a_new_event_appears<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyAtomJson)]
+		public class when_polling_the_head_forward_and_a_new_event_appears(string contentType) : SpecificationWithLongFeed {
 			private JObject _feed;
 			private JObject _head;
 			private string _previous;
@@ -574,7 +535,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			protected override async Task Given() {
 				await base.Given();
-				_head = await GetJson<JObject>(TestStream, ContentType.AtomJson);
+				_head = await GetJson<JObject>(TestStream, contentType);
 				Console.WriteLine(new string('*', 60));
 				Console.WriteLine(_head);
 				Console.WriteLine(TestStream);
@@ -584,7 +545,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>(_previous, ContentType.AtomJson);
+				_feed = await GetJson<JObject>(_previous, contentType);
 			}
 
 			[Test]
@@ -599,16 +560,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class
-			when_reading_a_stream_forward_from_beginning_asking_for_less_events_than_in_the_stream<TLogFormat, TStreamId>  :
-				SpecificationWithLongFeed<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyAtomJson)]
+		public class when_reading_a_stream_forward_from_beginning_asking_for_less_events_than_in_the_stream(string contentType) : SpecificationWithLongFeed {
 			private JObject _feed;
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>(TestStream + "/0/forward/" + (_numberOfEvents - 1),
-					accept: ContentType.AtomJson);
+				_feed = await GetJson<JObject>(TestStream + "/0/forward/" + (_numberOfEvents - 1), accept: contentType);
 			}
 
 			[Test]
@@ -618,16 +576,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class
-			when_reading_a_stream_forward_from_beginning_asking_for_more_events_than_in_the_stream<TLogFormat, TStreamId> :
-				SpecificationWithLongFeed<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyAtomJson)]
+		public class when_reading_a_stream_forward_from_beginning_asking_for_more_events_than_in_the_stream(string contentType) : SpecificationWithLongFeed {
 			private JObject _feed;
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>(TestStream + "/0/forward/" + (_numberOfEvents + 1),
-					accept: ContentType.AtomJson);
+				_feed = await GetJson<JObject>(TestStream + "/0/forward/" + (_numberOfEvents + 1), accept: contentType);
 			}
 
 			[Test]
@@ -637,15 +592,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class
-			when_reading_a_stream_forward_from_beginning_asking_for_exactly_the_events_in_the_stream<TLogFormat, TStreamId> :
-				SpecificationWithLongFeed<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyAtomJson)]
+		public class when_reading_a_stream_forward_from_beginning_asking_for_exactly_the_events_in_the_stream(string contentType) : SpecificationWithLongFeed {
 			private JObject _feed;
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>(TestStream + "/0/forward/" + _numberOfEvents, accept: ContentType.AtomJson);
+				_feed = await GetJson<JObject>(TestStream + "/0/forward/" + _numberOfEvents, accept: contentType);
 			}
 
 			[Test]
@@ -655,16 +608,16 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_reading_a_stream_forward_with_etag_in_header<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyAtomJson)]
+		public class when_reading_a_stream_forward_with_etag_in_header(string contentType) : SpecificationWithLongFeed {
 			private JObject _feed;
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>(TestStream, accept: ContentType.AtomJson);
+				_feed = await GetJson<JObject>(TestStream, accept: contentType);
 				var etag = _feed.Value<string>("eTag");
 				var headers = new NameValueCollection { { "If-None-Match", EntityTagHeaderValue.Parse($@"""{etag}""").Tag } };
-				_feed = await GetJson<JObject>(TestStream, accept: ContentType.AtomJson, headers: headers);
+				_feed = await GetJson<JObject>(TestStream, accept: contentType, headers: headers);
 			}
 
 			[Test]
@@ -675,10 +628,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_reading_the_all_stream_backward_with_resolve_link_to<TLogFormat, TStreamId>
-		: HttpSpecificationWithLinkToToEvents<TLogFormat, TStreamId> {
+	[TestFixture]
+	public class when_reading_the_all_stream_backward_with_resolve_link_to : HttpSpecificationWithLinkToToEvents {
 		private JObject _feed;
 		private List<JToken> _entries;
 
@@ -694,13 +645,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(StreamName));
 			Assert.AreEqual(3, events.Count());
 		}
-		
+
 		[Test]
 		public void there_are_two_events_for_the_second_original_stream() {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(Stream2Name));
 			Assert.AreEqual(2, events.Count());
 		}
-		
+
 		[Test]
 		public void there_are_no_events_for_the_linked_stream() {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(LinkedStreamName));
@@ -709,10 +660,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_reading_the_all_stream_backward_with_resolve_link_to_disabled<TLogFormat, TStreamId>
-		: HttpSpecificationWithLinkToToEvents<TLogFormat, TStreamId> {
+	[TestFixture]
+	public class when_reading_the_all_stream_backward_with_resolve_link_to_disabled : HttpSpecificationWithLinkToToEvents {
 		private JObject _feed;
 		private List<JToken> _entries;
 
@@ -728,31 +677,29 @@ namespace EventStore.Core.Tests.Http.Streams {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(StreamName));
 			Assert.AreEqual(2, events.Count());
 		}
-		
+
 		[Test]
 		public void there_is_one_event_for_the_second_original_stream() {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(Stream2Name));
 			Assert.AreEqual(1, events.Count());
 		}
-		
+
 		[Test]
 		public void there_are_two_events_for_the_linked_stream() {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(LinkedStreamName));
 			Assert.AreEqual(2, events.Count());
 		}
 	}
-		
+
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_reading_the_all_stream_forward_with_resolve_link_to<TLogFormat, TStreamId>
-		: HttpSpecificationWithLinkToToEvents<TLogFormat, TStreamId> {
+	[TestFixture]
+	public class when_reading_the_all_stream_forward_with_resolve_link_to : HttpSpecificationWithLinkToToEvents {
 		private JObject _feed;
 		private List<JToken> _entries;
 
 		protected override async Task When() {
 			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "True"}};
-			_feed = await GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/30", 
+			_feed = await GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/30",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
 		}
@@ -762,13 +709,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(StreamName));
 			Assert.AreEqual(3, events.Count());
 		}
-		
+
 		[Test]
 		public void there_are_two_events_for_the_second_original_stream() {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(Stream2Name));
 			Assert.AreEqual(2, events.Count());
 		}
-		
+
 		[Test]
 		public void there_are_no_events_for_the_linked_stream() {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(LinkedStreamName));
@@ -777,16 +724,14 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_reading_the_all_stream_forward_with_resolve_link_to_disabled<TLogFormat, TStreamId>
-		: HttpSpecificationWithLinkToToEvents<TLogFormat, TStreamId> {
+	[TestFixture]
+	public class when_reading_the_all_stream_forward_with_resolve_link_to_disabled : HttpSpecificationWithLinkToToEvents {
 		private JObject _feed;
 		private List<JToken> _entries;
 
 		protected override async Task When() {
 			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "False"}};
-			_feed = await GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/30", 
+			_feed = await GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/30",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
 		}
@@ -796,13 +741,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(StreamName));
 			Assert.AreEqual(2, events.Count());
 		}
-		
+
 		[Test]
 		public void there_is_one_event_for_the_second_original_stream() {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(Stream2Name));
 			Assert.AreEqual(1, events.Count());
 		}
-		
+
 		[Test]
 		public void there_are_two_events_for_the_linked_stream() {
 			var events = _entries.Where(x => x["title"].Value<string>().Contains(LinkedStreamName));
@@ -815,22 +760,25 @@ namespace EventStore.Core.Tests.Http.Streams {
 namespace EventStore.Core.Tests.Http {
 	public class when_running_the_node_advertising_a_different_ip_as {
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class when_retrieving_feed_head_and_http_advertise_ip_is_set<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.EventsJson, ContentType.AtomJson)]
+		[TestFixture(ContentType.LegacyEventsJson, ContentType.AtomJson)]
+		[TestFixture(ContentType.EventsJson, ContentType.LegacyAtomJson)]
+		[TestFixture(ContentType.LegacyEventsJson, ContentType.LegacyAtomJson)]
+		public class when_retrieving_feed_head_and_http_advertise_ip_is_set(string postContentType, string getContentType) : with_admin_user {
 			private JObject _feed;
 			private string advertisedAddress = "127.0.10.1";
 			private int advertisedPort = 2116;
 
-			protected override MiniNode<TLogFormat, TStreamId> CreateMiniNode() {
-				return new MiniNode<TLogFormat, TStreamId>(PathName,
+			protected override MiniNode<LogFormat.V2, string> CreateMiniNode() {
+				return new MiniNode<LogFormat.V2, string>(PathName,
 					advertisedExtHostAddress: advertisedAddress, advertisedHttpPort: advertisedPort);
 			}
 
 			protected override async Task Given() {
 				var response = await MakeArrayEventsPost(
 					TestStream,
-					new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { Number = 1 } } });
+					new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { Number = 1 } } },
+					contentType: postContentType);
 				Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
 			}
 
@@ -853,7 +801,7 @@ namespace EventStore.Core.Tests.Http {
 
 			protected override async Task When() {
 				Console.WriteLine("Getting feed");
-				_feed = await GetJson<JObject>(TestStream, ContentType.AtomJson);
+				_feed = await GetJson<JObject>(TestStream, getContentType);
 				Console.WriteLine("Feed: {0}", _feed);
 			}
 

--- a/src/EventStore.Core.Tests/Http/Streams/filtered.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/filtered.cs
@@ -8,13 +8,13 @@ using System.Threading.Tasks;
 using EventStore.Core.Tests.Http.Users.users;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using HttpStatusCode = System.Net.HttpStatusCode;
 using EventStore.Transport.Http;
+using HttpStatusCode = System.Net.HttpStatusCode;
 
 namespace EventStore.Core.Tests.Http.Streams;
 
 public class Filtered {
-	public abstract class SpecificationWithLongFeed<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
+	public abstract class SpecificationWithLongFeed : with_admin_user {
 		protected int NumberOfEvents;
 
 		protected override async Task Given() {
@@ -54,12 +54,12 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_with_invalid_context<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_with_invalid_context(string contentType) : SpecificationWithLongFeed {
 		protected override Task When() =>
 			GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson,
+				contentType,
 				DefaultData.AdminNetworkCredentials,
 				extra: "context=foo");
 
@@ -69,12 +69,12 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_with_invalid_type<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_with_invalid_type(string contentType) : SpecificationWithLongFeed {
 		protected override Task When() =>
 			GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson,
+				contentType,
 				DefaultData.AdminNetworkCredentials,
 				extra: "context=streamid&type=foo");
 
@@ -84,12 +84,12 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_with_invalid_data<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_with_invalid_data(string contentType) : SpecificationWithLongFeed {
 		protected override Task When() =>
 			GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson,
+				contentType,
 				DefaultData.AdminNetworkCredentials,
 				extra: "context=streamid&type=prefix");
 
@@ -99,14 +99,14 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_feed_head<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_feed_head(string contentType) : SpecificationWithLongFeed {
 		private JObject _feed;
 
 		protected override async Task When() =>
 			_feed = await GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson, 
+				contentType,
 				DefaultData.AdminNetworkCredentials,
 				extra: "context=eventtype&type=prefix&data=event1-");
 
@@ -149,14 +149,14 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_feed_events_by_event_type_and_prefix<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_feed_events_by_event_type_and_prefix(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson, 
+				contentType,
 				DefaultData.AdminNetworkCredentials,
 				extra: "context=eventtype&type=prefix&data=event1-,event2-");
 			_eventTypes = GetEventTypes(feed);
@@ -172,14 +172,14 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_feed_events_by_event_type_and_regex<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_feed_events_by_event_type_and_regex(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson, 
+				contentType,
 				DefaultData.AdminNetworkCredentials,
 				extra: "context=eventtype&type=regex&data=^.*eventtype1.*$");
 			_eventTypes = GetEventTypes(feed);
@@ -194,14 +194,14 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_feed_events_by_stream_id_and_prefix<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_feed_events_by_stream_id_and_prefix(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson, 
+				contentType,
 				DefaultData.AdminNetworkCredentials,
 				extra: $"context=streamid&type=prefix&data={TestStream}-filter");
 			_eventTypes = GetEventTypes(feed);
@@ -216,14 +216,14 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_feed_events_by_stream_id_and_regex<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_feed_events_by_stream_id_and_regex(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson, 
+				contentType,
 				DefaultData.AdminNetworkCredentials,
 				extra: $"context=streamid&type=regex&data=^.*{TestStream}-filter.*$");
 			_eventTypes = GetEventTypes(feed);
@@ -238,15 +238,15 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_backward_feed_events_filtering_system_events<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_backward_feed_events_filtering_system_events(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStream,
-				ContentType.AtomJson, 
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: "exclude-system-events=true" );
 			_eventTypes = GetEventTypes(feed);
 		}
@@ -260,13 +260,13 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_with_invalid_context<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_with_invalid_context(string contentType) : SpecificationWithLongFeed {
 		protected override Task When() =>
 			GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson,
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: "context=foo");
 
 
@@ -276,13 +276,13 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_with_invalid_type<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_with_invalid_type(string contentType) : SpecificationWithLongFeed {
 		protected override Task When() =>
 			GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson,
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: "context=streamid&type=foo");
 
 		[Test]
@@ -291,13 +291,13 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_with_invalid_data<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_with_invalid_data(string contentType) : SpecificationWithLongFeed {
 		protected override Task When() =>
 			GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson,
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: "context=streamid&type=prefix");
 
 		[Test]
@@ -306,15 +306,15 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_feed_head<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_feed_head(string contentType) : SpecificationWithLongFeed {
 		private JObject _feed;
 
 		protected override async Task When() =>
 			_feed = await GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson, 
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: "context=eventtype&type=prefix&data=event1-" );
 
 		[Test]
@@ -348,15 +348,15 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_feed_events_by_event_type_and_prefix<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_feed_events_by_event_type_and_prefix(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson, 
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: "context=eventtype&type=prefix&data=event1-,event2-");
 			_eventTypes = GetEventTypes(feed);
 		}
@@ -371,15 +371,15 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_feed_events_by_event_type_and_regex<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_feed_events_by_event_type_and_regex(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson, 
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: "context=eventtype&type=regex&data=^.*eventtype1.*$");
 			_eventTypes = GetEventTypes(feed);
 		}
@@ -393,15 +393,15 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_feed_events_by_stream_id_and_prefix<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_feed_events_by_stream_id_and_prefix(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson, 
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: $"context=streamid&type=prefix&data={TestStream}-filter");
 			_eventTypes = GetEventTypes(feed);
 		}
@@ -415,15 +415,15 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_feed_events_by_stream_id_and_regex<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_feed_events_by_stream_id_and_regex(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson, 
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: $"context=streamid&type=regex&data=^.*{TestStream}-filter.*$");
 			_eventTypes = GetEventTypes(feed);
 		}
@@ -437,15 +437,15 @@ public class Filtered {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class when_retrieving_forward_feed_events_filtering_system_events<TLogFormat, TStreamId> : SpecificationWithLongFeed<TLogFormat, TStreamId> {
+	[TestFixture(ContentType.AtomJson)]
+	[TestFixture(ContentType.LegacyAtomJson)]
+	public class when_retrieving_forward_feed_events_filtering_system_events(string contentType) : SpecificationWithLongFeed {
 		private List<string> _eventTypes;
 
 		protected override async Task When() {
 			var feed = await GetJson<JObject>(AllFilteredStreamForward,
-				ContentType.AtomJson, 
-				DefaultData.AdminNetworkCredentials, 
+				contentType,
+				DefaultData.AdminNetworkCredentials,
 				extra: "exclude-system-events=true");
 			_eventTypes = GetEventTypes(feed);
 		}

--- a/src/EventStore.Core.Tests/Http/Streams/idempotency.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/idempotency.cs
@@ -9,14 +9,14 @@ using System.Threading.Tasks;
 using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
-using HttpStatusCode = System.Net.HttpStatusCode;
 using EventStore.Core.Tests.Http.Users.users;
+using EventStore.Transport.Http;
+using HttpStatusCode = System.Net.HttpStatusCode;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	namespace idempotency {
 		[SetUpFixture]
-		abstract class HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId>
-			: with_admin_user<TLogFormat, TStreamId> {
+		abstract class HttpBehaviorSpecificationOfSuccessfulCreateEvent : with_admin_user {
 			protected HttpResponseMessage _response;
 
 			[OneTimeSetUp]
@@ -60,10 +60,9 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 		}
 
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_posting_to_idempotent_guid_id_then_as_array<TLogFormat, TStreamId>
-			: HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.EventsJson)]
+		[TestFixture(ContentType.LegacyEventsJson)]
+		class when_posting_to_idempotent_guid_id_then_as_array(string contentType) : HttpBehaviorSpecificationOfSuccessfulCreateEvent {
 			private Guid _eventId;
 
 			protected override Task Given() {
@@ -74,27 +73,26 @@ namespace EventStore.Core.Tests.Http.Streams {
 			protected override async Task When() {
 				_response = await MakeArrayEventsPost(
 					TestStream,
-					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } });
+					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } },
+					contentType: contentType);
 			}
 
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream + "/incoming/" + _eventId.ToString(), "", "POST",
-					"application/json");
+					ContentType.Json);
 				request.Headers.Add("ES-EventType", "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				_response = await GetRequestResponse(request);
 				Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
 			}
 		}
 
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_posting_to_idempotent_guid_id_twice<TLogFormat, TStreamId>
-			: HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId>  {
+		[TestFixture]
+		class when_posting_to_idempotent_guid_id_twice : HttpBehaviorSpecificationOfSuccessfulCreateEvent  {
 			private Guid _eventId;
 
 			protected override Task Given() {
@@ -108,23 +106,20 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream + "/incoming/" + _eventId.ToString(), "", "POST",
-					"application/json");
+					ContentType.Json);
 				request.Headers.Add("ES-EventType", "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				_response = await GetRequestResponse(request);
 				Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
 			}
 		}
 
-
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_posting_to_idempotent_guid_id_three_times<TLogFormat, TStreamId>
-			: HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId>  {
+		[TestFixture]
+		class when_posting_to_idempotent_guid_id_three_times : HttpBehaviorSpecificationOfSuccessfulCreateEvent  {
 			private Guid _eventId;
 
 			protected override async Task Given() {
@@ -139,24 +134,22 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream + "/incoming/" + _eventId.ToString(), "", "POST",
-					"application/json");
+					ContentType.Json);
 				request.Headers.Add("ES-EventType", "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				_response = await GetRequestResponse(request);
 				Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
 			}
 		}
 
-
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_posting_an_event_once_raw_once_with_array<TLogFormat, TStreamId>
-			: HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId>  {
+		[TestFixture(ContentType.EventsJson)]
+		[TestFixture(ContentType.LegacyEventsJson)]
+		class when_posting_an_event_once_raw_once_with_array(string contentType) : HttpBehaviorSpecificationOfSuccessfulCreateEvent  {
 			private Guid _eventId;
 
 			protected override Task Given() {
@@ -167,29 +160,27 @@ namespace EventStore.Core.Tests.Http.Streams {
 			protected override async Task When() {
 				_response = await MakeArrayEventsPost(
 					TestStream,
-					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } });
+					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } },
+					contentType: contentType);
 			}
 
 			private async Task PostEvent() {
-				var request = CreateRequest(TestStream, "", "POST", "application/json");
+				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
 				request.Headers.Add("ES-EventId", _eventId.ToString());
 				request.Headers.Add("ES-EventType", "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				_response = await GetRequestResponse(request);
 				Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
 			}
 		}
 
-
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_posting_an_event_twice_raw<TLogFormat, TStreamId>
-			: HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId> {
+		[TestFixture]
+		class when_posting_an_event_twice_raw : HttpBehaviorSpecificationOfSuccessfulCreateEvent {
 			private Guid _eventId;
 
 			protected override Task Given() {
@@ -202,13 +193,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 
 			private async Task PostEvent() {
-				var request = CreateRequest(TestStream, "", "POST", "application/json");
+				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
 				request.Headers.Add("ES-EventId", _eventId.ToString());
 				request.Headers.Add("ES-EventType", "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				_response = await GetRequestResponse(request);
 				Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
@@ -216,10 +207,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_posting_an_event_three_times_raw<TLogFormat, TStreamId>
-			: HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId> {
+		[TestFixture]
+		class when_posting_an_event_three_times_raw : HttpBehaviorSpecificationOfSuccessfulCreateEvent {
 			private Guid _eventId;
 
 			protected override async Task Given() {
@@ -233,13 +222,13 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 
 			private async Task PostEvent() {
-				var request = CreateRequest(TestStream, "", "POST", "application/json");
+				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
 				request.Headers.Add("ES-EventId", _eventId.ToString());
 				request.Headers.Add("ES-EventType", "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				_response = await GetRequestResponse(request);
 				Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
@@ -247,51 +236,53 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_posting_an_event_twice_array<TLogFormat, TStreamId>
-			: HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.EventsJson)]
+		[TestFixture(ContentType.LegacyEventsJson)]
+		class when_posting_an_event_twice_array(string contentType) : HttpBehaviorSpecificationOfSuccessfulCreateEvent {
 			private Guid _eventId;
 
 			protected override async Task Given() {
 				_eventId = Guid.NewGuid();
 				var response1 = await MakeArrayEventsPost(
 					TestStream,
-					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } });
+					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } },
+					contentType: contentType);
 				Assert.AreEqual(HttpStatusCode.Created, response1.StatusCode);
 			}
 
 			protected override async Task When() {
 				_response = await MakeArrayEventsPost(
 					TestStream,
-					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } });
+					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } },
+					contentType: contentType);
 			}
 		}
 
-
 		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		class when_posting_an_event_three_times_as_array<TLogFormat, TStreamId>
-			: HttpBehaviorSpecificationOfSuccessfulCreateEvent<TLogFormat, TStreamId> {
+		[TestFixture(ContentType.EventsJson)]
+		[TestFixture(ContentType.LegacyEventsJson)]
+		class when_posting_an_event_three_times_as_array(string contentType) : HttpBehaviorSpecificationOfSuccessfulCreateEvent {
 			private Guid _eventId;
 
 			protected override async Task Given() {
 				_eventId = Guid.NewGuid();
 				var response1 = await MakeArrayEventsPost(
 					TestStream,
-					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } });
+					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } },
+					contentType: contentType);
 				Assert.AreEqual(HttpStatusCode.Created, response1.StatusCode);
 				var response2 = await MakeArrayEventsPost(
 					TestStream,
-					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } });
+					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } },
+					contentType: contentType);
 				Assert.AreEqual(HttpStatusCode.Created, response2.StatusCode);
 			}
 
 			protected override async Task When() {
 				_response = await MakeArrayEventsPost(
 					TestStream,
-					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } });
+					new[] { new { EventId = _eventId, EventType = "event-type", Data = new { A = "1" } } },
+					contentType: contentType);
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Http/Streams/metadata.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/metadata.cs
@@ -2,23 +2,21 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.Http.Streams.basic;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using System.Xml.Linq;
 using EventStore.Common.Utils;
 using EventStore.Core.Tests.Http.Users.users;
+using HttpStatusCode = System.Net.HttpStatusCode;
+using ContentType = EventStore.Transport.Http.ContentType;
 
 namespace EventStore.Core.Tests.Http.Streams;
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-public class when_posting_metadata_as_json_to_non_existing_stream<TLogFormat, TStreamId>
-	: with_admin_user<TLogFormat, TStreamId> {
+[TestFixture]
+public class when_posting_metadata_as_json_to_non_existing_stream : with_admin_user {
 	private HttpResponseMessage _response;
 
 	protected override Task Given() => Task.CompletedTask;
@@ -47,14 +45,14 @@ public class when_posting_metadata_as_json_to_non_existing_stream<TLogFormat, TS
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-public class when_posting_metadata_as_json_to_existing_stream<TLogFormat, TStreamId>
-	: HttpBehaviorSpecificationWithSingleEvent<TLogFormat, TStreamId> {
+[TestFixture(ContentType.EventsJson)]
+[TestFixture(ContentType.LegacyEventsJson)]
+public class when_posting_metadata_as_json_to_existing_stream(string contentType) : HttpBehaviorSpecificationWithSingleEvent {
 	protected override async Task Given() {
 		_response = await MakeArrayEventsPost(
 			TestStream,
-			new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { A = "1" } } });
+			new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { A = "1" } } },
+			contentType: contentType);
 	}
 
 	protected override async Task When() {
@@ -81,11 +79,8 @@ public class when_posting_metadata_as_json_to_existing_stream<TLogFormat, TStrea
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-public class
-	when_getting_metadata_for_an_existing_stream_without_an_accept_header<TLogFormat, TStreamId> :
-		HttpBehaviorSpecificationWithSingleEvent<TLogFormat, TStreamId> {
+[TestFixture]
+public class when_getting_metadata_for_an_existing_stream_without_an_accept_header : HttpBehaviorSpecificationWithSingleEvent {
 	protected override Task When() {
 		return Get(TestStream + "/metadata", null, null, DefaultData.AdminNetworkCredentials, false);
 	}
@@ -101,19 +96,18 @@ public class
 	}
 }
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-public class
-	when_getting_metadata_for_an_existing_stream_and_no_metadata_exists<TLogFormat, TStreamId>
-	: HttpBehaviorSpecificationWithSingleEvent<TLogFormat, TStreamId> {
+[TestFixture(ContentType.EventsJson)]
+[TestFixture(ContentType.LegacyEventsJson)]
+public class when_getting_metadata_for_an_existing_stream_and_no_metadata_exists(string contentType) : HttpBehaviorSpecificationWithSingleEvent {
 	protected override async Task Given() {
 		_response = await MakeArrayEventsPost(
 			TestStream,
-			new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { A = "1" } } });
+			new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { A = "1" } } },
+			contentType: contentType);
 	}
 
 	protected override Task When() {
-		return Get(TestStream + "/metadata", String.Empty, Transport.Http.ContentType.Json,
+		return Get(TestStream + "/metadata", String.Empty, ContentType.Json,
 			DefaultData.AdminNetworkCredentials);
 	}
 

--- a/src/EventStore.Core.Tests/Http/TestController.cs
+++ b/src/EventStore.Core.Tests/Http/TestController.cs
@@ -64,7 +64,7 @@ public class TestController : CommunicationController {
 		var b = match.BoundVariables["b"];
 
 		http.Reply(new {a = a, b = b, rawSegment = http.RequestedUrl.Segments[2]}.ToJson(), 200, "OK",
-			"application/json");
+			ContentType.Json);
 	}
 
 	private void TestEncodingHandler(HttpEntityManager http, UriTemplateMatch match, string a) {
@@ -77,7 +77,7 @@ public class TestController : CommunicationController {
 				rawSegment = http.RequestedUrl.Segments[1],
 				requestUri = match.RequestUri,
 				rawUrl = http.HttpEntity.Request.RawUrl
-			}.ToJson(), 200, "OK", "application/json");
+			}.ToJson(), 200, "OK", ContentType.Json);
 	}
 
 	private void TestTimeoutHandler(HttpEntityManager http, UriTemplateMatch match) {

--- a/src/EventStore.Core.Tests/Http/Users/users.cs
+++ b/src/EventStore.Core.Tests/Http/Users/users.cs
@@ -4,20 +4,16 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using EventStore.Core.Services;
-using EventStore.Core.Services.Transport.Http.Controllers;
 using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 
 namespace EventStore.Core.Tests.Http.Users {
 	namespace users {
+		public abstract class with_admin_user : with_admin_user<LogFormat.V2, string>;
+
 		public abstract class with_admin_user<TLogFormat, TStreamId> : HttpBehaviorSpecification<TLogFormat, TStreamId> {
 			protected readonly NetworkCredential _admin = DefaultData.AdminNetworkCredentials;
-
-			protected override bool GivenSkipInitializeStandardUsersCheck() {
-				return false;
-			}
 
 			public with_admin_user() {
 				SetDefaultCredentials(_admin);

--- a/src/EventStore.Core.Tests/Integration/authenticated_requests_made_from_a_follower.cs
+++ b/src/EventStore.Core.Tests/Integration/authenticated_requests_made_from_a_follower.cs
@@ -18,6 +18,7 @@ using Grpc.Core;
 using Grpc.Net.Client;
 using NUnit.Framework;
 using StatusCode = Grpc.Core.StatusCode;
+using ContentType = EventStore.Transport.Http.ContentType;
 
 namespace EventStore.Core.Tests.Integration;
 
@@ -59,7 +60,7 @@ public abstract class authenticated_requests_made_from_a_follower<TLogFormat, TS
 
 			using var response = await httpClient.PostAsync($"/streams/{ProtectedStream}",
 				new ReadOnlyMemoryContent(content) {
-					Headers = { ContentType = new MediaTypeHeaderValue("application/vnd.eventstore.events+json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.EventsJson) }
 				});
 
 			_statusCode = response.StatusCode;

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.Tests.Integration;
 using NUnit.Framework;
+using ContentType = EventStore.Transport.Http.ContentType;
 
 namespace EventStore.Core.Tests.Services.Transport.Http;
 
@@ -28,7 +29,7 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 		}) {
 			Timeout = _timeout
 		};
-		
+
 		if (!string.IsNullOrEmpty(username)) {
 			client.DefaultRequestHeaders.Authorization =
 				new AuthenticationHeaderValue(
@@ -95,7 +96,7 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 				var data = Helper.UTF8NoBom.GetBytes(dataStr);
 				var stream = new MemoryStream(data);
 				var content = new StreamContent(stream);
-				content.Headers.Add("Content-Type", "application/json");
+				content.Headers.Add("Content-Type", ContentType.Json);
 
 				var res = await _httpClients["Admin"].PostAsync(
 					string.Format("https://{0}/users/", _nodes[_leaderId].HttpEndPoint),
@@ -234,7 +235,7 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 
 		var url = $"https://{nodeEndpoint}{endpointUrl}";
 		var body = GetData(httpMethod, endpointUrl);
-		var contentType = httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete ? "application/json" : null;
+		var contentType = httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete ? ContentType.Json : null;
 		var statusCode = await SendRequest(_httpClients[userAuthorizationLevel], httpMethod, url, body, contentType);
 
 		if (GetAuthLevel(userAuthorizationLevel) >= GetAuthLevel(requiredMinAuthorizationLevel)) {

--- a/src/EventStore.Core.Tests/Services/Transport/Http/media_type.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/media_type.cs
@@ -71,22 +71,22 @@ public class media_type {
 
 	[Test]
 	public void parses_with_encoding() {
-		var c = MediaType.Parse("application/json;charset=utf-8");
+		var c = MediaType.Parse($"{ContentType.Json};charset=utf-8");
 
 		Assert.AreEqual("application", c.Type);
 		Assert.AreEqual("json", c.Subtype);
-		Assert.AreEqual("application/json", c.Range);
+		Assert.AreEqual(ContentType.Json, c.Range);
 		Assert.IsTrue(c.EncodingSpecified);
 		Assert.AreEqual(Helper.UTF8NoBom, c.Encoding);
 	}
 
 	[Test]
 	public void parses_with_encoding_and_priority() {
-		var c = MediaType.Parse("application/json;q=0.3;charset=utf-8");
+		var c = MediaType.Parse($"{ContentType.Json};q=0.3;charset=utf-8");
 
 		Assert.AreEqual("application", c.Type);
 		Assert.AreEqual("json", c.Subtype);
-		Assert.AreEqual("application/json", c.Range);
+		Assert.AreEqual(ContentType.Json, c.Range);
 		Assert.AreEqual(0.3f, c.Priority);
 		Assert.IsTrue(c.EncodingSpecified);
 		Assert.AreEqual(Helper.UTF8NoBom, c.Encoding);
@@ -94,33 +94,33 @@ public class media_type {
 
 	[Test]
 	public void parses_unknown_encoding() {
-		var c = MediaType.Parse("application/json;charset=woftam");
+		var c = MediaType.Parse($"{ContentType.Json};charset=woftam");
 
 		Assert.AreEqual("application", c.Type);
 		Assert.AreEqual("json", c.Subtype);
-		Assert.AreEqual("application/json", c.Range);
+		Assert.AreEqual(ContentType.Json, c.Range);
 		Assert.IsTrue(c.EncodingSpecified);
 		Assert.IsNull(c.Encoding);
 	}
 
 	[Test]
 	public void parses_with_spaces_between_parameters() {
-		var c = MediaType.Parse("application/json; charset=woftam");
+		var c = MediaType.Parse($"{ContentType.Json}; charset=woftam");
 
 		Assert.AreEqual("application", c.Type);
 		Assert.AreEqual("json", c.Subtype);
-		Assert.AreEqual("application/json", c.Range);
+		Assert.AreEqual(ContentType.Json, c.Range);
 		Assert.IsTrue(c.EncodingSpecified);
 		Assert.IsNull(c.Encoding);
 	}
 
 	[Test]
 	public void parses_upper_case_parameters() {
-		var c = MediaType.Parse("application/json; charset=UTF-8");
+		var c = MediaType.Parse($"{ContentType.Json}; charset=UTF-8");
 
 		Assert.AreEqual("application", c.Type);
 		Assert.AreEqual("json", c.Subtype);
-		Assert.AreEqual("application/json", c.Range);
+		Assert.AreEqual(ContentType.Json, c.Range);
 		Assert.IsTrue(c.EncodingSpecified);
 		Assert.AreEqual(Helper.UTF8NoBom, c.Encoding);
 	}

--- a/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
@@ -48,6 +48,7 @@ public static class AutoEventConverter {
 			}
 
 			case ContentType.EventJson:
+			case ContentType.LegacyEventJson:
 				return targetCodec.To(dto);
 
 

--- a/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
@@ -80,8 +80,11 @@ public static class AutoEventConverter {
 			case ContentType.Json:
 				return LoadRaw(sourceCodec.Encoding.GetString(request), true, includedId, includedType);
 			case ContentType.EventJson:
+			case ContentType.LegacyEventJson:
 			case ContentType.EventsJson:
+			case ContentType.LegacyEventsJson:
 			case ContentType.AtomJson:
+			case ContentType.LegacyAtomJson:
 				var writeEvents = LoadFromJson(sourceCodec.Encoding.GetString(request));
 				if (writeEvents.IsEmpty())
 					return null;

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -10,6 +10,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.Transport.Http.Controllers;
+using ContentType = EventStore.Transport.Http.ContentType;
 using HttpStatusCode = EventStore.Transport.Http.HttpStatusCode;
 using OperationResult = EventStore.Core.Messages.OperationResult;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
@@ -56,7 +57,7 @@ public static class Configure {
 		var targetBase = new Uri(string.Format("{0}://{1}:{2}/", originalUrl.Scheme, targetHost, targetPort),
 			UriKind.Absolute);
 		var forwardUri = new Uri(targetBase, srcBase.MakeRelativeUri(originalUrl));
-		return new ResponseConfiguration(HttpStatusCode.TemporaryRedirect, "Temporary Redirect", "text/plain",
+		return new ResponseConfiguration(HttpStatusCode.TemporaryRedirect, "Temporary Redirect", ContentType.PlainText,
 			Helper.UTF8NoBom,
 			new KeyValuePair<string, string>("Location", forwardUri.ToString()));
 	}
@@ -69,13 +70,13 @@ public static class Configure {
 			UriKind.Absolute);
 		var forwardUri = new Uri(targetBase, srcBase.MakeRelativeUri(originalUrl));
 		return new ResponseConfiguration(HttpStatusCode.InternalServerError,
-			"Operation Not Supported on Read Only Replica", "text/plain",
+			"Operation Not Supported on Read Only Replica", ContentType.PlainText,
 			Helper.UTF8NoBom,
 			new KeyValuePair<string, string>("Location", forwardUri.ToString()));
 	}
 
 	public static ResponseConfiguration NotFound() {
-		return new ResponseConfiguration(HttpStatusCode.NotFound, "Not Found", "text/plain", Helper.UTF8NoBom);
+		return new ResponseConfiguration(HttpStatusCode.NotFound, "Not Found", ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	public static ResponseConfiguration NotFound(string etag, int? cacheSeconds, bool isCachePublic,
@@ -94,37 +95,37 @@ public static class Configure {
 	}
 
 	public static ResponseConfiguration Gone(string description = null) {
-		return new ResponseConfiguration(HttpStatusCode.Gone, description ?? "Deleted", "text/plain",
+		return new ResponseConfiguration(HttpStatusCode.Gone, description ?? "Deleted", ContentType.PlainText,
 			Helper.UTF8NoBom);
 	}
 
 	public static ResponseConfiguration NotModified() {
-		return new ResponseConfiguration(HttpStatusCode.NotModified, "Not Modified", "text/plain",
+		return new ResponseConfiguration(HttpStatusCode.NotModified, "Not Modified", ContentType.PlainText,
 			Helper.UTF8NoBom);
 	}
 
 	public static ResponseConfiguration BadRequest(string description = null) {
-		return new ResponseConfiguration(HttpStatusCode.BadRequest, description ?? "Bad Request", "text/plain",
+		return new ResponseConfiguration(HttpStatusCode.BadRequest, description ?? "Bad Request", ContentType.PlainText,
 			Helper.UTF8NoBom);
 	}
 
 	public static ResponseConfiguration InternalServerError(string description = null) {
 		return new ResponseConfiguration(HttpStatusCode.InternalServerError, description ?? "Internal Server Error",
-			"text/plain", Helper.UTF8NoBom);
+			ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	public static ResponseConfiguration ServiceUnavailable(string description = null) {
 		return new ResponseConfiguration(HttpStatusCode.ServiceUnavailable, description ?? "Service Unavailable",
-			"text/plain", Helper.UTF8NoBom);
+			ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	public static ResponseConfiguration NotImplemented(string description = null) {
 		return new ResponseConfiguration(HttpStatusCode.NotImplemented, description ?? "Not Implemented",
-			"text/plain", Helper.UTF8NoBom);
+			ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	public static ResponseConfiguration Unauthorized(string description = null) {
-		return new ResponseConfiguration(HttpStatusCode.Unauthorized, description ?? "Unauthorized", "text/plain",
+		return new ResponseConfiguration(HttpStatusCode.Unauthorized, description ?? "Unauthorized", ContentType.PlainText,
 			Helper.UTF8NoBom);
 	}
 
@@ -372,7 +373,7 @@ public static class Configure {
 				case OperationResult.Success:
 					var location = HostName.Combine(entity.ResponseUrl, "/streams/{0}/{1}",
 						Uri.EscapeDataString(eventStreamId), msg.FirstEventNumber);
-					return new ResponseConfiguration(HttpStatusCode.Created, "Created", "text/plain",
+					return new ResponseConfiguration(HttpStatusCode.Created, "Created", ContentType.PlainText,
 						Helper.UTF8NoBom,
 						new KeyValuePair<string, string>("Location", location));
 				case OperationResult.PrepareTimeout:
@@ -381,7 +382,7 @@ public static class Configure {
 					return InternalServerError("Write timeout");
 				case OperationResult.WrongExpectedVersion:
 					return new ResponseConfiguration(HttpStatusCode.BadRequest, "Wrong expected EventNumber",
-						"text/plain", Helper.UTF8NoBom,
+						ContentType.PlainText, Helper.UTF8NoBom,
 						new KeyValuePair<string, string>(SystemHeaders.CurrentVersion,
 							msg.CurrentVersion.ToString()));
 				case OperationResult.StreamDeleted:
@@ -407,7 +408,7 @@ public static class Configure {
 		if (msg != null) {
 			switch (msg.Result) {
 				case OperationResult.Success:
-					return new ResponseConfiguration(HttpStatusCode.NoContent, "Stream deleted", "text/plain",
+					return new ResponseConfiguration(HttpStatusCode.NoContent, "Stream deleted", ContentType.PlainText,
 						Helper.UTF8NoBom);
 				case OperationResult.PrepareTimeout:
 				case OperationResult.CommitTimeout:
@@ -415,7 +416,7 @@ public static class Configure {
 					return InternalServerError("Delete timeout");
 				case OperationResult.WrongExpectedVersion:
 					return new ResponseConfiguration(HttpStatusCode.BadRequest, "Wrong expected EventNumber",
-						"text/plain", Helper.UTF8NoBom,
+						ContentType.PlainText, Helper.UTF8NoBom,
 						new KeyValuePair<string, string>(SystemHeaders.CurrentVersion,
 							msg.CurrentVersion.ToString()));
 				case OperationResult.StreamDeleted:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -400,7 +400,8 @@ public class AdminController : CommunicationController {
 		Log.Debug("Error while closing HTTP connection (admin controller): {e}.", exc.Message);
 	}
 		private bool GetDescriptionDocument(HttpEntityManager manager, UriTemplateMatch match) {
-		if (manager.ResponseCodec.ContentType == ContentType.DescriptionDocJson) {
+		if (manager.ResponseCodec.ContentType == ContentType.DescriptionDocJson ||
+		    manager.ResponseCodec.ContentType == ContentType.LegacyDescriptionDocJson) {
 			var stream = match.BoundVariables["stream"];
 			var accepts = (manager.HttpEntity.Request.AcceptTypes?.Length ?? 0) == 0 ||
 			              manager.HttpEntity.Request.AcceptTypes.Contains(ContentType.Any);

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -28,6 +28,15 @@ public class AdminController : CommunicationController {
 	private static readonly ICodec[] SupportedCodecs = new ICodec[]
 		{Codec.Text, Codec.Json, Codec.Xml, Codec.ApplicationXml};
 
+	private static readonly ICodec[] SupportedStreamCodecs = new ICodec[] {
+		Codec.DescriptionJson,
+		Codec.LegacyDescriptionJson,
+		Codec.Text,
+		Codec.Json,
+		Codec.Xml,
+		Codec.ApplicationXml
+	};
+
 	public static readonly char[] ETagSeparatorArray = { ';' };
 
 	private static readonly Func<UriTemplateMatch, Operation> ReadStreamOperationForScavengeStream =
@@ -68,9 +77,9 @@ public class AdminController : CommunicationController {
 			new ControllerAction("/admin/login", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Login)),
 			OnGetLogin);
 		Register(service, "/streams/$scavenges/{scavengeId}/{event}/{count}?embed={embed}", HttpMethod.Get, GetStreamEventsBackwardScavenges, Codec.NoCodecs,
-			SupportedCodecs, ReadStreamOperationForScavengeStream);
+			SupportedStreamCodecs, ReadStreamOperationForScavengeStream);
 		Register(service, "/streams/$scavenges?embed={embed}", HttpMethod.Get, GetStreamEventsBackwardScavenges, Codec.NoCodecs,
-			SupportedCodecs, ReadStreamOperationForScavengeStream);
+			SupportedStreamCodecs, ReadStreamOperationForScavengeStream);
 	}
 
 	private static Func<UriTemplateMatch, Operation> ForScavengeStream(OperationDefinition definition) {
@@ -373,7 +382,7 @@ public class AdminController : CommunicationController {
 	}
 
 	private ResponseConfiguration ScavengeInProgressConfigurator(ICodec codec, ClientMessage.ScavengeDatabaseInProgressResponse message) {
-		return new ResponseConfiguration(HttpStatusCode.BadRequest, "Bad Request", "text/plain", Helper.UTF8NoBom);
+		return new ResponseConfiguration(HttpStatusCode.BadRequest, "Bad Request", ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	private string ScavengeInProgressFormatter(ICodec codec, ClientMessage.ScavengeDatabaseInProgressResponse message) {
@@ -381,7 +390,7 @@ public class AdminController : CommunicationController {
 	}
 
 	private ResponseConfiguration ScavengeNotFoundConfigurator(ICodec codec, ClientMessage.ScavengeDatabaseNotFoundResponse message) {
-		return new ResponseConfiguration(HttpStatusCode.NotFound, "Not Found", "text/plain", Helper.UTF8NoBom);
+		return new ResponseConfiguration(HttpStatusCode.NotFound, "Not Found", ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	private string ScavengeNotFoundFormatter(ICodec codec, ClientMessage.ScavengeDatabaseNotFoundResponse message) {
@@ -389,7 +398,7 @@ public class AdminController : CommunicationController {
 	}
 
 	private ResponseConfiguration ScavengeUnauthorizedConfigurator(ICodec codec, ClientMessage.ScavengeDatabaseUnauthorizedResponse message) {
-		return new ResponseConfiguration(HttpStatusCode.Unauthorized, "Unauthorized", "text/plain", Helper.UTF8NoBom);
+		return new ResponseConfiguration(HttpStatusCode.Unauthorized, "Unauthorized", ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	private string ScavengeUnauthorizedFormatter(ICodec codec, ClientMessage.ScavengeDatabaseUnauthorizedResponse message) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -52,7 +52,8 @@ public class AtomController : CommunicationController {
 
 	private static readonly ICodec[] AtomCodecsWithoutBatches = {
 		Codec.EventStoreXmlCodec,
-		Codec.EventStoreJsonCodec,
+		Codec.KurrentJsonCodec,
+		Codec.LegacyEventStoreJsonCodec,
 		Codec.Xml,
 		Codec.ApplicationXml,
 		Codec.Json
@@ -60,40 +61,50 @@ public class AtomController : CommunicationController {
 
 	private static readonly ICodec[] AtomCodecs = {
 		Codec.DescriptionJson,
+		Codec.LegacyDescriptionJson,
 		Codec.EventStoreXmlCodec,
-		Codec.EventStoreJsonCodec,
+		Codec.KurrentJsonCodec,
+		Codec.LegacyEventStoreJsonCodec,
 		Codec.Xml,
 		Codec.ApplicationXml,
 		Codec.Json,
 		Codec.EventXml,
 		Codec.EventJson,
+		Codec.LegacyEventJson,
 		Codec.EventsXml,
 		Codec.EventsJson,
+		Codec.LegacyEventsJson,
 		Codec.Raw,
 	};
 
 	private static readonly ICodec[] AtomWithHtmlCodecs = {
 		Codec.DescriptionJson,
+		Codec.LegacyDescriptionJson,
 		Codec.EventStoreXmlCodec,
-		Codec.EventStoreJsonCodec,
+		Codec.KurrentJsonCodec,
+		Codec.LegacyEventStoreJsonCodec,
 		Codec.Xml,
 		Codec.ApplicationXml,
 		Codec.Json,
 		Codec.EventXml,
 		Codec.EventJson,
+		Codec.LegacyEventJson,
 		Codec.EventsXml,
 		Codec.EventsJson,
+		Codec.LegacyEventsJson,
 		HtmlFeedCodec // initialization order matters
 	};
 
 	private static readonly ICodec[] DefaultCodecs = {
 		Codec.EventStoreXmlCodec,
-		Codec.EventStoreJsonCodec,
+		Codec.KurrentJsonCodec,
+		Codec.LegacyEventStoreJsonCodec,
 		Codec.Xml,
 		Codec.ApplicationXml,
 		Codec.Json,
 		Codec.EventXml,
 		Codec.EventJson,
+		Codec.LegacyEventJson,
 		Codec.Raw,
 		HtmlFeedCodec // initialization order matters
 	};
@@ -875,13 +886,13 @@ public class AtomController : CommunicationController {
 
 	private bool GetRequireLeader(HttpEntityManager manager, out bool requireLeader) {
 		requireLeader = false;
-		
+
 		var onlyLeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireLeader);
 		var onlyMaster = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireMaster);
-		
+
 		if (StringValues.IsNullOrEmpty(onlyLeader) && StringValues.IsNullOrEmpty(onlyMaster))
 			return true;
-	
+
 		if (string.Equals(onlyLeader, "True", StringComparison.OrdinalIgnoreCase) ||
 		    string.Equals(onlyMaster, "True", StringComparison.OrdinalIgnoreCase)) {
 			requireLeader = true;

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -245,7 +245,8 @@ public class AtomController : CommunicationController {
 	}
 
 	private bool GetDescriptionDocument(HttpEntityManager manager, UriTemplateMatch match) {
-		if (manager.ResponseCodec.ContentType == ContentType.DescriptionDocJson) {
+		if (manager.ResponseCodec.ContentType == ContentType.DescriptionDocJson ||
+		    manager.ResponseCodec.ContentType == ContentType.LegacyDescriptionDocJson) {
 			var stream = match.BoundVariables["stream"];
 			var accepts = (manager.HttpEntity.Request.AcceptTypes?.Length ?? 0) == 0 ||
 						  manager.HttpEntity.Request.AcceptTypes.Contains(ContentType.Any);
@@ -324,7 +325,7 @@ public class AtomController : CommunicationController {
 			var header = new[]
 				{new KeyValuePair<string, string>("Location", uri)};
 			manager.ReplyTextContent("Forwarding to idempotent URI", HttpStatusCode.RedirectKeepVerb,
-				"Temporary Redirect", "text/plain", header, e => { });
+				"Temporary Redirect", ContentType.PlainText, header, e => { });
 			return;
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
@@ -42,7 +42,7 @@ public class ClusterWebUiController : CommunicationController {
 			Codec.Json.To(_enabledNodeSubsystems),
 			200,
 			"OK",
-			"application/json",
+			ContentType.Json,
 			null,
 			ex => Log.Information(ex, "Failed to prepare main menu")
 		);
@@ -57,7 +57,7 @@ public class ClusterWebUiController : CommunicationController {
 				new ICodec[] {Codec.ManualEncoding},
 				new Operation(Operations.Node.Redirect)),
 			(http, match) => http.ReplyTextContent(
-				"Moved", 302, "Found", "text/plain",
+				"Moved", 302, "Found", ContentType.PlainText,
 				new[] {
 					new KeyValuePair<string, string>(
 						"Location", new Uri(http.HttpEntity.RequestedUrl, toUrl).AbsoluteUri)

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -40,9 +40,9 @@ public abstract class CommunicationController : IHttpController {
 
 	protected RequestParams SendBadRequest(HttpEntityManager httpEntityManager, string reason) {
 		httpEntityManager.ReplyContent(Encoding.ASCII.GetBytes(reason), HttpStatusCode.BadRequest,
-			"Bad Request",type: "text/plain", headers:null,
+			"Bad Request",type: ContentType.PlainText, headers:null,
 			e => Log.Debug("Error while closing HTTP connection (bad request): {e}.", e.Message));
- 
+
 		return new RequestParams(done: true);
 	}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/HttpHelpers.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/HttpHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/HttpHelpers.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/HttpHelpers.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+﻿// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
@@ -21,7 +21,7 @@ public static class HttpHelpers {
 				new ICodec[] {Codec.ManualEncoding},
 				new Operation(Operations.Node.Redirect)),
 			(http, match) => http.ReplyTextContent(
-				"Moved", 302, "Found", "text/plain",
+				"Moved", 302, "Found", ContentType.PlainText,
 				new[] {
 					new KeyValuePair<string, string>(
 						"Location", new Uri(match.BaseUri, toUrl).AbsoluteUri)

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/MetricsController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/MetricsController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+﻿// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
@@ -13,8 +13,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers;
 
 public class MetricsController : CommunicationController {
 	private static readonly ICodec[] SupportedCodecs = new ICodec[] {
-		Codec.CreateCustom(Codec.Text, "text/plain", Helper.UTF8NoBom, false, false),
-		Codec.CreateCustom(Codec.Text, "application/openmetrics-text", Helper.UTF8NoBom, false, false),
+		Codec.CreateCustom(Codec.Text, ContentType.PlainText, Helper.UTF8NoBom, false, false),
+		Codec.CreateCustom(Codec.Text, ContentType.OpenMetricsText, Helper.UTF8NoBom, false, false),
 	};
 
 	public MetricsController() : base(new NoOpPublisher()) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/MetricsController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/MetricsController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -780,7 +780,7 @@ public class PersistentSubscriptionController : CommunicationController {
 	}
 
 	private ResponseConfiguration ErrorConfigurator(ICodec codec, SubscriptionMessage.InvalidPersistentSubscriptionsRestart message) {
-		return new ResponseConfiguration(HttpStatusCode.BadRequest, "Bad Request", "text/plain",
+		return new ResponseConfiguration(HttpStatusCode.BadRequest, "Bad Request", ContentType.PlainText,
 			Helper.UTF8NoBom);
 	}
 

--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -309,18 +309,21 @@ public static class Convert {
 			@"The description document will be presented when no accept header is present or it was requested");
 
 		descriptionDocument.SetSelf("/streams/" + escapedStreamId,
-			Codec.DescriptionJson.ContentType);
+			Codec.DescriptionJson.ContentType,
+			Codec.LegacyDescriptionJson.ContentType);
 
 		descriptionDocument.SetStream("/streams/" + escapedStreamId,
 			Codec.EventStoreXmlCodec.ContentType,
-			Codec.EventStoreJsonCodec.ContentType);
+			Codec.KurrentJsonCodec.ContentType,
+			Codec.LegacyEventStoreJsonCodec.ContentType);
 
 		if (subscriptions != null) {
 			foreach (var group in subscriptions) {
 				descriptionDocument.AddStreamSubscription(
 					String.Format("/subscriptions/{0}/{1}", escapedStreamId, group),
 					Codec.CompetingXml.ContentType,
-					Codec.CompetingJson.ContentType);
+					Codec.CompetingJson.ContentType,
+					Codec.LegacyCompetingJson.ContentType);
 			}
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -68,7 +68,7 @@ public static class Convert {
 	}
 
 	public static FeedElement ToStreamEventBackwardFeed(ClientMessage.ReadStreamEventsBackwardCompleted msg,
-		Uri requestedUrl, EmbedLevel embedContent, bool headOfStream) {
+		Uri requestedUrl, EmbedLevel embedContent, bool headOfStream, string contentType) {
 		Ensure.NotNull(msg, "msg");
 
 		string escapedStreamId = Uri.EscapeDataString(msg.EventStreamId);
@@ -81,11 +81,10 @@ public static class Convert {
 			? msg.Events[0].Event.TimeStamp
 			: DateTime.MinValue.ToUniversalTime());
 		feed.SetAuthor(AtomSpecs.Author);
-		feed.SetHeadOfStream(headOfStream); //TODO AN: remove this ?
+		feed.SetHeadOfStream(headOfStream);
 		feed.SetSelfUrl(self);
-		//TODO AN: remove this ?
 		if (headOfStream) //NOTE: etag workaround - to be fixed with better http handling model
-			feed.SetETag(Configure.GetPositionETag(msg.LastEventNumber, ContentType.AtomJson));
+			feed.SetETag(Configure.GetPositionETag(msg.LastEventNumber, contentType));
 
 		var prevEventNumber = Math.Min(msg.FromEventNumber, msg.LastEventNumber) + 1;
 		var nextEventNumber = msg.FromEventNumber - msg.MaxCount;
@@ -301,16 +300,14 @@ public static class Convert {
 	}
 
 	public static DescriptionDocument ToDescriptionDocument(Uri requestedUrl, string streamId,
-		string[] subscriptions) {
+		string[] subscriptions, string contentType) {
 		string escapedStreamId = Uri.EscapeDataString(streamId);
 		var descriptionDocument = new DescriptionDocument();
 		descriptionDocument.SetTitle(string.Format("Description document for '{0}'", streamId));
 		descriptionDocument.SetDescription(
 			@"The description document will be presented when no accept header is present or it was requested");
 
-		descriptionDocument.SetSelf("/streams/" + escapedStreamId,
-			Codec.DescriptionJson.ContentType,
-			Codec.LegacyDescriptionJson.ContentType);
+		descriptionDocument.SetSelf("/streams/" + escapedStreamId, contentType);
 
 		descriptionDocument.SetStream("/streams/" + escapedStreamId,
 			Codec.EventStoreXmlCodec.ContentType,

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -27,6 +27,7 @@ public static class Format {
 		switch (entity.ResponseCodec.ContentType) {
 			case ContentType.Atom:
 			case ContentType.AtomJson:
+			case ContentType.LegacyAtomJson:
 			case ContentType.Html:
 				return entity.ResponseCodec.To(Convert.ToEntry(msg.Record, entity.ResponseUrl, embed,
 					singleEntry: true));
@@ -62,7 +63,7 @@ public static class Format {
 
 		return entity.ResponseCodec.To(Convert.ToAllEventsBackwardFeed(msg, entity.ResponseUrl, embed));
 	}
-	
+
 	public static string ReadAllEventsBackwardFilteredCompleted(HttpResponseFormatterArgs entity, Message message,
 		EmbedLevel embed) {
 		var msg = message as ClientMessage.FilteredReadAllEventsBackwardCompleted;
@@ -80,7 +81,7 @@ public static class Format {
 
 		return entity.ResponseCodec.To(Convert.ToAllEventsForwardFeed(msg, entity.ResponseUrl, embed));
 	}
-	
+
 	public static string ReadAllEventsForwardFilteredCompleted(HttpResponseFormatterArgs entity, Message message,
 		EmbedLevel embed) {
 		var msg = message as ClientMessage.FilteredReadAllEventsForwardCompleted;
@@ -142,7 +143,7 @@ public static class Format {
 			    .ReadNextNPersistentMessagesResult.Success) {
 			return msg != null ? entity.ResponseCodec.To(msg.Reason) : string.Empty;
 		}
-		
+
 		return entity.ResponseCodec.To(Convert.ToNextNPersistentMessagesFeed(msg, entity.ResponseUrl, streamId,
 			groupName, count, embed));
 	}

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -43,7 +43,7 @@ public static class Format {
 			return String.Empty;
 
 		return entity.ResponseCodec.To(
-			Convert.ToStreamEventBackwardFeed(msg, entity.ResponseUrl, embed, headOfStream));
+			Convert.ToStreamEventBackwardFeed(msg, entity.ResponseUrl, embed, headOfStream, entity.ResponseCodec.ContentType));
 	}
 
 	public static string GetStreamEventsForward(HttpResponseFormatterArgs entity, Message message,
@@ -151,6 +151,6 @@ public static class Format {
 	public static string GetDescriptionDocument(HttpResponseFormatterArgs entity, string streamId,
 		string[] persistentSubscriptionStats) {
 		return entity.ResponseCodec.To(Convert.ToDescriptionDocument(entity.RequestedUrl, streamId,
-			persistentSubscriptionStats));
+			persistentSubscriptionStats, entity.ResponseCodec.ContentType));
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/SendToHttpEnvelope.cs
+++ b/src/EventStore.Core/Services/Transport/Http/SendToHttpEnvelope.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+﻿// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
@@ -96,7 +96,7 @@ public class SendToHttpEnvelope<TExpectedResponseMessage> : IEnvelope where TExp
 			return _configurator(http.ResponseCodec, (TExpectedResponseMessage)message);
 		} catch (InvalidCastException) {
 			//NOTE: using exceptions to allow handling errors in debugger
-			return new ResponseConfiguration(500, "Internal server error", "text/plain", Helper.UTF8NoBom);
+			return new ResponseConfiguration(500, "Internal server error", ContentType.PlainText, Helper.UTF8NoBom);
 		}
 	}
 

--- a/src/EventStore.Core/Services/Transport/Http/SendToHttpEnvelope.cs
+++ b/src/EventStore.Core/Services/Transport/Http/SendToHttpEnvelope.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;

--- a/src/EventStore.Core/Util/MiniWeb.cs
+++ b/src/EventStore.Core/Util/MiniWeb.cs
@@ -75,7 +75,7 @@ public class MiniWeb {
 			    || !File.Exists(fullPath)) {
 				Logger.Information("Replying 404 for {contentLocalPath} ==> {fullPath}", contentLocalPath, fullPath);
 				http.ReplyTextContent(
-					"Not Found", 404, "Not Found", "text/plain", null,
+					"Not Found", 404, "Not Found", ContentType.PlainText, null,
 					ex => Logger.Information(ex, "Error while replying from MiniWeb"));
 			} else {
 				var config = GetWebPageConfig(contentType);
@@ -90,7 +90,7 @@ public class MiniWeb {
 					ex => Logger.Information(ex, "Error while replying from MiniWeb"));
 			}
 		} catch (Exception ex) {
-			http.ReplyTextContent(ex.ToString(), 500, "Internal Server Error", "text/plain", null,
+			http.ReplyTextContent(ex.ToString(), 500, "Internal Server Error", ContentType.PlainText, null,
 				Console.WriteLine);
 		}
 	}

--- a/src/EventStore.Licensing.Tests/Keygen/KeygenSimulator.cs
+++ b/src/EventStore.Licensing.Tests/Keygen/KeygenSimulator.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Text;
 using System.Net;
 using System;
+using ContentType = EventStore.Transport.Http.ContentType;
 
 namespace EventStore.Licensing.Tests.Keygen;
 
@@ -44,7 +45,7 @@ partial class KeygenSimulator : HttpMessageHandler {
 		var content = JsonSerializer.Serialize(response, _serializerOptions);
 		await _responses.Writer.WriteAsync(new HttpResponseMessage {
 			StatusCode = httpStatusCode,
-			Content = new StringContent(content, Encoding.UTF8, "application/json")
+			Content = new StringContent(content, Encoding.UTF8, ContentType.Json)
 		});
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/http_service/authorization_tests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/http_service/authorization_tests.cs
@@ -11,6 +11,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Tests;
 using EventStore.Projections.Core.Tests.ClientAPI.Cluster;
 using NUnit.Framework;
+using ContentType = EventStore.Transport.Http.ContentType;
 
 namespace EventStore.Projections.Core.Tests.Services.Transport.Http;
 
@@ -91,7 +92,7 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_standard_
 				var data = Helper.UTF8NoBom.GetBytes(dataStr);
 				var stream = new MemoryStream(data);
 				var content = new StreamContent(stream);
-				content.Headers.Add("Content-Type", "application/json");
+				content.Headers.Add("Content-Type", ContentType.Json);
 
 				var res = await _httpClients["Admin"].PostAsync(
 					string.Format("http://{0}/users/", _nodes[_leaderId].HttpEndPoint),
@@ -180,7 +181,7 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_standard_
 
 		var url = $"http://{nodeEndpoint}{endpointUrl}";
 		var body = GetData(httpMethod, endpointUrl);
-		var contentType = httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete ? "application/json" : null;
+		var contentType = httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete ? ContentType.Json : null;
 		var statusCode = await SendRequest(_httpClients[userAuthorizationLevel], httpMethod, url, body, contentType);
 
 		if (GetAuthLevel(userAuthorizationLevel) >= GetAuthLevel(requiredMinAuthorizationLevel)) {

--- a/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
+++ b/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using EventStore.Common.Utils;
-using EventStore.Core;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
@@ -111,7 +110,7 @@ public class ProjectionsController : CommunicationController {
 			return;
 
 		http.ReplyTextContent(
-			"Moved", 302, "Found", "text/plain",
+			"Moved", 302, "Found", ContentType.PlainText,
 			new[] {
 				new KeyValuePair<string, string>(
 					"Location", new Uri(match.BaseUri, "/web/projections.htm").AbsoluteUri)
@@ -432,10 +431,10 @@ public class ProjectionsController : CommunicationController {
 			return Configure.InternalServerError();
 		else
 			return state.Position != null
-				? Configure.Ok("application/json", Helper.UTF8NoBom, null, null, false,
+				? Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false,
 					new KeyValuePair<string, string>(SystemHeaders.ProjectionPosition,
 						state.Position.ToJsonString()))
-				: Configure.Ok("application/json", Helper.UTF8NoBom, null, null, false);
+				: Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false);
 	}
 
 	private ResponseConfiguration ResultConfigurator(ICodec codec,
@@ -444,16 +443,16 @@ public class ProjectionsController : CommunicationController {
 			return Configure.InternalServerError();
 		else
 			return state.Position != null
-				? Configure.Ok("application/json", Helper.UTF8NoBom, null, null, false,
+				? Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false,
 					new KeyValuePair<string, string>(SystemHeaders.ProjectionPosition,
 						state.Position.ToJsonString()))
-				: Configure.Ok("application/json", Helper.UTF8NoBom, null, null, false);
+				: Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false);
 	}
 
 	private ResponseConfiguration FeedPageConfigurator(ICodec codec, FeedReaderMessage.FeedPage page) {
 		if (page.Error == FeedReaderMessage.FeedPage.ErrorStatus.NotAuthorized)
 			return Configure.Unauthorized();
-		return Configure.Ok("application/json", Helper.UTF8NoBom, null, null, false);
+		return Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false);
 	}
 
 	private string StateFormatter(ICodec codec, ProjectionManagementMessage.ProjectionState state) {
@@ -519,7 +518,7 @@ public class ProjectionsController : CommunicationController {
 
 	private ResponseConfiguration QueryConfigConfigurator(ICodec codec,
 		ProjectionManagementMessage.ProjectionQuery state) {
-		return Configure.Ok("application/json", Helper.UTF8NoBom, null, null, false);
+		return Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false);
 	}
 
 	private string ProjectionConfigFormatter(ICodec codec, ProjectionManagementMessage.ProjectionConfig config) {
@@ -528,7 +527,7 @@ public class ProjectionsController : CommunicationController {
 
 	private ResponseConfiguration ProjectionConfigConfigurator(ICodec codec,
 		ProjectionManagementMessage.ProjectionConfig state) {
-		return Configure.Ok("application/json", Helper.UTF8NoBom, null, null, false);
+		return Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false);
 	}
 
 	private ResponseConfiguration OkResponseConfigurator<T>(ICodec codec, T message) {
@@ -569,7 +568,7 @@ public class ProjectionsController : CommunicationController {
 	}
 
 	private ResponseConfiguration NotFoundConfigurator(ICodec codec, ProjectionManagementMessage.NotFound message) {
-		return new ResponseConfiguration(404, "Not Found", "text/plain", Helper.UTF8NoBom);
+		return new ResponseConfiguration(404, "Not Found", ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	private string NotFoundFormatter(ICodec codec, ProjectionManagementMessage.NotFound message) {
@@ -578,7 +577,7 @@ public class ProjectionsController : CommunicationController {
 
 	private ResponseConfiguration NotAuthorizedConfigurator(
 		ICodec codec, ProjectionManagementMessage.NotAuthorized message) {
-		return new ResponseConfiguration(401, "Not Authorized", "text/plain", Encoding.UTF8);
+		return new ResponseConfiguration(401, "Not Authorized", ContentType.PlainText, Encoding.UTF8);
 	}
 
 	private string NotAuthorizedFormatter(ICodec codec, ProjectionManagementMessage.NotAuthorized message) {
@@ -587,7 +586,7 @@ public class ProjectionsController : CommunicationController {
 
 	private ResponseConfiguration OperationFailedConfigurator(
 		ICodec codec, ProjectionManagementMessage.OperationFailed message) {
-		return new ResponseConfiguration(500, "Failed", "text/plain", Helper.UTF8NoBom);
+		return new ResponseConfiguration(500, "Failed", ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	private string OperationFailedFormatter(ICodec codec, ProjectionManagementMessage.OperationFailed message) {
@@ -596,7 +595,7 @@ public class ProjectionsController : CommunicationController {
 
 	private ResponseConfiguration ConflictConfigurator(
 		ICodec codec, ProjectionManagementMessage.OperationFailed message) {
-		return new ResponseConfiguration(409, "Conflict", "text/plain", Helper.UTF8NoBom);
+		return new ResponseConfiguration(409, "Conflict", ContentType.PlainText, Helper.UTF8NoBom);
 	}
 
 	private string ConflictFormatter(ICodec codec, ProjectionManagementMessage.OperationFailed message) {
@@ -608,7 +607,7 @@ public class ProjectionsController : CommunicationController {
 	}
 
 	private ResponseConfiguration InvalidSubsystemRestartConfigurator(ICodec codec, ProjectionSubsystemMessage.InvalidSubsystemRestart message) {
-		return new ResponseConfiguration(HttpStatusCode.BadRequest, "Bad Request", "text/plain",
+		return new ResponseConfiguration(HttpStatusCode.BadRequest, "Bad Request", ContentType.PlainText,
 			Helper.UTF8NoBom);
 	}
 

--- a/src/EventStore.Transport.Http/Codecs/Codec.cs
+++ b/src/EventStore.Transport.Http/Codecs/Codec.cs
@@ -23,26 +23,41 @@ public static class Codec {
 	public static readonly CustomCodec EventJson =
 		new CustomCodec(Json, ContentType.EventJson, Helper.UTF8NoBom, true, true);
 
+	public static readonly CustomCodec LegacyEventJson =
+		new CustomCodec(Json, ContentType.LegacyEventJson, Helper.UTF8NoBom, true, true);
+
 	public static readonly CustomCodec EventsXml =
 		new CustomCodec(Xml, ContentType.EventsXml, Helper.UTF8NoBom, true, true);
 
 	public static readonly CustomCodec EventsJson =
 		new CustomCodec(Json, ContentType.EventsJson, Helper.UTF8NoBom, true, true);
 
+	public static readonly CustomCodec LegacyEventsJson =
+		new CustomCodec(Json, ContentType.LegacyEventsJson, Helper.UTF8NoBom, true, true);
+
 	public static readonly ICodec EventStoreXmlCodec =
 		Codec.CreateCustom(Codec.Xml, ContentType.Atom, Helper.UTF8NoBom, false, false);
 
-	public static readonly ICodec EventStoreJsonCodec =
+	public static readonly ICodec KurrentJsonCodec =
 		Codec.CreateCustom(Codec.Json, ContentType.AtomJson, Helper.UTF8NoBom, false, false);
+
+	public static readonly ICodec LegacyEventStoreJsonCodec =
+		Codec.CreateCustom(Codec.Json, ContentType.LegacyAtomJson, Helper.UTF8NoBom, false, false);
 
 	public static readonly CustomCodec DescriptionJson =
 		new CustomCodec(Json, ContentType.DescriptionDocJson, Helper.UTF8NoBom, true, true);
+
+	public static readonly CustomCodec LegacyDescriptionJson =
+		new CustomCodec(Json, ContentType.LegacyDescriptionDocJson, Helper.UTF8NoBom, true, true);
 
 	public static readonly CustomCodec CompetingXml =
 		new CustomCodec(Xml, ContentType.Competing, Helper.UTF8NoBom, true, true);
 
 	public static readonly CustomCodec CompetingJson =
 		new CustomCodec(Json, ContentType.CompetingJson, Helper.UTF8NoBom, true, true);
+
+	public static readonly CustomCodec LegacyCompetingJson =
+		new CustomCodec(Json, ContentType.LegacyCompetingJson, Helper.UTF8NoBom, true, true);
 
 	public static readonly CustomCodec Raw = new CustomCodec(NoCodec, ContentType.Raw, null, false, false);
 	public static readonly TextCodec Text = new TextCodec();

--- a/src/EventStore.Transport.Http/ContentType.cs
+++ b/src/EventStore.Transport.Http/ContentType.cs
@@ -35,4 +35,6 @@ public static class ContentType {
 	public const string LegacyCompetingJson = "application/vnd.eventstore.competingatom+json";
 
 	public const string Raw = "application/octet-stream";
+
+	public const string OpenMetricsText = "application/openmetrics-text";
 }

--- a/src/EventStore.Transport.Http/ContentType.cs
+++ b/src/EventStore.Transport.Http/ContentType.cs
@@ -13,21 +13,26 @@ public static class ContentType {
 	public const string Html = "text/html";
 
 	public const string Atom = "application/atom+xml";
-	public const string AtomJson = "application/vnd.eventstore.atom+json";
+	public const string AtomJson = "application/vnd.kurrent.atom+json";
+	public const string LegacyAtomJson = "application/vnd.eventstore.atom+json";
 
 	public const string AtomServiceDoc = "application/atomsvc+xml";
-	public const string AtomServiceDocJson = "application/vnd.eventstore.atomsvc+json";
+	public const string AtomServiceDocJson = "application/vnd.kurrent.atomsvc+json";
 
-	public const string EventJson = "application/vnd.eventstore.event+json";
+	public const string EventJson = "application/vnd.kurrent.event+json";
+	public const string LegacyEventJson = "application/vnd.eventstore.event+json";
 	public const string EventXml = "application/vnd.eventstore.event+xml";
 
-	public const string EventsJson = "application/vnd.eventstore.events+json";
+	public const string EventsJson = "application/vnd.kurrent.events+json";
+	public const string LegacyEventsJson = "application/vnd.eventstore.events+json";
 	public const string EventsXml = "application/vnd.eventstore.events+xml";
 
-	public const string DescriptionDocJson = "application/vnd.eventstore.streamdesc+json";
+	public const string DescriptionDocJson = "application/vnd.kurrent.streamdesc+json";
+	public const string LegacyDescriptionDocJson = "application/vnd.eventstore.streamdesc+json";
 
 	public const string Competing = "application/vnd.eventstore.competingatom+xml";
-	public const string CompetingJson = "application/vnd.eventstore.competingatom+json";
+	public const string CompetingJson = "application/vnd.kurrent.competingatom+json";
+	public const string LegacyCompetingJson = "application/vnd.eventstore.competingatom+json";
 
 	public const string Raw = "application/octet-stream";
 }


### PR DESCRIPTION
Add content types with the Kurrent branding.

This deprecates the `vnd.eventstore.*` content types, `vnd.kurrent.*` should be used instead:

| Deprecated | Use instead | Purpose |
|--------------|--------------|----------|
| `application/vnd.eventstore.atom+json` | `application/vnd.kurrent.atom+json` | Requesting streams as an atom feed. |
| `application/vnd.eventstore.event+json` | `application/vnd.kurrent.event+json` | Posting a single event to a stream. |
| `application/vnd.eventstore.events+json` | `application/vnd.kurrent.events+json` | Posting an array of events to a stream. |
| `application/vnd.eventstore.streamdesc+json` | `application/vnd.kurrent.streamdesc+json` | Stream description document. |
| `application/vnd.eventstore.competingatom+json` | `application/vnd.kurrent.competingatom+json` |  Requesting persistent subscriptions as an atom feed. |

The `application/vnd.eventstore.atomsvc+json` content type has been removed and replaced with `application/vnd.kurrent.atomsvc+json`.

Xml content types are unchanged.