### PR TITLE
Account for custom chunk sizes in scavenge

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_single_node_and_custom_settings.cs
@@ -113,7 +113,7 @@ public class
 
 	[Test]
 	public void should_set_max_chunk_size_to_the_size_of_the_number_of_cached_chunks() {
-		var chunkSizeResult = _cachedChunks * (long)(TFConsts.ChunkSize + ChunkHeader.Size + ChunkFooter.Size);
+		var chunkSizeResult = _cachedChunks * (long)(_node.Db.Config.ChunkSize + ChunkHeader.Size + ChunkFooter.Size);
 		Assert.AreEqual(chunkSizeResult, _node.Db.Config.MaxChunksCacheSize);
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -442,7 +442,7 @@ public class ClusterVNode<TStreamId> :
 			}
 
 			var cache = options.Database.CachedChunks >= 0
-				? options.Database.CachedChunks * (long)(TFConsts.ChunkSize + ChunkHeader.Size + ChunkFooter.Size)
+				? options.Database.CachedChunks * (long)(options.Database.ChunkSize + ChunkHeader.Size + ChunkFooter.Size)
 				: options.Database.ChunksCacheSize;
 
 			// Calculate automatic configuration changes
@@ -1304,14 +1304,14 @@ public class ClusterVNode<TStreamId> :
 
 			var accumulator = new Accumulator<TStreamId>(
 				logger: logger,
-				chunkSize: TFConsts.ChunkSize,
+				chunkSize: options.Database.ChunkSize,
 				metastreamLookup: logFormat.Metastreams,
 				chunkReader: new ChunkReaderForAccumulator<TStreamId>(
 					Db.Manager,
 					logFormat.Metastreams,
 					logFormat.StreamIdConverter,
 					Db.Config.ReplicationCheckpoint.AsReadOnly(),
-					TFConsts.ChunkSize),
+					options.Database.ChunkSize),
 				index: new IndexReaderForAccumulator<TStreamId>(readIndex),
 				cancellationCheckPeriod: cancellationCheckPeriod,
 				throttle: throttle);
@@ -1322,7 +1322,7 @@ public class ClusterVNode<TStreamId> :
 					readIndex,
 					() => new TFReaderLease(readerPool),
 					state.LookupUniqueHashUser),
-				chunkSize: TFConsts.ChunkSize,
+				chunkSize: options.Database.ChunkSize,
 				cancellationCheckPeriod: cancellationCheckPeriod,
 				buffer: calculatorBuffer,
 				throttle: throttle);


### PR DESCRIPTION
(still best not change the chunk sizes in production)