### PR TITLE
[KDB-698] Add option to limit the maximum projection state size

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -80,7 +80,8 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable {
 					TimeSpan.FromMinutes(options.Projection.ProjectionsQueryExpiry),
 					options.Projection.FaultOutOfOrderProjections,
 					options.Projection.ProjectionCompilationTimeout,
-					options.Projection.ProjectionExecutionTimeout)))
+					options.Projection.ProjectionExecutionTimeout,
+					options.Projection.MaxProjectionStateSize)))
 			: options;
 
 		if (!_options.Database.MemDb) {

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -747,10 +747,12 @@ public partial record ClusterVNodeOptions {
 		[Description("The time in milliseconds allowed for the compilation phase of user projections"),
 		 Unit("ms")]
 		public int ProjectionCompilationTimeout { get; set; } = 500;
-
 		[Description("The maximum execution time in milliseconds for executing a handler in a user projection. It can be overridden for a specific projection by setting ProjectionExecutionTimeout config for that projection"),
 		 Unit("ms")]
 		public int ProjectionExecutionTimeout { get; set; } = DefaultProjectionExecutionTimeout;
+
+		[Description("The maximum size, in bytes, of a projection's state and result. A projection will fault if its state size exceeds this value. May not exceed 16mb.")]
+		public int MaxProjectionStateSize { get; set; } = Opts.MaxProjectionStateSizeDefault;
 	}
 
 	public record UnknownOptions(IReadOnlyList<(string, string)> Options) {

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -747,6 +747,7 @@ public partial record ClusterVNodeOptions {
 		[Description("The time in milliseconds allowed for the compilation phase of user projections"),
 		 Unit("ms")]
 		public int ProjectionCompilationTimeout { get; set; } = 500;
+
 		[Description("The maximum execution time in milliseconds for executing a handler in a user projection. It can be overridden for a specific projection by setting ProjectionExecutionTimeout config for that projection"),
 		 Unit("ms")]
 		public int ProjectionExecutionTimeout { get; set; } = DefaultProjectionExecutionTimeout;

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -97,6 +97,11 @@ public static class ClusterVNodeOptionsValidator {
 			throw new InvalidConfigurationException(
 				"Only Read Only Replica nodes can be Archivers.");
 		}
+
+		if (options.Projection.MaxProjectionStateSize > TFConsts.EffectiveMaxLogRecordSize) {
+			throw new ArgumentOutOfRangeException(nameof(options.Projection.MaxProjectionStateSize),
+				$"{nameof(options.Projection.MaxProjectionStateSize)} exceeded {TFConsts.EffectiveMaxLogRecordSize} bytes.");
+		}
 	}
 
 	public static bool ValidateForStartup(ClusterVNodeOptions options) {

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -97,11 +97,6 @@ public static class ClusterVNodeOptionsValidator {
 			throw new InvalidConfigurationException(
 				"Only Read Only Replica nodes can be Archivers.");
 		}
-
-		if (options.Projection.MaxProjectionStateSize > TFConsts.EffectiveMaxLogRecordSize) {
-			throw new ArgumentOutOfRangeException(nameof(options.Projection.MaxProjectionStateSize),
-				$"{nameof(options.Projection.MaxProjectionStateSize)} exceeded {TFConsts.EffectiveMaxLogRecordSize} bytes.");
-		}
 	}
 
 	public static bool ValidateForStartup(ClusterVNodeOptions options) {

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -19,7 +19,7 @@ public static class Opts {
 
 	public const int ProjectionsQueryExpiryDefault = 5;
 
-	public const int MaxProjectionStateSizeDefault = 8 * 1024 * 1024;
+	public const int MaxProjectionStateSizeDefault = int.MaxValue;
 
 	public const byte IndexBitnessVersionDefault = Index.PTableVersions.IndexV4;
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -10,7 +10,7 @@ namespace EventStore.Core.Util;
 
 public static class Opts {
 	public const int ConnectionPendingSendBytesThresholdDefault = 10 * 1024 * 1024;
-	
+
 	public const int ConnectionQueueSizeThresholdDefault = 50000;
 
 	public const int HashCollisionReadLimitDefault = 100;
@@ -18,6 +18,8 @@ public static class Opts {
 	public const bool FaultOutOfOrderProjectionsDefault = false;
 
 	public const int ProjectionsQueryExpiryDefault = 5;
+
+	public const int MaxProjectionStateSizeDefault = 8 * 1024 * 1024;
 
 	public const byte IndexBitnessVersionDefault = Index.PTableVersions.IndexV4;
 

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
@@ -11,6 +11,7 @@ using EventStore.Core.Services.Transport.Http;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Util;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -28,7 +29,7 @@ public abstract class ProjectionRuntimeScenario: SubsystemScenario {
 	}
 
 	static (Action, IPublisher) CreateRuntime(SynchronousScheduler mainBus, IQueuedHandler mainQueue, ICheckpoint writerCheckpoint) {
-		var options = new ProjectionSubsystemOptions(3, ProjectionType.All, true, TimeSpan.FromMinutes(5), false, 500, 500);
+		var options = new ProjectionSubsystemOptions(3, ProjectionType.All, true, TimeSpan.FromMinutes(5), false, 500, 500, Opts.MaxProjectionStateSizeDefault);
 		var config = new TFChunkDbConfig("mem", new VersionedPatternFileNamingStrategy("mem", "chunk-"), 10000, 0, writerCheckpoint, new InMemoryCheckpoint(-1), new InMemoryCheckpoint(-1), new InMemoryCheckpoint(-1), new InMemoryCheckpoint(-1), new InMemoryCheckpoint(-1), new InMemoryCheckpoint(-1), new InMemoryCheckpoint(-1), true);
 		var db = new TFChunkDb(config);
 		var qs = new QueueStatsManager();

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -119,7 +119,7 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 	}
 
 	private MiniClusterNode<TLogFormat, TStreamId> CreateNode(int index, Endpoints endpoints, EndPoint[] gossipSeeds) {
-		_projections[index] = new ProjectionsSubsystem(new ProjectionSubsystemOptions(1, ProjectionType.All, false, TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), Opts.FaultOutOfOrderProjectionsDefault, 500, 250));
+		_projections[index] = new ProjectionsSubsystem(new ProjectionSubsystemOptions(1, ProjectionType.All, false, TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), Opts.FaultOutOfOrderProjectionsDefault, 500, 250, Opts.MaxProjectionStateSizeDefault));
 		var node = new MiniClusterNode<TLogFormat, TStreamId>(
 			PathName, index, endpoints.InternalTcp,
 			endpoints.ExternalTcp, endpoints.HttpEndPoint,

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
@@ -74,7 +74,7 @@ public abstract class SpecificationWithNodeAndProjectionsManager<TLogFormat, TSt
 	public abstract Task When();
 
 	protected MiniNode<TLogFormat, TStreamId> CreateNode() {
-		_projectionsSubsystem = new ProjectionsSubsystem(new ProjectionSubsystemOptions(1, ProjectionType.All, false, TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), Opts.FaultOutOfOrderProjectionsDefault, 500, 250));
+		_projectionsSubsystem = new ProjectionsSubsystem(new ProjectionSubsystemOptions(1, ProjectionType.All, false, TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), Opts.FaultOutOfOrderProjectionsDefault, 500, 250, Opts.MaxProjectionStateSizeDefault));
 		_systemProjectionsCreated = SystemProjections.Created(_projectionsSubsystem.LeaderInputBus);
 		return new MiniNode<TLogFormat, TStreamId>(
 			PathName, inMemDb: true,

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -43,7 +43,7 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 			TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
 			Opts.FaultOutOfOrderProjectionsDefault,
 			500,
-			250);
+			250, Opts.MaxProjectionStateSizeDefault);
 		_projections = new ProjectionsSubsystem(configuration);
 		_node = new MiniNode<TLogFormat, TStreamId>(
 			PathName, inMemDb: true,

--- a/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
@@ -13,6 +13,7 @@ using EventStore.Core.Services.Monitoring.Stats;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Bus.Helpers;
 using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
@@ -106,7 +107,7 @@ public class TestFixtureWithProjectionCoreService {
 		_workerId = Guid.NewGuid();
 		var guardBus = new GuardBusToTriggerFixingIfUsed();
 		var configuration = new ProjectionsStandardComponents(1, ProjectionType.All, guardBus, guardBus, guardBus, guardBus, true,
-			 500, 250);
+			 500, 250, Opts.MaxProjectionStateSizeDefault);
 		_service = new ProjectionCoreService(
 			_workerId, _bus, _bus, _subscriptionDispatcher, new RealTimeProvider(), ioDispatcher, configuration);
 		_bus.Subscribe(

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Bus.Helpers;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -84,13 +85,13 @@ public abstract class TestFixtureWithCoreProjection<TLogFormat, TStreamId> : Tes
 	protected ProjectionProcessingStrategy CreateProjectionProcessingStrategy() {
 		return new ContinuousProjectionProcessingStrategy(
 			_projectionName, _version, _stateHandler, _projectionConfig, _stateHandler.GetSourceDefinition(), null,
-			_subscriptionDispatcher, true);
+			_subscriptionDispatcher, true, Opts.MaxProjectionStateSizeDefault);
 	}
 
 	protected ProjectionProcessingStrategy CreateQueryProcessingStrategy() {
 		return new QueryProcessingStrategy(
 			_projectionName, _version, _stateHandler, _projectionConfig, _stateHandler.GetSourceDefinition(), null,
-			_subscriptionDispatcher, true);
+			_subscriptionDispatcher, true, Opts.MaxProjectionStateSizeDefault);
 	}
 
 	protected virtual ProjectionConfig GivenProjectionConfig() {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/FakeCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/FakeCoreProjection.cs
@@ -24,6 +24,9 @@ public class FakeCoreProjection : ICoreProjection,
 	public readonly List<CoreProjectionProcessingMessage.PrerecordedEventsLoaded> _prerecordedEventsLoadedMessages =
 		new List<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>();
 
+	public readonly List<CoreProjectionProcessingMessage.Failed> _failedMessages =
+		new List<CoreProjectionProcessingMessage.Failed>();
+
 	public void Handle(CoreProjectionProcessingMessage.CheckpointCompleted message) {
 		_checkpointCompletedMessages.Add(message);
 	}
@@ -37,7 +40,7 @@ public class FakeCoreProjection : ICoreProjection,
 	}
 
 	public void Handle(CoreProjectionProcessingMessage.Failed message) {
-		throw new System.NotImplementedException();
+		_failedMessages.Add(message);
 	}
 
 	public void Handle(CoreProjectionProcessingMessage.PrerecordedEventsLoaded message) {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -36,6 +36,7 @@ public abstract class TestFixtureWithCoreProjectionCheckpointManager<TLogFormat,
 	protected CoreProjectionCheckpointReader _checkpointReader;
 	protected string _projectionName;
 	protected ProjectionVersion _projectionVersion;
+	protected int _maxProjectionStateSize = Opts.MaxProjectionStateSizeDefault;
 
 	[SetUp]
 	public void setup() {
@@ -64,7 +65,7 @@ public abstract class TestFixtureWithCoreProjectionCheckpointManager<TLogFormat,
 			_bus, _projectionCorrelationId, _projectionVersion, null, _ioDispatcher, _config, _projectionName,
 			new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled, _producesResults,
 			_definesFold,
-			_checkpointWriter, Opts.MaxProjectionStateSizeDefault);
+			_checkpointWriter, _maxProjectionStateSize);
 	}
 
 	protected new virtual void Given() {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
@@ -51,7 +52,7 @@ public abstract class TestFixtureWithCoreProjectionCheckpointManager<TLogFormat,
 		_projectionVersion = new ProjectionVersion(1, 0, 0);
 		_projectionName = "projection";
 		_checkpointWriter = new CoreProjectionCheckpointWriter(
-			_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, _projectionVersion, _projectionName);
+			_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, _projectionVersion, _projectionName, Opts.MaxProjectionStateSizeDefault);
 		_checkpointReader = new CoreProjectionCheckpointReader(
 			GetInputQueue(), _projectionCorrelationId, _ioDispatcher, _projectionCheckpointStreamId,
 			_projectionVersion, _checkpointsEnabled);
@@ -63,7 +64,7 @@ public abstract class TestFixtureWithCoreProjectionCheckpointManager<TLogFormat,
 			_bus, _projectionCorrelationId, _projectionVersion, null, _ioDispatcher, _config, _projectionName,
 			new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled, _producesResults,
 			_definesFold,
-			_checkpointWriter);
+			_checkpointWriter, Opts.MaxProjectionStateSizeDefault);
 	}
 
 	protected new virtual void Given() {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -52,7 +52,7 @@ public abstract class TestFixtureWithCoreProjectionCheckpointManager<TLogFormat,
 		_projectionVersion = new ProjectionVersion(1, 0, 0);
 		_projectionName = "projection";
 		_checkpointWriter = new CoreProjectionCheckpointWriter(
-			_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, _projectionVersion, _projectionName, Opts.MaxProjectionStateSizeDefault);
+			_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, _projectionVersion, _projectionName);
 		_checkpointReader = new CoreProjectionCheckpointReader(
 			GetInputQueue(), _projectionCorrelationId, _ioDispatcher, _projectionCheckpointStreamId,
 			_projectionVersion, _checkpointsEnabled);

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/TestFixtureWithMultiStreamCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/TestFixtureWithMultiStreamCheckpointManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Checkpointing;
 using EventStore.Projections.Core.Services.Processing.MultiStream;
