### PR TITLE
[KDB-591] Rename HTTP headers

### DIFF
--- a/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_follower.cs
+++ b/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_follower.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
+using EventStore.Core.Services;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.Integration;
 using NUnit.Framework;
@@ -193,9 +194,9 @@ public class when_requesting_from_follower<TLogFormat, TStreamId> : specificatio
 		var uri = CreateUri(nodeEndpoint, path);
 		var request = CreateRequest(uri, HttpMethod.Post, requireLeader);
 
-		request.Headers.Add("ES-EventType", "SomeType");
-		request.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
-		request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+		request.Headers.Add(SystemHeaders.EventType, "SomeType");
+		request.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+		request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 		var data = "{a : \"1\", b:\"3\", c:\"5\" }";
 		request.Content = new StringContent(data, Encoding.UTF8, ContentType.Json);
 
@@ -207,7 +208,7 @@ public class when_requesting_from_follower<TLogFormat, TStreamId> : specificatio
 
 	private HttpRequestMessage CreateRequest(Uri uri, HttpMethod method, bool requireLeader) {
 		var request = new HttpRequestMessage(method, uri);
-		request.Headers.Add("ES-RequireLeader", requireLeader ? "True" : "False");
+		request.Headers.Add(SystemHeaders.RequireLeader, requireLeader ? "True" : "False");
 		request.Headers.Authorization = new AuthenticationHeaderValue("Basic",
             					GetAuthorizationHeader(DefaultData.AdminNetworkCredentials));
 		return request;

--- a/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
+++ b/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
@@ -59,11 +59,13 @@ namespace EventStore.Core.Tests.Http.StreamSecurity {
 			}
 
 			[Test]
-			public async Task accepts_post_event_as_authorized_user_by_trusted_auth() {
+			[TestCase(SystemHeaders.TrustedAuth)]
+			[TestCase(SystemHeaders.LegacyTrustedAuth)]
+			public async Task accepts_post_event_as_authorized_user_by_trusted_auth(string trustedAuthHeader) {
 				var uri = MakeUrl(TestStream);
 
 				var request = new HttpRequestMessage(HttpMethod.Post, uri) {
-					Headers = { { SystemHeaders.TrustedAuth, "root; admin, other" } },
+					Headers = { { trustedAuthHeader, "root; admin, other" } },
 					Content = new ByteArrayContent(
 						new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { Some = "Data" } } }
 							.ToJsonBytes()) {

--- a/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
+++ b/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Tests.Http.StreamSecurity {
 				var uri = MakeUrl(TestStream);
 
 				var request = new HttpRequestMessage(HttpMethod.Post, uri) {
-					Headers = { { "ES-TrustedAuth", "root; admin, other" } },
+					Headers = { { SystemHeaders.TrustedAuth, "root; admin, other" } },
 					Content = new ByteArrayContent(
 						new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { Some = "Data" } } }
 							.ToJsonBytes()) {

--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -30,9 +30,9 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			public Task<HttpResponseMessage> PostEventWithExpectedVersion(long expectedVersion) {
 				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
-				request.Headers.Add("ES-EventType", "SomeType");
-				request.Headers.Add("ES-ExpectedVersion", expectedVersion.ToString());
-				request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
+				request.Headers.Add(SystemHeaders.ExpectedVersion, expectedVersion.ToString());
+				request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
 				request.Content = new ByteArrayContent(data) {
 					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
@@ -42,16 +42,16 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			public Task TombstoneTestStream() {
 				var deleteRequest = CreateRequest(TestStream, "", "DELETE", ContentType.Json);
-				deleteRequest.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
-				deleteRequest.Headers.Add("ES-HardDelete", bool.TrueString);
+				deleteRequest.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+				deleteRequest.Headers.Add(SystemHeaders.HardDelete, bool.TrueString);
 				return GetRequestResponse(deleteRequest);
 			}
 
 			public Task SoftDeleteTestStream() {
 				var deleteRequest = CreateRequest(TestMetadataStream, "", "POST", ContentType.Json);
-				deleteRequest.Headers.Add("ES-EventType", SystemEventTypes.StreamMetadata);
-				deleteRequest.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
-				deleteRequest.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+				deleteRequest.Headers.Add(SystemHeaders.EventType, SystemEventTypes.StreamMetadata);
+				deleteRequest.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+				deleteRequest.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				deleteRequest.Content = new ByteArrayContent(StreamMetadata
 					.Create(truncateBefore: long.MaxValue)
 					.AsJsonBytes()) {
@@ -402,9 +402,9 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			protected override async Task Given() {
 				var request = CreateRequest(TestMetadataStream, "", "POST", ContentType.Json);
-				request.Headers.Add("ES-EventType", "$user-created");
-				request.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
-				request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+				request.Headers.Add(SystemHeaders.EventType, "$user-created");
+				request.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+				request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
 				request.Content = new ByteArrayContent(data) {
 					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }

--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -19,6 +19,8 @@ using Microsoft.Extensions.Primitives;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	namespace append_to_stream {
+		public abstract class ExpectedVersionSpecification : ExpectedVersionSpecification<LogFormat.V2, string>;
+
 		public abstract class ExpectedVersionSpecification<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
 			public string WrongExpectedVersionDesc {
 				get { return "Wrong expected EventNumber"; }
@@ -28,10 +30,10 @@ namespace EventStore.Core.Tests.Http.Streams {
 				get { return "Stream deleted"; }
 			}
 
-			public Task<HttpResponseMessage> PostEventWithExpectedVersion(long expectedVersion) {
+			public Task<HttpResponseMessage> PostEventWithExpectedVersion(long expectedVersion, string expectedVersionHeader = SystemHeaders.ExpectedVersion) {
 				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
 				request.Headers.Add(SystemHeaders.EventType, "SomeType");
-				request.Headers.Add(SystemHeaders.ExpectedVersion, expectedVersion.ToString());
+				request.Headers.Add(expectedVersionHeader, expectedVersion.ToString());
 				request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
 				request.Content = new ByteArrayContent(data) {
@@ -63,6 +65,118 @@ namespace EventStore.Core.Tests.Http.Streams {
 			public async Task<List<JToken>> GetTestStream() {
 				var stream = await GetJson<JObject>(TestStream + "/0/forward/10", accept: ContentType.Json);
 				return stream != null ? stream["entries"].ToList() : new List<JToken>();
+			}
+		}
+
+		[Category("LongRunning")]
+		[TestFixture(-2, HttpStatusCode.Created)]
+		[TestFixture(2, HttpStatusCode.Created)]
+		[TestFixture(3, HttpStatusCode.BadRequest)]
+		public class should_support_legacy_expected_version_header(int expectedVersion, HttpStatusCode expectedResult) : ExpectedVersionSpecification {
+			private HttpResponseMessage _response;
+			private List<JToken> _read;
+
+			protected override async Task Given() {
+				for (var i = 0; i < 3; i++) {
+					await PostEventWithExpectedVersion(ExpectedVersion.Any);
+				}
+			}
+
+			protected override async Task When() {
+				_response = await PostEventWithExpectedVersion(expectedVersion, SystemHeaders.LegacyExpectedVersion);
+				_read = await GetTestStream();
+			}
+
+			[Test]
+			public void should_return_the_correct_status_code() {
+				Assert.AreEqual(expectedResult, _response.StatusCode);
+			}
+
+			[Test]
+			public void should_append_event_to_stream_if_created() {
+				if (expectedResult == HttpStatusCode.Created)
+					Assert.AreEqual(4, _read.Count);
+				else
+					Assert.AreEqual(3, _read.Count);
+			}
+		}
+
+		[TestFixture(SystemHeaders.EventId)]
+		[TestFixture(SystemHeaders.LegacyEventId)]
+		class should_support_legacy_event_id_header(string eventIdHeader) : ExpectedVersionSpecification {
+			private HttpResponseMessage _response;
+			private string _eventId = Guid.NewGuid().ToString();
+
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override async Task When() {
+				var request = CreateRawJsonPostRequest(TestStream, "POST", new { A = "1" });
+				request.Headers.Add(eventIdHeader, _eventId);
+				request.Headers.Add(SystemHeaders.EventType, "event-type");
+				_response = await GetRequestResponse(request);
+			}
+
+			[Test]
+			public void returns_created_status_code() {
+				Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+			}
+
+			[Test]
+			public async Task created_event_uses_event_id() {
+				var stream = await GetJson<JObject>(TestStream + "/0/forward/10", accept: ContentType.Json, extra: "?embed=body");
+				var read = stream["entries"]?.ToList();
+				Assert.AreEqual(_eventId, read[0].Value<string>("eventId"));
+			}
+		}
+
+		[TestFixture(SystemHeaders.EventType)]
+		[TestFixture(SystemHeaders.LegacyEventType)]
+		class should_support_legacy_event_type_header(string eventTypeHeader) : ExpectedVersionSpecification {
+			private HttpResponseMessage _response;
+			private string _eventType = "event-type";
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override async Task When() {
+				var request = CreateRawJsonPostRequest(TestStream, "POST", new { A = "1" });
+				request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
+				request.Headers.Add(eventTypeHeader, _eventType);
+				_response = await GetRequestResponse(request);
+			}
+
+			[Test]
+			public void returns_created_status_code() {
+				Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+			}
+
+			[Test]
+			public async Task created_event_uses_event_type() {
+				var stream = await GetJson<JObject>(TestStream + "/0/forward/10", accept: ContentType.Json, extra: "?embed=body");
+				var read = stream["entries"]?.ToList();
+				Assert.AreEqual(_eventType, read[0].Value<string>("eventType"));
+			}
+		}
+
+		[Category("LongRunning")]
+		[TestFixture(SystemHeaders.HardDelete)]
+		[TestFixture(SystemHeaders.LegacyHardDelete)]
+		public class should_support_legacy_hard_delete_header(string hardDeleteHeader) : ExpectedVersionSpecification<LogFormat.V2, string> {
+			private HttpResponseMessage _response;
+
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override async Task When() {
+				var deleteRequest = CreateRequest(TestStream, "", "DELETE", ContentType.Json);
+				deleteRequest.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+				deleteRequest.Headers.Add(hardDeleteHeader, bool.TrueString);
+				var response = await GetRequestResponse(deleteRequest);
+				Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+
+				_response = await PostEventWithExpectedVersion(ExpectedVersion.Any);
+			}
+
+			[Test]
+			public void should_return_gone_status_code() {
+				Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
 			}
 		}
 
@@ -118,6 +232,12 @@ namespace EventStore.Core.Tests.Http.Streams {
 			public void should_return_the_current_version_in_the_header() {
 				Assert.AreEqual("0",
 					new StringValues(_response.Headers.GetValues(SystemHeaders.CurrentVersion).ToArray()));
+			}
+
+			[Test]
+			public void should_return_the_current_version_in_the_legacy_header() {
+				Assert.AreEqual("0",
+					new StringValues(_response.Headers.GetValues(SystemHeaders.LegacyCurrentVersion).ToArray()));
 			}
 
 			[Test]
@@ -260,6 +380,12 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 
 			[Test]
+			public void should_return_the_current_version_in_the_legacy_header() {
+				Assert.AreEqual("1",
+					new StringValues(_response.Headers.GetValues(SystemHeaders.LegacyCurrentVersion).ToArray()));
+			}
+
+			[Test]
 			public void should_not_append_event() {
 				Assert.AreEqual(2, _read.Count);
 			}
@@ -288,6 +414,12 @@ namespace EventStore.Core.Tests.Http.Streams {
 			public void should_return_the_current_version_in_the_header() {
 				Assert.AreEqual("-1",
 					new StringValues(_response.Headers.GetValues(SystemHeaders.CurrentVersion).ToArray()));
+			}
+
+			[Test]
+			public void should_return_the_current_version_in_the_legacy_header() {
+				Assert.AreEqual("-1",
+					new StringValues(_response.Headers.GetValues(SystemHeaders.LegacyCurrentVersion).ToArray()));
 			}
 
 			[Test]
@@ -453,6 +585,12 @@ namespace EventStore.Core.Tests.Http.Streams {
 			public void should_return_the_current_version_in_the_header() {
 				Assert.AreEqual("-1",
 					new StringValues(_response.Headers.GetValues(SystemHeaders.CurrentVersion).ToArray()));
+			}
+
+			[Test]
+			public void should_return_the_current_version_in_the_legacy_header() {
+				Assert.AreEqual("-1",
+					new StringValues(_response.Headers.GetValues(SystemHeaders.LegacyCurrentVersion).ToArray()));
 			}
 
 			[Test]

--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -125,7 +125,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			public async Task created_event_uses_event_id() {
 				var stream = await GetJson<JObject>(TestStream + "/0/forward/10", accept: ContentType.Json, extra: "?embed=body");
 				var read = stream["entries"]?.ToList();
-				Assert.AreEqual(_eventId, read[0].Value<string>("eventId"));
+				Assert.AreEqual(_eventId, read?[0].Value<string>("eventId"));
 			}
 		}
 
@@ -152,7 +152,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			public async Task created_event_uses_event_type() {
 				var stream = await GetJson<JObject>(TestStream + "/0/forward/10", accept: ContentType.Json, extra: "?embed=body");
 				var read = stream["entries"]?.ToList();
-				Assert.AreEqual(_eventType, read[0].Value<string>("eventType"));
+				Assert.AreEqual(_eventType, read?[0].Value<string>("eventType"));
 			}
 		}
 

--- a/src/EventStore.Core.Tests/Http/Streams/basic.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/basic.cs
@@ -757,7 +757,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			protected override async Task When() {
 				var request = CreateRequest(TestStream, "", "DELETE", ContentType.Json,
-					headers: new NameValueCollection{{SystemHeaders.ExpectedVersion, expectedVersion.ToString()}});
+					headers: new NameValueCollection{{SystemHeaders.LegacyExpectedVersion, expectedVersion.ToString()}});
 				_response = await _client.SendAsync(request);
 			}
 

--- a/src/EventStore.Core.Tests/Http/Streams/basic.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/basic.cs
@@ -14,6 +14,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using EventStore.Common.Utils;
+using EventStore.Core.Services;
 using EventStore.Core.Tests.Http.Users.users;
 using HttpMethod = EventStore.Transport.Http.HttpMethod;
 using HttpStatusCode = System.Net.HttpStatusCode;
@@ -131,7 +132,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			protected override async Task When() {
 				var request = CreateRequest(TestStream + "/incoming/" + Guid.NewGuid(), "", "POST",
 					ContentType.Json);
-				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
 				var data = "{a : \"1\", b:\"3\", c:\"5\" }";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
@@ -165,7 +166,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			protected override async Task When() {
 				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
-				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
 				var data = "{A : \"1\", B:\"3\", C:\"5\" }";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
@@ -712,8 +713,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			protected override async Task Given() {
 				var request = CreateRequest(TestStream, String.Empty, HttpMethod.Post, ContentType.Raw);
-				request.Headers.Add("ES-EventType", "TestEventType");
-				request.Headers.Add("ES-EventID", Guid.NewGuid().ToString());
+				request.Headers.Add(SystemHeaders.EventType, "TestEventType");
+				request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				if (_data == null) {
 					var fileData = HelperExtensions.GetFilePathFromAssembly("Resources/es-tile.png");
 					_data = File.ReadAllBytes(fileData);

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -18,6 +18,7 @@ using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using EventStore.Core.Tests.Http.Users.users;
 using HttpStatusCode = System.Net.HttpStatusCode;
+using SystemHeaders = EventStore.Core.Services.SystemHeaders;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	namespace feed {
@@ -634,7 +635,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		private List<JToken> _entries;
 
 		protected override async Task When() {
-			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "True"}};
+			var headers = new NameValueCollection {{SystemHeaders.ResolveLinkTos, "True"}};
 			_feed = await GetJson<JObject>("/streams/$all/head/backward/30",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
@@ -666,7 +667,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		private List<JToken> _entries;
 
 		protected override async Task When() {
-			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "False"}};
+			var headers = new NameValueCollection {{SystemHeaders.ResolveLinkTos, "False"}};
 			_feed = await GetJson<JObject>("/streams/$all",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
@@ -698,7 +699,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		private List<JToken> _entries;
 
 		protected override async Task When() {
-			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "True"}};
+			var headers = new NameValueCollection {{SystemHeaders.ResolveLinkTos, "True"}};
 			_feed = await GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/30",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
@@ -730,7 +731,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		private List<JToken> _entries;
 
 		protected override async Task When() {
-			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "False"}};
+			var headers = new NameValueCollection {{SystemHeaders.ResolveLinkTos, "False"}};
 			_feed = await GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/30",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -629,13 +629,14 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture]
-	public class when_reading_the_all_stream_backward_with_resolve_link_to : HttpSpecificationWithLinkToToEvents {
+	[TestFixture(SystemHeaders.ResolveLinkTos)]
+	[TestFixture(SystemHeaders.LegacyResolveLinkTos)]
+	public class when_reading_the_all_stream_backward_with_resolve_link_to(string resolveLinkTosHeader) : HttpSpecificationWithLinkToToEvents {
 		private JObject _feed;
 		private List<JToken> _entries;
 
 		protected override async Task When() {
-			var headers = new NameValueCollection {{SystemHeaders.ResolveLinkTos, "True"}};
+			var headers = new NameValueCollection {{resolveLinkTosHeader, "True"}};
 			_feed = await GetJson<JObject>("/streams/$all/head/backward/30",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
@@ -661,13 +662,14 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture]
-	public class when_reading_the_all_stream_backward_with_resolve_link_to_disabled : HttpSpecificationWithLinkToToEvents {
+	[TestFixture(SystemHeaders.ResolveLinkTos)]
+	[TestFixture(SystemHeaders.LegacyResolveLinkTos)]
+	public class when_reading_the_all_stream_backward_with_resolve_link_to_disabled(string resolveLinkTosHeader) : HttpSpecificationWithLinkToToEvents {
 		private JObject _feed;
 		private List<JToken> _entries;
 
 		protected override async Task When() {
-			var headers = new NameValueCollection {{SystemHeaders.ResolveLinkTos, "False"}};
+			var headers = new NameValueCollection {{resolveLinkTosHeader, "False"}};
 			_feed = await GetJson<JObject>("/streams/$all",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
@@ -693,13 +695,14 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture]
-	public class when_reading_the_all_stream_forward_with_resolve_link_to : HttpSpecificationWithLinkToToEvents {
+	[TestFixture(SystemHeaders.ResolveLinkTos)]
+	[TestFixture(SystemHeaders.LegacyResolveLinkTos)]
+	public class when_reading_the_all_stream_forward_with_resolve_link_to(string resolveLinkTosHeader) : HttpSpecificationWithLinkToToEvents {
 		private JObject _feed;
 		private List<JToken> _entries;
 
 		protected override async Task When() {
-			var headers = new NameValueCollection {{SystemHeaders.ResolveLinkTos, "True"}};
+			var headers = new NameValueCollection {{resolveLinkTosHeader, "True"}};
 			_feed = await GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/30",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
@@ -725,13 +728,14 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[Category("LongRunning")]
-	[TestFixture]
-	public class when_reading_the_all_stream_forward_with_resolve_link_to_disabled : HttpSpecificationWithLinkToToEvents {
+	[TestFixture(SystemHeaders.ResolveLinkTos)]
+	[TestFixture(SystemHeaders.LegacyResolveLinkTos)]
+	public class when_reading_the_all_stream_forward_with_resolve_link_to_disabled(string resolveLinkTosHeader) : HttpSpecificationWithLinkToToEvents {
 		private JObject _feed;
 		private List<JToken> _entries;
 
 		protected override async Task When() {
-			var headers = new NameValueCollection {{SystemHeaders.ResolveLinkTos, "False"}};
+			var headers = new NameValueCollection {{resolveLinkTosHeader, "False"}};
 			_feed = await GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/30",
 				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
 			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();

--- a/src/EventStore.Core.Tests/Http/Streams/idempotency.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/idempotency.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using EventStore.Core.Services;
 using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
@@ -80,7 +81,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream + "/incoming/" + _eventId.ToString(), "", "POST",
 					ContentType.Json);
-				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
@@ -107,7 +108,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream + "/incoming/" + _eventId.ToString(), "", "POST",
 					ContentType.Json);
-				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
@@ -135,7 +136,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream + "/incoming/" + _eventId.ToString(), "", "POST",
 					ContentType.Json);
-				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
@@ -166,8 +167,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
-				request.Headers.Add("ES-EventId", _eventId.ToString());
-				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add(SystemHeaders.EventId, _eventId.ToString());
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
@@ -194,8 +195,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
-				request.Headers.Add("ES-EventId", _eventId.ToString());
-				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add(SystemHeaders.EventId, _eventId.ToString());
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {
@@ -223,8 +224,8 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			private async Task PostEvent() {
 				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
-				request.Headers.Add("ES-EventId", _eventId.ToString());
-				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add(SystemHeaders.EventId, _eventId.ToString());
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
 				var data = "{a : \"1\"}";
 				var bytes = Encoding.UTF8.GetBytes(data);
 				request.Content = new ByteArrayContent(bytes) {

--- a/src/EventStore.Core.Tests/Http/Streams/metadata.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/metadata.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Tests.Http.Streams.basic;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using EventStore.Common.Utils;
+using EventStore.Core.Services;
 using EventStore.Core.Tests.Http.Users.users;
 using HttpStatusCode = System.Net.HttpStatusCode;
 using ContentType = EventStore.Transport.Http.ContentType;
@@ -24,7 +25,7 @@ public class when_posting_metadata_as_json_to_non_existing_stream : with_admin_u
 	protected override async Task When() {
 		var req = CreateRawJsonPostRequest(TestStream + "/metadata", "POST", new { A = "1" },
 			DefaultData.AdminNetworkCredentials);
-		req.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+		req.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 		_response = await _client.SendAsync(req);
 	}
 
@@ -58,7 +59,7 @@ public class when_posting_metadata_as_json_to_existing_stream(string contentType
 	protected override async Task When() {
 		var req = CreateRawJsonPostRequest(TestStream + "/metadata", "POST", new { A = "1" },
 			DefaultData.AdminNetworkCredentials);
-		req.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+		req.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 		_response = await _client.SendAsync(req);
 	}
 

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -7,17 +7,29 @@ using EventStore.Common.Utils;
 namespace EventStore.Core.Services;
 
 public static class SystemHeaders {
-	public const string ExpectedVersion = "ES-ExpectedVersion";
-	public const string RequireLeader = "ES-RequireLeader";
+	public const string ExpectedVersion = "Kurrent-ExpectedVersion";
+	public const string RequireLeader = "Kurrent-RequireLeader";
+	public const string ResolveLinkTos = "Kurrent-ResolveLinkTos";
+	public const string LongPoll = "Kurrent-LongPoll";
+	public const string TrustedAuth = "Kurrent-TrustedAuth";
+	public const string ProjectionPosition = "Kurrent-Position";
+	public const string HardDelete = "Kurrent-HardDelete";
+	public const string EventId = "Kurrent-EventId";
+	public const string EventType = "Kurrent-EventType";
+	public const string CurrentVersion = "Kurrent-CurrentVersion";
+
+	// Legacy ES-* headers
+	public const string LegacyExpectedVersion = "ES-ExpectedVersion";
+	public const string LegacyRequireLeader = "ES-RequireLeader";
 	public const string RequireMaster = "ES-RequireMaster"; // For backwards compatibility
-	public const string ResolveLinkTos = "ES-ResolveLinkTos";
-	public const string LongPoll = "ES-LongPoll";
-	public const string TrustedAuth = "ES-TrustedAuth";
-	public const string ProjectionPosition = "ES-Position";
-	public const string HardDelete = "ES-HardDelete";
-	public const string EventId = "ES-EventId";
-	public const string EventType = "ES-EventType";
-	public const string CurrentVersion = "ES-CurrentVersion";
+	public const string LegacyResolveLinkTos = "ES-ResolveLinkTos";
+	public const string LegacyLongPoll = "ES-LongPoll";
+	public const string LegacyTrustedAuth = "ES-TrustedAuth";
+	public const string LegacyProjectionPosition = "ES-Position";
+	public const string LegacyHardDelete = "ES-HardDelete";
+	public const string LegacyEventId = "ES-EventId";
+	public const string LegacyEventType = "ES-EventType";
+	public const string LegacyCurrentVersion = "ES-CurrentVersion";
 }
 
 public static class SystemStreams {

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/TrustedHttpAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/TrustedHttpAuthenticationProvider.cs
@@ -13,7 +13,8 @@ public class TrustedHttpAuthenticationProvider : IHttpAuthenticationProvider {
 
 	public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
 		request = null;
-		if (!context.Request.Headers.TryGetValue(SystemHeaders.TrustedAuth, out var values)) {
+		if (!context.Request.Headers.TryGetValue(SystemHeaders.TrustedAuth, out var values) &&
+		    !context.Request.Headers.TryGetValue(SystemHeaders.LegacyTrustedAuth, out values)) {
 			return false;
 		}
 		request = new HttpAuthenticationRequest(context, null, null);

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -383,8 +383,8 @@ public static class Configure {
 				case OperationResult.WrongExpectedVersion:
 					return new ResponseConfiguration(HttpStatusCode.BadRequest, "Wrong expected EventNumber",
 						ContentType.PlainText, Helper.UTF8NoBom,
-						new KeyValuePair<string, string>(SystemHeaders.CurrentVersion,
-							msg.CurrentVersion.ToString()));
+						new KeyValuePair<string, string>(SystemHeaders.CurrentVersion, msg.CurrentVersion.ToString()),
+						new KeyValuePair<string, string>(SystemHeaders.LegacyCurrentVersion, msg.CurrentVersion.ToString()));
 				case OperationResult.StreamDeleted:
 					return Gone("Stream deleted");
 				case OperationResult.InvalidTransaction:
@@ -417,8 +417,8 @@ public static class Configure {
 				case OperationResult.WrongExpectedVersion:
 					return new ResponseConfiguration(HttpStatusCode.BadRequest, "Wrong expected EventNumber",
 						ContentType.PlainText, Helper.UTF8NoBom,
-						new KeyValuePair<string, string>(SystemHeaders.CurrentVersion,
-							msg.CurrentVersion.ToString()));
+						new KeyValuePair<string, string>(SystemHeaders.CurrentVersion, msg.CurrentVersion.ToString()),
+						new KeyValuePair<string, string>(SystemHeaders.LegacyCurrentVersion, msg.CurrentVersion.ToString()));
 				case OperationResult.StreamDeleted:
 					return Gone("Stream deleted");
 				case OperationResult.InvalidTransaction:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -528,6 +528,9 @@ public class AdminController : CommunicationController {
 		resolveLinkTos = defaultOption;
 		var linkToHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.ResolveLinkTos);
 		if (StringValues.IsNullOrEmpty(linkToHeader))
+			linkToHeader =  manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyResolveLinkTos);
+
+		if (StringValues.IsNullOrEmpty(linkToHeader))
 			return true;
 		if (string.Equals(linkToHeader, "False", StringComparison.OrdinalIgnoreCase)) {
 			return true;
@@ -544,18 +547,21 @@ public class AdminController : CommunicationController {
 		requireLeader = false;
 
 		var onlyLeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireLeader);
+		var onlyLeaderLegacy = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyRequireLeader);
 		var onlyMaster = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireMaster);
 
-		if (StringValues.IsNullOrEmpty(onlyLeader) && StringValues.IsNullOrEmpty(onlyMaster))
+		if (StringValues.IsNullOrEmpty(onlyLeader) && StringValues.IsNullOrEmpty(onlyMaster) && StringValues.IsNullOrEmpty(onlyLeaderLegacy))
 			return true;
 
 		if (string.Equals(onlyLeader, "True", StringComparison.OrdinalIgnoreCase) ||
+		    string.Equals(onlyLeaderLegacy, "True", StringComparison.OrdinalIgnoreCase) ||
 		    string.Equals(onlyMaster, "True", StringComparison.OrdinalIgnoreCase)) {
 			requireLeader = true;
 			return true;
 		}
 
 		return string.Equals(onlyLeader, "False", StringComparison.OrdinalIgnoreCase) ||
+		       string.Equals(onlyLeaderLegacy, "False", StringComparison.OrdinalIgnoreCase) ||
 		       string.Equals(onlyMaster, "False", StringComparison.OrdinalIgnoreCase);
 	}
 	private long? GetETagStreamVersion(HttpEntityManager manager) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -855,9 +855,9 @@ public class AtomController : CommunicationController {
 
 	private bool GetExpectedVersion(HttpEntityManager manager, out long expectedVersion) {
 		var expVer = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.ExpectedVersion);
-		if (StringValues.IsNullOrEmpty(expVer)) {
+		if (StringValues.IsNullOrEmpty(expVer))
 			expVer = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyExpectedVersion);
-		}
+
 		if (StringValues.IsNullOrEmpty(expVer)) {
 			expectedVersion = ExpectedVersion.Any;
 			return true;

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -310,7 +310,7 @@ public class AtomController : CommunicationController {
 
 		if (!manager.RequestCodec.HasEventTypes && includedType == null) {
 			SendBadRequest(manager,
-				"Must include an event type with the request either in body or as ES-EventType header.");
+				$"Must include an event type with the request either in body or as {SystemHeaders.EventType} header.");
 			return;
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -856,6 +856,9 @@ public class AtomController : CommunicationController {
 	private bool GetExpectedVersion(HttpEntityManager manager, out long expectedVersion) {
 		var expVer = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.ExpectedVersion);
 		if (StringValues.IsNullOrEmpty(expVer)) {
+			expVer = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyExpectedVersion);
+		}
+		if (StringValues.IsNullOrEmpty(expVer)) {
 			expectedVersion = ExpectedVersion.Any;
 			return true;
 		}
@@ -865,6 +868,9 @@ public class AtomController : CommunicationController {
 
 	private bool GetIncludedId(HttpEntityManager manager, out Guid includedId) {
 		var id = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.EventId);
+		if (StringValues.IsNullOrEmpty(id))
+			id = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyEventId);
+
 		if (StringValues.IsNullOrEmpty(id)) {
 			includedId = Guid.Empty;
 			return true;
@@ -875,6 +881,9 @@ public class AtomController : CommunicationController {
 
 	private bool GetIncludedType(HttpEntityManager manager, out string includedType) {
 		var type = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.EventType);
+		if (StringValues.IsNullOrEmpty(type))
+			type = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyEventType);
+
 		if (StringValues.IsNullOrEmpty(type)) {
 			includedType = null;
 			return true;
@@ -889,24 +898,30 @@ public class AtomController : CommunicationController {
 		requireLeader = false;
 
 		var onlyLeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireLeader);
+		var onlyLeaderLegacy = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyRequireLeader);
 		var onlyMaster = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireMaster);
 
-		if (StringValues.IsNullOrEmpty(onlyLeader) && StringValues.IsNullOrEmpty(onlyMaster))
+		if (StringValues.IsNullOrEmpty(onlyLeader) && StringValues.IsNullOrEmpty(onlyMaster) && StringValues.IsNullOrEmpty(onlyLeaderLegacy))
 			return true;
 
 		if (string.Equals(onlyLeader, "True", StringComparison.OrdinalIgnoreCase) ||
+		    string.Equals(onlyLeaderLegacy, "True", StringComparison.OrdinalIgnoreCase) ||
 		    string.Equals(onlyMaster, "True", StringComparison.OrdinalIgnoreCase)) {
 			requireLeader = true;
 			return true;
 		}
 
 		return string.Equals(onlyLeader, "False", StringComparison.OrdinalIgnoreCase) ||
+		       string.Equals(onlyLeaderLegacy, "False", StringComparison.OrdinalIgnoreCase) ||
 		       string.Equals(onlyMaster, "False", StringComparison.OrdinalIgnoreCase);
 	}
 
 	private bool GetLongPoll(HttpEntityManager manager, out TimeSpan? longPollTimeout) {
 		longPollTimeout = null;
 		var longPollHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LongPoll);
+		if (StringValues.IsNullOrEmpty(longPollHeader))
+			longPollHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyLongPoll);
+
 		if (StringValues.IsNullOrEmpty(longPollHeader))
 			return true;
 		int longPollSec;
@@ -921,6 +936,9 @@ public class AtomController : CommunicationController {
 	private bool GetResolveLinkTos(HttpEntityManager manager, out bool resolveLinkTos, bool defaultOption = false) {
 		resolveLinkTos = defaultOption;
 		var linkToHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.ResolveLinkTos);
+		if (StringValues.IsNullOrEmpty(linkToHeader))
+			linkToHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyResolveLinkTos);
+
 		if (StringValues.IsNullOrEmpty(linkToHeader))
 			return true;
 		if (string.Equals(linkToHeader, "False", StringComparison.OrdinalIgnoreCase)) {
@@ -938,6 +956,9 @@ public class AtomController : CommunicationController {
 	private bool GetHardDelete(HttpEntityManager manager, out bool hardDelete) {
 		hardDelete = false;
 		var hardDel = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.HardDelete);
+		if (StringValues.IsNullOrEmpty(hardDel))
+			hardDel = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyHardDelete);
+
 		if (StringValues.IsNullOrEmpty(hardDel))
 			return true;
 		if (string.Equals(hardDel, "True", StringComparison.OrdinalIgnoreCase)) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -119,6 +119,9 @@ public class PersistentSubscriptionController : CommunicationController {
 		longPollTimeout = null;
 		var longPollHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LongPoll);
 		if (StringValues.IsNullOrEmpty(longPollHeader))
+			longPollHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyLongPoll);
+
+		if (StringValues.IsNullOrEmpty(longPollHeader))
 			return true;
 		int longPollSec;
 		if (int.TryParse(longPollHeader, out longPollSec) && longPollSec > 0) {
@@ -197,23 +200,29 @@ public class PersistentSubscriptionController : CommunicationController {
 		requireLeader = false;
 
 		var onlyLeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireLeader);
+		var onlyLeaderLegacy = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyRequireLeader);
 		var onlyMaster = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.RequireMaster);
 
-		if (StringValues.IsNullOrEmpty(onlyLeader) && StringValues.IsNullOrEmpty(onlyMaster))
+		if (StringValues.IsNullOrEmpty(onlyLeader) && StringValues.IsNullOrEmpty(onlyMaster) && StringValues.IsNullOrEmpty(onlyLeaderLegacy))
 			return true;
 
 		if (string.Equals(onlyLeader, "True", StringComparison.OrdinalIgnoreCase) ||
+		    string.Equals(onlyLeaderLegacy, "True", StringComparison.OrdinalIgnoreCase) ||
 		    string.Equals(onlyMaster, "True", StringComparison.OrdinalIgnoreCase)) {
 			requireLeader = true;
 			return true;
 		}
 
 		return string.Equals(onlyLeader, "False", StringComparison.OrdinalIgnoreCase) ||
+		       string.Equals(onlyLeaderLegacy, "False", StringComparison.OrdinalIgnoreCase) ||
 		       string.Equals(onlyMaster, "False", StringComparison.OrdinalIgnoreCase);
 	}
 	private bool GetResolveLinkTos(HttpEntityManager manager, out bool resolveLinkTos, bool defaultOption = false) {
 		resolveLinkTos = defaultOption;
 		var linkToHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.ResolveLinkTos);
+		if (StringValues.IsNullOrEmpty(linkToHeader))
+			linkToHeader = manager.HttpEntity.Request.GetHeaderValues(SystemHeaders.LegacyResolveLinkTos);
+
 		if (StringValues.IsNullOrEmpty(linkToHeader))
 			return true;
 		if (string.Equals(linkToHeader, "False", StringComparison.OrdinalIgnoreCase)) {

--- a/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
+++ b/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
@@ -432,8 +432,8 @@ public class ProjectionsController : CommunicationController {
 		else
 			return state.Position != null
 				? Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false,
-					new KeyValuePair<string, string>(SystemHeaders.ProjectionPosition,
-						state.Position.ToJsonString()))
+					new KeyValuePair<string, string>(SystemHeaders.ProjectionPosition, state.Position.ToJsonString()),
+					new KeyValuePair<string, string>(SystemHeaders.LegacyProjectionPosition, state.Position.ToJsonString()))
 				: Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false);
 	}
 
@@ -444,8 +444,8 @@ public class ProjectionsController : CommunicationController {
 		else
 			return state.Position != null
 				? Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false,
-					new KeyValuePair<string, string>(SystemHeaders.ProjectionPosition,
-						state.Position.ToJsonString()))
+					new KeyValuePair<string, string>(SystemHeaders.ProjectionPosition, state.Position.ToJsonString()),
+					new KeyValuePair<string, string>(SystemHeaders.LegacyProjectionPosition, state.Position.ToJsonString()))
 				: Configure.Ok(ContentType.Json, Helper.UTF8NoBom, null, null, false);
 	}
 

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -144,17 +144,22 @@ public sealed class HttpEntityManager {
 		}
 	}
 
-	// TODO: Add new Kurrent headers here
 	private void SetRequiredHeaders() {
 		try {
 			HttpEntity.Response.AddHeader("Access-Control-Allow-Methods", string.Join(", ", _allowedMethods));
 			HttpEntity.Response.AddHeader("Access-Control-Allow-Headers",
-				"Content-Type, X-Requested-With, X-Forwarded-Host, X-Forwarded-Prefix, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion, ES-EventId, ES-EventType, ES-RequireMaster, ES-RequireLeader, ES-HardDelete, ES-ResolveLinkTos");
+				"Content-Type, X-Requested-With, X-Forwarded-Host, X-Forwarded-Prefix, X-PINGOTHER, Authorization, " +
+				"Kurrent-LongPoll, Kurrent-ExpectedVersion, Kurrent-EventId, Kurrent-EventType, Kurrent-RequireLeader, Kurrent-HardDelete, Kurrent-ResolveLinkTos, " +
+				"ES-LongPoll, ES-ExpectedVersion, ES-EventId, ES-EventType, ES-RequireMaster, ES-RequireLeader, ES-HardDelete, ES-ResolveLinkTos");
 			HttpEntity.Response.AddHeader("Access-Control-Allow-Origin", "*");
 			HttpEntity.Response.AddHeader("Access-Control-Expose-Headers",
-				"Location, ES-Position, ES-CurrentVersion");
-			if (HttpEntity.Response.StatusCode == HttpStatusCode.Unauthorized)
+				"Location, " +
+				"Kurrent-Position, Kurrent-CurrentVersion, " +
+				"ES-Position, ES-CurrentVersion, ");
+			if (HttpEntity.Response.StatusCode == HttpStatusCode.Unauthorized) {
+				HttpEntity.Response.AddHeader("WWW-Authenticate", "BasicCustom realm=\"Kurrent\"");
 				HttpEntity.Response.AddHeader("WWW-Authenticate", "BasicCustom realm=\"ES\"");
+			}
 		} catch (ObjectDisposedException) {
 			// ignore
 		} catch (Exception e) {

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -144,6 +144,7 @@ public sealed class HttpEntityManager {
 		}
 	}
 
+	// TODO: Add new Kurrent headers here
 	private void SetRequiredHeaders() {
 		try {
 			HttpEntity.Response.AddHeader("Access-Control-Allow-Methods", string.Join(", ", _allowedMethods));


### PR DESCRIPTION
Add custom HTTP headers with the Kurrent branding.

This deprecates the `ES-*` HTTP headers, `Kurrent-*` headers should be used instead.

Deprecated headers accepted by the server:

| Deprecated | Use instead |
|--------------|--------------|
| `ES-ExpectedVersion` | `Kurrent-ExpectedVersion` |
| `ES-RequireLeader` | `Kurrent-RequireLeader` |
| `ES-RequireMaster` | `Kurrent-RequireLeader` |
| `ES-ResolveLinkTos` | `Kurrent-ResolveLinkTos` |
| `ES-LongPoll` | `Kurrent-LongPoll` |
| `ES-TrustedAuth` | `Kurrent-TrustedAuth` |
| `ES-HardDelete` | `Kurrent-HardDelete` |
| `ES-EventId` | `Kurrent-EventId` |
| `ES-EventType` | `Kurrent-EventType` |

Deprecated headers provided by the server in certain responses:

| Deprecated | Use instead |
|--------------|--------------|
| `ES-Position` | `Kurrent-Position` |
| `ES-CurrentVersion` | `Kurrent-CurrentVersion` |
