### PR TITLE
Enable claim mapping

### DIFF
--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -213,9 +213,8 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 					}
 					o.SaveTokens = true;
 					o.GetClaimsFromUserInfoEndpoint = true;
-					o.MapInboundClaims = false;
+					// o.MapInboundClaims = false;
 					o.TokenValidationParameters.NameClaimType = JwtRegisteredClaimNames.Name;
-					o.TokenValidationParameters.RoleClaimType = "roles";
 					o.Events.OnUserInformationReceived = async ctx => {
 						if (ctx.Principal != null) {
 							await ctx.HttpContext.SignInAsync(ctx.Principal, ctx.Properties);


### PR DESCRIPTION
When mapping claims is disabled, the policy that matches roles (and uses full claim namespace) doesn't work.