### PR TITLE
Avoid FTL log message after successful truncation

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1667,6 +1667,7 @@ public class ClusterVNode<TStreamId> :
 			perSubscrQueue.Start();
 			redactionQueue.Start();
 			dynamicCacheManager.Start();
+			_mainQueue.Publish(new SystemMessage.SystemInit());
 		}
 		_start = StartNode;
 
@@ -1878,7 +1879,6 @@ public class ClusterVNode<TStreamId> :
 		}
 
 		await _start(token);
-		_mainQueue.Publish(new SystemMessage.SystemInit());
 
 		if (IsShutdown)
 			tcs.TrySetResult(this);


### PR DESCRIPTION
When truncation completes successfully the server gets shutdown so that it can be restarted.

Before this PR the shutdown wasn't clean, resulting in a safe but ugly FTL error from the storage chaser.