### PR TITLE
Add "MetricsLabelTests" collection

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Metrics/MessageLabelConfiguratorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/MessageLabelConfiguratorTests.cs
@@ -29,6 +29,7 @@ partial class ReadStreamForward : ReadMessage { }
 [DerivedMessage(TestGroup.Reads)]
 partial class ReadStreamBackward : ReadMessage { }
 
+[Collection("MetricsLabelTests")] // labels are static
 public class MessageLabelConfiguratorTests {
 	private readonly Type[] _messageTypes;
 

--- a/src/EventStore.Core.XUnit.Tests/Metrics/MetricsEndpointTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/MetricsEndpointTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Metrics;
 
+[Collection("MetricsLabelTests")]
 public class MetricsEndpointTests : DirectoryPerTest<MetricsEndpointTests> {
 	[Fact]
 	public async Task can_produce_kurrent_metrics() {


### PR DESCRIPTION
To avoid label tests running in parallel with the MiniNode. The labels are static and can interfere