### PR TITLE
Validate against attempts to set metadata for the "" stream (#4799)

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Messages/ClientMessageTests/WriteEventsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Messages/ClientMessageTests/WriteEventsTests.cs
@@ -1,0 +1,41 @@
+using System;
+using EventStore.Core.Messaging;
+using EventStore.Core.Messages;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Messages.ClientMessageTests;
+
+public class WriteEventsTests {
+	static ClientMessage.WriteEvents CreateSut(
+		string eventStreamId = default,
+		long expectedVersion = default) =>
+
+		new(internalCorrId: Guid.NewGuid(),
+			correlationId: Guid.NewGuid(),
+			envelope: new NoopEnvelope(),
+			requireLeader: false,
+			eventStreamId: eventStreamId,
+			expectedVersion: expectedVersion,
+			events: [],
+			user: default);
+
+	[Theory]
+	[InlineData("normal")]
+	[InlineData("  not normal  ")] // doubtful that this is a good idea. would be a breaking change to reject though
+	[InlineData("$$normal")]
+	public void accepts_valid_stream_ids(string streamId) {
+		CreateSut(eventStreamId: streamId);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("$$")] // "" is an invalid name, and so metadata cannot be set for it
+	public void rejects_invalid_stream_ids(string streamId) {
+		var ex = Assert.Throws<ArgumentOutOfRangeException>(() => {
+			CreateSut(eventStreamId: streamId);
+		});
+
+		Assert.Contains("eventStreamId", ex.Message);
+	}
+}

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -179,10 +179,14 @@ namespace EventStore.Core.Messages {
 				string eventStreamId, long expectedVersion, Event[] events, ClaimsPrincipal user,
 				IReadOnlyDictionary<string, string> tokens = null, CancellationToken cancellationToken = default)
 				: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens) {
-				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
+
+				if (SystemStreams.IsInvalidStream(eventStreamId))
+					throw new ArgumentOutOfRangeException(nameof(eventStreamId));
+
 				if (expectedVersion < Data.ExpectedVersion.StreamExists ||
 				    expectedVersion == Data.ExpectedVersion.Invalid)
 					throw new ArgumentOutOfRangeException(nameof(expectedVersion));
+
 				Ensure.NotNull(events, "events");
 
 				EventStreamId = eventStreamId;

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -33,6 +33,11 @@ namespace EventStore.Core.Services {
 			return streamId.Length != 0 && streamId[0] == '$';
 		}
 
+		// "" is an invalid name, and so metadata cannot be set for it
+		public static bool IsInvalidStream(string streamId) {
+			return string.IsNullOrEmpty(streamId) || streamId == "$$";
+		}
+
 		public static string MetastreamOf(string streamId) {
 			return "$$" + streamId;
 		}


### PR DESCRIPTION
Fixed: Validate against attempts to set metadata for the "" stream

"" has never been a valid stream name. Attempting to set the metadata for it results in an attempt to write to the stream "$$" which, until now, has been a valid stream name.

However, writing to $$ involves checking on the "" stream, to see if it is soft deleted. This results in the storage writer exiting which shuts down the server to avoid a 'sick but not dead' scenario

This PR makes "$$" an invalid stream name, and so the attempt to write to it is rejected at an early stage.

cherry pick of https://github.com/EventStore/EventStore/pull/4799