### PR TITLE
[KDB-629] Fix some disk IO stats being 0 on linux

### DIFF
--- a/src/EventStore.SystemRuntime.Tests/EventStore.SystemRuntime.Tests.csproj
+++ b/src/EventStore.SystemRuntime.Tests/EventStore.SystemRuntime.Tests.csproj
@@ -21,5 +21,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.SystemRuntime\EventStore.SystemRuntime.csproj" />
+		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
+++ b/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
@@ -15,7 +15,9 @@ public sealed class ProcessStatsTests : IDisposable {
 	public ProcessStatsTests() {
 		string directoryPath = Path.Combine(Path.GetTempPath(), string.Format("ESX-{0}-{1}", Guid.NewGuid(), nameof(ProcessStatsTests)));
 		_directory = Directory.CreateDirectory(directoryPath);
-		File.WriteAllText(Path.Combine(directoryPath, "file.txt"), "the data");
+		var filePath = Path.Combine(directoryPath, "file.txt");
+		File.WriteAllText(filePath, "the data");
+		File.ReadAllText(filePath);
 	}
 
 	public void Dispose() {

--- a/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
+++ b/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime;
+using System.Text;
 using Xunit;
 
 namespace EventStore.SystemRuntime.Tests;
@@ -16,8 +17,14 @@ public sealed class ProcessStatsTests : IDisposable {
 		string directoryPath = Path.Combine(Path.GetTempPath(), string.Format("ESX-{0}-{1}", Guid.NewGuid(), nameof(ProcessStatsTests)));
 		_directory = Directory.CreateDirectory(directoryPath);
 		var filePath = Path.Combine(directoryPath, "file.txt");
-		File.WriteAllText(filePath, "the data");
+		WriteAllText(filePath, "the data");
 		File.ReadAllText(filePath);
+	}
+
+	private static void WriteAllText(string path, string data) {
+		using var handle = File.OpenHandle(path, FileMode.Create, FileAccess.Write, FileShare.Read, FileOptions.WriteThrough);
+		RandomAccess.Write(handle, Encoding.UTF8.GetBytes(data), 0L);
+		RandomAccess.FlushToDisk(handle);
 	}
 
 	public void Dispose() {

--- a/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
+++ b/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime;
+using Xunit;
+
+namespace EventStore.SystemRuntime.Tests;
+
+public sealed class ProcessStatsTests : IDisposable {
+	private readonly DirectoryInfo _directory;
+
+	public ProcessStatsTests() {
+		string directoryPath = Path.Combine(Path.GetTempPath(), string.Format("ESX-{0}-{1}", Guid.NewGuid(), nameof(ProcessStatsTests)));
+		_directory = Directory.CreateDirectory(directoryPath);
+		File.WriteAllText(Path.Combine(directoryPath, "file.txt"), "the data");
+	}
+
+	public void Dispose() {
+		_directory.Delete(recursive: true);
+	}
+
+	[Fact]
+	public void TestProcessStats() {
+		var diskIo = ProcessStats.GetDiskIo();
+
+		Assert.True(diskIo.ReadBytes > 0);
+		Assert.True(diskIo.WrittenBytes > 0);
+
+		if (RuntimeInformation.OsPlatform != RuntimeOSPlatform.OSX) {
+			// ops not supported on OSX
+			Assert.True(diskIo.ReadOps > 0);
+			Assert.True(diskIo.WriteOps > 0);
+		}
+	}
+}

--- a/src/EventStore.SystemRuntime/Diagnostics/ProcessStats.cs
+++ b/src/EventStore.SystemRuntime/Diagnostics/ProcessStats.cs
@@ -35,8 +35,13 @@ public static class ProcessStats {
                         result = result with { ReadOps = readOps };
                     else if (TryExtractIoValue(line, "syscw", out var writeOps)) {
                         result = result with { WriteOps = writeOps };
-                        break;
                     }
+
+                    if (result.ReadBytes is not 0 &&
+                        result.WrittenBytes is not 0 &&
+                        result.ReadOps is not 0 &&
+                        result.WriteOps is not 0)
+                        break;
                 }
 
                 return result;


### PR DESCRIPTION
Bug introduced in 24.6 assumed that the `/proc/<pid>/io` file was in a particular order and returned early without reading all the values