### PR TITLE
[Cherry pick][24.10] Prevent swallowing of gRPC exceptions that lead to hanging writes on client 

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs
@@ -40,17 +40,8 @@ partial class Streams<TStreamId> {
 			requestStream, responseStream,
 			context.GetHttpContext().User, _maxAppendSize, _writeTimeout,
 			GetRequiresLeader(context.RequestHeaders));
-		try {
-			await worker.Work(context.CancellationToken);
-		} catch (IOException) {
-			// ignored
-		} catch (TaskCanceledException) {
-			//ignored
-		} catch (InvalidOperationException) {
-			//ignored
-		} catch (OperationCanceledException) {
-			//ignored
-		}
+
+		await worker.Work(context.CancellationToken);
 	}
 
 	private class BatchAppendWorker {

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading;
@@ -86,14 +85,6 @@ internal partial class Streams<TStreamId> {
 				}
 			} catch (ReadResponseException ex) {
 				ConvertReadResponseException(ex);
-			} catch (IOException) {
-				// ignored
-			} catch (TaskCanceledException) {
-				//ignored
-			} catch (InvalidOperationException) {
-				//ignored
-			} catch (OperationCanceledException) {
-				//ignored
 			}
 		} catch (Exception ex) {
 			duration.SetException(ex);


### PR DESCRIPTION
Fixed: Prevent swallowing of gRPC exceptions that lead to hanging writes on client

Cherry pick of #4857

Reverting f9791cf - Reduce gRPC log level on the server

If we swallow the exception the call terminates successfully, which the client isn't expecting in case of failure. e.g. in the dotnet client the user's Append call will not be terminated.

There is room to discuss later if we should be converting some of these to RpcExceptions, to avoid logging Errors for them.