### PR TITLE
Update RedirectUris in idsrv4.conf with correct indentation

### DIFF
--- a/docs/server/security/user-authentication.md
+++ b/docs/server/security/user-authentication.md
@@ -506,9 +506,9 @@ You need to configure the following:
 			"AllowedScopes": [
 				"streams",
 				"openid",
-				"profile",
+				"profile"
 			],
-			"RedirectUris": ["https://localhost:2113/oauth/callback","https://127.0.0.1:2113/oauth/callback"],
+			"RedirectUris": ["https://localhost:2113/signin-oidc","https://127.0.0.1:2113/signin-oidc","https://localhost:2113/oauth/callback","https://127.0.0.1:2113/oauth/callback"],
 			"AlwaysIncludeUserClaimsInIdToken": true,
 			"RequireConsent": false,
 			"AlwaysSendClientClaims": true,


### PR DESCRIPTION
Update the RedirectUris in the sample idsrv4.conf file to include "https://localhost:2113/signin-oidc" and "https://127.0.0.1:2113/signin-oidc".