### PR TITLE
[KDB-696] Add an option to limit the size of events appended over gRPC and HTTP

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -4942,6 +4942,26 @@
             ]
           },
           {
+            "name": "MaximumAppendEventSizeExceeded",
+            "fields": [
+              {
+                "id": 1,
+                "name": "eventId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "proposedEventSize",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "maxAppendEventSize",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
             "name": "BadRequest",
             "fields": [
               {

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -88,7 +88,8 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 		IAuthorizationProviderFactory authorizationProviderFactory = null,
 		IExpiryStrategy expiryStrategy = null,
 		string transform = "identity",
-		IReadOnlyList<IDbTransform> newTransforms = null) {
+		IReadOnlyList<IDbTransform> newTransforms = null,
+		int maxAppendEventSize = TFConsts.EffectiveMaxLogRecordSize) {
 
 		RunningTime.Start();
 		RunCount += 1;
@@ -119,7 +120,8 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 					AllowAnonymousEndpointAccess = true,
 					AllowAnonymousStreamAccess = true,
 					StatsPeriodSec = 60 * 60,
-					WorkerThreads = 1
+					WorkerThreads = 1,
+					MaxAppendEventSize = maxAppendEventSize
 				},
 				Interface = new() {
 					ReplicationHeartbeatInterval = 10_000,

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/AppendBatchToStreamTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/AppendBatchToStreamTests.cs
@@ -8,6 +8,7 @@ using EventStore.Client;
 using EventStore.Client.Streams;
 using EventStore.Core.Services.Transport.Grpc;
 using Google.Protobuf;
+using Google.Rpc;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests;
@@ -42,13 +43,60 @@ public class AppendBatchToStreamTests {
 		public void is_success() {
 			Assert.AreEqual(_response.ResultCase, BatchAppendResp.ResultOneofCase.Success);
 		}
-		
+
 		[Test]
 		public void is_correlated() {
 			Assert.AreEqual(_correlationId.ToDto(), _response.CorrelationId);
 		}
 	}
-	
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class single_batch_with_too_large_events<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private BatchAppendResp _response;
+		private readonly Uuid _correlationId;
+		private const int MaxAppendEventSize = 1024;
+		private BatchAppendReq.Types.ProposedMessage _tooLargeEvent;
+
+		public single_batch_with_too_large_events() : base(maxAppendEventSize: MaxAppendEventSize) {
+			_correlationId = Uuid.NewUuid();
+		}
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			_tooLargeEvent = CreateEvent(dataSize: MaxAppendEventSize, metadataSize: MaxAppendEventSize);
+			_response = await AppendToStreamBatch(new BatchAppendReq {
+				Options = new() {
+					Any = new(),
+					StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8("stream") }
+				},
+				IsFinal = true,
+				ProposedMessages = { CreateEvent(), _tooLargeEvent, CreateEvent() },
+				CorrelationId = _correlationId.ToDto()
+			});
+		}
+
+		[Test]
+		public void is_error() {
+			Assert.AreEqual(BatchAppendResp.ResultOneofCase.Error, _response.ResultCase);
+			Assert.AreEqual(Code.InvalidArgument, _response.Error.Code);
+		}
+
+		[Test]
+		public void is_correlated() {
+			Assert.AreEqual(_correlationId.ToDto(), _response.CorrelationId);
+		}
+
+		[Test]
+		public void contains_error_details() {
+			Assert.True(_response.Error.Details.Is(MaximumAppendEventSizeExceeded.Descriptor));
+			var details = _response.Error.Details.Unpack<MaximumAppendEventSizeExceeded>();
+			Assert.AreEqual(Uuid.FromDto(_tooLargeEvent.Id).ToString(), details.EventId);
+			Assert.AreEqual(MaxAppendEventSize * 2 + 2, details.ProposedEventSize);
+			Assert.AreEqual(MaxAppendEventSize, details.MaxAppendEventSize);
+		}
+	}
+
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
 	public class single_batch_non_structured_uuid<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
@@ -81,6 +129,52 @@ public class AppendBatchToStreamTests {
 		[Test]
 		public void is_correlated() {
 			Assert.AreEqual(new UUID() {String = _correlationId.ToString()}, _response.CorrelationId);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class multiple_batches_with_one_having_too_large_events<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private BatchAppendResp _response;
+		private const int MaxAppendEventSize = 1024;
+		private BatchAppendReq.Types.ProposedMessage _tooLargeEvent;
+
+		public multiple_batches_with_one_having_too_large_events()
+			: base(maxAppendEventSize: MaxAppendEventSize) {
+		}
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			_tooLargeEvent = CreateEvent(dataSize: MaxAppendEventSize, metadataSize: MaxAppendEventSize);
+			var correlationId = Uuid.NewUuid();
+			_response = await AppendToStreamBatch(new BatchAppendReq {
+				Options = new() {
+					Any = new(),
+					StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8("stream") }
+				},
+				IsFinal = false,
+				ProposedMessages = { CreateEvents(1) },
+				CorrelationId = correlationId.ToDto(),
+			}, new() {
+				IsFinal = true,
+				ProposedMessages = { _tooLargeEvent },
+				CorrelationId = correlationId.ToDto()
+			});
+		}
+
+		[Test]
+		public void is_error() {
+			Assert.AreEqual(BatchAppendResp.ResultOneofCase.Error, _response.ResultCase);
+			Assert.AreEqual(Code.InvalidArgument, _response.Error.Code);
+		}
+
+		[Test]
+		public void contains_error_details() {
+			Assert.True(_response.Error.Details.Is(MaximumAppendEventSizeExceeded.Descriptor));
+			var details = _response.Error.Details.Unpack<MaximumAppendEventSizeExceeded>();
+			Assert.AreEqual(Uuid.FromDto(_tooLargeEvent.Id).ToString(), details.EventId);
+			Assert.AreEqual(MaxAppendEventSize * 2 + 2, details.ProposedEventSize);
+			Assert.AreEqual(MaxAppendEventSize, details.MaxAppendEventSize);
 		}
 	}
 
@@ -180,7 +274,7 @@ public class AppendBatchToStreamTests {
 			Assert.AreEqual(_response.ResultCase, BatchAppendResp.ResultOneofCase.Error);
 			Assert.AreEqual(_response.Error.Code, Google.Rpc.Code.DeadlineExceeded);
 		}
-		
+
 		[Test]
 		public void is_correlated() {
 			Assert.AreEqual(_correlationId.ToDto(), _response.CorrelationId);

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/AppendBatchToStreamTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/AppendBatchToStreamTests.cs
@@ -235,7 +235,7 @@ public class AppendBatchToStreamTests {
 		[Test]
 		public void is_error() {
 			Assert.AreEqual(_response.ResultCase, BatchAppendResp.ResultOneofCase.Error);
-			Assert.AreEqual(_response.Error.Code, Google.Rpc.Code.DeadlineExceeded);
+			Assert.AreEqual(_response.Error.Code, Code.DeadlineExceeded);
 		}
 
 		[Test]
@@ -272,7 +272,7 @@ public class AppendBatchToStreamTests {
 		[Test]
 		public void is_error() {
 			Assert.AreEqual(_response.ResultCase, BatchAppendResp.ResultOneofCase.Error);
-			Assert.AreEqual(_response.Error.Code, Google.Rpc.Code.DeadlineExceeded);
+			Assert.AreEqual(_response.Error.Code, Code.DeadlineExceeded);
 		}
 
 		[Test]

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1018,7 +1018,7 @@ public class ClusterVNode<TStreamId> :
 		var statController = new StatController(monitoringQueue, _workersHandler);
 		var metricsController = new MetricsController();
 		var atomController = new AtomController(_mainQueue, _workersHandler,
-			options.Application.DisableHttpCaching, TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs));
+			options.Application.DisableHttpCaching, options.Application.MaxAppendEventSize, TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs));
 		var gossipController = new GossipController(_mainQueue, _workersHandler,
 			trackers.GossipTrackers.ProcessingRequestFromHttpClient);
 		var persistentSubscriptionController =

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1622,6 +1622,7 @@ public class ClusterVNode<TStreamId> :
 			_mainQueue, monitoringQueue, _mainBus, _workersHandler,
 			_authenticationProvider, _authorizationProvider,
 			options.Application.MaxAppendSize,
+			options.Application.MaxAppendEventSize,
 			TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs),
 			expiryStrategy ?? new DefaultExpiryStrategy(),
 			_httpService,

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -157,7 +157,7 @@ public partial record ClusterVNodeOptions {
 		             "May not exceed 16MB.")]
 		public int MaxAppendSize { get; init; } = 1_024 * 1_024;
 
