### PR TITLE
Avoid FTL log message after successful truncation

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1829,7 +1829,8 @@ public class ClusterVNode<TStreamId> :
 			tcs.TrySetResult(this);
 		}
 
-		Start();
+		if (!IsShutdown)
+			Start();
 
 		if (IsShutdown)
 			tcs.TrySetResult(this);


### PR DESCRIPTION
Fixed: Avoid FTL log message after successful truncation

When truncation completes successfully the server gets shutdown so that it can be restarted.

Before this PR the shutdown wasn't clean, resulting in a safe but ugly FTL error from the storage chaser.