@@ -20,6 +21,6 @@ public abstract class TestFixtureWithMultiStreamCheckpointManager<TLogFormat, TS
 		return new MultiStreamMultiOutputCheckpointManager(
 			_bus, _projectionCorrelationId, _projectionVersion, null, _ioDispatcher, _config, _projectionName,
 			new MultiStreamPositionTagger(0, _streams), _namingBuilder, _checkpointsEnabled, true, true,
-			_checkpointWriter);
+			_checkpointWriter, Opts.MaxProjectionStateSizeDefault);
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
@@ -52,7 +52,7 @@ public abstract class with_multi_stream_checkpoint_manager<TLogFormat, TStreamId
 
 		_coreProjectionCheckpointWriter = new CoreProjectionCheckpointWriter(
 			_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher,
-			_projectionVersion, _projectionName, Opts.MaxProjectionStateSizeDefault);
+			_projectionVersion, _projectionName);
 
 		_checkpointManager = new MultiStreamMultiOutputCheckpointManager(_bus, _projectionId, _projectionVersion,
 			SystemAccounts.System,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Checkpointing;
@@ -51,12 +52,12 @@ public abstract class with_multi_stream_checkpoint_manager<TLogFormat, TStreamId
 
 		_coreProjectionCheckpointWriter = new CoreProjectionCheckpointWriter(
 			_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher,
-			_projectionVersion, _projectionName);
+			_projectionVersion, _projectionName, Opts.MaxProjectionStateSizeDefault);
 
 		_checkpointManager = new MultiStreamMultiOutputCheckpointManager(_bus, _projectionId, _projectionVersion,
 			SystemAccounts.System,
 			_ioDispatcher, _projectionConfig, _projectionName, _positionTagger, _namingBuilder, true, true, false,
-			_coreProjectionCheckpointWriter);
+			_coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 
 		When();
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_creating_a_default_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_creating_a_default_checkpoint_manager.cs
@@ -20,7 +20,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 		// do not create
 		_coreProjectionCheckpointWriter =
 			new CoreProjectionCheckpointWriter(
-				_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, _projectionVersion, _projectionName, Opts.MaxProjectionStateSizeDefault);
+				_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, _projectionVersion, _projectionName);
 		_namingBuilder = ProjectionNamesBuilder.CreateForTest("projection");
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_creating_a_default_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_creating_a_default_checkpoint_manager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using EventStore.Core.Tests;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Checkpointing;
 using EventStore.Projections.Core.Services.Processing.SingleStream;
