### PR TITLE
[KDB-645] Track initialized services so we know what to wait for on shutdown

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -93,6 +93,9 @@ namespace EventStore.Core;
 public abstract class ClusterVNode {
 	protected static readonly ILogger Log = Serilog.Log.ForContext<ClusterVNode>();
 
+	public static readonly TimeSpan ShutdownTimeout =
+		ClusterVNodeController.ShutdownTimeout + TimeSpan.FromSeconds(1);
+
 	public static ClusterVNode<TStreamId> Create<TStreamId>(
 		ClusterVNodeOptions options,
 		ILogFormatAbstractorFactory<TStreamId> logFormatAbstractorFactory,
@@ -142,8 +145,6 @@ public class ClusterVNode<TStreamId> :
 	IHandle<SystemMessage.BecomeShutdown>,
 	IHandle<SystemMessage.SystemStart>,
 	IHandle<ClientMessage.ReloadConfig> {
-	private static readonly TimeSpan DefaultShutdownTimeout =
-		ClusterVNodeController<TStreamId>.ShutdownTimeout + TimeSpan.FromSeconds(1);
 
 	private readonly ClusterVNodeOptions _options;
 
@@ -1631,7 +1632,7 @@ public class ClusterVNode<TStreamId> :
 				Log.Information("Truncation successful. Shutting down.");
 				var shutdownGuid = Guid.NewGuid();
 				using var linked = CancellationTokenSource.CreateLinkedTokenSource(token);
-				linked.CancelAfter(DefaultShutdownTimeout);
+				linked.CancelAfter(ShutdownTimeout);
 
 				await HandleAsync(
 						new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
@@ -1799,7 +1800,7 @@ public class ClusterVNode<TStreamId> :
 		_mainQueue.Publish(new ClientMessage.RequestShutdown(false, true));
 
 		try {
-			await _shutdownSource.Task.WaitAsync(timeout ?? DefaultShutdownTimeout, cancellationToken);
+			await _shutdownSource.Task.WaitAsync(timeout ?? ShutdownTimeout, cancellationToken);
 		} catch (Exception) {
 			Log.Error("Graceful shutdown not complete. Forcing shutdown now.");
 			throw;

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -197,11 +197,13 @@ public static partial class SystemMessage {
 	[DerivedMessage(CoreMessage.System)]
 	public partial class ServiceShutdown : Message {
 		public readonly string ServiceName;
+		public string Details { get; }
 
-		public ServiceShutdown(string serviceName) {
-			if (String.IsNullOrEmpty(serviceName))
-				throw new ArgumentNullException("serviceName");
+		public ServiceShutdown(string serviceName, string details = "") {
+			ArgumentNullException.ThrowIfNull(serviceName, nameof(serviceName));
+			ArgumentNullException.ThrowIfNull(details, nameof(details));
 			ServiceName = serviceName;
+			Details = details;
 		}
 	}
 

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -441,6 +441,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 
 	private async void MainLoop() {
 		try {
+			_publisher.Publish(new SystemMessage.ServiceInitialized(nameof(LeaderReplicationService)));
 			_queueStats.Start();
 			QueueMonitor.Default.Register(this);
 
@@ -485,7 +486,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 
 			_db.Config.WriterCheckpoint.Flushed -= OnWriterFlushed;
 
-			_publisher.Publish(new SystemMessage.ServiceShutdown(Name));
+			_publisher.Publish(new SystemMessage.ServiceShutdown(nameof(LeaderReplicationService)));
 			_tcs.TrySetResult();
 		} catch (Exception e) {
 			_tcs.TrySetException(e);

--- a/src/EventStore.Core/Services/Replication/ReplicationTrackingService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicationTrackingService.cs
@@ -74,7 +74,7 @@ public class ReplicationTrackingService :
 	}
 
 	private void TrackReplication() {
-
+		_publisher.Publish(new SystemMessage.ServiceInitialized(nameof(ReplicationTrackingService)));
 		try {
 			while (!_stop) {
 				_replicationChange.Reset();

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -107,6 +107,7 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 	}
 
 	async void IThreadPoolWorkItem.Execute() {
+		_publisher.Publish(new SystemMessage.ServiceInitialized(nameof(IndexCommitterService)));
 		try {
 			_queueStats.Start();
 			QueueMonitor.Default.Register(this);
@@ -146,7 +147,7 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 			QueueMonitor.Default.Unregister(this);
 		}
 
-		_publisher.Publish(new SystemMessage.ServiceShutdown(Name));
+		_publisher.Publish(new SystemMessage.ServiceShutdown(nameof(IndexCommitterService)));
 	}
 
 	private async ValueTask ProcessCommitReplicated(StorageMessage.CommitAck message, CancellationToken token) {

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -111,7 +111,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 			// with no concurrency issues with writer, as writer before jumping
 			// into leader mode and accepting writes will wait till chaser caught up.
 			await _indexCommitterService.Init(_chaser.Checkpoint.Read(), _stopToken);
-			_leaderBus.Publish(new SystemMessage.ServiceInitialized("StorageChaser"));
+			_leaderBus.Publish(new SystemMessage.ServiceInitialized(nameof(StorageChaser)));
 
 			while (!_stopToken.IsCancellationRequested) {
 				if (_systemStarted)
@@ -137,7 +137,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 
 		_writerCheckpoint.Flushed -= OnWriterFlushed;
 		_chaser.Close();
-		_leaderBus.Publish(new SystemMessage.ServiceShutdown(Name));
+		_leaderBus.Publish(new SystemMessage.ServiceShutdown(nameof(StorageChaser)));
 	}
 
 	private void OnWriterFlushed(long obj) {

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -90,7 +90,7 @@ public class StorageReaderService<TStreamId> : StorageReaderService, IHandle<Sys
 	}
 
 	void IHandle<SystemMessage.SystemInit>.Handle(SystemMessage.SystemInit message) {
-		_bus.Publish(new SystemMessage.ServiceInitialized("StorageReader"));
+		_bus.Publish(new SystemMessage.ServiceInitialized(nameof(StorageReaderService)));
 	}
 
 	async ValueTask IAsyncHandle<SystemMessage.BecomeShuttingDown>.HandleAsync(SystemMessage.BecomeShuttingDown message, CancellationToken token) {
@@ -100,7 +100,7 @@ public class StorageReaderService<TStreamId> : StorageReaderService, IHandle<Sys
 			Log.Error(exc, "Error while stopping readers multi handler.");
 		}
 
-		_bus.Publish(new SystemMessage.ServiceShutdown("StorageReader"));
+		_bus.Publish(new SystemMessage.ServiceShutdown(nameof(StorageReaderService)));
 	}
 
 	void IHandle<SystemMessage.BecomeShutdown>.Handle(SystemMessage.BecomeShutdown message) {

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -204,7 +204,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 	}
 
 	void IHandle<SystemMessage.SystemInit>.Handle(SystemMessage.SystemInit message) {
-		Bus.Publish(new SystemMessage.ServiceInitialized("StorageWriter"));
+		Bus.Publish(new SystemMessage.ServiceInitialized(nameof(StorageWriterService)));
 	}
 
 	public virtual async ValueTask HandleAsync(SystemMessage.StateChangeMessage message, CancellationToken token) {
@@ -897,5 +897,5 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 
 file static class MessageBusHelpers {
 	internal static void PublishStorageWriterShutdown(this IPublisher publisher)
-		=> publisher.Publish(new SystemMessage.ServiceShutdown("StorageWriter"));
+		=> publisher.Publish(new SystemMessage.ServiceShutdown(nameof(StorageWriterService)));
 }

--- a/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
@@ -7,17 +7,10 @@ using System.Net;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
-using EventStore.Core.Messaging;
-using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.Transport.Http.Messages;
 using EventStore.Core.Settings;
 using EventStore.Transport.Http.EntityManagement;
 using ILogger = Serilog.ILogger;
-using MidFunc = System.Func<
-	Microsoft.AspNetCore.Http.HttpContext,
-	System.Func<System.Threading.Tasks.Task>,
-	System.Threading.Tasks.Task
->;
 
 namespace EventStore.Core.Services.Transport.Http;
 
@@ -63,8 +56,8 @@ public class KestrelHttpService : IHttpService,
 	}
 
 	public void Handle(SystemMessage.SystemInit message) {
-
 		_isListening = true;
+		_inputBus.Publish(new SystemMessage.ServiceInitialized(nameof(KestrelHttpService)));
 	}
 
 	public void Handle(SystemMessage.BecomeShuttingDown message) {
@@ -72,7 +65,7 @@ public class KestrelHttpService : IHttpService,
 			Shutdown();
 		_inputBus.Publish(
 			new SystemMessage.ServiceShutdown(
-				$"HttpServer [{String.Join(", ", EndPoints)}]"));
+				nameof(KestrelHttpService), $"[{string.Join(", ", EndPoints)}]"));
 	}
 
 	public void Shutdown() {

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -24,10 +24,10 @@ namespace EventStore.Core.Services.VNode;
 
 public abstract class ClusterVNodeController {
 	protected static readonly ILogger Log = Serilog.Log.ForContext<ClusterVNodeController>();
+	public static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
 }
 
 public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
-	public static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
 	public static readonly TimeSpan LeaderReconnectionDelay = TimeSpan.FromMilliseconds(500);
 	private static readonly TimeSpan LeaderSubscriptionRetryDelay = TimeSpan.FromMilliseconds(500);
 	private static readonly TimeSpan LeaderSubscriptionTimeout = TimeSpan.FromMilliseconds(1000);

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -12,6 +13,7 @@ using EventStore.Core.Cluster;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services.Storage;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.Chunks;
@@ -63,16 +65,13 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 
 	private int _subSystemInitsToExpect;
 
-	private int _serviceInitsToExpect = 1 /* StorageChaser */
-										+ 1 /* StorageReader */
-										+ 1 /* StorageWriter */;
+	enum ServiceState {
+		Initialized,
+		Shutdown,
+	};
 
-	private int _serviceShutdownsToExpect = 1 /* StorageChaser */
-											+ 1 /* StorageReader */
-											+ 1 /* StorageWriter */
-											+ 1 /* IndexCommitterService */
-											+ 1 /* LeaderReplicationService */
-											+ 1 /* HttpService */;
+	private readonly Dictionary<string, ServiceState> _initializedServices = [];
+	private bool _publishedSystemStart;
 
 	private bool _exitProcessOnShutdown;
 
@@ -98,14 +97,6 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		_subsystemCount = options.Subsystems.Count;
 		_subSystemInitsToExpect = _subsystemCount;
 		_clusterSize = options.Cluster.ClusterSize;
-		if (_clusterSize == 1) {
-			_serviceShutdownsToExpect = 1 /* StorageChaser */
-										+ 1 /* StorageReader */
-										+ 1 /* StorageWriter */
-										+ 1 /* IndexCommitterService */
-										+ 1 /* HttpService */;
-		}
-
 
 		_forwardingProxy = forwardingProxy;
 		_forwardingTimeout = TimeSpan.FromMilliseconds(options.Database.PrepareTimeoutMs +
@@ -599,10 +590,22 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	private async ValueTask Handle(SystemMessage.ServiceInitialized message, CancellationToken token) {
 		Log.Information("========== [{httpEndPoint}] Service '{service}' initialized.", _nodeInfo.HttpEndPoint,
 			message.ServiceName);
-		_serviceInitsToExpect -= 1;
+
+		_initializedServices[message.ServiceName] = ServiceState.Initialized;
+
 		await _outputBus.DispatchAsync(message, token);
-		if (_serviceInitsToExpect == 0) {
-			_mainQueue.Publish(new SystemMessage.SystemStart());
+
+		if (!_publishedSystemStart) {
+			// may be interested in these three because they facilitate the initialization of the authentication provider
+			var trioStarted =
+				_initializedServices.TryGetValue(nameof(StorageChaser), out var x) && x is ServiceState.Initialized &&
+				_initializedServices.TryGetValue(nameof(StorageReaderService), out var y) && y is ServiceState.Initialized &&
+				_initializedServices.TryGetValue(nameof(StorageWriterService), out var z) && z is ServiceState.Initialized;
+
+			if (trioStarted) {
+				_mainQueue.Publish(new SystemMessage.SystemStart());
+				_publishedSystemStart = true;
+			}
 		}
 	}
 
@@ -1287,11 +1290,13 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	}
 
 	private async ValueTask Handle(SystemMessage.ServiceShutdown message, CancellationToken token) {
+		var serviceInfo = message.ServiceName + (string.IsNullOrWhiteSpace(message.Details) ? "" : $" {message.Details}");
 		Log.Information("========== [{httpEndPoint}] Service '{service}' has shut down.", _nodeInfo.HttpEndPoint,
-			message.ServiceName);
+			serviceInfo);
 
-		_serviceShutdownsToExpect -= 1;
-		if (_serviceShutdownsToExpect is 0) {
+		_initializedServices[message.ServiceName] = ServiceState.Shutdown;
+
+		if (_initializedServices.All(kvp => kvp.Value is ServiceState.Shutdown)) {
 			Log.Information("========== [{httpEndPoint}] All Services Shutdown.", _nodeInfo.HttpEndPoint);
 			await Shutdown(token);
 		}
@@ -1302,7 +1307,13 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	private async ValueTask Handle(SystemMessage.ShutdownTimeout message, CancellationToken token) {
 		Debug.Assert(State is VNodeState.ShuttingDown);
 
-		Log.Error("========== [{httpEndPoint}] Shutdown Timeout.", _nodeInfo.HttpEndPoint);
+		var services = string.Join(", ", _initializedServices
+			.Where(kvp => kvp.Value is not ServiceState.Shutdown)
+			.Select(kvp => kvp.Key));
+		var error = $"Gave up waiting for services: [{services}]";
+
+		Log.Error("========== [{httpEndPoint}] Shutdown Timeout. {error}", _nodeInfo.HttpEndPoint, error);
+
 		await Shutdown(token);
 		await _outputBus.DispatchAsync(message, token);
 	}

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -206,7 +206,7 @@ internal static class Program {
 						.ConfigureServices(services => services
 							.Configure<KestrelServerOptions>(configuration.GetSection("Kestrel"))
 							.Configure<HostOptions>(x => {
-								x.ShutdownTimeout = TimeSpan.FromSeconds(5);
+								x.ShutdownTimeout = ClusterVNode.ShutdownTimeout + TimeSpan.FromSeconds(1);
 #if DEBUG
 								x.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
 #else

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -190,16 +190,14 @@ internal static class Program {
 			};
 
 			using (var hostedService = new ClusterVNodeHostedService(options, certificateProvider, configuration)) {
-				using var signal = new ManualResetEventSlim(false);
-				_ = Run(hostedService, signal);
-				// ReSharper disable MethodSupportsCancellation
-				signal.Wait();
-				// ReSharper restore MethodSupportsCancellation
+				// Synchronous Wait() because ClusterVNodeHostedService must be disposed on the same thread
+				// that it was constructed on, because it makes use of ExclusiveDbLock which uses a Mutex.
+				Run(hostedService).Wait();
 			}
 
 			return await exitCodeSource.Task;
 
-			async Task Run(ClusterVNodeHostedService hostedService, ManualResetEventSlim signal) {
+			async Task Run(ClusterVNodeHostedService hostedService) {
 				try {
 					await new HostBuilder()
 						.ConfigureHostConfiguration(builder => builder.AddEnvironmentVariables("DOTNET_").AddCommandLine(args))
@@ -243,8 +241,6 @@ internal static class Program {
 				} catch (Exception ex) {
 					Log.Fatal(ex, "Exiting");
 					exitCodeSource.TrySetResult(1);
-				} finally {
-					signal.Set();
 				}
 			}
 


### PR DESCRIPTION
Before this commit, on shutdown we waited for a hard coded number of services to terminate but
1. The count of services was wrong (didn't include ReplicationTrackingService)
2. Not all unit tests that start the server actually involve starting all the services (e.g. starting a single node of a three node cluster)
   in which case shutdown will timeout waiting for services to terminate that never started.

Now we ensure that any service that sends ServiceShutdown also sends ServiceInitialized, and we track which services were initialized to know
which services we need to wait for on shutdown.

The overall effect here is that the server should shutdown smoothly in more scenarios.