### PR TITLE
Refactor the chunk switching so that it not done via the ChunkWriterF…

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/CancellationAndContinuationTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/CancellationAndContinuationTests.cs
@@ -145,6 +145,7 @@ public class CancellationAndContinuationTests : SqliteDbPerTest<CancellationAndC
 				Tracer.Line("    Commit"),
 				Tracer.Line("    Retaining Chunk 0-0"),
 				Tracer.Line("    Opening Chunk 0-0"),
+				Tracer.Line("    Aborted chunk writing. DeleteImmediately: False"),
 				Tracer.Line("Exception executing chunks"))
 			.AssertState(state => {
 				Assert.Equal(ScavengeResult.Stopped, logger.Result);
@@ -606,6 +607,7 @@ public class CancellationAndContinuationTests : SqliteDbPerTest<CancellationAndC
 				Tracer.Line("    Commit"),
 				Tracer.Line("    Retaining Chunk 1-1"),
 				Tracer.Line("    Opening Chunk 1-1"),
+				Tracer.Line("    Aborted chunk writing. DeleteImmediately: False"),
 				Tracer.Line("Exception executing chunks"))
 			.AssertState(state => {
 				Assert.Equal(ScavengeResult.Stopped, logger.Result);

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -449,7 +449,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 				buffer: new(checkpointPeriod),
 				throttle: throttle);
 
-			IChunkExecutor<TStreamId> chunkExecutor = new ChunkExecutor<TStreamId, ILogRecord>(
+			IChunkExecutor<TStreamId> chunkExecutor = new ChunkExecutor<TStreamId, ILogRecord, TFChunk>(
 				logger: logger,
 				metastreamLookup: chunkExecutorMetastreamLookup,
 				chunkRemover: new TracingChunkRemover<TStreamId, ILogRecord>(
@@ -461,7 +461,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 						retainPeriod: TimeSpan.FromDays(_retainDays),
 						retainBytes: _retainBytes),
 					Tracer),
-				chunkManager: new TracingChunkManagerForChunkExecutor<TStreamId, ILogRecord>(
+				chunkManager: new TracingChunkManagerForChunkExecutor<TStreamId, ILogRecord, TFChunk>(
 					new ChunkManagerForExecutor<TStreamId>(
 						logger,
 						dbResult.Db.Manager,

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
@@ -77,6 +77,8 @@ public abstract class ArchiveStorageTestsBase<T> : DirectoryPerTest<T> {
 				? ValueTask.FromCanceled<IChunkRawReader>(token)
 				: ValueTask.FromResult<IChunkRawReader>(new StreamReader(this));
 
+		public int FileSize => throw new NotImplementedException();
+
 		public IAsyncEnumerable<IChunkBlob> UnmergeAsync(CancellationToken token) {
 			throw new NotImplementedException();
 		}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1338,7 +1338,7 @@ public class ClusterVNode<TStreamId> :
 					retainBytes: archiveOptions.RetainAtLeast.LogicalBytes);
 			}
 
-			var chunkExecutor = new ChunkExecutor<TStreamId, ILogRecord>(
+			var chunkExecutor = new ChunkExecutor<TStreamId, ILogRecord, TFChunk>(
 				logger,
 				logFormat.Metastreams,
 				chunkRemover,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkBlob.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkBlob.cs
@@ -14,6 +14,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 public interface IChunkBlob : IDisposable {
 	string ChunkLocator { get; }
 
+	int FileSize { get; }
+
 	ValueTask<IChunkRawReader> AcquireRawReader(CancellationToken token);
 
 	IAsyncEnumerable<IChunkBlob> UnmergeAsync(CancellationToken token);

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForExecutor.cs
@@ -13,7 +13,7 @@ using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging.DbAccess;
 
-public class ChunkManagerForExecutor<TStreamId> : IChunkManagerForChunkExecutor<TStreamId, ILogRecord> {
+public class ChunkManagerForExecutor<TStreamId> : IChunkManagerForChunkExecutor<TStreamId, ILogRecord, TFChunk> {
 	private readonly ILogger _logger;
 	private readonly TFChunkManager _manager;
 	private readonly TFChunkDbConfig _dbConfig;
@@ -26,12 +26,10 @@ public class ChunkManagerForExecutor<TStreamId> : IChunkManagerForChunkExecutor<
 		_transformManager = transformManager;
 	}
 
-	public IChunkFileSystem FileSystem => _manager.FileSystem;
-
-	public async ValueTask<IChunkWriterForExecutor<TStreamId, ILogRecord>> CreateChunkWriter(
+	public async ValueTask<IChunkWriterForExecutor<TStreamId, ILogRecord, TFChunk>> CreateChunkWriter(
 		IChunkReaderForExecutor<TStreamId, ILogRecord> sourceChunk,
 		CancellationToken token)
-		=> await ChunkWriterForExecutor<TStreamId>.CreateAsync(_logger, this, _dbConfig, sourceChunk,
+		=> await ChunkWriterForExecutor<TStreamId>.CreateAsync(_logger, _manager.FileSystem, _dbConfig, sourceChunk,
 			_transformManager, token);
 
 	public IChunkReaderForExecutor<TStreamId, ILogRecord> GetChunkReaderFor(long position) {

--- a/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
@@ -8,26 +8,26 @@ using EventStore.Core.TransactionLog.Chunks.TFChunk;
 
 namespace EventStore.Core.TransactionLog.Scavenging.Interfaces;
 
-public interface IChunkManagerForChunkExecutor<TStreamId, TRecord> {
-	IChunkFileSystem FileSystem { get; }
-
-	ValueTask<IChunkWriterForExecutor<TStreamId, TRecord>> CreateChunkWriter(
+public interface IChunkManagerForChunkExecutor<TStreamId, TRecord, TChunk> where TChunk : IChunkBlob {
+	ValueTask<IChunkWriterForExecutor<TStreamId, TRecord, TChunk>> CreateChunkWriter(
 		IChunkReaderForExecutor<TStreamId, TRecord> sourceChunk,
 		CancellationToken token);
 
 	IChunkReaderForExecutor<TStreamId, TRecord> GetChunkReaderFor(long position);
+
+	ValueTask<string> SwitchInTempChunk(TChunk chunk, CancellationToken token);
 }
 
 public interface IChunkManagerForChunkRemover {
 	ValueTask<bool> SwitchInChunks(IReadOnlyList<string> locators, CancellationToken token);
 }
 
-public interface IChunkWriterForExecutor<TStreamId, TRecord> {
+public interface IChunkWriterForExecutor<TStreamId, TRecord, TChunk> where TChunk : IChunkBlob {
 	string LocalFileName { get; }
 
 	ValueTask WriteRecord(RecordForExecutor<TStreamId, TRecord> record, CancellationToken token);
 
-	ValueTask<(string NewFileName, long NewFileSize)> Complete(CancellationToken token);
+	ValueTask<TChunk> Complete(CancellationToken token);
 
 	void Abort(bool deleteImmediately);
 }


### PR DESCRIPTION
…orExecutor

Instead the ChunkWriterForExecutor passes the completed chunk back to the main ChunkExecutor and it does the swap. The swap is still done via the ChunkManager.

This is preparation for scavenging the archive, where we will want to upload the newly scavenged chunk instead of swapping it in.

Also added a trace when aborting chunk writing