### PR TITLE
Place CORS before Routing in the pipeline

### DIFF
--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -113,6 +113,8 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		_mainBus.Subscribe(internalDispatcher);
 
 		app.Map("/health", _statusCheck.Configure);
+		app.UseCors("default");
+
 		// AuthenticationMiddleware uses _httpAuthenticationProviders and assigns
 		// the resulting ClaimsPrinciple to HttpContext.User
 		app.UseMiddleware<AuthenticationMiddleware>();
@@ -123,7 +125,6 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		// is driven by the HttpContext.User established above
 		app.UseAuthentication();
 		app.UseRouting();
-		app.UseCors("default");
 		app.UseAuthorization();
 		app.UseAntiforgery();
 


### PR DESCRIPTION
To avoid AmbiguousMatchException when the webui accesses /stats/replication cross origin.
Curiously the error only occurs in the presence of the Connectors plugin. It will be easier to create a test for this once the code is moved into this repo