### PR TITLE
[KDB-710] Make sure not to send invalid checkpoint when filtered $all subscription transitions to live

### DIFF
--- a/src/EventStore.Core.Tests/AssertEx.cs
+++ b/src/EventStore.Core.Tests/AssertEx.cs
@@ -10,6 +10,11 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests;
 
 public static class AssertEx {
+	public static T IsType<T>(object o) {
+		Assert.IsInstanceOf<T>(o);
+		return (T)o;
+	}
+
 	public static async Task<TException> ThrowsAsync<TException>(Func<Task> code)
 		where TException : Exception {
 		var expected = default(TException);

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.CombinationTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.CombinationTests.cs
@@ -552,6 +552,7 @@ public partial class EnumeratorTests {
 						// not always straightforward to calculate how many checkpoints we will receive.
 						numResponsesExpected++;
 
+						Assert.True(checkpoint.CheckpointPosition < Position.End);
 						var checkpointPos = checkpoint.CheckpointPosition.ToInt64();
 						var checkpointTfPos = new TFPos(checkpointPos.commitPosition, checkpointPos.preparePosition);
 
@@ -580,7 +581,8 @@ public partial class EnumeratorTests {
 
 			// then expect a final checkpoint
 			if (shouldCheckpoint) {
-				Assert.True(await sub.GetNext() is Checkpoint);
+				var checkpoint = AssertEx.IsType<Checkpoint>(await sub.GetNext());
+				Assert.True(checkpoint.CheckpointPosition < Position.End);
 				numEventsSinceLastCheckpoint = 0;
 			}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
@@ -60,7 +60,19 @@ public partial class EnumeratorTests {
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
-			Assert.True(await sub.GetNext() is Checkpoint);
+			var c = AssertEx.IsType<Checkpoint>(await sub.GetNext());
+			Assert.True(c.CheckpointPosition < Position.End);
+			Assert.True(await sub.GetNext() is CaughtUp);
+		}
+
+		[Test]
+		public async Task when_matching_nothing_transition_to_live_checkpoint_should_be_valid() {
+			await using var sub = CreateAllSubscriptionFiltered(
+				_publisher, null, EventFilter.EventType.Prefixes(false, "match-nothing"));
+
+			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+			var checkpoint = AssertEx.IsType<Checkpoint>(await sub.GetNext());
+			Assert.True(checkpoint.CheckpointPosition < Position.End);
 			Assert.True(await sub.GetNext() is CaughtUp);
 		}
 	}
@@ -110,7 +122,21 @@ public partial class EnumeratorTests {
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
-			Assert.True(await sub.GetNext() is Checkpoint);
+			var c = AssertEx.IsType<Checkpoint>(await sub.GetNext());
+			Assert.True(c.CheckpointPosition < Position.End);
+			Assert.True(await sub.GetNext() is CaughtUp);
+		}
+
+		[Test]
+		public async Task when_matching_nothing_transition_to_live_checkpoint_should_be_valid() {
+			await using var sub = CreateAllSubscriptionFiltered(
+				_publisher,
+				new Position((ulong)_subscribeFrom.CommitPosition, (ulong)_subscribeFrom.PreparePosition),
+				EventFilter.EventType.Prefixes(false, "match-nothing"));
+
+			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+			var checkpoint = AssertEx.IsType<Checkpoint>(await sub.GetNext());
+			Assert.True(checkpoint.CheckpointPosition < Position.End);
 			Assert.True(await sub.GetNext() is CaughtUp);
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/InaugurationManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/InaugurationManagerTests.cs
@@ -79,11 +79,6 @@ public abstract class InaugurationManagerTests {
 		_indexCheckpoint.Flush();
 	}
 
-	protected static T AssertIsType<T>(object o) {
-		Assert.IsInstanceOf<T>(o);
-		return (T)o;
-	}
-
 	// check that we have reset to initial state, do this by checking we can
 	// proceed forward from it
 	protected void AssertInitial() {
@@ -103,7 +98,7 @@ public abstract class InaugurationManagerTests {
 
 	protected void AssertSentBecomeLeader() {
 		Assert.AreEqual(1, _publisher.Messages.Count);
-		var becomeLeader = AssertIsType<SystemMessage.BecomeLeader>(_publisher.Messages[0]);
+		var becomeLeader = AssertEx.IsType<SystemMessage.BecomeLeader>(_publisher.Messages[0]);
 		Assert.AreEqual(_correlationId1, becomeLeader.CorrelationId);
 		_publisher.Messages.Clear();
 		AssertInitial();

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser.cs
@@ -20,7 +20,7 @@ public class given_waiting_for_chaser : InaugurationManagerTests {
 	public void when_chaser_caught_up() {
 		When(new SystemMessage.ChaserCaughtUp(_correlationId1));
 		Assert.AreEqual(1, _publisher.Messages.Count);
-		var writeEpoch = AssertIsType<SystemMessage.WriteEpoch>(_publisher.Messages[0]);
+		var writeEpoch = AssertEx.IsType<SystemMessage.WriteEpoch>(_publisher.Messages[0]);
 		Assert.AreEqual(_epochNumber, writeEpoch.EpochNumber);
 	}
 

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_writing_epoch.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_writing_epoch.cs
@@ -22,7 +22,7 @@ public class given_writing_epoch : InaugurationManagerTests {
 		When(GenEpoch(_epochNumber));
 		Assert.AreEqual(2, _publisher.Messages.Count);
 		Assert.IsInstanceOf<SystemMessage.EnablePreLeaderReplication>(_publisher.Messages[0]);
-		var schedule = AssertIsType<TimerMessage.Schedule>(_publisher.Messages[1]);
+		var schedule = AssertEx.IsType<TimerMessage.Schedule>(_publisher.Messages[1]);
 		Assert.IsInstanceOf<SystemMessage.CheckInaugurationConditions>(schedule.ReplyMessage);
 	}
 


### PR DESCRIPTION
Before this change it was possible to incorrectly send a checkpoint of (ulong.max, ulong.max) to a filtered $all subscription if
- the filtered subscription started from the beginning of the database and
- none of the events in the database matched the filter and
- checkpoint interval is greater than the number of events in the database.

In these circumstances the first checkpoint would be when the subscription transitions to live, but the checkpoint would be (-1, -1)
i.e. outside of the log. The checkpoint datastructure we send to the client is only able to express positions within the log, not
a position before the beginning, and it gets translated to (ulong.max, ulong.max).

This fix updates the checkpoint to a valid value before sending it when transitioning to live, since we do have one.

We also add a failsafe to make sure that invalid checkpoints are not sent under any circumstances.