### PR TITLE
Disable server GC by default again

### DIFF
--- a/src/KurrentDB/KurrentDB.csproj
+++ b/src/KurrentDB/KurrentDB.csproj
@@ -4,6 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<ApplicationIcon>app2.ico</ApplicationIcon>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
+		<ServerGarbageCollection>false</ServerGarbageCollection>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -86,6 +86,10 @@ try {
 		GCSettings.IsServerGC,
 		GCSettings.LatencyMode);
 	Log.Information("{description,-25} {logsDirectory}", "LOGS:", options.Logging.Log);
+
+	var gcSettings = string.Join($"{Environment.NewLine}    ", GC.GetConfigurationVariables().Select(kvp => $"{kvp.Key}: {kvp.Value}"));
+	Log.Information($"GC Configuration settings:{Environment.NewLine}    {{settings}}", gcSettings);
+
 	Log.Information(options.DumpOptions());
 
 	var level = options.Application.AllowUnknownOptions


### PR DESCRIPTION
- It was recently enabled accidentally with the ASP hosting changes (not in any production releases)
- Some users have reported positive experiences enabling server gc themselves, however we are concerned about the impact of having less memory available for the OS page cache and want to perform more tests before we change the default.
- DATAS may end up being a sensible compromise