### PR TITLE
Tune Amazon log levels

### DIFF
--- a/src/EventStore.Core/Resilience/ResiliencePipelines.cs
+++ b/src/EventStore.Core/Resilience/ResiliencePipelines.cs
@@ -26,10 +26,11 @@ public static class ResiliencePipelines {
 						: Log.Logger;
 
 					logger.Warning(
-						"Retrying {Operation}. Attempt {Attempt}. Duration {Duration}. Delay {Delay}. " +
+						"Retrying {Operation}. Attempt {Attempt}/{MaxAttempts}. Duration {Duration}. Delay {Delay}. " +
 						"Error: {ExceptionMessage} ({ExceptionType})",
 						args.Context.OperationKey,
 						args.AttemptNumber,
+						maxRetryAttempts == int.MaxValue ? "Infinite" : maxRetryAttempts,
 						args.Duration,
 						args.RetryDelay,
 						args.Outcome.Exception?.Message,

--- a/src/EventStore.Core/Services/Archive/Storage/S3/AmazonTraceSerilogger.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3/AmazonTraceSerilogger.cs
@@ -8,7 +8,7 @@ using Serilog.Events;
 
 namespace EventStore.Core.Services.Archive.Storage.S3;
 
-public class AmazonTraceSerilogger : TraceListener {
+public class AmazonTraceSerilogger(Func<LogEventLevel, Exception, LogEventLevel> adjustLevel) : TraceListener {
 	private static readonly Serilog.ILogger Logger = Serilog.Log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, "Amazon");
 
 	public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id,
@@ -49,7 +49,7 @@ public class AmazonTraceSerilogger : TraceListener {
 			Log(TraceEventType.Information, message);
 	}
 
-	private static void Log(TraceEventType eventType, params object[] data) {
+	private void Log(TraceEventType eventType, params object[] data) {
 		if (data.Length is 0)
 			return;
 
@@ -58,7 +58,7 @@ public class AmazonTraceSerilogger : TraceListener {
 		if (data[0] is not LogMessage logMessage)
 			return;
 
-		var logLevel = GetLogLevel(eventType);
+		var logLevel = adjustLevel(GetLogLevel(eventType), exception);
 		Logger.Write(logLevel, exception, logMessage.Format, logMessage.Args);
 	}
 


### PR DESCRIPTION
The Amazon 'errors' are not really errors for us, downgrade everything to warning to avoid alarming users / cluttering dashboards. Some errors are specifically expected and handled by the application. Downgrade these to verbose.