### PR TITLE
Do not execute chunks on the Archiver node

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ArchiverTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ArchiverTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Threading.Tasks;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.XUnit.Tests.Scavenge.Infrastructure;
+using EventStore.Core.XUnit.Tests.Scavenge.Sqlite;
+using Xunit;
+using static EventStore.Core.XUnit.Tests.Scavenge.Infrastructure.StreamMetadatas;
+
+namespace EventStore.Core.XUnit.Tests.Scavenge;
+
+public class ArchiverTests : SqliteDbPerTest<ArchiverTests> {
+	[Fact]
+	public async Task archiver_does_not_execute_chunks() {
+		var t = 0;
+		await new Scenario<LogFormat.V2, string>()
+			.IsArchiver()
+			.WithDbPath(Fixture.Directory)
+			.WithDb(x => x
+				.Chunk(
+					Rec.Write(t++, "ab-1"),
+					Rec.Write(t++, "ab-1"),
+					Rec.Write(t++, "ab-1"),
+					Rec.Write(t++, "ab-1"),
+					Rec.Write(t++, "$$ab-1", "$metadata", metadata: MaxCount1))
+				.Chunk(ScavengePointRec(t++)))
+			.WithState(x => x.WithConnectionPool(Fixture.DbConnectionPool))
+			.RunAsync(
+				// chunks not scavenged
+				x => [
+					x.Recs[0],
+					x.Recs[1],
+				],
+				// indexes still scavenged
+				x => [
+					x.Recs[0].KeepIndexes(3, 4),
+					x.Recs[1],
+				]);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -55,6 +55,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 	private ITFChunkScavengerLog _logger;
 
 	private int _threads = 1;
+	private bool _isArchiver;
 	private bool _skipIndexCheck;
 	private bool _mergeChunks;
 	private bool _syncOnly;
@@ -104,6 +105,11 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 
 	public Scenario<TLogFormat, TStreamId> WithThreads(int threads) {
 		_threads = threads;
+		return this;
+	}
+
+	public Scenario<TLogFormat, TStreamId> IsArchiver(bool isArchiver = true) {
+		_isArchiver = isArchiver;
 		return this;
 	}
 
@@ -481,6 +487,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 				unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes,
 				cancellationCheckPeriod: cancellationCheckPeriod,
 				threads: _threads,
+				isArchiver: _isArchiver,
 				throttle: throttle);
 
 			IChunkMerger chunkMerger = new ChunkMerger(

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ScavengeOptionsCalculatorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ScavengeOptionsCalculatorTests.cs
@@ -3,16 +3,17 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using EventStore.Core.Messaging;
+using EventStore.Core.Configuration.Sources;
 using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Archive;
+using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.Scavenging;
 using Microsoft.Extensions.Configuration;
 using Xunit;
-using EventStore.Core.Services.UserManagement;
-using System;
-using EventStore.Core.Configuration.Sources;
 
 namespace EventStore.Core.XUnit.Tests.Scavenge;
 
@@ -37,7 +38,8 @@ public class ScavengeOptionsCalculatorTests {
 				vNodeOptions.Append(new($"{SectionName}:ClusterSize", "1")))
 			.Build();
 		var options = ClusterVNodeOptions.FromConfiguration(config);
-		var sut = new ScavengeOptionsCalculator(options, message);
+		var archiveOptions = config.GetSection($"{SectionName}:Archive").Get<ArchiveOptions>() ?? new();
+		var sut = new ScavengeOptionsCalculator(options, archiveOptions, message);
 		return sut;
 	}
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1249,7 +1249,7 @@ public class ClusterVNode<TStreamId> :
 
 		scavengerFactory = new ScavengerFactory((message, scavengerLogger, logger) => {
 			// currently on the main queue
-			var optionsCalculator = new ScavengeOptionsCalculator(options, message);
+			var optionsCalculator = new ScavengeOptionsCalculator(options, archiveOptions, message);
 
 			var throttle = new Throttle(
 				logger: logger,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1347,6 +1347,7 @@ public class ClusterVNode<TStreamId> :
 				unsafeIgnoreHardDeletes: options.Database.UnsafeIgnoreHardDelete,
 				cancellationCheckPeriod: cancellationCheckPeriod,
 				threads: message.Threads,
+				isArchiver: options.Cluster.Archiver,
 				throttle: throttle);
 
 			var chunkMerger = new ChunkMerger(

--- a/src/EventStore.Core/TransactionLog/Scavenging/ScavengeOptionsCalculator.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/ScavengeOptionsCalculator.cs
@@ -3,31 +3,25 @@
 
 #nullable enable
 
-using EventStore.Core.Configuration.Sources;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Archive;
-using Microsoft.Extensions.Configuration;
 
 namespace EventStore.Core.TransactionLog.Scavenging;
 
 // Calculates the way to configure the scavenge based on various configuration sources
 public class ScavengeOptionsCalculator {
 	readonly ClusterVNodeOptions _vNodeOptions;
+	readonly ArchiveOptions _archiveOptions;
 	readonly ClientMessage.ScavengeDatabase _message;
-	readonly bool _archiveEnabled;
 
 	public ScavengeOptionsCalculator(
 		ClusterVNodeOptions vNodeOptions,
+		ArchiveOptions archiveOptions,
 		ClientMessage.ScavengeDatabase message) {
 
 		_vNodeOptions = vNodeOptions;
+		_archiveOptions = archiveOptions;
 		_message = message;
-
-		var archiveOptions = vNodeOptions.ConfigurationRoot?
-			.GetSection($"{KurrentConfigurationKeys.Prefix}:Archive")
-			.Get<ArchiveOptions>() ?? new();
-
-		_archiveEnabled = archiveOptions.Enabled;
 	}
 
 	// Archiving disables chunk merging because the two in combination make things
@@ -39,7 +33,7 @@ public class ScavengeOptionsCalculator {
 	// files in the archive because we do not open file handles to all of them
 	// continuously
 	public bool MergeChunks =>
-		!_archiveEnabled &&
+		!_archiveOptions.Enabled &&
 		!_vNodeOptions.Database.DisableScavengeMerging;
 
 	public int ChunkExecutionThreshold => _message.Threshold ?? 0;


### PR DESCRIPTION
To keep the local and remote chunks in sync and with the same weights so that the remote chunks can be scavenged later when it is supported.