@@ -19,7 +20,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 		// do not create
 		_coreProjectionCheckpointWriter =
 			new CoreProjectionCheckpointWriter(
-				_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, _projectionVersion, _projectionName);
+				_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, _projectionVersion, _projectionName, Opts.MaxProjectionStateSizeDefault);
 		_namingBuilder = ProjectionNamesBuilder.CreateForTest("projection");
 	}
 
@@ -28,7 +29,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 		_manager = new DefaultCheckpointManager(
 			_bus, _projectionCorrelationId, new ProjectionVersion(1, 0, 0), null, _ioDispatcher, _config,
 			"projection", new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled,
-			_producesResults, _definesFold, _coreProjectionCheckpointWriter);
+			_producesResults, _definesFold, _coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 	}
 
 	[Test]
@@ -37,7 +38,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 			_manager = new DefaultCheckpointManager(
 				null, _projectionCorrelationId, new ProjectionVersion(1, 0, 0), null, _ioDispatcher, _config,
 				"projection", new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled,
-				_producesResults, _definesFold, _coreProjectionCheckpointWriter);
+				_producesResults, _definesFold, _coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 		});
 	}
 
@@ -47,7 +48,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 			_manager = new DefaultCheckpointManager(
 				_bus, _projectionCorrelationId, new ProjectionVersion(1, 0, 0), null, null, _config, "projection",
 				new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled, _producesResults,
-				_definesFold, _coreProjectionCheckpointWriter);
+				_definesFold, _coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 		});
 	}
 
@@ -58,7 +59,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 				_bus, _projectionCorrelationId, new ProjectionVersion(1, 0, 0), null, _ioDispatcher, null,
 				"projection",
 				new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled, _producesResults,
-				_definesFold, _coreProjectionCheckpointWriter);
+				_definesFold, _coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 		});
 	}
 
@@ -68,7 +69,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 			_manager = new DefaultCheckpointManager(
 				_bus, _projectionCorrelationId, new ProjectionVersion(1, 0, 0), null, _ioDispatcher, _config, null,
 				new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled, _producesResults,
-				_definesFold, _coreProjectionCheckpointWriter);
+				_definesFold, _coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 		});
 	}
 
@@ -78,7 +79,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 			_manager = new DefaultCheckpointManager(
 				_bus, _projectionCorrelationId, new ProjectionVersion(1, 0, 0), null, _ioDispatcher, _config,
 				"projection", null, _namingBuilder, _checkpointsEnabled, _producesResults,
-				_definesFold, _coreProjectionCheckpointWriter);
+				_definesFold, _coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 		});
 	}
 
@@ -88,7 +89,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 			_manager = new DefaultCheckpointManager(
 				_bus, _projectionCorrelationId, new ProjectionVersion(1, 0, 0), null, _ioDispatcher, _config, "",
 				new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled, _producesResults,
-				_definesFold, _coreProjectionCheckpointWriter);
+				_definesFold, _coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 		});
 	}
 