-		[Description("The maximum size of an individual event in an append request received over gRPC or HTTP, in bytes. ")]
+		[Description("The maximum size of an individual event in an append request received over gRPC or HTTP, in bytes.")]
 		public int MaxAppendEventSize { get; init; } = int.MaxValue;
 
 		[Description("Disable Authentication, Authorization and TLS on all TCP/HTTP interfaces.")]

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -153,8 +153,14 @@ public partial record ClusterVNodeOptions {
 		             "to stop reading duplicates.")]
 		public bool SkipIndexScanOnReads { get; init; } = false;
 
-		[Description("The maximum size of appends, in bytes. May not exceed 16MB.")]
+		[Description("The maximum size of appends, in bytes. This is the total size of all events in the append request. " +
+		             "May not exceed 16MB.")]
 		public int MaxAppendSize { get; init; } = 1_024 * 1_024;
+
+		[Description(
+			"The maximum size of an individual event in an append request received over gRPC or HTTP, in bytes. " +
+			"May not exceed 16MB.")]
+		public int MaxAppendEventSize { get; init; } = TFConsts.EffectiveMaxLogRecordSize;
 
 		[Description("Disable Authentication, Authorization and TLS on all TCP/HTTP interfaces.")]
 		public bool Insecure { get; init; } = false;

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -157,10 +157,8 @@ public partial record ClusterVNodeOptions {
 		             "May not exceed 16MB.")]
 		public int MaxAppendSize { get; init; } = 1_024 * 1_024;
 
