### PR TITLE
[KDB-697]: Removed buffer copy

### DIFF
--- a/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkReadStream.cs
+++ b/src/EventStore.Core.Tests/Transforms/BitFlip/BitFlipChunkReadStream.cs
@@ -1,16 +1,17 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
 using EventStore.Plugins.Transforms;
 
 namespace EventStore.Core.Tests.Transforms.BitFlip;
 
 public class BitFlipChunkReadStream(ChunkDataReadStream stream)
 	: ChunkDataReadStream(stream.ChunkFileStream) {
-	public override int Read(byte[] buffer, int offset, int count) {
-		int numRead = base.Read(buffer, offset, count);
-		for (int i = 0; i < count; i++)
-			buffer[i + offset] ^= 0xFF;
+	public override int Read(Span<byte> buffer) {
+		int numRead = base.Read(buffer);
+		for (int i = 0; i < buffer.Length; i++)
+			buffer[i] ^= 0xFF;
 
 		return numRead;
 	}

--- a/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkReadStream.cs
+++ b/src/EventStore.Core.Tests/Transforms/ByteDup/ByteDupChunkReadStream.cs
@@ -11,11 +11,11 @@ public class ByteDupChunkReadStream(ChunkDataReadStream stream)
 	: ChunkDataReadStream(stream.ChunkFileStream) {
 	private const int HeaderSize = 128;
 
-	public override int Read(byte[] buffer, int offset, int count) {
-		var buf = new byte[count * 2];
-		int numRead = base.Read(buf, 0, buf.Length);
-		for (int i = 0; i < count; i++)
-			buffer[i + offset] = buf[i * 2];
+	public override int Read(Span<byte> buffer) {
+		var buf = new byte[buffer.Length * 2];
+		int numRead = base.Read(buf);
+		for (int i = 0; i < buffer.Length; i++)
+			buffer[i] = buf[i * 2];
 
 		return numRead / 2;
 	}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -8,7 +8,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="EventStore.Plugins" Version="24.10.6" />
+		<PackageReference Include="EventStore.Plugins" Version="24.10.7" />
 		<PackageReference Include="Google.Protobuf" Version="3.27.2" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.64.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.65.0">

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -58,7 +58,7 @@ internal sealed class WriterWorkItem : Disposable {
 
 	public void AppendData(ReadOnlyMemory<byte> buf) {
 		// as we are always append-only, stream's position should be right here
-		if (MemoryMarshal.TryGetArray(buf, out var array)) {
+		if (MemoryMarshal.TryGetArray(buf, out var array) && array.Array is not null) {
 			_fileStream?.Write(array.Array, array.Offset, array.Count);
 			_memStream?.Write(array.Array, array.Offset, array.Count);
 		} else {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using DotNext;
 using DotNext.IO;
@@ -57,7 +58,13 @@ internal sealed class WriterWorkItem : Disposable {
 
 	public void AppendData(ReadOnlyMemory<byte> buf) {
 		// as we are always append-only, stream's position should be right here
-		_fileStream?.Write(buf.Span);
+		if (_fileStream is not null) {
+			if (MemoryMarshal.TryGetArray(buf, out var array)) {
+				_fileStream.Write(array.Array, array.Offset, array.Count);
+			} else {
+				_fileStream.Write(buf.Span);
+			}
+		}
 
 		//MEMORY
 		_memStream?.Write(buf.Span);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -58,16 +58,13 @@ internal sealed class WriterWorkItem : Disposable {
 
 	public void AppendData(ReadOnlyMemory<byte> buf) {
 		// as we are always append-only, stream's position should be right here
-		if (_fileStream is not null) {
-			if (MemoryMarshal.TryGetArray(buf, out var array)) {
-				_fileStream.Write(array.Array, array.Offset, array.Count);
-			} else {
-				_fileStream.Write(buf.Span);
-			}
+		if (MemoryMarshal.TryGetArray(buf, out var array)) {
+			_fileStream?.Write(array.Array, array.Offset, array.Count);
+			_memStream?.Write(array.Array, array.Offset, array.Count);
+		} else {
+			_fileStream?.Write(buf.Span);
+			_memStream?.Write(buf.Span);
 		}
-
-		//MEMORY
-		_memStream?.Write(buf.Span);
 	}
 
 	public void ResizeStream(int fileSize) {

--- a/src/EventStore.Licensing/EventStore.Licensing.csproj
+++ b/src/EventStore.Licensing/EventStore.Licensing.csproj
@@ -10,7 +10,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="EventStore.Plugins" Version="24.10.6" />
+		<PackageReference Include="EventStore.Plugins" Version="24.10.7" />
 		<PackageReference Include="RestSharp" Version="112.0.0" />
 		<PackageReference Include="Serilog" Version="4.0.1" />
 	</ItemGroup>


### PR DESCRIPTION
Fixed: default implementation of `ChunkDataReadStream.Read(Span<byte>)` doesn't copy the input span to the rented buffer anymore