### PR TITLE
[KDB-699] Reduce allocations when projections validate json

### DIFF
--- a/src/EventStore.Common.Tests/Utils/JsonTests.cs
+++ b/src/EventStore.Common.Tests/Utils/JsonTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System.Text;
+using EventStore.Common.Utils;
+
+namespace EventStore.Common.Tests.Utils;
+
+public class JsonTests {
+	[Theory]
+	[InlineData("""
+		{
+			"some": "actually",
+			"correct": ["json", true, false, null]
+		}
+		""")]
+	[InlineData("""
+		// a comment
+		{
+			// b comment
+			"foo": "bar", // cheeky trailing comma
+			// c comment
+		}
+		// d comment
+		""")]
+	public void accepts_valid(string json) {
+		Assert.True(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(json)).IsValidUtf8Json());
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("{} invalid")]
+	[InlineData("""{ "foo": "bar", invalid }""")]
+	[InlineData("""
+		// comment
+		{ "foo": "bar" }
+		invalid
+		""")]
+	[InlineData("""
+		{ "foo": "bar" }
+		invalid
+		""")]
+	[InlineData("""
+		{ "foo": "bar" }
+		{ "foo": "bar" }
+		""")]
+	public void rejects_invalid(string invalidJson) {
+		Assert.False(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(invalidJson)).IsValidUtf8Json());
+	}
+
+	[Theory]
+	[InlineData(64, true)]
+	[InlineData(65, false)]
+	public void check_depth(int depth, bool isValid) {
+		var json =
+			new string('[', depth) +
+			new string(']', depth);
+
+		Assert.Equal(isValid, new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(json)).IsValidUtf8Json());
+	}
+
+	[Fact]
+	public void rejects_bom() {
+		var json = new byte[] {
+			0xEF, 0xBB, 0xBF, // bom
+			(byte)'{',
+			(byte)'}',
+		};
+		Assert.False(new ReadOnlyMemory<byte>(json).IsValidUtf8Json());
+	}
+
+	[Fact]
+	public void utf16_is_not_valid() {
+		var json = """{ "foo": "bar" }""";
+		Assert.False(new ReadOnlyMemory<byte>(Encoding.Unicode.GetBytes(json)).IsValidUtf8Json());
+	}
+}

--- a/src/EventStore.Common/Utils/Json.cs
+++ b/src/EventStore.Common/Utils/Json.cs
@@ -2,10 +2,9 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
-using System.Xml;
+using System.Text.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using Formatting = Newtonsoft.Json.Formatting;
 
@@ -52,46 +51,24 @@ public static class Json {
 		return result;
 	}
 
-	public static object DeserializeObject(JObject value, Type type, JsonSerializerSettings settings) {
-		JsonSerializer jsonSerializer = JsonSerializer.Create(settings);
-		return jsonSerializer.Deserialize(new JTokenReader(value), type);
-	}
+	private static JsonReaderOptions JsonReaderOptions = new() {
+		AllowTrailingCommas = true,
+		CommentHandling = JsonCommentHandling.Skip,
+		MaxDepth = 64, // default - just being explicit
+	};
 
-	public static object DeserializeObject(JObject value, Type type, params JsonConverter[] converters) {
-		var settings = converters == null || converters.Length <= 0
-			? null
-			: new JsonSerializerSettings {Converters = converters};
-		return DeserializeObject(value, type, settings);
-	}
+	public static bool IsValidUtf8Json(this ReadOnlyMemory<byte> value) {
+		// Don't bother letting an Exception getting thrown.
+		if (value.IsEmpty)
+			return false;
 
-	public static XmlDocument ToXmlDocument(this JObject value, string deserializeRootElementName,
-		bool writeArrayAttribute) {
-		return (XmlDocument)DeserializeObject(value, typeof(XmlDocument), new JsonConverter[] {
-			new XmlNodeConverter {
-				DeserializeRootElementName = deserializeRootElementName,
-				WriteArrayAttribute = writeArrayAttribute
-			}
-		});
-	}
-
-	public static bool IsValidJson(this string value) {
 		try {
-			JToken.Parse(value);
+			var reader = new Utf8JsonReader(value.Span, JsonReaderOptions);
+			while (reader.Read())
+				reader.Skip();
+			return true;
 		} catch {
 			return false;
 		}
-
-		return true;
-	}
-
-	public static bool IsValidJson(this ReadOnlyMemory<byte> value) {
-		if (value.IsEmpty) return false;  //Don't bother letting an Exception getting thrown.
-		try {
-			JToken.Parse(Helper.UTF8NoBom.GetString(value.Span));
-		} catch {
-			return false;
-		}
-
-		return true;
 	}
 }