-		[Description(
-			"The maximum size of an individual event in an append request received over gRPC or HTTP, in bytes. " +
-			"May not exceed 16MB.")]
-		public int MaxAppendEventSize { get; init; } = TFConsts.EffectiveMaxLogRecordSize;
+		[Description("The maximum size of an individual event in an append request received over gRPC or HTTP, in bytes. ")]
+		public int MaxAppendEventSize { get; init; } = int.MaxValue;
 
 		[Description("Disable Authentication, Authorization and TLS on all TCP/HTTP interfaces.")]
 		public bool Insecure { get; init; } = false;

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -65,11 +65,6 @@ public static class ClusterVNodeOptionsValidator {
 				$"{nameof(options.Application.MaxAppendSize)} exceeded {TFConsts.EffectiveMaxLogRecordSize} bytes.");
 		}
 
-		if (options.Application.MaxAppendEventSize > TFConsts.EffectiveMaxLogRecordSize) {
-			throw new ArgumentOutOfRangeException(nameof(options.Application.MaxAppendSize),
-				$"{nameof(options.Application.MaxAppendEventSize)} exceeded {TFConsts.EffectiveMaxLogRecordSize} bytes.");
-		}
-
 		if (options.Cluster.DiscoverViaDns && string.IsNullOrWhiteSpace(options.Cluster.ClusterDns))
 			throw new ArgumentException(
 				"Either DNS Discovery must be disabled (and seeds specified), or a cluster DNS name must be provided.");

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -65,6 +65,11 @@ public static class ClusterVNodeOptionsValidator {
 				$"{nameof(options.Application.MaxAppendSize)} exceeded {TFConsts.EffectiveMaxLogRecordSize} bytes.");
 		}
 
+		if (options.Application.MaxAppendEventSize > TFConsts.EffectiveMaxLogRecordSize) {
+			throw new ArgumentOutOfRangeException(nameof(options.Application.MaxAppendSize),
+				$"{nameof(options.Application.MaxAppendEventSize)} exceeded {TFConsts.EffectiveMaxLogRecordSize} bytes.");
+		}
+
 		if (options.Cluster.DiscoverViaDns && string.IsNullOrWhiteSpace(options.Cluster.ClusterDns))
 			throw new ArgumentException(
 				"Either DNS Discovery must be disabled (and seeds specified), or a cluster DNS name must be provided.");

--- a/src/EventStore.Core/Data/Event.cs
+++ b/src/EventStore.Core/Data/Event.cs
@@ -21,7 +21,7 @@ public class Event {
 	}
 
 	public static int SizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
-		data?.Length ?? 0 + metadata?.Length ?? 0 + eventType.Length * 2;
+		(data?.Length ?? 0) + (metadata?.Length ?? 0) + (eventType.Length * 2);
 
 	private static bool ExceedsMaximumSizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
 		SizeOnDisk(eventType, data, metadata) > TFConsts.EffectiveMaxLogRecordSize;