@@ -98,7 +99,7 @@ public class when_creating_a_default_checkpoint_manager<TLogFormat, TStreamId> :
 			_manager = new DefaultCheckpointManager(
 				_bus, _projectionCorrelationId, new ProjectionVersion(1, 0, 0), null, _ioDispatcher, _config, "",
 				new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled, _producesResults,
-				_definesFold, _coreProjectionCheckpointWriter);
+				_definesFold, _coreProjectionCheckpointWriter, Opts.MaxProjectionStateSizeDefault);
 		});
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using EventStore.Core.Tests;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing.Checkpointing;
+using EventStore.Projections.Core.Services.Processing.Partitioning;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_projection_state_is_too_large<TLogFormat, TStreamId> :
+	TestFixtureWithCoreProjectionCheckpointManager<TLogFormat, TStreamId> {
+	private Exception _exception;
+
+	protected override void Given() {
+		AllWritesSucceed();
+		base.Given();
+		this._checkpointHandledThreshold = 2;
+		this._maxProjectionStateSize = 1024 * 1024;
+	}
+
+	protected override void When() {
+		base.When();
+		_exception = null;
+		try {
+			_checkpointReader.BeginLoadState();
+			var checkpointLoaded =
+				_consumer.HandledMessages.OfType<CoreProjectionProcessingMessage.CheckpointLoaded>().First();
+			_checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
+			_manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
+
+			// Initial checkpoint and state
+			var initialCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 10);
+			_manager.Start(initialCheckpointTag, null);
+			var oldState = new PartitionState("", "", initialCheckpointTag);
+
+			// checkpoint and state after first event processed
+			var firstEventCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 11);
+			var newState = new PartitionState("{ \"state\": \"foo\"}", "",
+				firstEventCheckpointTag);
+			_manager.StateUpdated("", oldState, newState);
+			_manager.EventProcessed(firstEventCheckpointTag, 55.5f);
+
+			// second event processed fails, as the state is too large
+			var secondEventCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 12);
+			oldState = newState;
+			newState = new PartitionState($"{{ \"state\": \"{new string('*', _maxProjectionStateSize)}\"}}", "",
+				firstEventCheckpointTag);
+			_manager.StateUpdated("", oldState, newState);
+			_manager.EventProcessed(secondEventCheckpointTag, 77.7f);
+		} catch (Exception ex) {
+			_exception = ex;
+		}
+	}
+
+	[Test]
+	public void messages_are_handled() {
+		Assert.IsNull(_exception);
+	}
+
+	[Test]
+	public void publishes_projection_failed_message() {
+		var failedMessages = _consumer.HandledMessages.OfType<CoreProjectionProcessingMessage.Failed>().ToArray();
+		Assert.AreEqual(1, failedMessages.Length);
+		Assert.True(failedMessages[0].Reason.Contains("exceeds the configured MaxProjectionStateSize"));
+	}
+
+	[Test]
+	public void the_second_event_is_not_processed() {
+		var stats = new ProjectionStatistics();
+		_manager.GetStatistics(stats);
+		Assert.AreEqual(1, stats.EventsProcessedAfterRestart);
+		Assert.AreEqual(55.5f, stats.Progress);
+		Assert.AreEqual(CheckpointTag.FromStreamPosition(0, "stream", 11).ToString(), stats.Position);
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/multi_phase/specification_with_multi_phase_core_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/multi_phase/specification_with_multi_phase_core_projection.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using EventStore.Core.Bus;
 using EventStore.Core.Helpers;
 using EventStore.Core.Services.TimerService;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
@@ -38,7 +39,7 @@ abstract class specification_with_multi_phase_core_projection<TLogFormat, TStrea
 		public FakeProjectionProcessingStrategy(
 			string name, ProjectionVersion projectionVersion, ILogger logger, FakeProjectionProcessingPhase phase1,
 			FakeProjectionProcessingPhase phase2)
-			: base(name, projectionVersion, logger) {
+			: base(name, projectionVersion, logger, Opts.MaxProjectionStateSizeDefault) {
 			_phase1 = phase1;
 			_phase2 = phase2;
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Helpers;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Strategies;
@@ -47,7 +48,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -74,7 +75,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -99,7 +100,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -124,7 +125,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -149,7 +150,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -174,7 +175,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				null,
 				Guid.NewGuid(),
@@ -198,7 +199,7 @@ public class when_creating_a_projection {
 			projectionStateHandler.GetSourceDefinition(),
 			null,
 			_subscriptionDispatcher,
-			true).Create(
+			true, Opts.MaxProjectionStateSizeDefault).Create(
 			Guid.NewGuid(),
 			new FakePublisher(),
 			Guid.NewGuid(),
@@ -222,7 +223,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -247,7 +248,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -274,7 +275,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -299,7 +300,7 @@ public class when_creating_a_projection {
 				projectionStateHandler.GetSourceDefinition(),
 				null,
 				_subscriptionDispatcher,
-				true).Create(
+				true, Opts.MaxProjectionStateSizeDefault).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Bus.Helpers;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
@@ -63,7 +64,7 @@ public class when_starting_a_projection {
 		var version = new ProjectionVersion(1, 0, 0);
 		var projectionProcessingStrategy = new ContinuousProjectionProcessingStrategy(
 			"projection", version, projectionStateHandler, _projectionConfig,
-			projectionStateHandler.GetSourceDefinition(), null, _subscriptionDispatcher, true);
+			projectionStateHandler.GetSourceDefinition(), null, _subscriptionDispatcher, true, Opts.MaxProjectionStateSizeDefault);
 		_coreProjection = projectionProcessingStrategy.Create(
 			Guid.NewGuid(),
 			_bus,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -190,7 +190,7 @@ public abstract class TestFixtureWithProjectionCoreAndManagementServices<TLogFor
 
 		var guardBus = new GuardBusToTriggerFixingIfUsed();
 		var configuration = new ProjectionsStandardComponents(1, ProjectionType.All, guardBus, guardBus, guardBus, guardBus, true,
-			500, 250);
+			500, 250, Opts.MaxProjectionStateSizeDefault);
 		var coreService = new ProjectionCoreService(
 			workerId,
 			inputQueue,

--- a/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
@@ -12,6 +12,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
@@ -61,7 +62,7 @@ public class TestFixtureWithProjectionSubsystem {
 		builder.Services.AddSingleton(_standardComponents);
 
 		Subsystem = new ProjectionsSubsystem(
-			new ProjectionSubsystemOptions(1, ProjectionType.All, true, TimeSpan.FromSeconds(3), true, 500, 250));
+			new ProjectionSubsystemOptions(1, ProjectionType.All, true, TimeSpan.FromSeconds(3), true, 500, 250, Opts.MaxProjectionStateSizeDefault));
 
 		Subsystem.ConfigureServices(builder.Services, new ConfigurationBuilder().Build());
 		Subsystem.ConfigureApplication(builder.Build().UseRouting(), EmptyConfiguration);

--- a/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
@@ -39,7 +39,7 @@ public class MultiStreamMultiOutputCheckpointManagerTests {
 		var envelope = new FakeEnvelope();
 		_ioDispatcher = new IODispatcher(_publisher, envelope);
 		_checkpointWriter = new CoreProjectionCheckpointWriter(
-				namingBuilder.MakeCheckpointStreamName(),_ioDispatcher, projectionVersion, ProjectionName, Opts.MaxProjectionStateSizeDefault);
+			namingBuilder.MakeCheckpointStreamName(), _ioDispatcher, projectionVersion, ProjectionName);
 		_existingStreams = new ExistingStreamsHelper();
 
 		var projectionConfig = new ProjectionConfig(SystemAccounts.System, 10, 1000, 20, 2,

--- a/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
@@ -21,7 +21,7 @@ using ExistingEvent = EventStore.Projections.Core.XUnit.Tests.TestHelpers.Existi
 namespace EventStore.Projections.Core.XUnit.Tests.CheckpointManagers;
 
 /// More tests for MultiStreamMultiOutputCheckpointManager exist in the NUnit tests,
-/// and derive from <see cref="Services.core_projection.checkpoint_manager.multi_stream.TestFixtureWithMultiStreamCheckpointManager"/>
+/// and derive from <see cref="Core.Tests.Services.core_projection.checkpoint_manager.multi_stream.TestFixtureWithMultiStreamCheckpointManager"/>
 public class MultiStreamMultiOutputCheckpointManagerTests {
 	private const string ProjectionName = "test-projection";
 	private const string OrderStreamName = $"$projections-{ProjectionName}-order";

--- a/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
@@ -14,7 +14,6 @@ using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Checkpointing;
 using EventStore.Projections.Core.Services.Processing.MultiStream;
 using EventStore.Projections.Core.XUnit.Tests.TestHelpers;
-using FluentAssertions.Common;
 using Xunit;
 using ExistingEvent = EventStore.Projections.Core.XUnit.Tests.TestHelpers.ExistingStreamsHelper.ExistingEvent;
 

--- a/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/CheckpointManagers/MultiStreamMultiOutputCheckpointManagerTests.cs
@@ -7,19 +7,21 @@ using EventStore.Core.Services;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Services.Replication;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Checkpointing;
 using EventStore.Projections.Core.Services.Processing.MultiStream;
 using EventStore.Projections.Core.XUnit.Tests.TestHelpers;
+using FluentAssertions.Common;
 using Xunit;
 using ExistingEvent = EventStore.Projections.Core.XUnit.Tests.TestHelpers.ExistingStreamsHelper.ExistingEvent;
 
 namespace EventStore.Projections.Core.XUnit.Tests.CheckpointManagers;
 
 /// More tests for MultiStreamMultiOutputCheckpointManager exist in the NUnit tests,
-/// and derive from <see cref="EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager.multi_stream.TestFixtureWithMultiStreamCheckpointManager"/>
+/// and derive from <see cref="Services.core_projection.checkpoint_manager.multi_stream.TestFixtureWithMultiStreamCheckpointManager"/>
 public class MultiStreamMultiOutputCheckpointManagerTests {
 	private const string ProjectionName = "test-projection";
 	private const string OrderStreamName = $"$projections-{ProjectionName}-order";
@@ -38,7 +40,7 @@ public class MultiStreamMultiOutputCheckpointManagerTests {
 		var envelope = new FakeEnvelope();
 		_ioDispatcher = new IODispatcher(_publisher, envelope);
 		_checkpointWriter = new CoreProjectionCheckpointWriter(
-				namingBuilder.MakeCheckpointStreamName(),_ioDispatcher, projectionVersion, ProjectionName);
+				namingBuilder.MakeCheckpointStreamName(),_ioDispatcher, projectionVersion, ProjectionName, Opts.MaxProjectionStateSizeDefault);
 		_existingStreams = new ExistingStreamsHelper();
 
 		var projectionConfig = new ProjectionConfig(SystemAccounts.System, 10, 1000, 20, 2,
@@ -48,7 +50,7 @@ public class MultiStreamMultiOutputCheckpointManagerTests {
 		_sut = new MultiStreamMultiOutputCheckpointManager(
 			_publisher, projectionId, projectionVersion, SystemAccounts.System, _ioDispatcher, projectionConfig, ProjectionName,
 			positionTagger, namingBuilder, usePersistentCheckpoints: true, producesRunningResults: true, definesFold: false,
-			_checkpointWriter);
+			_checkpointWriter, Opts.MaxProjectionStateSizeDefault);
 	}
 
 	[Theory]

--- a/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
+++ b/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
@@ -43,5 +43,6 @@ public class ProjectionsStandardComponents {
 	public int ProjectionCompilationTimeout { get; }
 
 	public int ProjectionExecutionTimeout { get; }
+
 	public int MaxProjectionStateSize { get; }
 }

--- a/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
+++ b/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
@@ -14,7 +14,8 @@ public class ProjectionsStandardComponents {
 		IPublisher leaderOutputQueue,
 		ISubscriber leaderInputBus,
 		IPublisher leaderInputQueue,
-		bool faultOutOfOrderProjections, int projectionCompilationTimeout, int projectionExecutionTimeout) {
+		bool faultOutOfOrderProjections, int projectionCompilationTimeout, int projectionExecutionTimeout,
+		int maxProjectionStateSize) {
 		ProjectionWorkerThreadCount = projectionWorkerThreadCount;
 		RunProjections = runProjections;
 		LeaderOutputBus = leaderOutputBus;
@@ -24,6 +25,7 @@ public class ProjectionsStandardComponents {
 		FaultOutOfOrderProjections = faultOutOfOrderProjections;
 		ProjectionCompilationTimeout = projectionCompilationTimeout;
 		ProjectionExecutionTimeout = projectionExecutionTimeout;
+		MaxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	public int ProjectionWorkerThreadCount { get; }
@@ -41,4 +43,5 @@ public class ProjectionsStandardComponents {
 	public int ProjectionCompilationTimeout { get; }
 
 	public int ProjectionExecutionTimeout { get; }
+	public int MaxProjectionStateSize { get; }
 }

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -33,7 +33,8 @@ public record ProjectionSubsystemOptions(
 	TimeSpan ProjectionQueryExpiry,
 	bool FaultOutOfOrderProjections,
 	int CompilationTimeout,
-	int ExecutionTimeout);
+	int ExecutionTimeout,
+	int MaxProjectionStateSize);
 
 public sealed class ProjectionsSubsystem : ISubsystem,
 	IHandle<SystemMessage.SystemCoreReady>,
@@ -70,6 +71,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 
 	private readonly int _compilationTimeout;
 	private readonly int _executionTimeout;
+	private readonly int _maxProjectionStateSize;
 
 	private readonly int _componentCount;
 	private readonly int _dispatcherCount;
@@ -115,6 +117,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 		_subsystemInitialized = new();
 		_executionTimeout = projectionSubsystemOptions.ExecutionTimeout;
 		_compilationTimeout = projectionSubsystemOptions.CompilationTimeout;
+		_maxProjectionStateSize = projectionSubsystemOptions.MaxProjectionStateSize;
 	}
 
 	public IPublisher LeaderOutputQueue => _leaderOutputQueue;
@@ -161,7 +164,8 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 			leaderInputQueue: _leaderInputQueue,
 			_faultOutOfOrderProjections,
 			_compilationTimeout,
-			_executionTimeout);
+			_executionTimeout,
+			_maxProjectionStateSize);
 
 		CreateAwakerService(standardComponents);
 		_coreWorkers = ProjectionCoreWorkersNode.CreateCoreWorkers(standardComponents, projectionsStandardComponents);

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Diagnostics.Contracts;
 using EventStore.Core.Bus;
+using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Processing.Emitting.EmittedEvents;
 using EventStore.Projections.Core.Services.Processing.Partitioning;
-using Serilog;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Projections.Core.Services.Processing.Checkpointing;
@@ -18,6 +18,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 	protected readonly ProjectionNamesBuilder _namingBuilder;
 	protected readonly ProjectionConfig _projectionConfig;
 	protected readonly ILogger _logger;
+	protected readonly int _maxProjectionStateSize;
 
 	private readonly bool _usePersistentCheckpoints;
 
@@ -41,7 +42,6 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 	protected bool _stopped;
 
 	private PartitionState _currentProjectionState;
-	private bool _largeStateWarningLogged = false;
 
 	protected CoreProjectionCheckpointManager(
 		IPublisher publisher,
@@ -50,13 +50,15 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		string name,
 		PositionTagger positionTagger,
 		ProjectionNamesBuilder namingBuilder,
-		bool usePersistentCheckpoints) {
+		bool usePersistentCheckpoints,
+		int maxProjectionStateSize) {
 		if (publisher == null) throw new ArgumentNullException("publisher");
 		if (projectionConfig == null) throw new ArgumentNullException("projectionConfig");
 		if (name == null) throw new ArgumentNullException("name");
 		if (positionTagger == null) throw new ArgumentNullException("positionTagger");
 		if (namingBuilder == null) throw new ArgumentNullException("namingBuilder");
 		if (name == "") throw new ArgumentException("name");
+		if (maxProjectionStateSize == 0) throw new ArgumentException(nameof(maxProjectionStateSize));
 
 		_lastProcessedEventPosition = new PositionTracker(positionTagger);
 		_zeroTag = positionTagger.MakeZeroCheckpointTag();
@@ -69,6 +71,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		_usePersistentCheckpoints = usePersistentCheckpoints;
 		_requestedCheckpointState = new PartitionState("", null, _zeroTag);
 		_currentProjectionState = new PartitionState("", null, _zeroTag);
+		_maxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	protected abstract ProjectionCheckpoint CreateProjectionCheckpoint(CheckpointTag checkpointPosition);
@@ -187,19 +190,11 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 	}
 
 	private void CheckStateSize(PartitionState result , string partition) {
-		if (!_largeStateWarningLogged && result.Size >= 8_000_000 && !partition.Equals("")) {
-			Log.Warning(
-				"State size for the Projection {projectionName} for Partition {partitionName} is greater than 8 MB. State size for a projection must be less than 16 MB. Current state size for Partition {partitionName} is {stateSize} MB.",
-				_namingBuilder.EffectiveProjectionName, partition, partition,
-				result.Size / Math.Pow(10, 6));
-			_largeStateWarningLogged = true;
-		}
-		else if (!_largeStateWarningLogged && result.Size >= 8_000_000 && partition.Equals("") ) {
-			Log.Warning(
-				"State size for the Projection {projectionName} is greater than 8 MB. State size for a projection must be less than 16 MB. Current state size for Projection {projectionName} is {stateSize} MB.",
-				_namingBuilder.EffectiveProjectionName, _namingBuilder.EffectiveProjectionName,
-				result.Size / Math.Pow(10, 6));
-			_largeStateWarningLogged = true;
+		if (result.Size >= _maxProjectionStateSize) {
+			var partitionMessage = partition == string.Empty ? string.Empty : $" in partition '{partition}'";
+			Failed(
+				$"The state size of projection '{_namingBuilder.EffectiveProjectionName}'{partitionMessage} " +
+				$"exceeds the maximum projection state size of {_maxProjectionStateSize} bytes. Current state size: {result.Size}");
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics.Contracts;
 using EventStore.Core.Bus;
-using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Processing.Emitting.EmittedEvents;
 using EventStore.Projections.Core.Services.Processing.Partitioning;

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -189,7 +189,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 	}
 
 	private void CheckStateSize(PartitionState result , string partition) {
-		if (result.Size >= _maxProjectionStateSize) {
+		if (result.Size > _maxProjectionStateSize) {
 			var partitionMessage = partition == string.Empty ? string.Empty : $" in partition '{partition}'";
 			Failed(
 				$"The state size of projection '{_namingBuilder.EffectiveProjectionName}'{partitionMessage} " +

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -192,8 +192,8 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		if (result.Size > _maxProjectionStateSize) {
 			var partitionMessage = partition == string.Empty ? string.Empty : $" in partition '{partition}'";
 			Failed(
-				$"The state size of projection '{_namingBuilder.EffectiveProjectionName}'{partitionMessage} " +
-				$"exceeds the maximum projection state size of {_maxProjectionStateSize} bytes. Current state size: {result.Size}");
+				$"The state size of projection '{_namingBuilder.EffectiveProjectionName}'{partitionMessage} is {result.Size:N0} bytes " +
+				$"which exceeds the configured MaxProjectionStateSize of {_maxProjectionStateSize:N0} bytes.");
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -57,7 +57,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		if (positionTagger == null) throw new ArgumentNullException("positionTagger");
 		if (namingBuilder == null) throw new ArgumentNullException("namingBuilder");
 		if (name == "") throw new ArgumentException("name");
-		if (maxProjectionStateSize == 0) throw new ArgumentException(nameof(maxProjectionStateSize));
+		if (maxProjectionStateSize <= 0) throw new ArgumentException(nameof(maxProjectionStateSize));
 
 		_lastProcessedEventPosition = new PositionTracker(positionTagger);
 		_zeroTag = positionTagger.MakeZeroCheckpointTag();

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
@@ -175,7 +175,7 @@ public class CoreProjectionCheckpointWriter {
 	}
 
 	private void CheckpointStateSizeCheck() {
-		if (_checkpointEventToBePublished.Data.Length >= _maxProjectionStateSize) {
+		if (_checkpointEventToBePublished.Data.Length > _maxProjectionStateSize) {
 			_envelope.ReplyWith(new CoreProjectionProcessingMessage.Failed(Guid.Empty,
 				$"Projection '{_name}' attempted to write a checkpoint with a state size that exceeds the maximum projection state size of {_maxProjectionStateSize}. " +
 				$"Attempted to create an event of {_checkpointEventToBePublished.Data.Length} bytes."

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
@@ -9,7 +9,6 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
 using EventStore.Core.Services.UserManagement;
-using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
 using ILogger = Serilog.ILogger;
 

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
@@ -32,7 +32,7 @@ public class CoreProjectionCheckpointWriter {
 	private const int MinAttemptWarnThreshold = 5;
 	private bool _metaStreamWritten;
 	private Random _random = new Random();
-	private bool _largeCheckpointStateWarningLogged = false;
+	private bool _largeCheckpointWarningLogged = false;
 
 	public CoreProjectionCheckpointWriter(
 		string projectionCheckpointStreamId, IODispatcher ioDispatcher, ProjectionVersion projectionVersion,
@@ -167,20 +167,20 @@ public class CoreProjectionCheckpointWriter {
 	}
 
 	private void PublishWriteCheckpointEvent() {
-		CheckpointStateSizeCheck();
+		CheckpointSizeCheck();
 		_writeRequestId = _ioDispatcher.WriteEvent(
 			_projectionCheckpointStreamId, _lastWrittenCheckpointEventNumber, _checkpointEventToBePublished,
 			SystemAccounts.System,
 			msg => WriteCheckpointEventCompleted(_projectionCheckpointStreamId, msg.Result, msg.FirstEventNumber));
 	}
 
-	private void CheckpointStateSizeCheck() {
-		if (!_largeCheckpointStateWarningLogged && _checkpointEventToBePublished.Data.Length >= 8_000_000) {
+	private void CheckpointSizeCheck() {
+		if (!_largeCheckpointWarningLogged && _checkpointEventToBePublished.Data.Length >= 8_000_000) {
 			Log.Warning(
-				"State size for the Projection {projectionName} is greater than 8 MB. State size for a projection should be less than 16 MB. Current state size for Projection {projectionName} is {stateSize} MB.",
+				"Checkpoint size for the Projection {projectionName} is greater than 8 MB. Checkpoint size for a projection should be less than 16 MB. Current checkpoint size for Projection {projectionName} is {stateSize} MB.",
 				_name, _name,
 				_checkpointEventToBePublished.Data.Length / Math.Pow(10, 6));
-			_largeCheckpointStateWarningLogged = true;
+			_largeCheckpointWarningLogged = true;
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
@@ -177,9 +177,8 @@ public class CoreProjectionCheckpointWriter {
 	private void CheckpointStateSizeCheck() {
 		if (_checkpointEventToBePublished.Data.Length > _maxProjectionStateSize) {
 			_envelope.ReplyWith(new CoreProjectionProcessingMessage.Failed(Guid.Empty,
-				$"Projection '{_name}' attempted to write a checkpoint with a state size that exceeds the maximum projection state size of {_maxProjectionStateSize}. " +
-				$"Attempted to create an event of {_checkpointEventToBePublished.Data.Length} bytes."
-			));
+				$"Projection '{_name}' attempted to write a checkpoint with a state size {_checkpointEventToBePublished.Data.Length:N0} bytes " +
+				$"which exceeds the configured MaxProjectionStateSize of {_maxProjectionStateSize:N0} bytes."));
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
@@ -9,8 +9,8 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
 using EventStore.Core.Services.UserManagement;
+using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
-using Serilog;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Projections.Core.Services.Processing.Checkpointing;
@@ -32,16 +32,17 @@ public class CoreProjectionCheckpointWriter {
 	private const int MinAttemptWarnThreshold = 5;
 	private bool _metaStreamWritten;
 	private Random _random = new Random();
-	private bool _largeCheckpointStateWarningLogged = false;
+	private readonly int _maxProjectionStateSize;
 
 	public CoreProjectionCheckpointWriter(
 		string projectionCheckpointStreamId, IODispatcher ioDispatcher, ProjectionVersion projectionVersion,
-		string name) {
+		string name, int maxProjectionStateSize) {
 		_projectionCheckpointStreamId = projectionCheckpointStreamId;
 		_logger = Serilog.Log.ForContext<CoreProjectionCheckpointWriter>();
 		_ioDispatcher = ioDispatcher;
 		_projectionVersion = projectionVersion;
 		_name = name;
+		_maxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	public void BeginWriteCheckpoint(IEnvelope envelope,
@@ -175,12 +176,11 @@ public class CoreProjectionCheckpointWriter {
 	}
 
 	private void CheckpointStateSizeCheck() {
-		if (!_largeCheckpointStateWarningLogged && _checkpointEventToBePublished.Data.Length >= 8_000_000) {
-			Log.Warning(
-				"State size for the Projection {projectionName} is greater than 8 MB. State size for a projection should be less than 16 MB. Current state size for Projection {projectionName} is {stateSize} MB.",
-				_name, _name,
-				_checkpointEventToBePublished.Data.Length / Math.Pow(10, 6));
-			_largeCheckpointStateWarningLogged = true;
+		if (_checkpointEventToBePublished.Data.Length >= _maxProjectionStateSize) {
+			_envelope.ReplyWith(new CoreProjectionProcessingMessage.Failed(Guid.Empty,
+				$"Projection '{_name}' attempted to write a checkpoint with a state size that exceeds the maximum projection state size of {_maxProjectionStateSize}. " +
+				$"Attempted to create an event of {_checkpointEventToBePublished.Data.Length} bytes."
+			));
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/DefaultCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/DefaultCheckpointManager.cs
@@ -35,10 +35,10 @@ public class DefaultCheckpointManager : CoreProjectionCheckpointManager,
 		IODispatcher ioDispatcher, ProjectionConfig projectionConfig, string name, PositionTagger positionTagger,
 		ProjectionNamesBuilder namingBuilder, bool usePersistentCheckpoints, bool producesRunningResults,
 		bool definesFold,
-		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter)
+		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter, int maxProjectionStateSize)
 		: base(
 			publisher, projectionCorrelationId, projectionConfig, name, positionTagger, namingBuilder,
-			usePersistentCheckpoints) {
+			usePersistentCheckpoints, maxProjectionStateSize) {
 		if (ioDispatcher == null) throw new ArgumentNullException("ioDispatcher");
 		_projectionVersion = projectionVersion;
 		_runAs = runAs;

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStream/MultiStreamMultiOutputCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStream/MultiStreamMultiOutputCheckpointManager.cs
@@ -33,11 +33,11 @@ public partial class MultiStreamMultiOutputCheckpointManager : DefaultCheckpoint
 		IODispatcher ioDispatcher, ProjectionConfig projectionConfig, string name, PositionTagger positionTagger,
 		ProjectionNamesBuilder namingBuilder, bool usePersistentCheckpoints, bool producesRunningResults,
 		bool definesFold,
-		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter)
+		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter, int maxProjectionStateSize)
 		: base(
 			publisher, projectionCorrelationId, projectionVersion, runAs, ioDispatcher, projectionConfig, name,
 			positionTagger, namingBuilder, usePersistentCheckpoints, producesRunningResults, definesFold,
-			coreProjectionCheckpointWriter) {
+			coreProjectionCheckpointWriter, maxProjectionStateSize) {
 		_positionTagger = positionTagger;
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Partitioning/PartitionState.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Partitioning/PartitionState.cs
@@ -51,7 +51,7 @@ public class PartitionState {
 	private readonly string _state;
 	private readonly string _result;
 	private readonly CheckpointTag _causedBy;
-	private int _size;
+	private readonly int _size;
 
 	public PartitionState(string state, string result, CheckpointTag causedBy) {
 		if (state == null) throw new ArgumentNullException("state");
@@ -60,7 +60,7 @@ public class PartitionState {
 		_state = state;
 		_result = result;
 		_causedBy = causedBy;
-		_size = _state.Length + _result?.Length ?? 0;
+		_size = _state.Length + (_result?.Length ?? 0);
 	}
 
 	public string State {

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -72,7 +72,7 @@ public class ProjectionCoreService
 		_ioDispatcher = ioDispatcher;
 		_subscriptionDispatcher = subscriptionDispatcher;
 		_timeProvider = timeProvider;
-		_processingStrategySelector = new ProcessingStrategySelector(_subscriptionDispatcher);
+		_processingStrategySelector = new ProcessingStrategySelector(_subscriptionDispatcher, configuration.MaxProjectionStateSize);
 		_factory = new ProjectionStateHandlerFactory(TimeSpan.FromMilliseconds(configuration.ProjectionCompilationTimeout),
 			TimeSpan.FromMilliseconds(configuration.ProjectionExecutionTimeout));
 	}

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/ContinuousProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/ContinuousProjectionProcessingStrategy.cs
@@ -16,10 +16,10 @@ public class ContinuousProjectionProcessingStrategy : DefaultProjectionProcessin
 	public ContinuousProjectionProcessingStrategy(
 		string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 		ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
+		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation, int maxProjectionStateSize)
 		: base(
 			name, projectionVersion, stateHandler, projectionConfig, sourceDefinition, logger,
-			subscriptionDispatcher, enableContentTypeValidation) {
+			subscriptionDispatcher, enableContentTypeValidation, maxProjectionStateSize) {
 	}
 
 	public override bool GetStopOnEof() {

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/DefaultProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/DefaultProjectionProcessingStrategy.cs
@@ -18,8 +18,9 @@ public abstract class DefaultProjectionProcessingStrategy : EventReaderBasedProj
 	protected DefaultProjectionProcessingStrategy(
 		string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 		ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
-		: base(name, projectionVersion, projectionConfig, sourceDefinition, logger, subscriptionDispatcher, enableContentTypeValidation) {
+		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation, int maxProjectionStateSize)
+		: base(name, projectionVersion, projectionConfig, sourceDefinition, logger, subscriptionDispatcher,
+			enableContentTypeValidation, maxProjectionStateSize) {
 		_stateHandler = stateHandler;
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/EventReaderBasedProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/EventReaderBasedProjectionProcessingStrategy.cs
@@ -23,8 +23,9 @@ public abstract class EventReaderBasedProjectionProcessingStrategy : ProjectionP
 
 	protected EventReaderBasedProjectionProcessingStrategy(
 		string name, ProjectionVersion projectionVersion, ProjectionConfig projectionConfig,
-		IQuerySources sourceDefinition, Serilog.ILogger logger, ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
-		: base(name, projectionVersion, logger) {
+		IQuerySources sourceDefinition, Serilog.ILogger logger, ReaderSubscriptionDispatcher subscriptionDispatcher,
+		bool enableContentTypeValidation, int maxProjectionStateSize)
+		: base(name, projectionVersion, logger, maxProjectionStateSize) {
 		_projectionConfig = projectionConfig;
 		_sourceDefinition = sourceDefinition;
 		_subscriptionDispatcher = subscriptionDispatcher;
@@ -152,13 +153,13 @@ public abstract class EventReaderBasedProjectionProcessingStrategy : ProjectionP
 				publisher, projectionCorrelationId, _projectionVersion, _projectionConfig.RunAs, ioDispatcher,
 				_projectionConfig, _name, readerStrategy.PositionTagger, namingBuilder,
 				_projectionConfig.CheckpointsEnabled, GetProducesRunningResults(), definesFold,
-				coreProjectionCheckpointWriter);
+				coreProjectionCheckpointWriter, _maxProjectionStateSize);
 		} else {
 			return new DefaultCheckpointManager(
 				publisher, projectionCorrelationId, _projectionVersion, _projectionConfig.RunAs, ioDispatcher,
 				_projectionConfig, _name, readerStrategy.PositionTagger, namingBuilder,
 				_projectionConfig.CheckpointsEnabled, GetProducesRunningResults(), definesFold,
-				coreProjectionCheckpointWriter);
+				coreProjectionCheckpointWriter, _maxProjectionStateSize);
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs
@@ -9,10 +9,12 @@ namespace EventStore.Projections.Core.Services.Processing.Strategies;
 public class ProcessingStrategySelector {
 	private readonly ILogger _logger = Serilog.Log.ForContext<ProcessingStrategySelector>();
 	private readonly ReaderSubscriptionDispatcher _subscriptionDispatcher;
+	private readonly int _maxProjectionStateSize;
 
 	public ProcessingStrategySelector(
-		ReaderSubscriptionDispatcher subscriptionDispatcher) {
+		ReaderSubscriptionDispatcher subscriptionDispatcher, int maxProjectionStateSize) {
 		_subscriptionDispatcher = subscriptionDispatcher;
+		_maxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	public ProjectionProcessingStrategy CreateProjectionProcessingStrategy(
@@ -33,7 +35,8 @@ public class ProcessingStrategySelector {
 				sourceDefinition,
 				_logger,
 				_subscriptionDispatcher,
-				enableContentTypeValidation)
+				enableContentTypeValidation,
+				_maxProjectionStateSize)
 			: new ContinuousProjectionProcessingStrategy(
 				name,
 				projectionVersion,
@@ -42,6 +45,7 @@ public class ProcessingStrategySelector {
 				sourceDefinition,
 				_logger,
 				_subscriptionDispatcher,
-				enableContentTypeValidation);
+				enableContentTypeValidation,
+				_maxProjectionStateSize);
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/ProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/ProjectionProcessingStrategy.cs
@@ -18,11 +18,13 @@ public abstract class ProjectionProcessingStrategy {
 	protected readonly string _name;
 	protected readonly ProjectionVersion _projectionVersion;
 	protected readonly ILogger _logger;
+	protected readonly int _maxProjectionStateSize;
 
-	protected ProjectionProcessingStrategy(string name, ProjectionVersion projectionVersion, ILogger logger) {
+	protected ProjectionProcessingStrategy(string name, ProjectionVersion projectionVersion, ILogger logger, int maxProjectionStateSize) {
 		_name = name;
 		_projectionVersion = projectionVersion;
 		_logger = logger;
+		_maxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	public CoreProjection Create(
@@ -47,7 +49,8 @@ public abstract class ProjectionProcessingStrategy {
 				namingBuilder.MakeCheckpointStreamName(),
 				ioDispatcher,
 				_projectionVersion,
-				namingBuilder.EffectiveProjectionName);
+				namingBuilder.EffectiveProjectionName,
+				_maxProjectionStateSize);
 
 		var partitionStateCache = new PartitionStateCache();
 

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/ProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/ProjectionProcessingStrategy.cs
@@ -49,8 +49,7 @@ public abstract class ProjectionProcessingStrategy {
 				namingBuilder.MakeCheckpointStreamName(),
 				ioDispatcher,
 				_projectionVersion,
-				namingBuilder.EffectiveProjectionName,
-				_maxProjectionStateSize);
+				namingBuilder.EffectiveProjectionName);
 
 		var partitionStateCache = new PartitionStateCache();
 

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/QueryProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/QueryProcessingStrategy.cs
@@ -43,7 +43,7 @@ public class QueryProcessingStrategy : DefaultProjectionProcessingStrategy {
 		IProjectionProcessingPhase firstPhase) {
 		var coreProjectionCheckpointWriter =
 			new CoreProjectionCheckpointWriter(
-				namingBuilder.MakeCheckpointStreamName(), ioDispatcher, _projectionVersion, _name, _maxProjectionStateSize);
+				namingBuilder.MakeCheckpointStreamName(), ioDispatcher, _projectionVersion, _name);
 		var checkpointManager2 = new DefaultCheckpointManager(
 			publisher, projectionCorrelationId, _projectionVersion, SystemAccounts.System, ioDispatcher,
 			_projectionConfig, _name, new PhasePositionTagger(1), namingBuilder, GetUseCheckpoints(), false,

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/QueryProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/QueryProcessingStrategy.cs
@@ -18,10 +18,10 @@ public class QueryProcessingStrategy : DefaultProjectionProcessingStrategy {
 	public QueryProcessingStrategy(
 		string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 		ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
+		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation, int maxProjectionStateSize)
 		: base(
 			name, projectionVersion, stateHandler, projectionConfig, sourceDefinition, logger,
-			subscriptionDispatcher, enableContentTypeValidation) {
+			subscriptionDispatcher, enableContentTypeValidation, maxProjectionStateSize) {
 	}
 
 	public override bool GetStopOnEof() {
@@ -43,11 +43,11 @@ public class QueryProcessingStrategy : DefaultProjectionProcessingStrategy {
 		IProjectionProcessingPhase firstPhase) {
 		var coreProjectionCheckpointWriter =
 			new CoreProjectionCheckpointWriter(
-				namingBuilder.MakeCheckpointStreamName(), ioDispatcher, _projectionVersion, _name);
+				namingBuilder.MakeCheckpointStreamName(), ioDispatcher, _projectionVersion, _name, _maxProjectionStateSize);
 		var checkpointManager2 = new DefaultCheckpointManager(
 			publisher, projectionCorrelationId, _projectionVersion, SystemAccounts.System, ioDispatcher,
 			_projectionConfig, _name, new PhasePositionTagger(1), namingBuilder, GetUseCheckpoints(), false,
-			_sourceDefinition.DefinesFold, coreProjectionCheckpointWriter);
+			_sourceDefinition.DefinesFold, coreProjectionCheckpointWriter, _maxProjectionStateSize);
 
 		IProjectionProcessingPhase writeResultsPhase;
 		if (GetProducesRunningResults())


### PR DESCRIPTION
Adds the `MaxProjectionStateSize` option, which configures the maximum size of a projection's state before the projection should fault. This defaults to int.MaxValue.

Fault a projection if the size of the state + result exceeds the `MaxProjectionStateSize`. This replaces the warning log in `CoreProjectionCheckpointManager` that was added in https://github.com/EventStore/EventStore/pull/4276.

In the future, we could provide the option to configure the maximum state size per projection (as with `ProjectionExecutionTimeout`) so that it can be changed without restarting the node.