### PR TITLE
Fix handling of transactions that are larger than an entire chunk

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream.cs
@@ -351,8 +351,14 @@ public class append_to_stream<TLogFormat, TStreamId> : SpecificationWithDirector
 
 			var largeData = new string(' ', 20000);
 			var events = Enumerable.Range(0, 100).Select(i => TestEvent.NewTestEvent(largeData, i.ToString()));
+
+			Assert.AreEqual(3, (await store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, events.Take(4))).NextExpectedVersion);
+
 			Assert.ThrowsAsync<InvalidTransactionException>(async () =>
-				await store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, events));
+				await store.AppendToStreamAsync(stream, 3, events));
+
+			// can still write to the stream with ExpectedVersion 3
+			Assert.AreEqual(7, (await store.AppendToStreamAsync(stream, 3, events.Take(4))).NextExpectedVersion);
 		}
 	}
 
@@ -615,8 +621,14 @@ public class ssl_append_to_stream<TLogFormat, TStreamId> : SpecificationWithDire
 
 			var largeData = new string(' ', 20000);
 			var events = Enumerable.Range(0, 100).Select(i => TestEvent.NewTestEvent(largeData, i.ToString()));
+
+			Assert.AreEqual(3, (await store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, events.Take(4))).NextExpectedVersion);
+
 			Assert.ThrowsAsync<InvalidTransactionException>(async () =>
-				await store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, events));
+				await store.AppendToStreamAsync(stream, 3, events));
+
+			// can still write to the stream with ExpectedVersion 3
+			Assert.AreEqual(7, (await store.AppendToStreamAsync(stream, 3, events.Take(4))).NextExpectedVersion);
 		}
 	}
 

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -360,6 +360,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 						endEventNumber: -1,
 						isSoftDeleted: false),
 					token);
+				return;
 			}
 
 			bool softUndeleteMetastream = _systemStreams.IsMetaStream(streamId)


### PR DESCRIPTION
They are still rejected, but subsequent writes will now succeed with the correct expected version.

The missing early return meant that if the transaction was larger than the entire chunk size (256mb by default) then although the write would correctly fail, we would expect the next write to have expected version as if it had succeeded.

Doubtful this is possible in practice without setting the chunk size to something small.