--- a/src/EventStore.Core/Services/Transport/Grpc/Constants.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Constants.cs
@@ -13,6 +13,7 @@ public static class Constants {
 		public const string WrongExpectedVersion = "wrong-expected-version";
 		public const string StreamNotFound = "stream-not-found";
 		public const string MaximumAppendSizeExceeded = "maximum-append-size-exceeded";
+		public const string MaximumAppendEventSizeExceeded = "maximum-append-event-size-exceeded";
 		public const string MissingRequiredMetadataProperty = "missing-required-metadata-property";
 		public const string NotLeader = "not-leader";
 
@@ -37,10 +38,13 @@ public static class Constants {
 		public const string GroupName = "group-name";
 		public const string Reason = "reason";
 		public const string MaximumAppendSize = "maximum-append-size";
+		public const string MaximumAppendEventSize = "maximum-append-event-size";
+		public const string ProposedAppendEventSize = "proposed-append-event-size";
 		public const string RequiredMetadataProperties = "required-metadata-properties";
 		public const string ScavengeId = "scavenge-id";
 		public const string LeaderEndpointHost = "leader-endpoint-host";
 		public const string LeaderEndpointPort = "leader-endpoint-port";
+		public const string EventId = "event-id";
 
 		public const string LoginName = "login-name";
 	}

--- a/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -127,6 +127,16 @@ public static class RpcExceptions {
 				{Constants.Exceptions.ActualVersion, actualVersion?.ToString() ?? string.Empty}
 			});
 
