### PR TITLE
Always cache midpoints for scavenged chunks

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -253,6 +253,7 @@ public class ClusterVNode<TStreamId> :
 			.Get<T>() ?? new();
 
 		var experimentalOptions = GetOptions<ExperimentalOptions>("Experimental");
+		OptionsFormatter.LogConfig("Experimental", experimentalOptions);
 		ChunkFileHandle.AsynchronousByDefault = experimentalOptions.AsyncIO;
 
 		var isRunningInContainer = ContainerizedEnvironment.IsRunningInContainer();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -382,9 +382,6 @@ public partial class TFChunk : IChunkBlob {
 			? new TFChunkReadSideScavenged(this, tracker)
 			: new TFChunkReadSideUnscavenged(this, tracker);
 
-		// do not actually cache now because it is too slow when opening the database
-		_readSide.RequestCaching();
-
 		if (verifyHash)
 			await VerifyFileHash(token);
 	}
@@ -775,8 +772,6 @@ public partial class TFChunk : IChunkBlob {
 				writerWorkItem.SetMemStream(memStream);
 			}
 
-			_readSide.Uncache();
-
 			Log.Debug("CACHED TFChunk {chunk} in {elapsed}.", this, sw.Elapsed);
 
 			if (_selfdestructin54321)
@@ -828,9 +823,6 @@ public partial class TFChunk : IChunkBlob {
 				return;
 			if (_cacheStatus is CacheStatus.Cached) {
 				// we won the right to un-cache and chunk was cached
-				// possibly we could use a mem reader work item and do the actual midpoint caching now
-				_readSide.RequestCaching();
-
 				_writerWorkItem?.DisposeMemStream();
 
 				Log.Debug("UNCACHING TFChunk {chunk}.", this);


### PR DESCRIPTION
Previously we cached midpoints exactly for chunks that are not in the chunk cache. This change caches midpoints even for chunks that are in the chunk cache.

The size of the midpoints array is only about 12k bytes per chunk, so adds little overhead on top of the chunk itself.

The advantage is that it saves us reading the whole posmap table into a buffer (which is what TranslateExactPosition/TranslateClosestForwardPosition currently does without midpoints) or repeatedly repositioning the readerworkitem (which is what the same methods used to do in v24.10). We prefer not to revert to the old v24.10 behaviour because using the midpoints is still good for performance even when cached, and especially so when encryption-at-rest is in use.

When populating the midpoints we also now return [] rather than null when the chunk is empty. This avoids reacquiring the lock next time.