### PR TITLE
github: add build docs webhook

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,14 @@
+name: Build Production Site
+
+on:
+  push:
+    branches: [release/v24.10,release/oss-v24.6,release/oss-v23.10,release/oss-v22.10,release/oss-v5]
+    paths:
+      - '**.md'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger build
+        run: curl -X POST -d {} "${{ secrets.CLOUDFLARE_BUILD_HOOK }}"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,7 @@ name: Build Production Site
 
 on:
   push:
-    branches: [release/v24.10,release/oss-v24.6,release/oss-v23.10,release/oss-v22.10,release/oss-v5]
+    branches: [release/*]
     paths:
       - '**.md'
 


### PR DESCRIPTION
## Description

Add a github action that builds the documentation website with a webhook whenever a change in an .md file is pushed into the following branches:

- release/v24.10
- release/oss-v24.6
- release/oss-v23.10
- release/oss-v22.10
- release/oss-v5