+	public static RpcException MaxAppendEventSizeExceeded(string eventId, int proposedEventSize, int maxAppendEventSize) =>
+		new(
+			new Status(StatusCode.InvalidArgument, $"Event with Id: {eventId}, Size: {proposedEventSize}, exceeds Maximum Append Event Size of {maxAppendEventSize}."),
+			new Metadata {
+				{Constants.Exceptions.ExceptionKey, Constants.Exceptions.MaximumAppendEventSizeExceeded},
+				{Constants.Exceptions.MaximumAppendEventSize, maxAppendEventSize.ToString()},
+				{Constants.Exceptions.EventId, eventId},
+				{Constants.Exceptions.ProposedAppendEventSize, proposedEventSize.ToString()}
+			});
+
 	public static RpcException MaxAppendSizeExceeded(int maxAppendSize) =>
 		new(
 			new Status(StatusCode.InvalidArgument, $"Maximum Append Size of {maxAppendSize} Exceeded."),

--- a/src/EventStore.Core/Services/Transport/Grpc/Status.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Status.cs
@@ -58,6 +58,17 @@ partial class Status {
 			Code = Code.InvalidArgument
 		};
 
+	public static Status MaximumAppendEventSizeExceeded(string eventId, uint proposedEventSize, uint maxAppendEventSize) =>
+		new() {
+			Details = Any.Pack(new MaximumAppendEventSizeExceeded {
+				EventId = eventId,
+				ProposedEventSize = proposedEventSize,
+				MaxAppendEventSize = maxAppendEventSize
+			}),
+			Message = nameof(MaximumAppendEventSizeExceeded),
+			Code = Code.InvalidArgument
+		};
+
 	public static Status BadRequest(string message) => new() {
 		Details = Any.Pack(new BadRequest {Message = message}),
 		Message = nameof(BadRequest),

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -71,7 +71,11 @@ internal partial class Streams<TStreamId> {
 					throw RpcExceptions.RequiredMetadataPropertyMissing(Constants.Metadata.ContentType);
 				}
 
-				size += Event.SizeOnDisk(eventType, data, metadata);
+				var eventSize = Event.SizeOnDisk(eventType, data, metadata);
+				if (eventSize > _maxAppendEventSize) {
+					throw RpcExceptions.MaxAppendEventSizeExceeded(proposedMessage.Id.ToString(), eventSize, _maxAppendEventSize);
+				}
+				size += eventSize;
 
 				if (size > _maxAppendSize) {
 					throw RpcExceptions.MaxAppendSizeExceeded(_maxAppendSize);

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs
@@ -38,7 +38,7 @@ partial class Streams<TStreamId> {
 		var worker = new BatchAppendWorker(_publisher, _provider,
 			_batchAppendTracker,
 			requestStream, responseStream,
-			context.GetHttpContext().User, _maxAppendSize, _writeTimeout,
+			context.GetHttpContext().User, _maxAppendSize, _maxAppendEventSize, _writeTimeout,
 			GetRequiresLeader(context.RequestHeaders));
 
 		await worker.Work(context.CancellationToken);
@@ -52,6 +52,7 @@ partial class Streams<TStreamId> {
 		private readonly IServerStreamWriter<BatchAppendResp> _responseStream;
 		private readonly ClaimsPrincipal _user;
 		private readonly int _maxAppendSize;
+		private readonly int _maxAppendEventSize;
 		private readonly TimeSpan _writeTimeout;
 		private readonly bool _requiresLeader;
 		private readonly Channel<BatchAppendResp> _channel;
@@ -61,7 +62,7 @@ partial class Streams<TStreamId> {
 		public BatchAppendWorker(IPublisher publisher, IAuthorizationProvider authorizationProvider,
 			IDurationTracker tracker,
 			IAsyncStreamReader<BatchAppendReq> requestStream, IServerStreamWriter<BatchAppendResp> responseStream,
-			ClaimsPrincipal user, int maxAppendSize, TimeSpan writeTimeout, bool requiresLeader) {
+			ClaimsPrincipal user, int maxAppendSize, int maxAppendEventSize, TimeSpan writeTimeout, bool requiresLeader) {
 			_publisher = publisher;
 			_authorizationProvider = authorizationProvider;
 			_tracker = tracker;
@@ -69,6 +70,7 @@ partial class Streams<TStreamId> {
 			_responseStream = responseStream;
 			_user = user;
 			_maxAppendSize = maxAppendSize;
+			_maxAppendEventSize = maxAppendEventSize;
 			_writeTimeout = writeTimeout;
 			_requiresLeader = requiresLeader;
 			_channel = Channel.CreateUnbounded<BatchAppendResp>(new() {
@@ -179,14 +181,23 @@ partial class Streams<TStreamId> {
 							continue;
 						}
 
-						clientWriteRequest.AddEvents(request.ProposedMessages.Select(FromProposedMessage));
+						try {
+							clientWriteRequest.AddEvents(request.ProposedMessages.Select(FromProposedMessage), _maxAppendEventSize);
 
-						if (clientWriteRequest.Size > _maxAppendSize) {
+							if (clientWriteRequest.Size > _maxAppendSize) {
+								pendingWrites.TryRemove(correlationId, out _);
+								await writer.WriteAsync(new BatchAppendResp {
+									CorrelationId = request.CorrelationId,
+									StreamIdentifier = clientWriteRequest.StreamId,
+									Error = Status.MaximumAppendSizeExceeded((uint)_maxAppendSize)
+								}, cancellationToken);
+							}
+						} catch (MaxAppendEventSizeExceededException ex) {
 							pendingWrites.TryRemove(correlationId, out _);
 							await writer.WriteAsync(new BatchAppendResp {
 								CorrelationId = request.CorrelationId,
 								StreamIdentifier = clientWriteRequest.StreamId,
-								Error = Status.MaximumAppendSizeExceeded((uint)_maxAppendSize)
+								Error = Status.MaximumAppendEventSizeExceeded(ex.EventId, (uint)ex.ProposedEventSize, (uint)ex.MaxAppendEventSize)
 							}, cancellationToken);
 						}
 
@@ -318,6 +329,19 @@ partial class Streams<TStreamId> {
 		}
 	}
 
+	private class MaxAppendEventSizeExceededException : Exception {
+		public string EventId { get; }
+		public int ProposedEventSize { get; }
+		public int MaxAppendEventSize { get; }
+
+		public MaxAppendEventSizeExceededException(string eventId, int proposedEventSize, int maxAppendEventSize)
+			: base($"Event with Id: {eventId}, Size: {proposedEventSize}, exceeded Max Append Event Size of {maxAppendEventSize}") {
+			EventId = eventId;
+			ProposedEventSize = proposedEventSize;
+			MaxAppendEventSize = maxAppendEventSize;
+		}
+	}
+
 	private record ClientWriteRequest {
 		public Guid CorrelationId { get; }
 		public string StreamId { get; }
@@ -338,9 +362,14 @@ partial class Streams<TStreamId> {
 			Task.Delay(timeout, cancellationToken).ContinueWith(_ => onTimeout(), cancellationToken);
 		}
 
-		public ClientWriteRequest AddEvents(IEnumerable<Event> events) {
+		public ClientWriteRequest AddEvents(IEnumerable<Event> events, int maxAppendEventSize) {
 			foreach (var e in events) {
-				_size += Event.SizeOnDisk(e.EventType, e.Data, e.Metadata);
+				var eventSize = Event.SizeOnDisk(e.EventType, e.Data, e.Metadata);
+				if (eventSize > maxAppendEventSize) {
+					throw new MaxAppendEventSizeExceededException(e.EventId.ToString(), eventSize, maxAppendEventSize);
+				}
+
+				_size += eventSize;
 				_events.Add(e);
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
@@ -13,6 +13,7 @@ namespace EventStore.Core.Services.Transport.Grpc;
 internal partial class Streams<TStreamId> : EventStore.Client.Streams.Streams.StreamsBase {
 	private readonly IPublisher _publisher;
 	private readonly int _maxAppendSize;
+	private readonly int _maxAppendEventSize;
 	private readonly TimeSpan _writeTimeout;
 	private readonly IExpiryStrategy _expiryStrategy;
 	private readonly IDurationTracker _readTracker;
@@ -25,7 +26,7 @@ internal partial class Streams<TStreamId> : EventStore.Client.Streams.Streams.St
 	private static readonly Operation WriteOperation = new Operation(Plugins.Authorization.Operations.Streams.Write);
 	private static readonly Operation DeleteOperation = new Operation(Plugins.Authorization.Operations.Streams.Delete);
 
-	public Streams(IPublisher publisher, int maxAppendSize, TimeSpan writeTimeout,
+	public Streams(IPublisher publisher, int maxAppendSize, int maxAppendEventSize, TimeSpan writeTimeout,
 		IExpiryStrategy expiryStrategy,
 		GrpcTrackers trackers,
 		IAuthorizationProvider provider) {
@@ -33,6 +34,7 @@ internal partial class Streams<TStreamId> : EventStore.Client.Streams.Streams.St
 		if (publisher == null) throw new ArgumentNullException(nameof(publisher));
 		_publisher = publisher;
 		_maxAppendSize = maxAppendSize;
+		_maxAppendEventSize = maxAppendEventSize;
 		_writeTimeout = writeTimeout;
 		_expiryStrategy = expiryStrategy;
 		_readTracker = trackers[MetricsConfiguration.GrpcMethod.StreamRead];

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -46,9 +46,9 @@ public abstract class CommunicationController : IHttpController {
 		return new RequestParams(done: true);
 	}
 
-	protected RequestParams SendTooBig(HttpEntityManager httpEntityManager) {
+	protected RequestParams SendTooBig(HttpEntityManager httpEntityManager, int maxAppendEventSize) {
 		httpEntityManager.ReplyStatus(HttpStatusCode.RequestEntityTooLarge,
-			"Too large events received. Limit is 4mb",
+			$"Too large events received. Limit is {maxAppendEventSize} bytes.",
 			e => Log.Debug("Too large events received over HTTP"));
 		return new RequestParams(done: true);
 	}

--- a/src/Protos/Grpc/shared.proto
+++ b/src/Protos/Grpc/shared.proto
@@ -56,6 +56,12 @@ message MaximumAppendSizeExceeded {
 	uint32 maxAppendSize = 1;
 }
 
+message MaximumAppendEventSizeExceeded {
+	string eventId = 1;
+	uint32 proposedEventSize = 2;
+	uint32 maxAppendEventSize = 3;
+}
+
 message BadRequest {
 	string message = 1;
 }


### PR DESCRIPTION
Adds the `MaxAppendEventSize` option which limits the size of individual events appended over gRPC and HTTP.
   - Default is int.MaxValue (no limit).
   - Events appended over HTTP may still not exceed 4mb.
   - This is different to `MaxAppendSize`, which is the maximum size of all events in an append request.

**Note**: This PR also fixes the calculation of event size for events appended over gRPC. Previously, this was only calculating the event size off of the event's data, without including the size of the event's metadata or event type. This could mean that append requests which previously did not trip the `MaxAppendSize` check will start failing after this change.

Currently, this PR adds a new rpc exception: `maximum-append-event-size-exceeded`, but we could re-use the `maximum-append-size-exceeded` code with a different message instead if that is easier to support.

I'm open to suggestions for the name of this option, especially something that distinguishes it from `MaxAppendSize` a bit more