--- a/src/EventStore.Core/Data/ResolvedEvent.cs
+++ b/src/EventStore.Core/Data/ResolvedEvent.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace EventStore.Core.Data;
 
-public struct ResolvedEvent : IEquatable<ResolvedEvent> {
+public readonly struct ResolvedEvent : IEquatable<ResolvedEvent> {
 	public static readonly ResolvedEvent[] EmptyArray = new ResolvedEvent[0];
 	public static readonly ResolvedEvent EmptyEvent = new ResolvedEvent();
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
@@ -99,7 +99,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 					new ReaderSubscriptionManagement.Subscribe(
 						_subscriptionId, fromZeroPosition, _readerStrategy, _readerSubscriptionOptions);
 				//DisableTimer();
-				yield return CreateWriteEvent("test-stream", "type1", "{Data: 3}", "{}");
+				yield return CreateWriteEvent("test-stream", "type1", """{"Data": 3}""", "{}");
 				_tfPos3 = _all.Last(v => v.Value.EventStreamId == "test-stream").Key;
 
 				yield return

--- a/src/EventStore.Projections.Core/Services/Processing/EventFilter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
 using System.Collections.Generic;
 using EventStore.Common.Utils;
 
@@ -32,12 +33,8 @@ public abstract class EventFilter {
 		           && (!isStreamDeletedEvent || _includeDeletedStreamEvents));
 	}
 
-	public bool PassesValidation(bool isJson, string data) {
-		if (!isJson) return true;
-		if (data is null) {
-			return false;
-		}
-		return data.IsValidJson();
+	public bool PassesValidation(bool isJson, ReadOnlyMemory<byte> data) {
+		return !isJson || data.IsValidUtf8Json();
 	}
 
 	protected abstract bool DeletedNotificationPasses(string positionStreamId);

--- a/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
@@ -30,6 +30,8 @@ public class ResolvedEvent {
 	public readonly bool IsJson;
 	public readonly DateTime Timestamp;
 
+	public readonly ReadOnlyMemory<byte> DataMemory;
+
 	public readonly string Data;
 	public readonly string Metadata;
 	public readonly string PositionMetadata;
@@ -51,6 +53,8 @@ public class ResolvedEvent {
 		EventType = @event != null ? @event.EventType : null;
 		IsJson = @event != null && (@event.Flags & PrepareFlags.IsJson) != 0;
 		Timestamp = positionEvent.TimeStamp;
+
+		DataMemory = @event?.Data ?? ReadOnlyMemory<byte>.Empty;
 
 		//TODO: handle utf-8 conversion exception
 		Data = @event != null && @event.Data.Length > 0 ? Helper.UTF8NoBom.GetString(@event.Data.Span) : null;
@@ -81,7 +85,7 @@ public class ResolvedEvent {
 					tag = positionEvent.Metadata.ParseCheckpointTagJson();
 					var parsedPosition = tag.Position;
 					if (parsedPosition == new TFPos(long.MinValue, long.MinValue) &&
-					    @event.Metadata.IsValidJson()) {
+					    @event.Metadata.IsValidUtf8Json()) {
 						tag = @event.Metadata.ParseCheckpointTagJson();
 						if (tag != null) {
 							parsedPosition = tag.Position;

--- a/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
@@ -120,7 +120,7 @@ public class ResolvedEvent {
 		_eventOrLinkTargetPosition = eventOrLinkTargetPosition;
 	}
 
-
+	// Called from tests only
 	public ResolvedEvent(
 		string positionStreamId, long positionSequenceNumber, string eventStreamId, long eventSequenceNumber,
 		bool resolvedLinkTo, TFPos position, TFPos eventOrLinkTargetPosition, Guid eventId, string eventType,
@@ -138,6 +138,8 @@ public class ResolvedEvent {
 		IsJson = isJson;
 		Timestamp = timestamp;
 
+		DataMemory = data ?? ReadOnlyMemory<byte>.Empty;
+
 		//TODO: handle utf-8 conversion exception
 		Data = data != null ? Helper.UTF8NoBom.GetString(data) : null;
 		Metadata = metadata != null ? Helper.UTF8NoBom.GetString(metadata) : null;
@@ -145,7 +147,7 @@ public class ResolvedEvent {
 		StreamMetadata = streamMetadata != null ? Helper.UTF8NoBom.GetString(streamMetadata) : null;
 	}
 
-
+	// Called from tests only
 	public ResolvedEvent(
 		string positionStreamId, long positionSequenceNumber, string eventStreamId, long eventSequenceNumber,
 		bool resolvedLinkTo, TFPos position, Guid eventId, string eventType, bool isJson, string data,
@@ -167,6 +169,7 @@ public class ResolvedEvent {
 		IsJson = isJson;
 		Timestamp = timestamp;
 
+		DataMemory = Helper.UTF8NoBom.GetBytes(data);
 		Data = data;
 		Metadata = metadata;
 		PositionMetadata = positionMetadata;

--- a/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
@@ -169,7 +169,7 @@ public class ResolvedEvent {
 		IsJson = isJson;
 		Timestamp = timestamp;
 
-		DataMemory = Helper.UTF8NoBom.GetBytes(data);
+		DataMemory = data is not null ? Helper.UTF8NoBom.GetBytes(data) : ReadOnlyMemory<byte>.Empty;
 		Data = data;
 		Metadata = metadata;
 		PositionMetadata = positionMetadata;

--- a/src/EventStore.Projections.Core/Services/Processing/Subscriptions/ReaderSubscriptionBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Subscriptions/ReaderSubscriptionBase.cs
@@ -95,7 +95,7 @@ public class ReaderSubscriptionBase {
 
 		bool passesStreamSourceFilter = _eventFilter.PassesSource(message.Data.ResolvedLinkTo, message.Data.PositionStreamId, message.Data.EventType);
 		bool passesEventFilter = _eventFilter.Passes(message.Data.ResolvedLinkTo, message.Data.PositionStreamId, message.Data.EventType, message.Data.IsStreamDeletedEvent);
-		bool isValid = !_enableContentTypeValidation || _eventFilter.PassesValidation(message.Data.IsJson, message.Data.Data);
+		bool isValid = !_enableContentTypeValidation || _eventFilter.PassesValidation(message.Data.IsJson, message.Data.DataMemory);
 		if (!isValid) {
 			_logger.Verbose($"Event {message.Data.EventSequenceNumber}@{message.Data.EventStreamId} is not valid json. Data: ({message.Data.Data})");
 		}


### PR DESCRIPTION
Changed: reduced memory allocations caused by projections

- Use Utf8JsonReader instead of JToken.Parse. Here we are not interested in the parsed object just that it is parsable
- Maintain the old behaviour though: comments and trailing commas are still allowed.
- Avoid converting the bytes back and forth to strings.

On a small database with large events

Before:
![image](https://github.com/user-attachments/assets/8907908d-509d-400c-88f8-999b260be0a9)

After:
![image](https://github.com/user-attachments/assets/bf31cc66-8190-47ff-bb67-1183d99af8dc)
