### PR TITLE
Move plugins from CoupledPlugins and CommercialHA

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 set -x
@@ -10,6 +10,21 @@ tests=$(find "$source_directory" -maxdepth 1 -type d -name "*.Tests")
 
 # Publish tests
 for test in $tests; do
+    if [ "$test" = "/build/src/EventStore.Auth.Ldaps.Tests" ] || 
+       [ "$test" = "/build/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests" ] || 
+       [ "$test" = "/build/src/EventStore.Auth.OAuth.Tests" ] || 
+       [ "$test" = "/build/src/EventStore.Auth.StreamPolicyPlugin.Tests" ] || 
+       [ "$test" = "/build/src/EventStore.Auth.UserCertificates.Tests" ] || 
+       [ "$test" = "/build/src/EventStore.AutoScavenge.Tests" ] || 
+       [ "$test" = "/build/src/EventStore.Diagnostics.LogsEndpointPlugin.Tests" ] || 
+       [ "$test" = "/build/src/EventStore.Security.EncryptionAtRest.Tests" ] || 
+       [ "$test" = "/build/src/EventStore.TcpPlugin.Tests" ]; then
+      echo Skipping tests for $test
+        continue
+    fi
+
+    echo Publishing tests for $test
+
     dotnet publish \
       --runtime="$RUNTIME" \
       --no-self-contained \

--- a/src/EventStore.Auth.Ldaps.Tests/EventStore.Auth.Ldaps.Tests.csproj
+++ b/src/EventStore.Auth.Ldaps.Tests/EventStore.Auth.Ldaps.Tests.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+      <TargetFramework>net8.0</TargetFramework>
+      <IsPackable>false</IsPackable>
+      <IsPublishable>false</IsPublishable>
+			<IsTestProject>true</IsTestProject>
+      <Configurations>Release;Debug</Configurations>
+      <Platforms>x64</Platforms>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+      <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Ductus.FluentDocker.XUnit" Version="2.10.59" />
+      <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.1.0" />
+			<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+			  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			  <PrivateAssets>all</PrivateAssets>
+			</PackageReference>
+			<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+			<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+			<PackageReference Include="xunit" Version="2.6.2" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\EventStore.Auth.Ldaps\EventStore.Auth.Ldaps.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="conf\ldaps.conf">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
+</Project>

--- a/src/EventStore.Auth.Ldaps.Tests/LdapsFixture.cs
+++ b/src/EventStore.Auth.Ldaps.Tests/LdapsFixture.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading.Tasks;
+using Ductus.FluentDocker.Builders;
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Services;
+using Ductus.FluentDocker.Services.Extensions;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.Ldaps.Tests;
+
+public class LdapsFixture : IDisposable{
+
+	private const int InsecurePort = 10389;
+	private const int SecurePort = 10636;
+
+	private readonly ITestOutputHelper _output;
+	private readonly IContainerService _ldapsServer;
+
+	public LdapsFixture(ITestOutputHelper output) {
+		_output = output;
+
+		_ldapsServer = new Builder()
+			.UseContainer()
+			.UseImage("rroemhild/test-openldap")
+			.WithName("es-openldap-server")
+			.ExposePort(InsecurePort, InsecurePort)
+			.ExposePort(SecurePort, SecurePort)
+			.Build();
+	}
+
+	public void Start() {
+		_ldapsServer.ShipContainerLogs(_output);
+		_ldapsServer.Start();
+	}
+
+	public void Dispose() => _ldapsServer?.Dispose();
+}
+internal static class ContainerExtensions {
+	public static void ShipContainerLogs(this IContainerService container, ITestOutputHelper testOutputHelper) =>
+		Task.Run(() => {
+			using var logs = container.Logs(true);
+			foreach (var line in logs.ReadToEnd()) {
+				testOutputHelper.WriteLine(line);
+			}
+		});
+}

--- a/src/EventStore.Auth.Ldaps.Tests/LdapsPluginTests.cs
+++ b/src/EventStore.Auth.Ldaps.Tests/LdapsPluginTests.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using EventStore.Plugins.Licensing;
+using EventStore.Plugins.Tests;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.Ldaps.Tests;
+
+public class LdapsPluginTests {
+
+	private const string _roleClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
+	private readonly ITestOutputHelper _output;
+
+	private readonly string _configFile;
+	private readonly TimeSpan _timeout = TimeSpan.FromSeconds(5);
+
+	public LdapsPluginTests(ITestOutputHelper output) {
+		_output = output;
+		_configFile = Path.Combine(Environment.CurrentDirectory, "conf", "ldaps.conf");
+	}
+
+	private async Task<LdapsFixture> CreateAndStartFixture() {
+		var fixture = new LdapsFixture(_output);
+		fixture.Start();
+
+		var sut = new LdapsAuthenticationPlugin()
+			.GetAuthenticationProviderFactory(_configFile)
+			.Build(false);
+
+		// There is no health check in this container
+		// Simply try a few requests until one succeeds
+		for (var i = 0; i < 5; i++) {
+			var completionSource = new TaskCompletionSource<TestAuthenticationResponse>();
+			var request = CreateAuthenticationRequest("professor", "professor", completionSource);
+			var task = completionSource.Task;
+			sut.Authenticate(request);
+
+			if (await Task.WhenAny(task, Task.Delay(_timeout)) == task &&
+			    string.IsNullOrEmpty(task.Result.FailureReason))
+				return fixture;
+
+			await Task.Delay(500);
+		}
+
+		throw new Exception("LDAPS fixture did not start up in time");
+	}
+
+	[Fact]
+	public async Task authenticate_admin_user_returns_admin_role() {
+		var sut = new LdapsAuthenticationPlugin()
+			.GetAuthenticationProviderFactory(_configFile)
+			.Build(false);
+
+		using var fixture = await CreateAndStartFixture();
+
+		var completionSource = new TaskCompletionSource<TestAuthenticationResponse>();
+		var request = CreateAuthenticationRequest("professor", "professor", completionSource);
+		sut.Authenticate(request);
+
+		var task = completionSource.Task;
+		if (await Task.WhenAny(task, Task.Delay(_timeout)) == task) {
+			var result = await completionSource.Task;
+
+			Assert.Null(result.FailureReason);
+			Assert.NotNull(result.Principal);
+			Assert.Equal("professor", result.Principal.Identity?.Name);
+			Assert.True(result.Principal.HasClaim(_roleClaimType, "$admins"));
+		}
+	}
+
+	[Fact]
+	public async Task authenticate_with_incorrect_password_returns_unauthorized() {
+		var sut = new LdapsAuthenticationPlugin()
+			.GetAuthenticationProviderFactory(_configFile)
+			.Build(false);
+
+		using var fixture = await CreateAndStartFixture();
+
+		var completionSource = new TaskCompletionSource<TestAuthenticationResponse>();
+		var request = CreateAuthenticationRequest("professor", "wrong", completionSource);
+		sut.Authenticate(request);
+
+		var task = completionSource.Task;
+		if (await Task.WhenAny(task, Task.Delay(_timeout)) == task) {
+			var result = await completionSource.Task;
+			Assert.Null(result.Principal);
+			Assert.Equal("unauthorized", result.FailureReason);
+		}
+	}
+
+	[Fact]
+	public async Task authenticate_with_non_existent_user_returns_unauthorized() {
+		var sut = new LdapsAuthenticationPlugin()
+			.GetAuthenticationProviderFactory(_configFile)
+			.Build(false);
+
+		using var fixture = await CreateAndStartFixture();
+
+		var completionSource = new TaskCompletionSource<TestAuthenticationResponse>();
+		var request = CreateAuthenticationRequest("wrong", "wrong", completionSource);
+		sut.Authenticate(request);
+
+		var task = completionSource.Task;
+		if (await Task.WhenAny(task, Task.Delay(_timeout)) == task) {
+			var result = await completionSource.Task;
+			Assert.Null(result.Principal);
+			Assert.Equal("unauthorized", result.FailureReason);
+		}
+	}
+
+	[Fact]
+	public async Task authenticate_user_with_custom_role_returns_expected_roles() {
+		var sut = new LdapsAuthenticationPlugin()
+			.GetAuthenticationProviderFactory(_configFile)
+			.Build(false);
+
+		using var fixture = await CreateAndStartFixture();
+
+		var completionSource = new TaskCompletionSource<TestAuthenticationResponse>();
+		var request = CreateAuthenticationRequest("fry", "fry", completionSource);
+		sut.Authenticate(request);
+
+		var task = completionSource.Task;
+		if (await Task.WhenAny(task, Task.Delay(_timeout)) == task) {
+			var result = await completionSource.Task;
+			Assert.Null(result.FailureReason);
+			Assert.NotNull(result.Principal);
+			Assert.Equal("fry", result.Principal.Identity?.Name);
+			Assert.True(result.Principal.HasClaim(_roleClaimType, "others"));
+			Assert.False(result.Principal.HasClaim(_roleClaimType, "$admins"));
+		}
+	}
+
+	[Fact(Skip="This currently results in an error and the request never returns")]
+	public async Task authenticate_user_with_no_roles_returns_no_roles() {
+		var sut = new LdapsAuthenticationPlugin()
+			.GetAuthenticationProviderFactory(_configFile)
+			.Build(false);
+
+		using var fixture = await CreateAndStartFixture();
+
+		var completionSource = new TaskCompletionSource<TestAuthenticationResponse>();
+		var request = CreateAuthenticationRequest("amy", "amy", completionSource);
+		sut.Authenticate(request);
+
+		var task = completionSource.Task;
+		if (await Task.WhenAny(task, Task.Delay(_timeout)) == task) {
+			var result = await completionSource.Task;
+
+			Assert.Null(result.FailureReason);
+			Assert.NotNull(result.Principal);
+			Assert.Equal("amy", result.Principal.Identity?.Name);
+			Assert.DoesNotContain(result.Principal.Claims, x => x.Type == _roleClaimType);
+		}
+	}
+
+	private TestAuthenticationRequest CreateAuthenticationRequest(string username, string password,
+		TaskCompletionSource<TestAuthenticationResponse> completionSource) {
+		return new(username, password,
+			p => completionSource.TrySetResult(new TestAuthenticationResponse(p)),
+			() => completionSource.TrySetResult(new TestAuthenticationResponse("unauthorized")),
+			() => completionSource.TrySetResult(new TestAuthenticationResponse("error")),
+			() => completionSource.TrySetResult(new TestAuthenticationResponse("notready")));
+	}
+
+	[Theory]
+	[InlineData(true, "LDAPS_AUTHENTICATION", false)]
+	[InlineData(true, "NONE", true)]
+	[InlineData(false, "NONE", true)]
+	public void respects_license(bool licensePresent, string entitlement, bool expectedException) {
+		// given
+		var sut = new LdapsAuthenticationPlugin()
+			.GetAuthenticationProviderFactory(_configFile)
+			.Build(false);
+
+		var config = new ConfigurationBuilder().Build();
+		var builder = WebApplication.CreateBuilder();
+
+		var licenseService = new Fixtures.FakeLicenseService(licensePresent, entitlement);
+		builder.Services.AddSingleton<ILicenseService>(licenseService);
+
+		sut.ConfigureServices(
+			builder.Services,
+			config);
+
+		var app = builder.Build();
+
+		// when
+		sut.ConfigureApplication(app, config);
+
+		// then
+		if (expectedException) {
+			Assert.NotNull(licenseService.RejectionException);
+		} else {
+			Assert.Null(licenseService.RejectionException);
+		}
+	}
+}

--- a/src/EventStore.Auth.Ldaps.Tests/TestAuthenticationRequest.cs
+++ b/src/EventStore.Auth.Ldaps.Tests/TestAuthenticationRequest.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using EventStore.Plugins.Authentication;
+
+namespace EventStore.Auth.Ldaps.Tests;
+
+public class TestAuthenticationRequest : AuthenticationRequest {
+	private Action<ClaimsPrincipal> _onAuthenticated;
+	private Action _onUnauthorized;
+	private Action _onError;
+	private Action _onNotReady;
+
+	public TestAuthenticationRequest(IReadOnlyDictionary<string, string> tokens) : base("test", tokens) {
+	}
+
+	public TestAuthenticationRequest(
+		string name,
+		string suppliedPassword,
+		Action<ClaimsPrincipal> onAuthenticated,
+		Action onUnauthorized = null,
+		Action onError = null,
+		Action onNotReady = null) : base("test", new Dictionary<string, string> {
+			["uid"] = name,
+			["pwd"] = suppliedPassword
+		}) {
+		_onAuthenticated = onAuthenticated;
+		_onUnauthorized = onUnauthorized;
+		_onError = onError;
+		_onNotReady = onNotReady;
+	}
+
+	public override void Unauthorized() {
+		_onUnauthorized?.Invoke();
+	}
+
+	public override void Authenticated(ClaimsPrincipal principal) {
+		_onAuthenticated?.Invoke(principal);
+	}
+
+	public override void Error() {
+		_onError?.Invoke();
+	}
+
+	public override void NotReady() {
+		_onNotReady?.Invoke();
+	}
+}
+
+public class TestAuthenticationResponse {
+	public readonly ClaimsPrincipal Principal;
+	public readonly string FailureReason;
+
+	public TestAuthenticationResponse(ClaimsPrincipal principal) {
+		Principal = principal;
+	}
+
+	public TestAuthenticationResponse(string failureReason) {
+		FailureReason = failureReason;
+	}
+}

--- a/src/EventStore.Auth.Ldaps.Tests/conf/ldaps.conf
+++ b/src/EventStore.Auth.Ldaps.Tests/conf/ldaps.conf
@@ -1,0 +1,19 @@
+AuthenticationType: ldaps
+LdapsAuth:
+  Host: 127.0.0.1
+  Port: 10636
+  ValidateServerCertificate: false
+  UseSSL: true
+  AnonymousBind: false
+  BindUser: cn=admin,dc=planetexpress,dc=com
+  BindPassword: GoodNewsEveryone
+  BaseDn: dc=planetexpress,dc=com
+  ObjectClass: organizationalPerson
+  Filter: uid
+  GroupMembershipAttribute: memberOf
+  RequireGroupMembership: false
+  RequiredGroupDn: 'cn=admin_staff,ou=people,dc=planetexpress,dc=com'
+  PrincipalCacheDurationSec: 60
+  LdapGroupRoles:
+    'cn=admin_staff,ou=people,dc=planetexpress,dc=com': '$admins'
+    'cn=ship_crew,ou=people,dc=planetexpress,dc=com': 'others'

--- a/src/EventStore.Auth.Ldaps/CachedPrincipalWithTimeout.cs
+++ b/src/EventStore.Auth.Ldaps/CachedPrincipalWithTimeout.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Security.Claims;
+
+namespace EventStore.Auth.Ldaps;
+
+internal class CachedPrincipalWithTimeout {
+	public readonly string Password;
+	public readonly ClaimsPrincipal Principal;
+	public readonly DateTime ValidUntil;
+
+	public CachedPrincipalWithTimeout(string password, ClaimsPrincipal principal, DateTime validUntil) {
+		Password = password;
+		Principal = principal;
+		ValidUntil = validUntil;
+	}
+}

--- a/src/EventStore.Auth.Ldaps/EventStore.Auth.Ldaps.csproj
+++ b/src/EventStore.Auth.Ldaps/EventStore.Auth.Ldaps.csproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Platforms>x64</Platforms>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+	</PropertyGroup>
+	<PropertyGroup>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+	  <DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Auth.Ldaps/ILdapsCredentialValidator.cs
+++ b/src/EventStore.Auth.Ldaps/ILdapsCredentialValidator.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+
+namespace EventStore.Auth.Ldaps;
+
+public interface ILdapsCredentialValidator : IDisposable {
+	bool TryValidateCredentials(string username, string password, out LdapInfo ldapUser);
+}

--- a/src/EventStore.Auth.Ldaps/LRUCache.cs
+++ b/src/EventStore.Auth.Ldaps/LRUCache.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+
+namespace EventStore.Auth.Ldaps;
+
+public class LRUCache<TKey, TValue> {
+	private class LRUItem {
+		public TKey Key;
+		public TValue Value;
+	}
+
+	private readonly LinkedList<LRUItem> _orderList = new LinkedList<LRUItem>();
+
+	private readonly Dictionary<TKey, LinkedListNode<LRUItem>> _items =
+		new Dictionary<TKey, LinkedListNode<LRUItem>>();
+
+	private readonly Queue<LinkedListNode<LRUItem>> _nodesPool = new Queue<LinkedListNode<LRUItem>>();
+
+	private readonly int _maxCount;
+	private readonly object _lock = new object();
+
+	private Func<object, bool>
+		_onPut, _onRemove; //_onPut is not called if a key-value pair already exists in the cache
+
+	public LRUCache(int maxCount) {
+		if (maxCount < 0) throw new ArgumentException("Should be non negative", nameof(maxCount));
+		_maxCount = maxCount;
+	}
+
+	public LRUCache(int maxCount, Func<object, bool> onPut, Func<object, bool> onRemove) {
+		if (maxCount < 0) throw new ArgumentException("Should be non negative", nameof(maxCount));
+		_maxCount = maxCount;
+		_onPut = onPut;
+		_onRemove = onRemove;
+	}
+
+	public bool TryGet(TKey key, out TValue value) {
+		lock (_lock) {
+			LinkedListNode<LRUItem> node;
+			if (_items.TryGetValue(key, out node)) {
+				_orderList.Remove(node);
+				_orderList.AddLast(node);
+				value = node.Value.Value;
+				return true;
+			}
+
+			value = default(TValue);
+			return false;
+		}
+	}
+
+	public TValue Put(TKey key, TValue value) {
+		lock (_lock) {
+			LinkedListNode<LRUItem> node;
+			if (!_items.TryGetValue(key, out node)) {
+				node = GetNode();
+				node.Value.Key = key;
+				node.Value.Value = value;
+
+				EnsureCapacity();
+
+				_items.Add(key, node);
+				_orderList.AddLast(node);
+
+				if (_onPut != null) _onPut(node.Value.Value);
+			} else {
+				node.Value.Value = value;
+
+				if (!ReferenceEquals(node, _orderList.Last)) {
+					_orderList.Remove(node);
+					_orderList.AddLast(node);
+				}
+			}
+
+			return value;
+		}
+	}
+
+	public void Remove(TKey key) {
+		lock (_lock) {
+			LinkedListNode<LRUItem> node;
+			if (_items.TryGetValue(key, out node)) {
+				_orderList.Remove(node);
+				_items.Remove(key);
+				if (_onRemove != null) _onRemove(node.Value.Value);
+
+				ReturnNode(node);
+			}
+		}
+	}
+
+	public void Clear() {
+		lock (_lock) {
+			while (_orderList.Count > 0) {
+				var node = _orderList.First;
+				_orderList.RemoveFirst();
+				_items.Remove(node.Value.Key);
+				if (_onRemove != null) _onRemove(node.Value.Value);
+
+				ReturnNode(node);
+			}
+		}
+	}
+
+	public TValue Put<T>(TKey key, T userData, Func<TKey, T, TValue> addFactory,
+		Func<TKey, TValue, T, TValue> updateFactory) {
+		lock (_lock) {
+			LinkedListNode<LRUItem> node;
+			if (!_items.TryGetValue(key, out node)) {
+				node = GetNode();
+				node.Value.Key = key;
+				node.Value.Value = addFactory(key, userData);
+
+				EnsureCapacity();
+
+				_items.Add(key, node);
+				_orderList.AddLast(node);
+				if (_onPut != null) _onPut(node.Value.Value);
+			} else {
+				node.Value.Value = updateFactory(key, node.Value.Value, userData);
+
+				if (!ReferenceEquals(node, _orderList.Last)) {
+					_orderList.Remove(node);
+					_orderList.AddLast(node);
+				}
+			}
+
+			return node.Value.Value;
+		}
+	}
+
+	private void EnsureCapacity() {
+		while (_items.Count > 0 && _items.Count >= _maxCount) {
+			var node = _orderList.First;
+			_orderList.Remove(node);
+			_items.Remove(node.Value.Key);
+			if (_onRemove != null) _onRemove(node.Value.Value);
+
+			ReturnNode(node);
+		}
+	}
+
+	private LinkedListNode<LRUItem> GetNode() {
+		if (_nodesPool.Count > 0)
+			return _nodesPool.Dequeue();
+		return new LinkedListNode<LRUItem>(new LRUItem());
+	}
+
+	private void ReturnNode(LinkedListNode<LRUItem> node) {
+		_nodesPool.Enqueue(node);
+	}
+}

--- a/src/EventStore.Auth.Ldaps/LdapInfo.cs
+++ b/src/EventStore.Auth.Ldaps/LdapInfo.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Linq;
+
+namespace EventStore.Auth.Ldaps;
+
+/// <summary>
+/// Represents the distinguished name of an object and an array of the distinguished names
+/// of groups to which the object belongs.
+/// </summary>
+public class LdapInfo {
+	/// <summary>
+	/// The login name of the object (for example, sAMAccountName on ActiveDirectory, uid on OpenLDAP)
+	/// </summary>
+	public readonly string LoginName;
+
+	/// <summary>
+	/// Distinguished name of the object
+	/// </summary>
+	public readonly string DistinguishedName;
+
+	/// <summary>
+	/// Array of group distinguished names to which the object with the distinguished name belongs
+	/// </summary>
+	public readonly string[] GroupDistinguishedNames;
+
+	/// <summary>
+	/// Creates a new LdapInfo struct
+	/// </summary>
+	/// <param name="loginName">The login name (e.g. sAMAccountName on Windows) of the object</param>
+	/// <param name="distinguishedName">The distinguished name of the object</param>
+	/// <param name="groupDistinguishedNames">The distinguished names of the groups to which the object belongs</param>
+	public LdapInfo(string loginName, string distinguishedName, string[] groupDistinguishedNames) {
+		LoginName = loginName;
+		DistinguishedName = distinguishedName;
+		GroupDistinguishedNames = groupDistinguishedNames;
+	}
+
+	/// <summary>
+	/// Tests whether the object is a member of the group with the given distinguished name
+	/// </summary>
+	/// <param name="groupDistinguishedName">The distinguished name of the group</param>
+	/// <returns>True if a member, false otherwise</returns>
+	public bool IsMemberOf(string groupDistinguishedName) {
+		return GroupDistinguishedNames.Contains(groupDistinguishedName);
+	}
+
+	/// <summary>
+	/// An empty LdapInfo (no DN, no group DNs).
+	/// </summary>
+	public static readonly LdapInfo Empty = new LdapInfo("", "", new string[0]);
+}

--- a/src/EventStore.Auth.Ldaps/LdapsAuthenticationPlugin.cs
+++ b/src/EventStore.Auth.Ldaps/LdapsAuthenticationPlugin.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.ComponentModel.Composition;
+using EventStore.Plugins.Authentication;
+
+namespace EventStore.Auth.Ldaps;
+
+[Export(typeof(IAuthenticationPlugin))]
+public class LdapsAuthenticationPlugin : IAuthenticationPlugin {
+	public string Name { get { return "LDAPS"; } }
+
+	public string Version {
+		get { return typeof(LdapsAuthenticationPlugin).Assembly.GetName().Version.ToString(); }
+	}
+
+	public string CommandLineName { get { return "ldaps"; } }
+
+	public IAuthenticationProviderFactory GetAuthenticationProviderFactory(string authenticationConfigPath) {
+		if (string.IsNullOrWhiteSpace(authenticationConfigPath))
+			throw new LdapsConfigurationException(string.Format(
+				"No LDAPS configuration file was specified. Use the --{0} option to specify " +
+				"the path to the LDAPS configuration.", "authentication-config-file"));
+
+		return new LdapsAuthenticationProviderFactory(authenticationConfigPath);
+	}
+}

--- a/src/EventStore.Auth.Ldaps/LdapsAuthenticationProvider.cs
+++ b/src/EventStore.Auth.Ldaps/LdapsAuthenticationProvider.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.Auth.Ldaps;
+
+internal class LdapsAuthenticationProvider : AuthenticationProviderBase {
+	private static readonly ILogger Logger = Log.ForContext<PolicyEvaluator>();
+	private readonly ILogger _logger;
+	private readonly LdapsSettings _ldapsSettings;
+	private readonly bool _logFailedAuthenticationAttempts;
+	private readonly IDictionary<string, string> _ldapGroupDistinguishedNameToRoleNames;
+	private readonly LRUCache<string, CachedPrincipalWithTimeout> _userPasswordsCache;
+	private readonly TimeSpan _cacheDuration;
+
+	public LdapsAuthenticationProvider(LdapsSettings settings, int cacheSize,
+		bool logFailedAuthenticationAttempts)
+		: base(
+			requiredEntitlements: ["LDAPS_AUTHENTICATION"]) {
+
+		_logger = Logger;
+		_ldapsSettings = settings;
+		_logFailedAuthenticationAttempts =
+			logFailedAuthenticationAttempts; //TODO: log failed authentication attempts
+		_userPasswordsCache = new LRUCache<string, CachedPrincipalWithTimeout>(cacheSize);
+		_ldapGroupDistinguishedNameToRoleNames = settings.LdapGroupRoles;
+		_cacheDuration = TimeSpan.FromSeconds(_ldapsSettings.PrincipalCacheDurationSec);
+		_logFailedAuthenticationAttempts = logFailedAuthenticationAttempts;
+	}
+
+	public override void Authenticate(AuthenticationRequest authenticationRequest) {
+		CachedPrincipalWithTimeout cached;
+		if (_userPasswordsCache.TryGet(authenticationRequest.Name, out cached)) {
+			if (cached.ValidUntil > DateTime.UtcNow) {
+				AuthenticateFromCache(authenticationRequest, cached);
+			} else {
+				_userPasswordsCache.Remove(authenticationRequest.Name);
+				AuthenticateWithLdapsServer(authenticationRequest);
+			}
+		} else {
+			AuthenticateWithLdapsServer(authenticationRequest);
+		}
+	}
+
+	public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() {
+		return new [] {
+			"Basic"
+		};
+	}
+
+	public ClaimsPrincipal GetUser(string loginName) {
+		CachedPrincipalWithTimeout cached;
+		if (_userPasswordsCache.TryGet(loginName, out cached)) {
+			return cached.Principal as ClaimsPrincipal;
+		}
+
+		return null;
+	}
+
+	private void AuthenticateWithLdapsServer(AuthenticationRequest authenticationRequest) {
+		var authenticateTask = new Task<LdapAuthenticationResponse>(() => {
+			using (var validator = new LdapsCredentialValidator(_ldapsSettings)) {
+				LdapInfo ldapInfo;
+				if (validator.TryValidateCredentials(authenticationRequest.Name,
+					authenticationRequest.SuppliedPassword, out ldapInfo))
+					return new LdapAuthenticationResponse(authenticationRequest, true, ldapInfo);
+
+				return new LdapAuthenticationResponse(authenticationRequest, false, LdapInfo.Empty);
+			}
+		});
+
+		authenticateTask.ContinueWith(ant => {
+			_logger.Error("Error authenticating with LDAPS server. {0}", ant.Exception);
+			ant.Result.Request.Error();
+		}, TaskContinuationOptions.OnlyOnFaulted);
+
+		authenticateTask.ContinueWith(ant => {
+			if (!ant.Result.IsAuthenticated) {
+				if (_logFailedAuthenticationAttempts)
+					_logger.Warning("LDAPS Authentication Failed for {id}.", authenticationRequest.Id);
+				authenticationRequest.Unauthorized();
+				return;
+			}
+
+			var principal = CreatePrincipal(ant.Result.LdapInfo);
+			CachePrincipal(authenticationRequest.Name, authenticationRequest.SuppliedPassword, principal);
+
+			authenticationRequest.Authenticated(principal);
+		}, TaskContinuationOptions.NotOnFaulted);
+
+		authenticateTask.Start();
+	}
+
+	private void AuthenticateFromCache(AuthenticationRequest authenticationRequest,
+		CachedPrincipalWithTimeout cached) {
+		if (authenticationRequest.SuppliedPassword != cached.Password) {
+			if (_logFailedAuthenticationAttempts)
+				_logger.Warning("LDAPS Authentication Failed for {id}.", authenticationRequest.Id);
+			authenticationRequest.Unauthorized();
+			_userPasswordsCache.Remove(authenticationRequest.Name);
+			return;
+		}
+
+		authenticationRequest.Authenticated(cached.Principal);
+	}
+
+	private void CachePrincipal(string loginName, string password, ClaimsPrincipal principal) {
+		var cachedPrincipal =
+			new CachedPrincipalWithTimeout(password, principal, DateTime.UtcNow.Add(_cacheDuration));
+		_userPasswordsCache.Put(loginName, cachedPrincipal);
+	}
+
+	private ClaimsPrincipal CreatePrincipal(LdapInfo ldapInfo) {
+		var claims = new List<Claim> {new Claim(ClaimTypes.Name, ldapInfo.LoginName)};
+		if (ldapInfo.GroupDistinguishedNames != null) {
+			claims.AddRange(ConvertLdapGroupsToRoleNames(ldapInfo).Select(x => new Claim(ClaimTypes.Role, x)));
+		}
+
+		var identity = new ClaimsIdentity(claims, "ES-Legacy");
+		var principal = new ClaimsPrincipal(identity);
+		return principal;
+	}
+
+	private string[] ConvertLdapGroupsToRoleNames(LdapInfo ldapInfo) {
+		var roles = new List<string> {ldapInfo.LoginName};
+		foreach (var ldapGroupDn in ldapInfo.GroupDistinguishedNames) {
+			string roleName;
+			if (!_ldapGroupDistinguishedNameToRoleNames.TryGetValue(ldapGroupDn, out roleName))
+				continue;
+			roles.Add(roleName);
+		}
+
+		return roles.ToArray();
+	}
+
+	private class LdapAuthenticationResponse {
+		public readonly AuthenticationRequest Request;
+		public readonly bool IsAuthenticated;
+		public readonly LdapInfo LdapInfo;
+
+		public LdapAuthenticationResponse(AuthenticationRequest request, bool isAuthenticated, LdapInfo ldapInfo) {
+			Request = request;
+			IsAuthenticated = isAuthenticated;
+			LdapInfo = ldapInfo;
+		}
+	}
+}

--- a/src/EventStore.Auth.Ldaps/LdapsAuthenticationProviderFactory.cs
+++ b/src/EventStore.Auth.Ldaps/LdapsAuthenticationProviderFactory.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Plugins;
+using EventStore.Plugins.Authentication;
+
+namespace EventStore.Auth.Ldaps;
+
+internal class LdapsAuthenticationProviderFactory : IAuthenticationProviderFactory {
+	public const int CachedPrincipalCount = 1000;
+	private readonly string _configPath;
+	private LdapsAuthenticationProvider _authenticationProvider;
+
+	public LdapsAuthenticationProviderFactory(string configPath) {
+		_configPath = configPath;
+	}
+
+	public IAuthenticationProvider Build(bool logFailedAuthenticationAttempts) {
+		var ldapsSettings = ConfigParser.ReadConfiguration<LdapsSettings>(_configPath, "LdapsAuth");
+		_authenticationProvider = new LdapsAuthenticationProvider(ldapsSettings,
+			CachedPrincipalCount, logFailedAuthenticationAttempts);
+		return _authenticationProvider;
+	}
+}

--- a/src/EventStore.Auth.Ldaps/LdapsConfigurationException.cs
+++ b/src/EventStore.Auth.Ldaps/LdapsConfigurationException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+
+namespace EventStore.Auth.Ldaps;
+
+public class LdapsConfigurationException : Exception {
+	public LdapsConfigurationException(string message)
+		: base(message) {
+	}
+}

--- a/src/EventStore.Auth.Ldaps/LdapsCredentialValidator.cs
+++ b/src/EventStore.Auth.Ldaps/LdapsCredentialValidator.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Novell.Directory.Ldap;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.Auth.Ldaps;
+
+/// <summary>
+/// A <see cref="LdapsCredentialValidator"/> can be used to validate user credentials with
+/// an LDAP server, connecting over SSL only (since we definitely send credentials
+/// over the connection).
+/// </summary>
+internal class LdapsCredentialValidator : ILdapsCredentialValidator, IDisposable {
+	private static readonly ILogger Log = Serilog.Log.ForContext<LdapsCredentialValidator>();
+	private readonly LdapSearchConstraints _ldapSearchConstraints;
+
+	private readonly LdapsSettings _settings;
+	private readonly LdapConnection _connection;
+
+	private string LdapServer {
+		get { return string.Format("{0}:{1}", _settings.Host, _settings.Port); }
+	}
+
+	public LdapsCredentialValidator(LdapsSettings settings) {
+		_settings = settings;
+
+		_ldapSearchConstraints = new LdapSearchConstraints {
+			BatchSize = 0, TimeLimit = _settings.LdapOperationTimeout, ServerTimeLimit = _settings.LdapOperationTimeout,
+			ReferralFollowing = true
+		};
+		var ldapConstraints = new LdapConstraints {TimeLimit = _settings.LdapOperationTimeout};
+		_connection = new LdapConnection {
+			SecureSocketLayer = _settings.UseSSL,
+			Constraints = ldapConstraints
+		};
+		
+#pragma warning disable CS0618 // Type or member is obsolete
+		_connection.UserDefinedServerCertValidationDelegate += ConnectionOnUserDefinedServerCertValidationDelegate;
+#pragma warning restore CS0618 // Type or member is obsolete
+	}
+
+	private bool ConnectionOnUserDefinedServerCertValidationDelegate
+		(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors certificateErrors) {
+		if (!_settings.ValidateServerCertificate)
+			return true;
+
+		if (certificateErrors == SslPolicyErrors.None)
+			return true;
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+			var certificate2 = new X509Certificate2(certificate);
+			return chain.Build(certificate2);
+		}
+
+		Log.Error("[LDAP-S: {server}] - Server certificate error: {e}", LdapServer,
+			string.Join(",", certificateErrors));
+		return false;
+	}
+
+	private void ConnectToLdapServer() {
+		if (_connection.Connected)
+			return;
+
+		Log.Debug("Connecting to LDAP server: {server}", LdapServer);
+		_connection.Connect(_settings.Host, _settings.Port);
+	}
+
+	private bool TryFindLdapInfoForLoginUsername(string username, out LdapInfo ldapInfo) {
+		ldapInfo = LdapInfo.Empty;
+		var query = string.Format("(&(objectClass={0})({1}={2}))", EscapeLdapSearchFilter(_settings.ObjectClass),
+			EscapeLdapSearchFilter(_settings.Filter), EscapeLdapSearchFilter(username));
+
+		try {
+			var search = _connection.Search(_settings.BaseDn, LdapConnection.ScopeSub, query,
+				new[] {_settings.GroupMembershipAttribute}, false, _ldapSearchConstraints);
+
+			var entries = new List<LdapEntry>();
+			while (search.HasMore())
+				entries.Add(search.Next());
+
+			if (entries.Count != 1)
+				return false;
+
+			var directoryEntry = entries[0];
+
+			//TODO: Return roles here instead of groups
+
+			var attributeSet = directoryEntry.GetAttribute(_settings.GroupMembershipAttribute);
+			ldapInfo = new LdapInfo(username, directoryEntry.Dn,
+				attributeSet == null ? new string[0] : attributeSet.StringValueArray);
+			return true;
+		} catch (LdapException ex) {
+			if (ex.ResultCode == LdapException.LdapTimeout || ex.ResultCode == LdapException.TimeLimitExceeded) {
+				Log.Error(ex, "[LDAP-S: {server}] - Search operation timed out.", LdapServer);
+				Disconnect();
+				return false;
+			}
+
+			Log.Error(ex, "[LDAP-S: {server}] - Exception during search.", LdapServer);
+			Disconnect();
+			return false;
+		}
+	}
+
+	public bool TryValidateCredentials(string username, string password, out LdapInfo ldapUser) {
+		ldapUser = LdapInfo.Empty;
+
+		if (string.IsNullOrEmpty(username))
+			return false;
+
+		try {
+			ConnectToLdapServer();
+		} catch (LdapException ex) {
+			Log.Error(ex, "Connecting to LDAP server {server} failed.", LdapServer);
+			Disconnect();
+			return false;
+		}
+
+		if (!_settings.AnonymousBind) {
+			try {
+				_connection.Bind(_settings.BindUser, _settings.BindPassword);
+			} catch (LdapException ex) {
+				if (ex.ResultCode == LdapException.LdapTimeout ||
+				    ex.ResultCode == LdapException.TimeLimitExceeded) {
+					Log.Error(ex, "[LDAP-S: {server}] - Bind operation timed out.", LdapServer);
+					Disconnect();
+					return false;
+				}
+
+				if (ex.ResultCode == LdapException.InvalidCredentials) {
+					Log.Error(ex, "[LDAP-S: {server}] - Invalid bind credentials specified.", LdapServer);
+					Disconnect();
+					return false;
+				}
+
+				Log.Error(ex, "[LDAP-S: {server}] - Exception during bind.", LdapServer);
+				Disconnect();
+				return false;
+			}
+		}
+
+		if (!TryFindLdapInfoForLoginUsername(username, out ldapUser))
+			return false;
+
+		if (_settings.RequireGroupMembership && !ldapUser.IsMemberOf(_settings.RequiredGroupDn))
+			return false;
+
+		try {
+			_connection.Bind(ldapUser.DistinguishedName, password);
+			return _connection.Bound;
+		} catch (LdapException ex) {
+			if (ex.ResultCode == LdapException.InvalidCredentials)
+				return false;
+
+			Log.Error(ex, "[LDAP-S: {server}] - Exception during bind.", LdapServer);
+			return false;
+		} finally {
+			Disconnect();
+		}
+	}
+
+	private void Disconnect() {
+		if (_connection != null && _connection.Connected)
+			_connection.Disconnect();
+	}
+
+	public void Dispose() {
+		Disconnect();
+	}
+
+	private static string EscapeLdapSearchFilter(string input) {
+		// escape values taken from http://msdn.microsoft.com/en-us/library/aa746475.aspx
+		var escapedFilterBuilder = new StringBuilder();
+		foreach (var character in input) {
+			switch (character) {
+				case '\\':
+					escapedFilterBuilder.Append(@"\5c");
+					break;
+				case '*':
+					escapedFilterBuilder.Append(@"\2a");
+					break;
+				case '(':
+					escapedFilterBuilder.Append(@"\28");
+					break;
+				case ')':
+					escapedFilterBuilder.Append(@"\29");
+					break;
+				case '\u0000':
+					escapedFilterBuilder.Append(@"\00");
+					break;
+				case '/':
+					escapedFilterBuilder.Append(@"\2f");
+					break;
+				default:
+					escapedFilterBuilder.Append(character);
+					break;
+			}
+		}
+
+		return escapedFilterBuilder.ToString();
+	}
+}

--- a/src/EventStore.Auth.Ldaps/LdapsSettings.cs
+++ b/src/EventStore.Auth.Ldaps/LdapsSettings.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+
+namespace EventStore.Auth.Ldaps;
+
+public class LdapsSettings {
+	public string Host { get; set; }
+	public int Port { get; set; }
+	public bool ValidateServerCertificate { get; set; }
+	public bool UseSSL { get; set; }
+
+	public bool AnonymousBind { get; set; }
+	public string BindUser { get; set; }
+	public string BindPassword { get; set; }
+
+	public string BaseDn { get; set; }
+	public string ObjectClass { get; set; }
+	public string Filter { get; set; }
+	public string GroupMembershipAttribute { get; set; }
+
+	public bool RequireGroupMembership { get; set; }
+	public string RequiredGroupDn { get; set; }
+
+	public int PrincipalCacheDurationSec { get; set; }
+
+	public Dictionary<string, string> LdapGroupRoles { get; set; }
+	public int LdapOperationTimeout { get; set; }
+
+	public LdapsSettings() {
+		Port = 636;
+		ObjectClass = "organizationalPerson";
+		Filter = "sAMAccountName";
+		GroupMembershipAttribute = "memberOf";
+		PrincipalCacheDurationSec = 60;
+		UseSSL = true;
+		LdapOperationTimeout = 5000;
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests.csproj
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests.csproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Platforms>x64</Platforms>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<IsPackable>false</IsPackable>
+		<IsPublishable>false</IsPublishable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Ductus.FluentDocker.XUnit" Version="2.10.59" />
+		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.1.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Polly" Version="8.2.0" />
+		<PackageReference Include="xunit" Version="2.6.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled\EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests/LegacyAuthorizationWithStreamAuthorizationDisabledPluginTests.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests/LegacyAuthorizationWithStreamAuthorizationDisabledPluginTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+using EventStore.Plugins.Licensing;
+using EventStore.Plugins.Tests;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests;
+
+public class LegacyAuthorizationWithStreamAuthorizationDisabledPluginTests {
+	private readonly ITestOutputHelper _outputHelper;
+
+	public LegacyAuthorizationWithStreamAuthorizationDisabledPluginTests(ITestOutputHelper outputHelper) {
+		_outputHelper = outputHelper;
+	}
+
+	public static IEnumerable<object[]> TestCases() {
+		yield return new object[] {new[] {new Claim(ClaimTypes.Role, SystemRoles.Admins)}};
+		yield return new object[] {Array.Empty<Claim>()};
+	}
+
+	[Theory, MemberData(nameof(TestCases))]
+	public async Task read_all_stream(Claim[] claims) {
+		var configurationPath = Path.GetTempFileName();
+
+		try {
+			var sut = new LegacyAuthorizationWithStreamAuthorizationDisabledPlugin();
+			var provider = sut.GetAuthorizationProviderFactory(configurationPath).Build();
+
+			var result = await provider.CheckAccessAsync(
+				new ClaimsPrincipal(new ClaimsIdentity(claims)),
+				new Operation(Operations.Streams.Read).WithParameter(
+					Operations.Streams.Parameters.StreamId("$all")), CancellationToken.None);
+
+			Assert.True(result);
+		} finally {
+			File.Delete(configurationPath);
+		}
+	}
+	
+	[Theory, MemberData(nameof(TestCases))]
+	public async Task write_all_stream(Claim[] claims) {
+		var configurationPath = Path.GetTempFileName();
+
+		try {
+			var sut = new LegacyAuthorizationWithStreamAuthorizationDisabledPlugin();
+			var provider = sut.GetAuthorizationProviderFactory(configurationPath).Build();
+
+			var result = await provider.CheckAccessAsync(
+				new ClaimsPrincipal(new ClaimsIdentity(claims)),
+				new Operation(Operations.Streams.Write).WithParameter(
+					Operations.Streams.Parameters.StreamId("$all")), CancellationToken.None);
+
+			Assert.False(result);
+		} finally {
+			File.Delete(configurationPath);
+		}
+	}
+
+	[Theory, MemberData(nameof(TestCases))]
+	public async Task create_user(Claim[] claims) {
+		var configurationPath = Path.GetTempFileName();
+
+		try {
+			var sut = new LegacyAuthorizationWithStreamAuthorizationDisabledPlugin();
+			var provider = sut.GetAuthorizationProviderFactory(configurationPath).Build();
+
+			var result = await provider.CheckAccessAsync(
+				new ClaimsPrincipal(new ClaimsIdentity(claims)),
+				new Operation(Operations.Users.Create), CancellationToken.None);
+
+			Assert.Equal(claims.Length > 0, result);
+		} finally {
+			File.Delete(configurationPath);
+		}
+	}
+
+	[Theory]
+	[InlineData(true, "LEGACY_AUTHORIZATION_WITH_STREAM_AUTHORIZATION_DISABLED", false)]
+	[InlineData(true, "NONE", true)]
+	[InlineData(false, "NONE", true)]
+	public void respects_license(bool licensePresent, string entitlement, bool expectedException) {
+		var configurationPath = Path.GetTempFileName();
+
+		try {
+			// given
+			var sut = new LegacyAuthorizationWithStreamAuthorizationDisabledPlugin();
+			var provider = sut.GetAuthorizationProviderFactory(configurationPath).Build();
+			var config = new ConfigurationBuilder().Build();
+			var builder = WebApplication.CreateBuilder();
+
+			var licenseService = new Fixtures.FakeLicenseService(licensePresent, entitlement);
+			builder.Services.AddSingleton<ILicenseService>(licenseService);
+
+			provider.ConfigureServices(
+				builder.Services,
+				config);
+
+			var app = builder.Build();
+
+			// when
+			provider.ConfigureApplication(app, config);
+
+			// then
+			if (expectedException) {
+				Assert.NotNull(licenseService.RejectionException);
+			} else {
+				Assert.Null(licenseService.RejectionException);
+			}
+		} finally {
+			File.Delete(configurationPath);
+		}
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AllowAnonymousAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AllowAnonymousAssertion.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal class AllowAnonymousAssertion : IAssertion {
+	public Grant Grant { get; } = Grant.Allow;
+
+	public AssertionInformation Information { get; } =
+		new AssertionInformation("authenticated", "not anonymous", Grant.Unknown);
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		context.Add(new AssertionMatch(policy, new AssertionInformation("match", "allow anonymous", Grant.Allow)));
+		return new ValueTask<bool>(true);
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AndAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AndAssertion.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal class AndAssertion : IAssertion {
+	private readonly ReadOnlyMemory<IAssertion> _assertions;
+	private readonly AssertionInformation _failedToMatchAllSubAssertions;
+
+	public AndAssertion(params IAssertion[] assertions) {
+		_assertions = assertions.OrderBy(x => x.Grant).ToArray();
+		_failedToMatchAllSubAssertions = new AssertionInformation("and",
+			$"({string.Join(",", _assertions.Span.ToArray().Select(x => x.ToString()))})", Grant.Deny);
+		Information = new AssertionInformation("and",
+			$"({string.Join(",", _assertions.ToArray().Select(x => x.ToString()))})", Grant.Unknown);
+	}
+
+	public AssertionInformation Information { get; }
+
+	public Grant Grant { get; } = Grant.Unknown;
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		var remaining = _assertions;
+		while (!remaining.IsEmpty && context.Grant != Grant.Deny) {
+			var pending = remaining.Span[0].Evaluate(cp, operation, policy, context);
+			remaining = remaining.Slice(1);
+			if (!pending.IsCompleted)
+				return EvaluateAsync(pending, remaining, cp, operation, policy, context);
+			if (!pending.Result) {
+				context.Add(new AssertionMatch(policy, _failedToMatchAllSubAssertions));
+				return new ValueTask<bool>(false);
+			}
+		}
+
+		return new ValueTask<bool>(true);
+	}
+
+	private async ValueTask<bool> EvaluateAsync(ValueTask<bool> pending, ReadOnlyMemory<IAssertion> remaining,
+		ClaimsPrincipal cp, Operation operation, PolicyInformation policy, EvaluationContext result) {
+		bool evaluated;
+		while ((evaluated = await pending.ConfigureAwait(false)) && !remaining.IsEmpty) {
+			pending = remaining.Span[0].Evaluate(cp, operation, policy, result);
+			remaining = remaining.Slice(1);
+		}
+
+		if (!evaluated)
+			result.Add(new AssertionMatch(policy, _failedToMatchAllSubAssertions));
+		return evaluated;
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AssertionComparer.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AssertionComparer.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal sealed class AssertionComparer : IComparer<IAssertion> {
+	private static readonly MethodInfo OpenTypeComparer =
+		new Func<IAssertion, IAssertion, int>(Compare<object>).Method.GetGenericMethodDefinition();
+
+	private AssertionComparer() { }
+
+	public static IComparer<IAssertion> Instance { get; } = new AssertionComparer();
+
+	public int Compare(IAssertion x, IAssertion y) {
+		var grant = x.Grant.CompareTo(y.Grant);
+		if (grant != 0) return grant * -1;
+
+		var type = Comparer<Type>.Default.Compare(x.GetType(), y.GetType());
+		if (type != 0) return type;
+
+		var closed = (Func<IAssertion, IAssertion, int>)OpenTypeComparer.MakeGenericMethod(x.GetType())
+			.CreateDelegate(typeof(Func<IAssertion, IAssertion, int>));
+		return closed(x, y);
+	}
+
+	private static int Compare<T>(IAssertion x, IAssertion y) {
+		if (x is IComparable<T> comparable)
+			return comparable.CompareTo((T)y);
+		throw new NotSupportedException(
+			"Assertion classes must implement IComparable<T> where T is the Assertion class");
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AssertionInformation.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AssertionInformation.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public struct AssertionInformation {
+	public Grant Grant { get; }
+	private readonly string _assertion;
+
+	public AssertionInformation(string type, string assertion, Grant grant) {
+		Grant = grant;
+		_assertion = $"{type}:{assertion}:{grant}";
+	}
+
+	public override string ToString() {
+		return _assertion;
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AssertionMatch.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/AssertionMatch.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public readonly struct AssertionMatch {
+	public readonly PolicyInformation Policy;
+	public readonly AssertionInformation Assertion;
+	public readonly IReadOnlyList<Claim> Matches;
+
+	public AssertionMatch(PolicyInformation policy, AssertionInformation assertion, params Claim[] matches) : this(
+		policy, assertion, (IReadOnlyList<Claim>)matches) {
+	}
+
+	public AssertionMatch(PolicyInformation policy, AssertionInformation assertion, IReadOnlyList<Claim> matches) {
+		Policy = policy;
+		Assertion = assertion;
+		Matches = matches;
+	}
+
+	public override string ToString() {
+		return $"{Policy} : {Assertion}, ${string.Join(Environment.NewLine + "\t", Matches)}";
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/ClaimMatchAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/ClaimMatchAssertion.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class ClaimMatchAssertion : IComparable<ClaimMatchAssertion>, IAssertion {
+	private readonly Claim _claim;
+
+	public ClaimMatchAssertion(Grant grant, Claim claim) {
+		_claim = claim;
+		Grant = grant;
+		Information = new AssertionInformation("equal", _claim.ToString(), grant);
+	}
+
+	public AssertionInformation Information { get; }
+
+	public Grant Grant { get; }
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		// ReSharper disable once PatternAlwaysOfType
+		if (cp.FindFirst(x =>
+			string.Equals(x.Type, _claim.Type, StringComparison.Ordinal) &&
+			string.Equals(x.Value, _claim.Value, StringComparison.Ordinal)) is Claim matched) {
+			context.Add(new AssertionMatch(policy, Information, matched));
+			return new ValueTask<bool>(true);
+		}
+
+		return new ValueTask<bool>(false);
+	}
+
+	public int CompareTo(ClaimMatchAssertion other) {
+		if (other == null)
+			throw new ArgumentNullException(nameof(other));
+
+		var grant = Grant.CompareTo(other.Grant);
+		if (grant != 0)
+			return grant * -1;
+		var type = string.CompareOrdinal(_claim.Type, other._claim.Type);
+		if (type != 0)
+			return type;
+		return string.CompareOrdinal(_claim.Value, other._claim.Value);
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/ClaimValueMatchesParameterValueAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/ClaimValueMatchesParameterValueAssertion.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class ClaimValueMatchesParameterValueAssertion : IAssertion {
+	private readonly string _claimType;
+	private readonly string _parameterName;
+
+	public ClaimValueMatchesParameterValueAssertion(string claimType, string parameterName, Grant grant) {
+		_claimType = claimType;
+		_parameterName = parameterName;
+		Grant = grant;
+		Information = new AssertionInformation("match", $"{_claimType} : {_parameterName}", Grant);
+	}
+
+	public AssertionInformation Information { get; }
+	public Grant Grant { get; }
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		if (cp.FindFirst(_claimType) is Claim matchedClaim &&
+		    operation.Parameters.Span.Contains(new Parameter(_parameterName, matchedClaim.Value))) {
+			context.Add(new AssertionMatch(policy, Information, matchedClaim));
+			return new ValueTask<bool>(true);
+		}
+
+		return new ValueTask<bool>(false);
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/EvaluationContext.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/EvaluationContext.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class EvaluationContext {
+	private readonly List<AssertionMatch> _matches;
+	private readonly Operation _operation;
+
+	public EvaluationContext(Operation operation, CancellationToken cancellationToken) {
+		CancellationToken = cancellationToken;
+		_operation = operation;
+		_matches = new List<AssertionMatch>();
+		Grant = Grant.Unknown;
+	}
+
+	public CancellationToken CancellationToken { get; }
+	public Grant Grant { get; private set; }
+
+	public void Add(AssertionMatch match) {
+		if (match.Assertion.Grant > Grant)
+			Grant = match.Assertion.Grant;
+		_matches.Add(match);
+	}
+
+	public EvaluationResult ToResult() {
+		return new EvaluationResult(_operation, Grant, _matches);
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/EvaluationResult.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/EvaluationResult.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public readonly struct EvaluationResult {
+	public readonly Grant Grant;
+	public readonly Operation Operation;
+	public readonly IReadOnlyList<AssertionMatch> Matches;
+
+	public EvaluationResult(Operation operation, Grant grant, params AssertionMatch[] matches) : this(operation,
+		grant, (IReadOnlyList<AssertionMatch>)matches) {
+	}
+
+	public EvaluationResult(Operation operation, Grant grant, IReadOnlyList<AssertionMatch> matches) {
+		Grant = grant;
+		Matches = matches;
+		Operation = operation;
+	}
+
+	public override string ToString() {
+		return $"{Operation} {Grant} : {string.Join(Environment.NewLine, Matches)}";
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.csproj
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Platforms>x64</Platforms>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+	</PropertyGroup>
+	<PropertyGroup>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+	  <DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/Grant.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/Grant.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public enum Grant {
+	Unknown = 0,
+	Allow = 1,
+	Deny = 2
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/IAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/IAssertion.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal interface IAssertion {
+	Grant Grant { get; }
+	AssertionInformation Information { get; }
+
+	ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context);
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/IPolicyEvaluator.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/IPolicyEvaluator.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public interface IPolicyEvaluator {
+	ValueTask<EvaluationResult> EvaluateAsync(ClaimsPrincipal cp, Operation operation,
+		CancellationToken cancellationToken);
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledPlugin.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledPlugin.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class LegacyAuthorizationWithStreamAuthorizationDisabledPlugin : IAuthorizationPlugin {
+	public IAuthorizationProviderFactory GetAuthorizationProviderFactory(string authorizationConfigPath) =>
+		new LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory();
+
+	public string Name { get; } = "LegacyAuthorizationWithStreamAuthorizationDisabled";
+
+	public string Version { get; } =
+		typeof(LegacyAuthorizationWithStreamAuthorizationDisabledPlugin).Assembly.GetName().Version!.ToString();
+
+	public string CommandLineName { get; } = "legacy-authorization-with-stream-authorization-disabled";
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledProvider.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledProvider.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Diagnostics;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+using Serilog;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal class LegacyAuthorizationWithStreamAuthorizationDisabledProvider : AuthorizationProviderBase {
+	private static readonly Stopwatch sw = Stopwatch.StartNew();
+	private readonly bool _logAuthorization;
+	private readonly ILogger _logger;
+	private readonly bool _logSuccesses;
+	private readonly IPolicyEvaluator _policyEvaluator;
+
+	public LegacyAuthorizationWithStreamAuthorizationDisabledProvider(IPolicyEvaluator policyEvaluator,
+		ILogger logger, bool logAuthorization,
+		bool logSuccesses)
+		: base(
+			name: "LegacyAuthorizationWithStreamAuthorizationDisabled",
+			requiredEntitlements: ["LEGACY_AUTHORIZATION_WITH_STREAM_AUTHORIZATION_DISABLED"]) {
+
+		_policyEvaluator = policyEvaluator;
+		_logger = logger;
+		_logAuthorization = logAuthorization;
+		_logSuccesses = logSuccesses;
+	}
+
+	public override ValueTask<bool> CheckAccessAsync(ClaimsPrincipal cp, Operation operation, CancellationToken ct) {
+		cp ??= SystemAccounts.Anonymous;
+
+		try {
+			var startedAt = sw.Elapsed;
+			var evaluationTask = _policyEvaluator.EvaluateAsync(cp, operation, ct);
+			if (evaluationTask.IsCompleted)
+				return new ValueTask<bool>(LogAndCheck(startedAt, cp, evaluationTask.Result));
+
+			return CheckAccessAsync(startedAt, cp, evaluationTask);
+		} catch (Exception ex) {
+			_logger.Error(ex, "Error performing permission check for {identity}",
+				cp.FindFirst(ClaimTypes.Name)?.Value ?? "unknown");
+			return new ValueTask<bool>(false);
+		}
+	}
+
+	private async ValueTask<bool> CheckAccessAsync(TimeSpan startedAt, ClaimsPrincipal cp,
+		ValueTask<EvaluationResult> evaluationTask) {
+		try {
+			return LogAndCheck(startedAt, cp, await evaluationTask.ConfigureAwait(false));
+		} catch (Exception ex) {
+			_logger.Error(ex, "Error performing permission check for {identity}",
+				cp.FindFirst(ClaimTypes.Name)?.Value ?? "unknown");
+			return false;
+		}
+	}
+
+	private bool LogAndCheck(TimeSpan startedAt, ClaimsPrincipal cp, EvaluationResult result) {
+		if (_logAuthorization) {
+			if (result.Grant == Grant.Allow && _logSuccesses)
+				_logger.Information(
+					"Successful authorization check for {identity} in {duration} with {evaluationResult}",
+					cp.FindFirst(ClaimTypes.Name).Value, sw.Elapsed.Subtract(startedAt), result);
+			else if (result.Grant != Grant.Allow)
+				_logger.Warning("Failed authorization check for {identity} in {duration} with {evaluationResult}",
+					cp.FindFirst(ClaimTypes.Name)?.Value ?? "(anonymous)", startedAt, result);
+		}
+
+		return result.Grant == Grant.Allow;
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using EventStore.Plugins.Authorization;
+using Serilog;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory : IAuthorizationProviderFactory {
+	private static readonly Claim[] Admins =
+		{new Claim(ClaimTypes.Role, SystemRoles.Admins), new Claim(ClaimTypes.Name, SystemUsers.Admin)};
+
+	private static readonly Claim[] OperationsOrAdmins = {
+		new Claim(ClaimTypes.Role, SystemRoles.Admins), new Claim(ClaimTypes.Name, SystemUsers.Admin),
+		new Claim(ClaimTypes.Role, SystemRoles.Operations), new Claim(ClaimTypes.Name, SystemUsers.Operations)
+	};
+
+	public IAuthorizationProvider Build() {
+		var policy = new Policy("Legacy", 1, DateTimeOffset.MinValue);
+		var streamAssertion = new LegacyStreamPermissionAssertion();
+
+		policy.AllowAnonymous(Operations.Node.Redirect);
+		policy.AllowAnonymous(Operations.Node.StaticContent);
+		policy.AllowAnonymous(Operations.Node.Ping);
+		policy.AllowAnonymous(Operations.Node.Options);
+
+		policy.AllowAnonymous(Operations.Node.Information.Read);
+		policy.AddMatchAnyAssertion(Operations.Node.Information.Subsystems, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Node.Information.Histogram, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Node.Information.Options, Grant.Allow, OperationsOrAdmins);
+
+		policy.AllowAnonymous(Operations.Node.Statistics.Read);
+		policy.AllowAnonymous(Operations.Node.Statistics.Replication);
+		policy.AllowAnonymous(Operations.Node.Statistics.Tcp);
+		policy.AllowAnonymous(Operations.Node.Statistics.Custom);
+
+		var isSystem = new MultipleClaimMatchAssertion(Grant.Allow, MultipleMatchMode.All, SystemAccounts.System.Claims.ToArray());
+		policy.Add(Operations.Node.Elections.Prepare, isSystem);
+		policy.Add(Operations.Node.Elections.PrepareOk, isSystem);
+		policy.Add(Operations.Node.Elections.ViewChange, isSystem);
+		policy.Add(Operations.Node.Elections.ViewChangeProof, isSystem);
+		policy.Add(Operations.Node.Elections.Proposal, isSystem);
+		policy.Add(Operations.Node.Elections.Accept, isSystem);
+		policy.Add(Operations.Node.Elections.LeaderIsResigning, isSystem);
+		policy.Add(Operations.Node.Elections.LeaderIsResigningOk, isSystem);
+
+		policy.AllowAnonymous(Operations.Node.Gossip.Read);
+		policy.AllowAnonymous(Operations.Node.Gossip.ClientRead);
+		policy.Add(Operations.Node.Gossip.Update, isSystem);
+
+		policy.AddMatchAnyAssertion(Operations.Node.Shutdown, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Node.MergeIndexes, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Node.SetPriority, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Node.Resign, Grant.Allow, OperationsOrAdmins);
+		policy.RequireAuthenticated(Operations.Node.Login);
+		policy.AddMatchAnyAssertion(Operations.Node.Scavenge.Start, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Node.Scavenge.Stop, Grant.Allow, OperationsOrAdmins);
+
+		var subscriptionAccess =
+			new AndAssertion(
+				new RequireAuthenticatedAssertion(),
+				new RequireStreamReadAssertion(streamAssertion));
+
+		policy.RequireAuthenticated(Operations.Subscriptions.Statistics);
+		policy.AddMatchAnyAssertion(Operations.Subscriptions.Create, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Subscriptions.Update, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Subscriptions.Delete, Grant.Allow, OperationsOrAdmins);
+		policy.Add(Operations.Subscriptions.ProcessMessages, subscriptionAccess);
+		policy.AddMatchAnyAssertion(Operations.Subscriptions.ReplayParked, Grant.Allow, OperationsOrAdmins);
+
+		policy.Add(Operations.Streams.Read, streamAssertion);
+		policy.Add(Operations.Streams.Write, streamAssertion);
+		policy.Add(Operations.Streams.Delete, streamAssertion);
+		policy.Add(Operations.Streams.MetadataRead, streamAssertion);
+		policy.Add(Operations.Streams.MetadataWrite, streamAssertion);
+
+		var matchUsername = new ClaimValueMatchesParameterValueAssertion(ClaimTypes.Name,
+			Operations.Users.Parameters.UserParameterName, Grant.Allow);
+		var isAdmin = new MultipleClaimMatchAssertion(Grant.Allow, MultipleMatchMode.Any, Admins);
+		policy.Add(Operations.Users.List, isAdmin);
+		policy.Add(Operations.Users.Create, isAdmin);
+		policy.Add(Operations.Users.Delete, isAdmin);
+		policy.Add(Operations.Users.Update, isAdmin);
+		policy.Add(Operations.Users.Enable, isAdmin);
+		policy.Add(Operations.Users.Disable, isAdmin);
+		policy.Add(Operations.Users.ResetPassword, isAdmin);
+		policy.RequireAuthenticated(Operations.Users.CurrentUser);
+		policy.Add(Operations.Users.Read, new OrAssertion(isAdmin, matchUsername));
+		policy.Add(Operations.Users.ChangePassword, matchUsername);
+
+
+		policy.RequireAuthenticated(Operations.Projections.List);
+
+		policy.RequireAuthenticated(Operations.Projections.Abort);
+		policy.RequireAuthenticated(Operations.Projections.Create);
+		policy.RequireAuthenticated(Operations.Projections.DebugProjection);
+		policy.AddMatchAnyAssertion(Operations.Projections.Delete, Grant.Allow, OperationsOrAdmins);
+		policy.RequireAuthenticated(Operations.Projections.Disable);
+		policy.RequireAuthenticated(Operations.Projections.Enable);
+		policy.RequireAuthenticated(Operations.Projections.Read);
+		policy.AddMatchAnyAssertion(Operations.Projections.ReadConfiguration, Grant.Allow, OperationsOrAdmins);
+		policy.RequireAuthenticated(Operations.Projections.Reset);
+		policy.RequireAuthenticated(Operations.Projections.Update);
+		policy.AddMatchAnyAssertion(Operations.Projections.UpdateConfiguration, Grant.Allow, OperationsOrAdmins);
+		policy.RequireAuthenticated(Operations.Projections.State);
+		policy.RequireAuthenticated(Operations.Projections.Status);
+		policy.RequireAuthenticated(Operations.Projections.Statistics);
+		policy.AddMatchAnyAssertion(Operations.Projections.Restart, Grant.Allow, OperationsOrAdmins);
+
+		return new LegacyAuthorizationWithStreamAuthorizationDisabledProvider(new PolicyEvaluator(policy.AsReadOnly()),
+			Log.ForContext<PolicyEvaluator>(), true, false);
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyStreamPermissionAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyStreamPermissionAssertion.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class LegacyStreamPermissionAssertion : IAssertion {
+	public AssertionInformation Information { get; } =
+		new AssertionInformation("stream", "legacy acl", Grant.Unknown);
+
+	public Grant Grant { get; } = Grant.Unknown;
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		var streamId = FindStreamId(operation.Parameters.Span);
+
+		return CheckStreamAccess(operation, policy, context, streamId);
+	}
+
+	private ValueTask<bool> CheckStreamAccess(Operation operation, PolicyInformation policy,
+		EvaluationContext context, string streamId) {
+		if (streamId == null) {
+			context.Add(new AssertionMatch(policy,
+				new AssertionInformation("streamId", "streamId is null", Grant.Deny)));
+			return new ValueTask<bool>(true);
+		}
+
+		if ((streamId == string.Empty || streamId == "$all") &&
+		    (operation == Operations.Streams.Delete || operation == Operations.Streams.Write)) {
+			context.Add(new AssertionMatch(policy,
+				new AssertionInformation("streamId", $"{operation.Action} denied on $all", Grant.Deny)));
+			return new ValueTask<bool>(true);
+		}
+
+		context.Add(new AssertionMatch(policy,
+			new AssertionInformation("stream", "public stream", Grant.Allow)));
+
+		return new ValueTask<bool>(true);
+	}
+
+	private string FindStreamId(ReadOnlySpan<Parameter> parameters) {
+		for (int i = 0; i < parameters.Length; i++) {
+			if (parameters[i].Name == "streamId")
+				return parameters[i].Value;
+		}
+
+		throw new InvalidOperationException();
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/MultipleClaimMatchAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/MultipleClaimMatchAssertion.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class MultipleClaimMatchAssertion : IComparable<MultipleClaimMatchAssertion>, IAssertion {
+	private readonly IReadOnlyList<Claim> _claims;
+	private readonly MultipleMatchMode _mode;
+
+	public MultipleClaimMatchAssertion(Grant grant, MultipleMatchMode mode, params Claim[] claims) {
+		if (claims.Length == 0) throw new ArgumentException("Value cannot be an empty collection.", nameof(claims));
+
+
+		_mode = mode;
+		Grant = grant;
+		_claims = claims.OrderBy(x => x.Type).ToArray();
+		var sb = new StringBuilder();
+		foreach (var claim in _claims) sb.AppendLine($"{claim.Type} {claim.Value}");
+
+		var assertion = sb.ToString();
+		Information = mode switch {
+			MultipleMatchMode.All => new AssertionInformation("all", assertion, grant),
+			MultipleMatchMode.Any => new AssertionInformation("any", assertion, Grant),
+			MultipleMatchMode.None => new AssertionInformation("none", assertion, Grant),
+			_ => throw new ArgumentOutOfRangeException(nameof(mode))
+		};
+	}
+
+	public AssertionInformation Information { get; }
+
+	public Grant Grant { get; }
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		var matches = new List<Claim>(_claims.Count);
+
+		foreach (var claim in _claims)
+			if (cp.FindFirst(x =>
+				string.Equals(x.Type, claim.Type, StringComparison.Ordinal) &&
+				string.Equals(x.Value, claim.Value, StringComparison.Ordinal)) is Claim matched) {
+				matches.Add(matched);
+				if (_mode != MultipleMatchMode.All) break;
+			}
+
+		var matchFound = false;
+		switch (_mode) {
+			case MultipleMatchMode.All:
+				if (matches.Count == _claims.Count) {
+					context.Add(new AssertionMatch(policy, Information, matches));
+					matchFound = true;
+				}
+
+				break;
+			case MultipleMatchMode.Any:
+				if (matches.Count > 0) {
+					context.Add(new AssertionMatch(policy, Information, matches));
+					matchFound = true;
+				}
+
+				break;
+			case MultipleMatchMode.None:
+				if (matches.Count == 0) {
+					context.Add(new AssertionMatch(policy, Information, matches));
+					matchFound = true;
+				}
+
+				break;
+			default:
+				throw new ArgumentOutOfRangeException();
+		}
+
+
+		return new ValueTask<bool>(matchFound);
+	}
+
+
+	public int CompareTo(MultipleClaimMatchAssertion other) {
+		var grant = Grant.CompareTo(other.Grant);
+		if (grant != 0)
+			return grant * -1;
+		var length = Comparer<int>.Default.Compare(_claims.Count, other._claims.Count);
+		if (length != 0)
+			return length;
+		for (int i = 0; i < _claims.Count; i++) {
+			var type = string.CompareOrdinal(_claims[i].Type, other._claims[i].Type);
+			if (type != 0)
+				return type;
+			var value = string.CompareOrdinal(_claims[i].Value, other._claims[i].Value);
+			if (value != 0)
+				return value;
+		}
+
+		return 0;
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/MultipleMatchMode.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/MultipleMatchMode.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public enum MultipleMatchMode {
+	All,
+	Any,
+	None
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/OrAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/OrAssertion.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal class OrAssertion : IAssertion {
+	private readonly ReadOnlyMemory<IAssertion> _assertions;
+
+	public OrAssertion(params IAssertion[] assertions) {
+		_assertions = assertions.OrderBy(x => x.Grant).ToArray();
+		Information = new AssertionInformation("or", $"({string.Join(",", _assertions)})", Grant.Unknown);
+	}
+
+	public AssertionInformation Information { get; }
+
+	public Grant Grant { get; } = Grant.Unknown;
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		var remaining = _assertions;
+		while (!remaining.IsEmpty && context.Grant != Grant.Deny) {
+			var pending = remaining.Span[0].Evaluate(cp, operation, policy, context);
+			remaining = remaining.Slice(1);
+			if (!pending.IsCompleted)
+				return EvaluateAsync(pending, remaining, cp, operation, policy, context);
+			if (pending.Result) return new ValueTask<bool>(true);
+		}
+
+		return new ValueTask<bool>(false);
+	}
+
+	private async ValueTask<bool> EvaluateAsync(ValueTask<bool> pending, ReadOnlyMemory<IAssertion> remaining,
+		ClaimsPrincipal cp, Operation operation, PolicyInformation policy, EvaluationContext result) {
+		bool evaluated;
+		while (!(evaluated = await pending.ConfigureAwait(false)) && !remaining.IsEmpty) {
+			pending = remaining.Span[0].Evaluate(cp, operation, policy, result);
+			remaining = remaining.Slice(1);
+		}
+
+		return evaluated;
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/Policy.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/Policy.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal class Policy {
+	private readonly Dictionary<OperationDefinition, List<IAssertion>> _assertions;
+	private readonly long _version;
+	private bool _sealed;
+
+	public Policy(string name, long version, DateTimeOffset validFrom) {
+		_version = version;
+		Name = name;
+		ValidFrom = validFrom;
+		_assertions = new Dictionary<OperationDefinition, List<IAssertion>>();
+		_sealed = false;
+	}
+
+	public string Name { get; }
+	public DateTimeOffset ValidFrom { get; }
+
+	public void AddMatchAnyAssertion(OperationDefinition operation, Grant grant, params Claim[] claims) {
+		var assertion = new MultipleClaimMatchAssertion(grant, MultipleMatchMode.Any, claims);
+		Add(operation, assertion);
+	}
+
+	public void AddClaimMatchAssertion(OperationDefinition operation, Grant grant, Claim claim) {
+		var assertion = new ClaimMatchAssertion(grant, claim);
+		Add(operation, assertion);
+	}
+
+	public void Add(OperationDefinition operation, IAssertion assertion) {
+		if (_sealed)
+			throw new InvalidOperationException("policy has been sealed and no further changes can be made");
+		if (!_assertions.TryGetValue(operation, out var assertions))
+			_assertions[operation] = assertions = new List<IAssertion>();
+		var insertAt = assertions.BinarySearch(assertion, AssertionComparer.Instance);
+		if (insertAt >= 0)
+			throw new InvalidOperationException("Assertion already exists");
+		assertions.Insert(~insertAt, assertion);
+	}
+
+	public ReadOnlyPolicy AsReadOnly() {
+		_sealed = true;
+		return new ReadOnlyPolicy(Name, _version, ValidFrom,
+			_assertions
+				.ToDictionary<KeyValuePair<OperationDefinition, List<IAssertion>>, OperationDefinition,
+					ReadOnlyMemory<IAssertion>>(x => x.Key, x => x.Value.ToArray()));
+	}
+
+	public void AllowAnonymous(in OperationDefinition operation) {
+		Add(operation, new AllowAnonymousAssertion());
+	}
+
+	public void RequireAuthenticated(in OperationDefinition operation) {
+		Add(operation, new RequireAuthenticatedAssertion());
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/PolicyEvaluator.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/PolicyEvaluator.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal class PolicyEvaluator : IPolicyEvaluator {
+	private static readonly AssertionInformation DeniedByDefault =
+		new AssertionInformation("default", "denied by default", Grant.Deny);
+
+	private readonly ReadOnlyPolicy _policy;
+	private readonly PolicyInformation _policyInfo;
+
+	public PolicyEvaluator(ReadOnlyPolicy policy) {
+		_policy = policy;
+		_policyInfo = policy.Information;
+	}
+
+	public ValueTask<EvaluationResult>
+		EvaluateAsync(ClaimsPrincipal cp, Operation operation, CancellationToken ct) {
+		var evaluation = new EvaluationContext(operation, ct);
+
+		if (_policy.TryGetAssertions(operation, out var assertions))
+			while (!assertions.IsEmpty && evaluation.Grant != Grant.Deny) {
+				if (ct.IsCancellationRequested) break;
+				var assertion = assertions.Span[0];
+				assertions = assertions.Slice(1);
+				var evaluate = assertion.Evaluate(cp, operation, _policyInfo, evaluation);
+				if (!evaluate.IsCompleted)
+					return EvaluateAsync(evaluate, cp, operation, assertions, evaluation, ct);
+			}
+
+		if (evaluation.Grant == Grant.Unknown) evaluation.Add(new AssertionMatch(_policyInfo, DeniedByDefault));
+
+		return new ValueTask<EvaluationResult>(evaluation.ToResult());
+	}
+
+	private async ValueTask<EvaluationResult> EvaluateAsync(
+		ValueTask<bool> pending,
+		ClaimsPrincipal cp,
+		Operation operation,
+		ReadOnlyMemory<IAssertion> assertions,
+		EvaluationContext evaluationContext,
+		CancellationToken ct) {
+		do {
+			if (ct.IsCancellationRequested) break;
+			await pending.ConfigureAwait(false);
+			if (ct.IsCancellationRequested) break;
+			if (assertions.IsEmpty) break;
+			pending = assertions.Span[0].Evaluate(cp, operation, _policyInfo, evaluationContext);
+			assertions = assertions.Slice(1);
+		} while (evaluationContext.Grant != Grant.Deny);
+
+		if (evaluationContext.Grant == Grant.Unknown)
+			evaluationContext.Add(new AssertionMatch(_policyInfo, DeniedByDefault));
+
+		return evaluationContext.ToResult();
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/PolicyInformation.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/PolicyInformation.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class PolicyInformation {
+	public readonly DateTimeOffset Expires;
+	public readonly string Name;
+
+	public PolicyInformation(string name, long version, DateTimeOffset expires) {
+		Version = version;
+		Name = name;
+		Expires = expires;
+	}
+
+	public long Version { get; }
+
+	public override string ToString() {
+		return $"Policy : {Name} {Version} {Expires}";
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/ReadOnlyPolicy.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/ReadOnlyPolicy.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal class ReadOnlyPolicy {
+	private readonly IReadOnlyDictionary<OperationDefinition, ReadOnlyMemory<IAssertion>> _assertions;
+	private readonly string _name;
+	private readonly DateTimeOffset _validFrom;
+	private readonly long _version;
+
+	public ReadOnlyPolicy(string name, long version, DateTimeOffset validFrom,
+		IReadOnlyDictionary<OperationDefinition, ReadOnlyMemory<IAssertion>> assertions) {
+		_name = name;
+		_version = version;
+		_validFrom = validFrom;
+		_assertions = assertions;
+	}
+
+	public PolicyInformation Information => new PolicyInformation(_name, _version, DateTimeOffset.MaxValue);
+
+	public bool TryGetAssertions(OperationDefinition operation, out ReadOnlyMemory<IAssertion> assertions) {
+		return _assertions.TryGetValue(operation, out assertions);
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/RequireAuthenticatedAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/RequireAuthenticatedAssertion.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal class RequireAuthenticatedAssertion : IAssertion {
+	public Grant Grant { get; } = Grant.Unknown;
+
+	public AssertionInformation Information { get; } =
+		new AssertionInformation("match", "authenticated", Grant.Unknown);
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		if (!cp.Claims.Any() ||
+		    cp.Claims.Any(x => string.Equals(x.Type, ClaimTypes.Anonymous, StringComparison.Ordinal)))
+			context.Add(new AssertionMatch(policy, new AssertionInformation("match", "authenticated", Grant.Deny)));
+		else
+			context.Add(new AssertionMatch(policy,
+				new AssertionInformation("match", "authenticated", Grant.Allow)));
+		return new ValueTask<bool>(true);
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/RequireStreamReadAssertion.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/RequireStreamReadAssertion.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public class RequireStreamReadAssertion : IAssertion {
+	private static readonly Operation StreamRead = new Operation(Operations.Streams.Read);
+	private readonly LegacyStreamPermissionAssertion _streamAssertion;
+
+	public RequireStreamReadAssertion(LegacyStreamPermissionAssertion streamAssertion) {
+		_streamAssertion = streamAssertion;
+		Information = streamAssertion.Information;
+	}
+
+	public AssertionInformation Information { get; }
+	public Grant Grant { get; } = Grant.Unknown;
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		if (operation == Operations.Subscriptions.ProcessMessages ||
+		    operation == Operations.Subscriptions.ReplayParked) {
+			var stream = FindStreamId(operation.Parameters.Span);
+			return _streamAssertion.Evaluate(cp,
+				StreamRead.WithParameter(Operations.Streams.Parameters.StreamId(stream)), policy, context);
+		}
+
+		return new ValueTask<bool>(false);
+	}
+
+	private string FindStreamId(ReadOnlySpan<Parameter> parameters) {
+		for (int i = 0; i < parameters.Length; i++)
+			if (parameters[i].Name == "streamId")
+				return parameters[i].Value;
+
+		return null;
+	}
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/SystemAccounts.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/SystemAccounts.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public static class SystemAccounts {
+	private static readonly IReadOnlyList<Claim> Claims = new[] {
+		new Claim(ClaimTypes.Name, "system"),
+		new Claim(ClaimTypes.Role, "system"),
+		new Claim(ClaimTypes.Role, SystemRoles.Admins),
+	};
+
+	public static readonly ClaimsPrincipal System = new ClaimsPrincipal(new ClaimsIdentity(Claims, "system"));
+
+	public static readonly ClaimsPrincipal Anonymous =
+		new ClaimsPrincipal(new ClaimsIdentity(new[] {new Claim(ClaimTypes.Anonymous, ""),}));
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/SystemRoles.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/SystemRoles.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public static class SystemRoles {
+	public const string Admins = "$admins";
+	public const string Operations = "$ops";
+	public const string All = "$all";
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/SystemUsers.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/SystemUsers.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+public static class SystemUsers {
+	public const string Admin = "admin";
+	public const string Operations = "ops";
+}

--- a/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/WellKnownAssertions.cs
+++ b/src/EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/WellKnownAssertions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+
+namespace EventStore.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled;
+
+internal static class WellKnownAssertions {
+	public static readonly IAssertion System = new MultipleClaimMatchAssertion(Grant.Allow, MultipleMatchMode.All,
+		new Claim(ClaimTypes.Name, "system"), new Claim(ClaimTypes.Authentication, "ES-Legacy"));
+
+	public static readonly IAssertion Admin = new MultipleClaimMatchAssertion(Grant.Allow, MultipleMatchMode.Any,
+		new Claim(ClaimTypes.Name, "admin"), new Claim(ClaimTypes.Role, SystemRoles.Admins));
+}

--- a/src/EventStore.Auth.OAuth.Tests/ContainerExtensions.cs
+++ b/src/EventStore.Auth.OAuth.Tests/ContainerExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Threading.Tasks;
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Services;
+using Ductus.FluentDocker.Services.Extensions;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.OAuth.Tests;
+
+internal static class ContainerExtensions {
+	public static void ShipContainerLogs(this IContainerService container, ITestOutputHelper testOutputHelper) =>
+		Task.Run(() => {
+			using var logs = container.Logs(true);
+			foreach (var line in logs.ReadToEnd()) {
+				testOutputHelper.WriteLine(line);
+			}
+		});
+}

--- a/src/EventStore.Auth.OAuth.Tests/Dockerfile
+++ b/src/EventStore.Auth.OAuth.Tests/Dockerfile
@@ -1,0 +1,23 @@
+ARG DB_IMAGE=docker.eventstore.com/eventstore-staging-ee/eventstoredb-ee:ci
+
+FROM mcr.microsoft.com/dotnet/core/sdk:8.0-jammy AS build
+
+WORKDIR /build/src
+
+COPY ./src/EventStore.CommercialHA.sln ./src/*/*.csproj ./src/Directory.Build.props ./
+
+RUN for file in $(ls *.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.*}/; done
+
+RUN dotnet restore --runtime=${RUNTIME}
+
+COPY ./src .
+
+RUN dotnet build --configuration=Release --runtime=${RUNTIME} --no-restore --framework=net8.0 && \
+	rm /build/bin/Release/EventStore.Auth.OAuth/net8.0/EventStore.Plugins.*
+
+FROM ${DB_IMAGE} as kurrentdb
+
+RUN mkdir -p /opt/kurrentdb/plugins
+
+COPY --from=build /build/bin/Release/EventStore.Auth.OAuth/net8.0 /opt/kurrentdb/plugins/oauth
+

--- a/src/EventStore.Auth.OAuth.Tests/EventStore.Auth.OAuth.Tests.csproj
+++ b/src/EventStore.Auth.OAuth.Tests/EventStore.Auth.OAuth.Tests.csproj
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Platforms>x64</Platforms>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<IsPackable>false</IsPackable>
+		<IsPublishable>false</IsPublishable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Ductus.FluentDocker.XUnit" Version="2.10.59" />
+		<PackageReference Include="EventStore.Client" Version="22.0.0" />
+		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.1.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Polly" Version="8.2.0" />
+		<PackageReference Include="xunit" Version="2.6.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.Auth.OAuth\EventStore.Auth.OAuth.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<Content Include="conf\idsrv4.conf.json">
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<Content Include="conf\users.conf.json">
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
+	<ItemGroup>
+	  <None Update="conf\oauth.conf">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Auth.OAuth.Tests/Fixture.cs
+++ b/src/EventStore.Auth.OAuth.Tests/Fixture.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Ductus.FluentDocker.Builders;
+using Ductus.FluentDocker.Model.Builders;
+using Ductus.FluentDocker.Services;
+using Polly;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.OAuth.Tests;
+
+internal class Fixture : IDisposable {
+	private const string PluginConfigurationPath = "/etc/kurrentdb/oauth.conf";
+
+	private const string BuildConfiguration =
+#if DEBUG
+		"Debug";
+#else
+			"Release";
+#endif
+
+	private static string SourceDirectory =>
+		Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "../../../../src"));
+
+	private static string BuildDirectory => Path.GetFullPath(Path.Combine(Environment.CurrentDirectory,
+		$"../../../../bin/{BuildConfiguration}"));
+
+	private static string CertificateDirectory => Path.Join(BuildDirectory, "testcerts");
+
+	private static string PluginSourceDirectory => Path.Combine(SourceDirectory, "EventStore.Auth.OAuth");
+
+	private static string PluginPublishDirectory =>
+		Path.Combine(BuildDirectory, "EventStore.Auth.OAuth", "net8.0", "publish");
+
+	private static string ESImage {
+		get {
+			var imageWithTag = Environment.GetEnvironmentVariable("DB_IMAGE");
+			if (!string.IsNullOrWhiteSpace(imageWithTag))
+				return imageWithTag;
+
+			var version = Assembly.GetAssembly(typeof(OAuthAuthenticationPlugin)).GetName().Version;
+
+			var tag = (version.Major, version.Minor) switch {
+				(24, 4) => TagForMajorMinor(version),
+				(24, 6) => TagForMajorMinor(version),
+				_ => "ci"
+			};
+
+			var image = "docker.eventstore.com/eventstore-staging-ee/eventstoredb-ee";
+			return image + ":" + tag;
+		}
+	}
+
+	private static string TagForMajorMinor(Version version) =>
+		$"{version.Major}.{version.Minor}.0-nightly-x64-8.0-bookworm-slim";
+
+	private IContainerService _eventStore;
+	private readonly ITestOutputHelper _output;
+	private readonly FileInfo _pluginConfiguration;
+	private readonly string[] _containerEnv;
+	public IdpFixture IdentityServer { get; }
+
+	private Fixture(ITestOutputHelper output, params string[] env) {
+		var defaultEnv = new[] {
+			"KURRENTDB_CERTIFICATE_FILE=/opt/kurrentdb/certs/test.crt",
+			"KURRENTDB_CERTIFICATE_PRIVATE_KEY_FILE=/opt/kurrentdb/certs/test.key",
+			"KURRENTDB_TRUSTED_ROOT_CERTIFICATES_PATH=/opt/kurrentdb/certs/",
+			$"KURRENTDB_AUTHENTICATION_CONFIG={PluginConfigurationPath}",
+			"KURRENTDB_AUTHENTICATION_TYPE=oauth",
+			"KURRENTDB_LOG_FAILED_AUTHENTICATION_ATTEMPTS=true",
+			"KURRENTDB_LOG_HTTP_REQUESTS=true",
+			"KURRENTDB__LICENSING__LICENSE_KEY=test",
+			"KURRENTDB__LICENSING__BASE_URL=https://localhost:1"
+		};
+
+		_output = output;
+		_containerEnv = defaultEnv.Concat(env).ToArray();
+		_pluginConfiguration = new FileInfo(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+
+		IdentityServer = new IdpFixture(_output);
+	}
+
+	public static async ValueTask<Fixture> Create(ITestOutputHelper output, params string[] env) {
+		var fixture = new Fixture(output, env);
+		await fixture.Start();
+
+		return fixture;
+	}
+
+	private async ValueTask Start() {
+		await IdentityServer.Start();
+		await PublishPlugin(PluginSourceDirectory);
+		await WritePluginConfiguration();
+		await GenerateSelfSignedCertificateKeyPair(CertificateDirectory);
+		await Task.Delay(TimeSpan.FromSeconds(2));
+
+		var imageName = "kurrentdb-for-oauth-plugins-unit-tests";
+
+		using var x = new Builder()
+			.DefineImage(imageName)
+			// start with enterprise edition
+			.From(ESImage)
+			// remove all the plugins. if the EventStore.Plugins reference has changed the server in
+			// the nightly cannot necessarily even load the commercial HA plugins yet
+			// (these tests need to pass in order to update the commercial HA plugins)
+			.Run("mv /opt/kurrentdb/plugins /opt/kurrentdb/all-plugins")
+			// reinstate the tcp plugin
+			.Run("mkdir -p /opt/kurrentdb/plugins")
+			.Run("cp -r /opt/kurrentdb/all-plugins/EventStore.TcpPlugin /opt/kurrentdb/plugins/EventStore.TcpPlugin")
+			.Build();
+
+		_eventStore = new Builder()
+			.UseContainer()
+			.UseImage(imageName)
+			.WithEnvironment(_containerEnv)
+			.WithName("es-oauth-tests")
+			.Mount(PluginPublishDirectory, "/opt/kurrentdb/plugins/oauth", MountType.ReadOnly)
+			.Mount(CertificateDirectory, "/opt/kurrentdb/certs", MountType.ReadOnly)
+			.Mount(_pluginConfiguration.FullName, PluginConfigurationPath, MountType.ReadOnly)
+			.ExposePort(1113, 1113)
+			.ExposePort(2113, 2113)
+			.WaitForPort("1113/tcp", 10000)
+			.Build();
+
+		_eventStore.Start();
+		_eventStore.ShipContainerLogs(_output);
+
+		try {
+			await Policy.Handle<Exception>()
+				.WaitAndRetryAsync(5, retryCount => TimeSpan.FromSeconds(retryCount * retryCount))
+				.ExecuteAsync(async () => {
+					using var client = new HttpClient(new SocketsHttpHandler {
+						SslOptions = {
+							RemoteCertificateValidationCallback = delegate { return true; }
+						}
+					});
+					using var response = await client.GetAsync("https://localhost:2113/");
+					if (response.StatusCode >= HttpStatusCode.BadRequest) {
+						throw new Exception($"Health check failed with status code {response.StatusCode}");
+					}
+				});
+		} catch (Exception) {
+			_eventStore.Dispose();
+			IdentityServer.Dispose();
+			throw;
+		}
+	}
+
+	private async Task WritePluginConfiguration() {
+		await using (var stream = _pluginConfiguration.Create()) {
+			await using var writer = new StreamWriter(stream);
+			await writer.WriteAsync($@"---
+OAuth:
+  Issuer: {IdentityServer.Issuer}
+  Audience: eventstore
+  Insecure: true
+  DisableIssuerValidation: true");
+		}
+
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+			chmod(_pluginConfiguration.FullName, Convert.ToInt32("0755", 8));
+		}
+	}
+
+	[DllImport("libc", SetLastError = true)]
+	private static extern int chmod(string pathname, int mode);
+
+	private async Task GenerateSelfSignedCertificateKeyPair(string outputDirectory) {
+		if (Directory.Exists(outputDirectory)) {
+			Directory.Delete(outputDirectory, true);
+		}
+
+		Directory.CreateDirectory(outputDirectory);
+
+		using var rsa = RSA.Create();
+		var certReq = new CertificateRequest("CN=eventstoredb-node", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+		var sanBuilder = new SubjectAlternativeNameBuilder();
+		sanBuilder.AddIpAddress(IPAddress.Loopback);
+		certReq.CertificateExtensions.Add(sanBuilder.Build());
+		var certificate = certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddMonths(-1), DateTimeOffset.UtcNow.AddMonths(1));
+
+		await using (var streamWriter = new StreamWriter(Path.Join(outputDirectory, "test.crt"), false))
+		{
+			var certBytes = certificate.Export(X509ContentType.Cert);
+			var certString = Convert.ToBase64String(certBytes);
+
+			await streamWriter.WriteLineAsync("-----BEGIN CERTIFICATE-----");
+			for (var i = 0; i < certString.Length; i += 64) {
+				await streamWriter.WriteLineAsync(certString.Substring(i, Math.Min(i+64, certString.Length) - i));
+			}
+			await streamWriter.WriteLineAsync("-----END CERTIFICATE-----");
+		}
+
+		await using (var streamWriter = new StreamWriter(Path.Join(outputDirectory, "test.key"), false)) {
+			var keyBytes = rsa.ExportRSAPrivateKey();
+			var keyString = Convert.ToBase64String(keyBytes);
+
+			await streamWriter.WriteLineAsync("-----BEGIN RSA PRIVATE KEY-----");
+			for (var i = 0; i < keyString.Length; i += 64) {
+				await streamWriter.WriteLineAsync(keyString.Substring(i, Math.Min(i+64, keyString.Length) - i));
+			}
+			await streamWriter.WriteLineAsync("-----END RSA PRIVATE KEY-----");
+		}
+	}
+
+	private static async Task PublishPlugin(string pluginDirectory) {
+		var tcs = new TaskCompletionSource<bool>();
+		using var process = new Process {
+			StartInfo = new ProcessStartInfo {
+				FileName = "dotnet",
+				Arguments = $"publish --configuration {BuildConfiguration} --framework=net8.0",
+				WorkingDirectory = pluginDirectory,
+				UseShellExecute = false,
+				RedirectStandardError = true,
+				RedirectStandardOutput = true
+			},
+			EnableRaisingEvents = true
+		};
+		process.Exited += (_, e) => tcs.SetResult(default);
+		process.Start();
+
+		var stdout = process.StandardOutput.ReadToEndAsync();
+		var stderr = process.StandardError.ReadToEndAsync();
+
+		await Task.WhenAll(tcs.Task, stdout, stderr);
+
+		if (process.ExitCode != 0) {
+			throw new Exception(stdout.Result);
+		}
+	}
+
+	public void Dispose() {
+		_eventStore?.Dispose();
+		IdentityServer?.Dispose();
+		_pluginConfiguration?.Delete();
+		if (Directory.Exists(CertificateDirectory)) {
+			Directory.Delete(CertificateDirectory, true);
+		}
+	}
+}

--- a/src/EventStore.Auth.OAuth.Tests/IdpFixture.cs
+++ b/src/EventStore.Auth.OAuth.Tests/IdpFixture.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Ductus.FluentDocker.Builders;
+using Ductus.FluentDocker.Model.Builders;
+using Ductus.FluentDocker.Services;
+using IdentityModel.Client;
+using Polly;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.OAuth.Tests;
+
+internal class IdpFixture : IDisposable {
+	private const int IdpPort = 5001;
+	public const string ClientId = "eventstore-tcp";
+	public const string ClientSecret = "secret";
+
+	private static string SourceDirectory =>
+		Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "../../../../src"));
+
+	private static string TestSourceDirectory => Path.Combine(SourceDirectory, "EventStore.Auth.OAuth.Tests");
+
+	private static string IdentityServerSourceDirectory => Path.Combine(SourceDirectory, "IdentityServer");
+
+	private static string IdentityServerConfigurationFile =>
+		Path.Combine(TestSourceDirectory, "conf", "idsrv4.conf.json");
+
+	private static string IdentityServerUserConfigurationFile =>
+		Path.Combine(TestSourceDirectory, "conf", "users.conf.json");
+
+	private readonly ITestOutputHelper _output;
+	private readonly IContainerService _identityServer;
+	private readonly TaskCompletionSource<DiscoveryDocumentResponse> _discoveryDocumentSource;
+	public HttpClient HttpClient { get; }
+
+	public IdpFixture(ITestOutputHelper output) {
+		_output = output;
+
+		_identityServer = new Builder()
+			.UseContainer()
+			.UseImage("ghcr.io/eventstore/idsrv4/idsrv4")
+			.WithName("es-oauth-tests-idsrv4")
+			.Mount(IdentityServerConfigurationFile, "/etc/idsrv4/idsrv4.conf", MountType.ReadOnly)
+			.Mount(IdentityServerUserConfigurationFile, "/etc/idsrv4/users.conf", MountType.ReadOnly)
+			.ExposePort(IdpPort, IdpPort)
+			.Build();
+
+		_identityServer.StopOnDispose = true;
+		_discoveryDocumentSource = new TaskCompletionSource<DiscoveryDocumentResponse>();
+
+		HttpClient = new HttpClient(new SocketsHttpHandler {
+			SslOptions = {
+				RemoteCertificateValidationCallback = delegate { return true; }
+			}
+		}, true) {
+			BaseAddress = new UriBuilder {
+				Scheme = Uri.UriSchemeHttps,
+				Port = IdpPort
+			}.Uri
+		};
+	}
+
+	public async Task Start() {
+		_identityServer.ShipContainerLogs(_output);
+		_identityServer.Start();
+
+		try {
+			await Policy.Handle<Exception>()
+				.WaitAndRetryAsync(5, retryCount => TimeSpan.FromSeconds(retryCount * retryCount))
+				.ExecuteAsync(async () => {
+					var discoveryDocument = await HttpClient.GetDiscoveryDocumentAsync();
+					if (discoveryDocument?.HttpResponse == null) {
+						throw new Exception("Health check not available yet");
+					}
+					if (discoveryDocument.HttpStatusCode != HttpStatusCode.OK) {
+						throw new Exception($"Health check failed with status code {discoveryDocument.HttpStatusCode}");
+					}
+					_discoveryDocumentSource.SetResult(discoveryDocument);
+				});
+		} catch (Exception) {
+			_identityServer.Dispose();
+			throw;
+		}
+	}
+
+
+	public async Task<string> GetAccessToken(string username, string password) {
+		var response = await GetTokenResponse(username, password);
+
+		return response.AccessToken;
+	}
+
+	public async Task<string> GetRefreshToken(string username, string password) {
+		var response = await GetTokenResponse(username, password);
+
+		return response.RefreshToken;
+	}
+
+	private async Task<TokenResponse> GetTokenResponse(string username, string password) {
+		var discoveryDocument = await _discoveryDocumentSource.Task;
+		var response = await HttpClient.RequestPasswordTokenAsync(new PasswordTokenRequest {
+			ClientId = ClientId,
+			ClientSecret = ClientSecret,
+			UserName = username,
+			Password = password,
+			Address = discoveryDocument.TokenEndpoint,
+			Scope = "openid streams offline_access"
+		});
+
+		if (response.Exception != null) {
+			throw response.Exception;
+		}
+
+		return response;
+	}
+
+	public string Issuer =>
+		$"https://{_identityServer.GetConfiguration().NetworkSettings.IPAddress}:{IdpPort}";
+
+
+	public void Dispose() {
+		_identityServer?.Dispose();
+	}
+}

--- a/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationGrpcIntegrationTests.cs
+++ b/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationGrpcIntegrationTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using EventStore.Client;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.OAuth.Tests;
+
+public class OAuthAuthenticationGrpcIntegrationTests {
+	private readonly ITestOutputHelper _output;
+
+	public OAuthAuthenticationGrpcIntegrationTests(ITestOutputHelper output) {
+		_output = output;
+	}
+
+	[Fact]
+	public async Task admin() {
+		using var fixture = await Fixture.Create(_output);
+		var token = await fixture.IdentityServer.GetAccessToken("admin", "password");
+
+		using var client = GetEventStoreClient(token);
+
+		await client.AppendToStreamAsync("a-stream", StreamState.Any, new[] {
+			new EventData(Uuid.NewUuid(), "-", ReadOnlyMemory<byte>.Empty, ReadOnlyMemory<byte>.Empty),
+		});
+		await client.ReadAllAsync(Direction.Forwards, Position.Start).ToArrayAsync();
+	}
+
+	[Fact]
+	public async Task user() {
+		using var fixture = await Fixture.Create(_output);
+		var token = await fixture.IdentityServer.GetAccessToken("user", "password");
+
+		using var client = GetEventStoreClient(token);
+
+		await Assert.ThrowsAsync<AccessDeniedException>(() =>
+			client.ReadAllAsync(Direction.Forwards, Position.Start).ToArrayAsync()
+				.AsTask());
+	}
+
+	private EventStoreClient GetEventStoreClient(string token) {
+		var settings = EventStoreClientSettings.Create("esdb://localhost:2113/?tlsVerifyCert=false");
+		settings.DefaultCredentials = new UserCredentials(token);
+		settings.LoggerFactory = new XUnitLoggerFactory(_output);
+		return new(settings);
+	}
+}

--- a/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationHttpIntegrationTests.cs
+++ b/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationHttpIntegrationTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Security;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.OAuth.Tests;
+
+public class OAuthAuthenticationHttpIntegrationTests {
+	private static readonly string[] EnableAtomPub = {
+		"KURRENTDB_ENABLE_ATOM_PUB_OVER_HTTP=true"
+	};
+
+	private readonly ITestOutputHelper _output;
+
+	public OAuthAuthenticationHttpIntegrationTests(ITestOutputHelper output) {
+		_output = output;
+	}
+
+	private StringContent GenerateEvents() {
+		var events = new[] {new {EventId = Guid.NewGuid(), EventType = "event-type", Data = new {A = "1"}}};
+		return new StringContent(JsonConvert.SerializeObject(events)) {
+			Headers = {ContentType = new MediaTypeHeaderValue("application/vnd.eventstore.events+json")}
+		};
+	}
+
+	[Fact]
+	public async Task admin() {
+		using var fixture = await Fixture.Create(_output,EnableAtomPub);
+		var token = await fixture.IdentityServer.GetAccessToken("admin", "password");
+
+		using var client = CreateHttpClient(token);
+
+		using var writeResponse = await client.PostAsync("/streams/a-stream", GenerateEvents());
+		Assert.Equal(HttpStatusCode.Created,writeResponse.StatusCode);
+
+		using var writeSystemResponse = await client.PostAsync("/streams/$systemstream", GenerateEvents());
+		Assert.Equal(HttpStatusCode.Created,writeSystemResponse.StatusCode);
+
+		using var readResponse = await client.GetAsync("/streams/$all");
+		Assert.Equal(HttpStatusCode.OK,readResponse.StatusCode);
+	}
+
+	[Fact]
+	public async Task user() {
+		using var fixture = await Fixture.Create(_output, EnableAtomPub);
+		var token = await fixture.IdentityServer.GetAccessToken("user", "password");
+
+		using var client = CreateHttpClient(token);
+
+		using var writeResponse = await client.PostAsync("/streams/a-stream", GenerateEvents());
+		Assert.Equal(HttpStatusCode.Created,writeResponse.StatusCode);
+
+		using var writeSystemResponse = await client.PostAsync("/streams/$systemstream", GenerateEvents());
+		Assert.Equal(HttpStatusCode.Unauthorized,writeSystemResponse.StatusCode);
+
+		using var readResponse = await client.GetAsync("/streams/$all");
+		Assert.Equal(HttpStatusCode.Unauthorized,readResponse.StatusCode);
+	}
+
+
+	private static HttpClient CreateHttpClient(string token) {
+		var socketsHttpHandler = new SocketsHttpHandler {
+			SslOptions = {
+				RemoteCertificateValidationCallback = delegate { return true; }
+			}
+		};
+
+		return new HttpClient(socketsHttpHandler)
+		{
+			BaseAddress = new UriBuilder {
+				Port = 2113,
+				Scheme = Uri.UriSchemeHttps
+			}.Uri,
+			DefaultRequestHeaders = {
+				Authorization = new AuthenticationHeaderValue("Bearer", token)
+			}
+		};
+	}
+}

--- a/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationPluginTests.cs
+++ b/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationPluginTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.IO;
+using EventStore.Plugins.Licensing;
+using EventStore.Plugins.Tests;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EventStore.Auth.OAuth.Tests;
+
+
+public class OAuthAuthenticationPluginTests {
+	private readonly string _configFile;
+
+	public OAuthAuthenticationPluginTests() {
+		_configFile = Path.Combine(Environment.CurrentDirectory, "conf", "oauth.conf");
+	}
+
+	[Theory]
+	[InlineData(true, "OAUTH_AUTHENTICATION", false)]
+	[InlineData(true, "NONE", true)]
+	[InlineData(false, "NONE", true)]
+	public void respects_license(bool licensePresent, string entitlement, bool expectedException) {
+		// given
+		var sut = new OAuthAuthenticationPlugin()
+			.GetAuthenticationProviderFactory(_configFile)
+			.Build(false);
+
+		var config = new ConfigurationBuilder().Build();
+		var builder = WebApplication.CreateBuilder();
+
+		var licenseService = new Fixtures.FakeLicenseService(licensePresent, entitlement);
+		builder.Services.AddSingleton<ILicenseService>(licenseService);
+
+		sut.ConfigureServices(
+			builder.Services,
+			config);
+
+		var app = builder.Build();
+
+		// when
+		sut.ConfigureApplication(app, config);
+
+		// then
+		if (expectedException) {
+			Assert.NotNull(licenseService.RejectionException);
+		} else {
+			Assert.Null(licenseService.RejectionException);
+		}
+	}
+}

--- a/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationTcpIntegrationTests.cs
+++ b/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationTcpIntegrationTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using EventStore.ClientAPI;
+using EventStore.ClientAPI.Exceptions;
+using EventStore.ClientAPI.SystemData;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.OAuth.Tests;
+
+public class OAuthAuthenticationTcpIntegrationTests {
+	private static readonly string[] EnableTcp = {
+		"KurrentDB__TcpPlugin__EnableExternalTcp=true"
+	};
+
+	private readonly ITestOutputHelper _output;
+
+	public OAuthAuthenticationTcpIntegrationTests(ITestOutputHelper output) {
+		_output = output;
+	}
+
+	[Fact]
+	public async Task admin() {
+		using var fixture = await Fixture.Create(_output, EnableTcp);
+		var token = await fixture.IdentityServer.GetAccessToken("admin", "password");
+
+		using var client = await GetEventStoreConnection(token);
+
+		await client.AppendToStreamAsync("a-stream", ExpectedVersion.Any,
+			new EventData(Guid.NewGuid(), "-", false, Array.Empty<byte>(), Array.Empty<byte>()));
+
+		await client.ReadAllEventsForwardAsync(Position.Start, 100, false);
+	}
+
+	[Fact]
+	public async Task user() {
+		using var fixture = await Fixture.Create(_output, EnableTcp);
+		var token = await fixture.IdentityServer.GetAccessToken("user", "password");
+
+		using var client = await GetEventStoreConnection(token);
+
+		await Assert.ThrowsAsync<AccessDeniedException>(() =>
+			client.ReadAllEventsForwardAsync(Position.Start, 100, false));
+	}
+
+	private async Task<IEventStoreConnection> GetEventStoreConnection(string token) {
+		var client = EventStoreConnection.Create(
+			ConnectionSettings.Create()
+				.DisableServerCertificateValidation()
+				.SetDefaultUserCredentials(new UserCredentials(token))
+				.UseCustomLogger(new XUnitLogger(_output)),
+			new IPEndPoint(IPAddress.Loopback, 1113));
+		await client.ConnectAsync();
+		return client;
+	}
+
+	private class XUnitLogger : ILogger {
+		private readonly ITestOutputHelper _output;
+
+		public XUnitLogger(ITestOutputHelper output) {
+			_output = output;
+		}
+
+		public void Error(string format, params object[] args) => Log(nameof(Error), format, args);
+
+		public void Error(Exception ex, string format, params object[] args) =>
+			Log(nameof(Error), ex, format, args);
+
+		public void Info(string format, params object[] args) => Log(nameof(Info), format, args);
+		public void Info(Exception ex, string format, params object[] args) => Log(nameof(Info), ex, format, args);
+		public void Debug(string format, params object[] args) => Log(nameof(Debug), format, args);
+
+		public void Debug(Exception ex, string format, params object[] args) =>
+			Log(nameof(Debug), ex, format, args);
+
+		private void Log(string level, string format, params object[] args) => Log(level, null, format, args);
+
+		private void Log(string level, Exception ex, string format, params object[] args)
+			=> _output.WriteLine($"[{level}] {string.Format(format, args)}{Environment.NewLine}{ex}");
+	}
+}

--- a/src/EventStore.Auth.OAuth.Tests/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Auth.OAuth.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/EventStore.Auth.OAuth.Tests/XUnitLoggerFactory.cs
+++ b/src/EventStore.Auth.OAuth.Tests/XUnitLoggerFactory.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace EventStore.Auth.OAuth.Tests;
+
+internal class XUnitLoggerFactory : ILoggerFactory {
+	private readonly ITestOutputHelper _output;
+
+	public XUnitLoggerFactory(ITestOutputHelper output) {
+		_output = output;
+	}
+
+	public void Dispose() {
+	}
+
+	public ILogger CreateLogger(string categoryName) => new XUnitLogger(categoryName, _output);
+
+	public void AddProvider(ILoggerProvider provider) {
+	}
+
+	private class XUnitLogger : ILogger {
+		private readonly string _categoryName;
+		private readonly ITestOutputHelper _output;
+
+		public XUnitLogger(string categoryName, ITestOutputHelper output) {
+			_categoryName = categoryName;
+			_output = output;
+		}
+
+		public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+			Func<TState, Exception, string> formatter) => _output
+			.WriteLine($"[{logLevel}] [{_categoryName}] {formatter(state, exception)}");
+
+		public bool IsEnabled(LogLevel logLevel) => true;
+
+		public IDisposable BeginScope<TState>(TState state) => new NoOpDisposable();
+
+		private class NoOpDisposable : IDisposable {
+			public void Dispose() { }
+		}
+	}
+}

--- a/src/EventStore.Auth.OAuth.Tests/conf/idsrv4.conf.json
+++ b/src/EventStore.Auth.OAuth.Tests/conf/idsrv4.conf.json
@@ -1,0 +1,72 @@
+﻿{
+	"IdentityResources": [
+		{
+			"Name": "openid",
+			"DisplayName": "Your user identifier",
+			"Required": true,
+			"UserClaims": [
+				"sub",
+				"role"
+			]
+		},
+		{
+			"Name": "profile",
+			"DisplayName": "User profile",
+			"Description": "Your user profile information (first name, last name, etc.)",
+			"Emphasize": true,
+			"UserClaims": [
+				"name",
+				"family_name",
+				"given_name",
+				"middle_name",
+				"preferred_username",
+				"profile",
+				"picture",
+				"website",
+				"gender",
+				"birthdate",
+				"zoneinfo",
+				"locale",
+				"updated_at"
+			]
+		}
+	],
+	"ApiResources": [
+		{
+			"Name": "eventstore",
+			"Scopes": ["streams"]
+		}
+	],
+	"ApiScopes": [
+		{
+			"Name": "streams",
+			"UserClaims": [
+				"http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+				"role"
+			]
+		}
+	],
+	"Clients": [
+		{
+			"ClientId": "eventstore-tcp",
+			"AllowedGrantTypes": [
+				"password"
+			],
+			"ClientSecrets": [
+				{
+					"Value": "K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols="
+				}
+			],
+			"AllowedScopes": [
+				"streams",
+				"openid",
+				"profile"
+			],
+			"AlwaysIncludeUserClaimsInIdToken": true,
+			"RequireConsent": false,
+			"AlwaysSendClientClaims": true,
+			"AllowOfflineAccess": true,
+			"RequireClientSecret": false
+		}
+	]
+}

--- a/src/EventStore.Auth.OAuth.Tests/conf/oauth.conf
+++ b/src/EventStore.Auth.OAuth.Tests/conf/oauth.conf
@@ -1,0 +1,4 @@
+---
+OAuth:
+  Audience: http://localhost/
+  Issuer: https://localhost:5001/

--- a/src/EventStore.Auth.OAuth.Tests/conf/users.conf.json
+++ b/src/EventStore.Auth.OAuth.Tests/conf/users.conf.json
@@ -1,0 +1,30 @@
+[
+	{
+		"subjectId": "1",
+		"username": "admin",
+		"password": "password",
+		"claims": [{
+			"type": "role",
+			"value": "$admins"
+		}, {
+			"type": "role",
+			"value": "$ops"
+		}, {
+			"type": "given_name",
+			"value": "Alice Smith"
+		}]
+	}, 	{
+		"subjectId": "2",
+		"username": "operator",
+		"password": "password",
+		"claims": [{
+			"type": "role",
+			"value": "$ops"
+		}]
+	}, 	{
+		"subjectId": "3",
+		"username": "user",
+		"password": "password",
+		"claims": []
+	}
+]

--- a/src/EventStore.Auth.OAuth/EventStore.Auth.OAuth.csproj
+++ b/src/EventStore.Auth.OAuth/EventStore.Auth.OAuth.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Platforms>x64</Platforms>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+	</PropertyGroup>
+	<PropertyGroup>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+	  <DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="IdentityModel" Version="4.3.0" />
+		<PackageReference Include="LruCacheNet" Version="1.2.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.1" />
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Auth.OAuth/OAuthAuthenticationPlugin.cs
+++ b/src/EventStore.Auth.OAuth/OAuthAuthenticationPlugin.cs
@@ -1,0 +1,537 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Plugins;
+using EventStore.Plugins.Authentication;
+using IdentityModel;
+using IdentityModel.Client;
+using LruCacheNet;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+using Serilog;
+
+#nullable enable
+namespace EventStore.Auth.OAuth;
+
+[Export(typeof(IAuthenticationPlugin))]
+public class OAuthAuthenticationPlugin : IAuthenticationPlugin {
+	public static readonly string[] ValidSigningAlgorithms = {
+		SecurityAlgorithms.RsaSha256Signature,
+		SecurityAlgorithms.RsaSha384Signature,
+		SecurityAlgorithms.RsaSha512Signature,
+		SecurityAlgorithms.RsaSsaPssSha256Signature,
+		SecurityAlgorithms.RsaSsaPssSha384Signature,
+		SecurityAlgorithms.RsaSsaPssSha512Signature,
+		SecurityAlgorithms.RsaSha256,
+		SecurityAlgorithms.RsaSha384,
+		SecurityAlgorithms.RsaSha512,
+		SecurityAlgorithms.RsaSsaPssSha256,
+		SecurityAlgorithms.RsaSsaPssSha384,
+		SecurityAlgorithms.RsaSsaPssSha512,
+	};
+
+	private static readonly ILogger _logger = Log.ForContext<OAuthAuthenticationPlugin>();
+	public string Name { get; } = "OAUTH";
+	public string Version { get; } = typeof(OAuthAuthenticationPlugin).Assembly.GetName().Version!.ToString();
+	public string CommandLineName { get; } = "oauth";
+
+	public IAuthenticationProviderFactory GetAuthenticationProviderFactory(string authenticationConfigPath)
+		=> new OAuthAuthenticationProviderFactory(authenticationConfigPath);
+
+	private class OAuthAuthenticationProviderFactory : IAuthenticationProviderFactory {
+		private readonly string _authenticationConfigPath;
+
+		public OAuthAuthenticationProviderFactory(string authenticationConfigPath) {
+			if (authenticationConfigPath == null) {
+				throw new ArgumentNullException(nameof(authenticationConfigPath));
+			}
+
+			if (!File.Exists(authenticationConfigPath)) {
+				throw new FileNotFoundException(null, authenticationConfigPath);
+			}
+
+			_authenticationConfigPath = authenticationConfigPath;
+		}
+
+		public IAuthenticationProvider Build(bool logFailedAuthenticationAttempts)
+			=> new OAuthAuthenticationProvider(new Options {
+				LogFailedAuthenticationAttempts = logFailedAuthenticationAttempts,
+				Settings = ConfigParser.ReadConfiguration<Settings>(_authenticationConfigPath, "OAuth")
+					?? throw new Exception("Could not read OAuth configuration")
+			});
+	}
+
+	private class OAuthAuthenticationProvider : AuthenticationProviderBase {
+		private readonly JwtSecurityTokenHandler _securityTokenHandler;
+		private readonly Options _options;
+		private AsymmetricSecurityKey[] _signingKeys;
+		private string _signingKeysUri;
+		private DateTime _signingKeysLastRefresh;
+		private readonly TimeSpan _signingKeysMinRefreshInterval = TimeSpan.FromMinutes(30);
+		private readonly object _signingKeysRefreshLock = new object();
+		private const string AuthorizationCodeResponseType = OidcConstants.ResponseTypes.Code;
+		private const string AuthorizationCodeGrantType = OidcConstants.GrantTypes.AuthorizationCode;
+		private const string SHA256CodeChallengeMethod = OidcConstants.CodeChallengeMethods.Sha256;
+		private const string CallBackUrl = "/oauth/callback";
+		private const string CodeChallengeUrl = "/oauth/codechallenge";
+		private string _authorizationEndpoint;
+		private string _tokenEndpoint;
+		private readonly HttpClient _httpClient;
+		private readonly RandomNumberGenerator _rngCsp;
+		private readonly LruCache<string, string> _codeVerifierLruCache;
+		private volatile bool _ready;
+
+		public OAuthAuthenticationProvider(Options options)
+			: base(
+				requiredEntitlements: ["OAUTH_AUTHENTICATION"]) {
+
+			_options = options;
+			_signingKeys = new AsymmetricSecurityKey[0];
+			_signingKeysUri = string.Empty;
+			_securityTokenHandler = new JwtSecurityTokenHandler();
+			_authorizationEndpoint = string.Empty;
+			_tokenEndpoint = string.Empty;
+			_httpClient = new HttpClient(new SocketsHttpHandler {
+				ConnectTimeout = TimeSpan.FromSeconds(10),
+				SslOptions = {
+					RemoteCertificateValidationCallback = _options.Settings.Insecure
+						? delegate { return true; }
+						: (RemoteCertificateValidationCallback)null!
+				}
+			});
+
+			_rngCsp = RandomNumberGenerator.Create();
+			_codeVerifierLruCache = new LruCache<string, string>(1024);
+		}
+
+		public override async Task Initialize() {
+			try {
+				_logger.Information("Obtaining auth token signing key from {idp}",
+					_options.Settings.IdpUri);
+				using var httpClient = new HttpClient(new SocketsHttpHandler {
+					SslOptions = {
+						RemoteCertificateValidationCallback = _options.Settings.Insecure
+							? delegate { return true; }
+							: (RemoteCertificateValidationCallback)null!
+					}
+				}) {
+					BaseAddress = _options.Settings.IdpUri
+				};
+
+				var request = new DiscoveryDocumentRequest {
+					Policy = new DiscoveryPolicy {
+						AdditionalEndpointBaseAddresses = _options.Settings.AdditionalEndpointBaseAddresses
+					}
+				};
+
+				var disco = await httpClient.GetDiscoveryDocumentAsync(request);
+
+				if (disco.IsError) {
+					throw new Exception(disco.Error);
+				}
+
+				_authorizationEndpoint = disco.AuthorizeEndpoint ?? throw new Exception("Authorization Endpoint is null in identity provider's discovery document.");
+				_tokenEndpoint = disco.TokenEndpoint ?? throw new Exception("Token Endpoint is null in identity provider's discovery document.");
+
+				// required field according to the specs
+				if (!disco.ResponseTypesSupported.Contains(AuthorizationCodeResponseType)) {
+					throw new Exception($"The specified identity provider does not support the '{AuthorizationCodeResponseType}' response type");
+				}
+
+				// the specs say: If omitted, the default value is ["authorization_code", "implicit"].
+				if (disco.GrantTypesSupported.Any() && !disco.GrantTypesSupported.Contains(AuthorizationCodeGrantType)) {
+					throw new Exception($"The specified identity provider does not support the '{AuthorizationCodeGrantType}' grant type");
+				}
+
+				//the specs say: If omitted, the authorization server does not support PKCE
+				if (!disco.CodeChallengeMethodsSupported.Any()) {
+					throw new Exception($"The specified identity provider does not support PKCE");
+				}
+
+				if (!disco.CodeChallengeMethodsSupported.Contains(SHA256CodeChallengeMethod)) {
+					throw new Exception($"The specified identity provider does not support the '{SHA256CodeChallengeMethod}' code challenge method");
+				}
+
+				_signingKeysUri = disco.JwksUri;
+				_signingKeys = disco.KeySet.Keys.Select(jwk =>
+					(AsymmetricSecurityKey)new RsaSecurityKey(
+						new RSAParameters {
+							Exponent = Base64Url.Decode(jwk.E),
+							Modulus = Base64Url.Decode(jwk.N)
+						}) {
+						KeyId = jwk.Kid
+					}).ToArray();
+				_signingKeysLastRefresh = DateTime.UtcNow;
+
+				var signingKeyIds = _signingKeys.Select(x => x.KeyId);
+				_logger.Information("Issuer signing keys have been retrieved. Key IDs: {signingKeyIds}", signingKeyIds);
+
+				_ready = true;
+			} catch (Exception ex) {
+				_logger.Fatal(ex, "Initialization failed.");
+				throw;
+			}
+		}
+
+		public override void Authenticate(AuthenticationRequest authenticationRequest) {
+			if (!_ready) {
+				authenticationRequest.NotReady();
+				return;
+			}
+
+			try {
+				var jwt = authenticationRequest.GetToken("jwt");
+
+				if (jwt == null) {
+					if (_options.LogFailedAuthenticationAttempts) {
+						_logger.Warning("Authentication failed for {id}: {reason}",
+							authenticationRequest.Id,
+							"No token present.");
+					}
+
+					authenticationRequest.Unauthorized();
+					return;
+				}
+
+				var jwtSecurityToken = _securityTokenHandler.ReadJwtToken(jwt);
+				if (_signingKeys.All(x => x.KeyId != jwtSecurityToken.Header.Kid)) {
+					lock(_signingKeysRefreshLock){
+						if(DateTime.UtcNow - _signingKeysLastRefresh >= _signingKeysMinRefreshInterval)
+						{
+							try {
+								//signing keys may have been rotated, refresh the keys before validation
+								_logger.Verbose("An authentication request with an unknown key ID has been received. Refreshing issuer signing keys.");
+								var oldKeyIds = _signingKeys.Select(x => x.KeyId).OrderBy(x => x);
+
+								_signingKeys = _httpClient
+									.GetJsonWebKeySetAsync(_signingKeysUri)
+									.GetAwaiter()
+									.GetResult()
+									.KeySet
+									.Keys.Select(jwk =>
+										(AsymmetricSecurityKey)new RsaSecurityKey(
+											new RSAParameters {
+												Exponent = Base64Url.Decode(jwk.E),
+												Modulus = Base64Url.Decode(jwk.N)
+											}) {
+											KeyId = jwk.Kid
+										}).ToArray();
+
+								var newKeyIds = _signingKeys.Select(x => x.KeyId).OrderBy(x => x);
+								if (!oldKeyIds.SequenceEqual(newKeyIds)) {
+									_logger.Information(
+										"Issuer signing keys have changed. New Key IDs: {signingKeyIds}", newKeyIds);
+								} else {
+									_logger.Verbose(
+										"Issuer signing keys have not changed. Key IDs: {signingKeyIds}", newKeyIds);
+								}
+
+								_signingKeysLastRefresh = DateTime.UtcNow;
+							} catch (Exception ex) {
+								_logger.Error(ex, "Failed to refresh issuer signing keys.");
+							}
+						} else {
+							_logger.Verbose("An authentication request with an unknown key ID has been received. Skipping refresh of issuer signing keys since the minimum refresh interval of {minRefreshInterval} minutes has not yet expired.", _signingKeysMinRefreshInterval.TotalMinutes);
+						}
+					}
+				}
+
+				ClaimsPrincipal principal = _securityTokenHandler.ValidateToken(jwt, new TokenValidationParameters {
+					ValidAudience = _options.Settings.Audience,
+					ValidIssuer = _options.Settings.Issuer,
+					ValidateAudience = true,
+					ValidateIssuer = !_options.Settings.DisableIssuerValidation,
+					ValidateLifetime = true,
+					RequireExpirationTime = true,
+					IssuerSigningKeys = _signingKeys
+				}, out _);
+
+				if (principal?.Identity == null) {
+					authenticationRequest.Unauthorized();
+					return;
+				}
+
+				if (!principal.Identity.IsAuthenticated) {
+					if (_options.LogFailedAuthenticationAttempts) {
+						_logger.Warning("Authentication failed for {id}: {reason}",
+							authenticationRequest.Id,
+							"Identity was not authenticated.");
+					}
+
+					authenticationRequest.Unauthorized();
+					return;
+				}
+
+				authenticationRequest.Authenticated(principal);
+			} catch (SecurityTokenValidationException ex) {
+				if (_options.LogFailedAuthenticationAttempts) {
+					_logger.Warning(ex, "Authentication failed for {id}: {reason}",
+						authenticationRequest.Id,
+						ex.Message);
+				}
+
+				authenticationRequest.Unauthorized();
+			} catch (Exception ex) {
+				if (_options.LogFailedAuthenticationAttempts) {
+					_logger.Warning(ex, "Authentication failed for {id}: {reason}",
+						authenticationRequest.Id,
+						ex.Message);
+				}
+
+				authenticationRequest.Error();
+			}
+		}
+
+		public override IEnumerable<KeyValuePair<string, string>> GetPublicProperties() {
+			var result = new Dictionary<string, string> {
+				{OidcConstants.Discovery.AuthorizationEndpoint, _authorizationEndpoint},
+				{OidcConstants.AuthorizeRequest.ClientId, _options.Settings.ClientId},
+				{OidcConstants.AuthorizeRequest.RedirectUri, CallBackUrl},
+				{OidcConstants.AuthorizeRequest.ResponseType, AuthorizationCodeResponseType},
+				{OidcConstants.AuthorizeRequest.Scope, OidcConstants.StandardScopes.OpenId + " " + OidcConstants.StandardScopes.Profile},
+				{"code_challenge_uri", CodeChallengeUrl},
+			};
+
+			return result;
+		}
+		public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() {
+			return new[] {
+				"Bearer"
+			};
+		}
+		public override void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
+			endpointRouteBuilder.Map(CallBackUrl, async context => {
+				if (!_ready) {
+					context.Response.StatusCode = (int) HttpStatusCode.ServiceUnavailable;
+					return;
+				}
+
+				if (!context.Request.Query.TryGetValue(OidcConstants.AuthorizeResponse.State, out var state)) {
+					if (_options.LogFailedAuthenticationAttempts) {
+						_logger.Warning($"'{OidcConstants.AuthorizeResponse.State}' parameter was not provided in the OAuth callback URL.");
+					}
+
+					context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+					return;
+				}
+
+				var codeChallengeCorrelationId = string.Empty;
+				try {
+					var decodedBase64Bytes = Convert.FromBase64String(state!);
+					var jsonString = Encoding.UTF8.GetString(decodedBase64Bytes);
+					var dictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonString);
+					if (dictionary == null || !dictionary.TryGetValue("code_challenge_correlation_id", out codeChallengeCorrelationId)) {
+						throw new ArgumentException("'code_challenge_correlation_id' is not present in the supplied JSON object");
+					}
+				} catch (Exception ex) {
+					if (_options.LogFailedAuthenticationAttempts) {
+						_logger.Warning(ex, $"Failed to parse the code challenge correlation ID from the '{OidcConstants.AuthorizeResponse.State}' parameter");
+					}
+
+					context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+					return;
+				}
+
+				if (!_codeVerifierLruCache.TryGetValue(codeChallengeCorrelationId, out var codeVerifier)) {
+					if (_options.LogFailedAuthenticationAttempts) {
+						_logger.Warning("Supplied code challenge correlation ID does not exist or may have expired.");
+					}
+
+					context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+					return;
+				}
+
+				_codeVerifierLruCache.Remove(codeChallengeCorrelationId);
+
+				if (context.Request.Query.ContainsKey(OidcConstants.AuthorizeResponse.Error)) {
+					var error = "Authorization Error: " + context.Request.Query[OidcConstants.AuthorizeResponse.Error];
+					var errorMessage = context.Request.Query.ContainsKey(OidcConstants.AuthorizeResponse.ErrorDescription)
+						? "Error Message: " + context.Request.Query[OidcConstants.AuthorizeResponse.ErrorDescription]
+						: null;
+					var stringBuilder = new StringBuilder();
+					stringBuilder.Append("<html>");
+					stringBuilder.Append("<head>");
+					stringBuilder.Append("<meta http-equiv=\"refresh\" content=\"10;url=/\" />");
+					stringBuilder.Append("</head>");
+					stringBuilder.Append("<body>");
+					stringBuilder.Append(error);
+					stringBuilder.Append("<br>");
+					if (errorMessage != null) {
+						stringBuilder.Append(errorMessage);
+						stringBuilder.Append("<br>");
+					}
+					stringBuilder.Append("</body>");
+					stringBuilder.Append("</html>");
+
+					var htmlOutput = stringBuilder.ToString();
+					await context.Response.Body.WriteAsync(UTF8Encoding.UTF8.GetBytes(htmlOutput));
+					return;
+				}
+
+				if (!context.Request.Query.ContainsKey(AuthorizationCodeResponseType)) {
+					if (_options.LogFailedAuthenticationAttempts) {
+						_logger.Warning($"'{AuthorizationCodeResponseType}' parameter was not provided in the OAuth callback URL.");
+					}
+
+					context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+					return;
+				}
+
+				try {
+					var redirectUriBuilder = new UriBuilder {
+						Scheme = context.Request.Scheme,
+						Host = context.Request.Host.Host,
+						Path = CallBackUrl
+					};
+
+					var port = context.Request.Host.Port;
+					if (port.HasValue) {
+						redirectUriBuilder.Port = port.Value;
+					}
+
+					var redirectUri = redirectUriBuilder.Uri.ToString();
+
+					var queryParams = new Dictionary<string, string> {
+						{OidcConstants.TokenRequest.GrantType, AuthorizationCodeGrantType},
+						//{OidcConstants.TokenRequest.Code, context.Request.Query[AuthorizationCodeResponseType]},
+						{OidcConstants.TokenRequest.RedirectUri, redirectUri},
+						{OidcConstants.TokenRequest.ClientId, _options.Settings.ClientId},
+						{OidcConstants.TokenRequest.CodeVerifier, codeVerifier}
+					};
+
+					if (context.Request.Query.TryGetValue(AuthorizationCodeResponseType, out var responseType)) {
+						queryParams.Add(OidcConstants.TokenRequest.Code, responseType!);
+					}
+
+					//since we're using PKCE, client secrets can be optional depending on the configuration of the Identity Provider
+					if (_options.Settings.ClientSecret != null) {
+						queryParams.Add(OidcConstants.TokenRequest.ClientSecret, _options.Settings.ClientSecret);
+					}
+
+					var tokenUri = new UriBuilder(_tokenEndpoint).Uri;
+					var result = await _httpClient.PostAsync(
+						tokenUri,
+						new FormUrlEncodedContent(queryParams.Select(
+							x => new KeyValuePair<string, string>(x.Key, x.Value))
+						)
+					);
+
+					if (result.StatusCode != HttpStatusCode.OK) {
+						context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+						if (_options.LogFailedAuthenticationAttempts) {
+							var content = await result.Content.ReadAsStringAsync();
+							_logger.Warning("Failed to retrieve access token for client ID: {clientId}. HTTP Status code: {httpStatusCode}, content: {content}", _options.Settings.ClientId, result.StatusCode, content);
+						}
+						return;
+					}
+
+					var resultString = await result.Content.ReadAsStringAsync();
+					var resultDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(resultString) ?? new();
+
+					const string idToken = OidcConstants.TokenResponse.IdentityToken;
+					const string tokenType = OidcConstants.TokenResponse.TokenType;
+					const string bearerTokenType = OidcConstants.TokenResponse.BearerTokenType;
+
+					if (!resultDictionary.ContainsKey(idToken)) {
+						throw new Exception($"'{idToken}' is not present in token response.");
+					}
+
+					if (!resultDictionary.ContainsKey(tokenType)) {
+						throw new Exception($"'{tokenType}' is not present in token response.");
+					}
+
+					if (resultDictionary[tokenType] != bearerTokenType) {
+						throw new Exception($"'{tokenType}' is not '{bearerTokenType}' in token response. Value is : {resultDictionary[tokenType]}");
+					}
+
+					var cookieManager = context.Response.Cookies;
+					var cookieOptions = new CookieOptions {
+						MaxAge = TimeSpan.FromMinutes(1)
+					};
+
+					cookieManager.Append("oauth_id_token", resultDictionary[idToken], cookieOptions);
+					context.Response.Redirect("/web");
+				} catch (Exception ex) {
+					context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+					_logger.Error(ex, " Error retrieving access token from {tokenEndpoint}", _tokenEndpoint);
+				}
+			});
+
+			endpointRouteBuilder.Map(CodeChallengeUrl, async context => {
+				if (!_ready) {
+					context.Response.StatusCode = (int) HttpStatusCode.ServiceUnavailable;
+					return;
+				}
+
+				var randomBytes = new byte[32];
+				_rngCsp.GetBytes(randomBytes);
+
+				var codeVerifier = Rfc7636Base64Encode(randomBytes);
+				var codeVerifierAsciiBytes = Encoding.ASCII.GetBytes(codeVerifier);
+
+				var codeChallenge = string.Empty;
+				using (SHA256 sha256Hash = SHA256.Create())
+				{
+					var sha256HashBytes = sha256Hash.ComputeHash(codeVerifierAsciiBytes);
+					codeChallenge = Rfc7636Base64Encode(sha256HashBytes);
+				}
+
+				var codeChallengeCorrelationId = Guid.NewGuid().ToString();
+				_codeVerifierLruCache.Add(codeChallengeCorrelationId, codeVerifier);
+
+				var result = new Dictionary<string, string> {
+					{"code_challenge", codeChallenge},
+					{"code_challenge_method", SHA256CodeChallengeMethod},
+					{"code_challenge_correlation_id", codeChallengeCorrelationId}
+				};
+
+				context.Response.ContentType = "application/json";
+				await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(result)));
+			});
+		}
+
+		private string Rfc7636Base64Encode(byte[] bytes) {
+			var s = Convert.ToBase64String(bytes);
+			s = s.Split('=')[0]; // Remove any trailing '='s
+			s = s.Replace('+', '-'); // 62nd char of encoding
+			s = s.Replace('/', '_'); // 63rd char of encoding
+			return s;
+		}
+	}
+
+	private class Options {
+		public Settings Settings { get; set; } = new Settings();
+		public bool LogFailedAuthenticationAttempts { get; set; }
+	}
+
+	private class Settings {
+		public string Audience { get; set; } = null!;
+		public string Issuer { get; set; } = null!;
+
+		public bool DisableIssuerValidation { get; set; } = false;
+		public string Idp { get; set; } = null!;
+		public bool Insecure { get; set; }
+		public Uri IdpUri => Uri.IsWellFormedUriString(Idp, UriKind.Absolute)
+			? new Uri(Idp)
+			: new Uri(Issuer);
+		public string ClientId { get; set; } = null!;
+		public string ClientSecret { get; set; } = null!;
+		public string[] AdditionalEndpointBaseAddresses { get; set; } = { };
+	}
+}

--- a/src/EventStore.Auth.OAuth/README.md
+++ b/src/EventStore.Auth.OAuth/README.md
@@ -1,0 +1,313 @@
+# EventStore OAuth Plugin
+
+The OAuth plugin allows EventStoreDB to connect to an identity server and authenticate users based on a JWT rather than username and password.
+
+Access tokens can contain a "role" claim, which will be mapped to the user's group for authorization.
+
+**Note** With default auth, EventStoreDB treats the username as a "role" in addition to the groups they are in. If you want to have the same behaviour with the OAuth plugin, you will need to add the user's username as an additional role claim.
+
+## Configuration
+
+You can enable the OAuth plugin by setting the following options in you eventstore config file:
+- Set the `AuthenticationType` to `oauth`
+- Provide an oath config file with the `AuthenticationConfig` option.
+
+For example:
+
+```
+---
+MemDb: true
+EnableAtomPubOverHttp: true
+
+CertificateFile: {node.crt}
+CertificatePrivateKeyFile: {node.key}
+TrustedRootCertificatesPath: {ca}
+
+AuthenticationType: oauth
+AuthenticationConfig: es-oauth.conf
+```
+
+Create a separate configuration file `es-oauth.conf` (the name is not important) to configure the OAuth plugin.
+The configuration options are:
+
+| Name 			 | Type	| Required?	| Default 	|Description |
+|------------------------|----------|-----------|-----------|------------|
+| Audience 			 | string 	| Y 		| - 		| The audience used in your identity provider. |
+| Issuer 			 | string 	| Y 		| - 		| The issuer endpoint for your identity provider. |
+| ClientId			 | string 	| N 		| "" 		| The id of the client configured in the identity provider. |
+| ClientSecret 		 | string 	| N 		| "" 		| The client secret configured in the identity provider. |
+| DisableIssuerValidation| bool 	| N 		| false 	| Disable issuer validation for testing purposes. |
+| Insecure 			 | bool 	| N 		| false 	| Whether to validate the certificates for the identity provider. This is not related to `Insecure` in the EventStoreDB configuration. |
+
+For example:
+```
+---
+OAuth:
+  Audience: eventstore-client
+  Issuer: https://localhost:5001/
+  ClientId: eventstore-client
+  ClientSecret: K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols=
+  # For testing
+  DisableIssuerValidation: true
+  Insecure: true
+```
+
+## Set up a local identity server
+
+We have an [Identity Server 4 docker container](https://github.com/EventStore/idsrv4) for testing.
+
+1. Create a `users.conf.json` file to configure the users for your test.
+
+<details>
+	<summary>users.conf.json</summary>
+
+```
+[
+	{
+		"subjectId": "1",
+		"username": "admin",
+		"password": "password",
+		"claims": [{
+			"type": "role",
+			"value": "$admins"
+		}, {
+			"type": "role",
+			"value": "$ops"
+		}, {
+			"type": "given_name",
+			"value": "Alice Smith"
+		}]
+	}, 	{
+		"subjectId": "2",
+		"username": "operator",
+		"password": "password",
+		"claims": [{
+			"type": "role",
+			"value": "$ops"
+		}]
+	}, 	{
+		"subjectId": "3",
+		"username": "ouro",
+		"password": "password",
+		"claims": [{
+			"type": "role",
+			"value": "custom"
+		}]
+	}, 	{
+		"subjectId": "4",
+		"username": "user",
+		"password": "password",
+		"claims": []
+	}
+]
+```
+</details>
+
+This creates the following users:
+
+| Username 		| Password 		| Roles |
+|---------------|---------------|-------|
+| `admin`		| `password` 	| `$admins`, `$ops` |
+| `operator` 	| `password` 	| `$ops` |
+| `ouro`		| `password`	| `custom` |
+| `user`		| `password`	| None |
+
+2. Create an identity server config file, `idsrv4.conf.json`.
+
+You need to configure the following:
+
+- A role claim must be added to the token: `http://schemas.microsoft.com/ws/2008/06/identity/claims/role`
+- The grant types of `password` and `authorization_code` must be allowed.
+- A redirect uri of `{eventstore_server_ip}/oauth/callback` must be allowed for the legacy UI to function.
+
+<details>
+	<summary>idsrv4.conf.json</summary>
+
+```
+{
+	"IdentityResources": [
+		{
+			"Name": "openid",
+			"DisplayName": "Your user identifier",
+			"Required": true,
+			"UserClaims": [
+				"sub",
+				"role"
+			]
+		},
+		{
+			"Name": "profile",
+			"DisplayName": "User profile",
+			"Description": "Your user profile information (first name, last name, etc.)",
+			"Emphasize": true,
+			"UserClaims": [
+				"name",
+				"given_name",
+				"middle_name",
+			]
+		}
+	],
+	"ApiResources": [
+		{
+			"Name": "eventstore-client",
+			"Scopes": [
+				"streams",
+				"openid",
+				"profile"
+			]
+		}
+	],
+	"ApiScopes": [
+		{
+			"Name": "streams",
+			"UserClaims": [
+				"http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+				"role"
+			]
+		}
+	],
+	"Clients": [
+		{
+			"ClientId": "eventstore-client",
+			"AllowedGrantTypes": [
+				"password",
+				"authorization_code"
+			],
+			"ClientSecrets": [
+				{
+					"Value": "K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols="
+				}
+			],
+			"AllowedScopes": [
+				"streams",
+				"openid",
+				"profile",
+			],
+			"RedirectUris": ["https://localhost:2113/oauth/callback"],
+			"AlwaysIncludeUserClaimsInIdToken": true,
+			"RequireConsent": false,
+			"AlwaysSendClientClaims": true,
+			"AllowOfflineAccess": true,
+			"RequireClientSecret": false,
+			"AllowAccessTokensViaBrowser": true
+		}
+	]
+}
+```
+</details>
+
+3. Pull and run the `eventstore/idsrv4` docker container:
+
+```
+docker pull ghcr.io/eventstore/idsrv4/idsrv4
+
+docker run \
+    --rm -it \
+    -p 5000:5000 \                                            # HTTP port
+    -p 5001:5001 \                                            # HTTPS port
+    --volume $PWD/users.conf.json:/etc/idsrv4/users.conf \    # mount users file; required
+    --volume $PWD/idsrv4.conf.json:/etc/idsrv4/idsrv4.conf \  # mount configuration file
+    ghcr.io/eventstore/idsrv4/idsrv4
+```
+
+You should see the identity server start up and start listening on the ports `5000` and `5001`:
+
+```
+info: Microsoft.Hosting.Lifetime[14]
+      Now listening on: https://[::]:5000
+info: Microsoft.Hosting.Lifetime[14]
+      Now listening on: https://[::]:5001
+```
+
+You should now be able to log into the UI with the configured users.
+
+### Local testing with dotnet gRPC client
+
+A full sample can be found in [EventStore.Auth.OAuth.Tests](https://github.com/EventStore/EventStore.CommercialHA/blob/master/src/EventStore.Auth.OAuth.Tests/OAuthAuthenticationGrpcIntegrationTests.cs).
+
+Install the following nuget packages:
+
+- EventStore.Client.Grpc.Streams
+- IdentityModel
+- System.IdentityModel.Tokens.Jwt
+
+You need to first request an access token from the Idp, and then provide this as the credentials for your requests to EventStoreDB.
+
+<details>
+	<summary>dotnet gRPC sample application</summary>
+
+```
+using System.Net;
+using EventStore.Client;
+using IdentityModel.Client;
+
+const int IdpPort = 5001;
+const string ClientId = "eventstore-client";
+const string ClientSecret = "K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols=";
+const string RequestedScopes = "openid streams offline_access";
+
+var token = await GetToken("admin", "password");
+var settings = EventStoreClientSettings.Create("esdb://localhost:2113?tlsVerifyCert=false");
+settings.DefaultCredentials = new UserCredentials(token);
+var client = new EventStoreClient(settings);
+
+try
+{
+    var res = client.ReadAllAsync(Direction.Backwards, Position.End, 10);
+    await foreach (var evnt in res)
+    {
+        Console.WriteLine($"{evnt.OriginalEventNumber}@{evnt.OriginalStreamId}");
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Could not read stream: {ex}");
+}
+
+async ValueTask<string> GetToken(string username, string password)
+{
+    var httpClient = new HttpClient(new SocketsHttpHandler
+    {
+        SslOptions =
+        {
+            RemoteCertificateValidationCallback = delegate { return true; }
+        }
+    }, true)
+    {
+        BaseAddress = new UriBuilder
+        {
+            Scheme = Uri.UriSchemeHttps,
+            Port = IdpPort
+        }.Uri
+    };
+
+    var request = new DiscoveryDocumentRequest();
+    var discoveryDocument = await httpClient.GetDiscoveryDocumentAsync(request);
+    if (discoveryDocument?.HttpResponse == null)
+    {
+        throw new Exception("Health check not available yet");
+    }
+
+    if (discoveryDocument.HttpStatusCode != HttpStatusCode.OK)
+    {
+        throw new Exception($"Health check failed with status code {discoveryDocument.HttpStatusCode}");
+    }
+
+    var response = await httpClient.RequestPasswordTokenAsync(new PasswordTokenRequest
+    {
+        ClientId = ClientId,
+        ClientSecret = ClientSecret,
+        UserName = username,
+        Password = password,
+        Address = discoveryDocument.TokenEndpoint,
+        Scope = RequestedScopes,
+    });
+    if (response.Exception != null)
+    {
+        throw response.Exception;
+    }
+
+    return response.AccessToken ?? "";
+}
+```
+</details>

--- a/src/EventStore.Auth.StreamPolicyPlugin.Tests/EventStore.Auth.StreamPolicyPlugin.Tests.csproj
+++ b/src/EventStore.Auth.StreamPolicyPlugin.Tests/EventStore.Auth.StreamPolicyPlugin.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+<PropertyGroup>
+	<TargetFramework>net8.0</TargetFramework>
+	<ImplicitUsings>enable</ImplicitUsings>
+	<Nullable>enable</Nullable>
+</PropertyGroup>
+
+<ItemGroup>
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+	<PackageReference Include="xunit" Version="2.8.1" />
+	<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		<PrivateAssets>all</PrivateAssets>
+	</PackageReference>
+</ItemGroup>
+
+<ItemGroup>
+	<ProjectReference Include="..\..\EventStore\src\EventStore.Core.Tests\EventStore.Core.Tests.csproj" />
+	<ProjectReference Include="..\EventStore.Auth.StreamPolicyPlugin\EventStore.Auth.StreamPolicyPlugin.csproj" />
+</ItemGroup>
+
+</Project>

--- a/src/EventStore.Auth.StreamPolicyPlugin.Tests/FakePolicyProvider.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin.Tests/FakePolicyProvider.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Core.Services;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Tests;
+
+public class FakePolicyProvider {
+	private readonly Dictionary<string, AccessPolicy> _streamRules = new();
+	private readonly AccessPolicy _publicStreamRule;
+
+	public FakePolicyProvider(string restrictedStreamName, string restrictedStreamUser) {
+		_streamRules.Add(restrictedStreamName, new AccessPolicy(
+			[restrictedStreamUser],
+			[restrictedStreamUser],
+			[restrictedStreamUser],
+			[restrictedStreamUser],
+			[restrictedStreamUser]
+		));
+		_publicStreamRule = new(
+			[SystemRoles.All],
+			[SystemRoles.All],
+			[SystemRoles.All],
+			[SystemRoles.All],
+			[SystemRoles.All]
+		);
+	}
+
+	public void SetCustomAccessPolicy(string streamId, AccessPolicy accessPolicy) {
+		_streamRules.Add(streamId, accessPolicy);
+	}
+
+	public AccessPolicy GetAccessPolicyFor(string streamId) {
+		return _streamRules.TryGetValue(streamId, out var rule) ? rule : _publicStreamRule;
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin.Tests/PolicySchemaTests.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin.Tests/PolicySchemaTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json;
+using Xunit;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Tests;
+
+public class PolicySchemaTests {
+	private static readonly JsonSerializerOptions SerializeOptions = new() {
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+	};
+
+	[Theory]
+	[MemberData(nameof(InvalidPolicies))]
+	public void when_deserializing_invalid_policies(string data) {
+		Assert.Throws<ArgumentNullException>(() =>
+			JsonSerializer.Deserialize<Schema.Policy>(data, SerializeOptions));
+	}
+
+	[Theory]
+	[MemberData(nameof(InvalidStreamRules))]
+	public void when_deserializing_invalid_stream_rules(string data) {
+		Assert.Throws<ArgumentNullException>(() =>
+			JsonSerializer.Deserialize<Schema.StreamRule>(data, SerializeOptions));
+	}
+
+	[Theory]
+	[MemberData(nameof(InvalidDefaultStreamRules))]
+	public void when_deserializing_invalid_default_stream_rules(string data) {
+		Assert.Throws<ArgumentNullException>(() =>
+			JsonSerializer.Deserialize<Schema.DefaultStreamRules>(data, SerializeOptions));
+	}
+
+	[Theory]
+	[MemberData(nameof(InvalidAccessPolicies))]
+	public void when_deserializing_invalid_access_policies(string data) {
+		Assert.Throws<ArgumentNullException>(() =>
+			JsonSerializer.Deserialize<Schema.AccessPolicy>(data, SerializeOptions));
+	}
+
+	public static IEnumerable<object[]> InvalidAccessPolicies() {
+		yield return ["""{"$r":null, "$w":[], "$d": [], "$mr": [], "$mw": []}"""];
+		yield return ["""{"$r": [], "$w":null, "$d": [], "$mr": [], "$mw": []}"""];
+		yield return ["""{"$r": [], "$w":[], "$d": null, "$mr": [], "$mw": []}"""];
+		yield return ["""{"$r": [], "$w":[], "$d": [], "$mr": null, "$mw": []}"""];
+		yield return ["""{"$r": [], "$w":[], "$d": [], "$mr": [], "$mw": null}"""];
+	}
+
+	public static IEnumerable<object[]> InvalidDefaultStreamRules() {
+		yield return ["""{"userStreams":null, "systemStreams":"test"}"""];
+		yield return ["""{"userStreams":"", "systemStreams":"test"}"""];
+		yield return ["""{"userStreams":"test", "systemStreams":null}"""];
+		yield return ["""{"userStreams":"test", "systemStreams":""}"""];
+	}
+
+	public static IEnumerable<object[]> InvalidStreamRules() {
+		yield return ["""{"startsWith":null, "policy":"test"}"""];
+		yield return ["""{"startsWith":"", "policy":"test"}"""];
+		yield return ["""{"startsWith":"test", "policy":null}"""];
+		yield return ["""{"startsWith":"test", "policy":""}"""];
+	}
+
+	public static IEnumerable<object[]> InvalidPolicies() {
+		yield return [
+			"""
+			{
+			  "streamPolicies": null,
+			  "streamRules": [],
+			  "defaultStreamRules": {
+			    "userStreams": null,
+			    "systemStreams": "adminsDefault"
+			  }
+			}
+			"""
+		];
+		yield return [
+			"""
+			{
+			  "streamPolicies": {
+			    "publicDefault": {
+			      "$r": ["$all"],
+			      "$w": ["$all"],
+			      "$d": ["$all"],
+			      "$mr": ["$all"],
+			      "$mw": ["$all"]
+			    }
+			  },
+			  "streamRules": null,
+			  "defaultStreamRules": {
+			    "userStreams": null,
+			    "systemStreams": "adminsDefault"
+			  }
+			}
+			"""
+		];
+		yield return [
+			"""
+			{
+			  "streamPolicies": {
+			    "publicDefault": {
+			      "$r": ["$all"],
+			      "$w": ["$all"],
+			      "$d": ["$all"],
+			      "$mr": ["$all"],
+			      "$mw": ["$all"]
+			    }
+			  },
+			  "streamRules": [],
+			  "defaultStreamRules": null
+			}
+			"""
+		];
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin.Tests/PolicyTestHelpers.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin.Tests/PolicyTestHelpers.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using System.Text.Json;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Tests;
+
+internal static class PolicyTestHelpers {
+	public static readonly string[] ValidActions = ["read", "write", "delete", "metadataRead", "metadataWrite"];
+
+	public static OperationDefinition ActionToOperationDefinition(string action) =>
+		action switch {
+			"read" => Operations.Streams.Read,
+			"write" => Operations.Streams.Write,
+			"delete" => Operations.Streams.Delete,
+			"metadataRead" => Operations.Streams.MetadataRead,
+			"metadataWrite" => Operations.Streams.MetadataWrite,
+			_ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+		};
+
+	public static ClaimsPrincipal CreateUser(string username, string[] roles) {
+		var claims = new List<Claim>();
+		if (roles.Length != 0) {
+			claims.AddRange(roles.Select(x => new Claim(ClaimTypes.Role, x)).ToList());
+		}
+		claims.Add(new Claim(ClaimTypes.Name, username));
+
+		return new(new[] {
+			new ClaimsIdentity(claims, authenticationType: "basic")
+		});
+	}
+
+	public static byte[] SerializePolicy(Schema.Policy policy) =>
+		JsonSerializer.SerializeToUtf8Bytes(policy, new JsonSerializerOptions {
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+		});
+
+	public static Schema.AccessPolicy CreateAccessPolicyDtoForAction(string allowedAction, string allowedUser) =>
+		allowedAction switch {
+			"read" => new Schema.AccessPolicy{ Readers = [allowedUser], Writers = [], Deleters = [], MetadataReaders = [], MetadataWriters = [] },
+			"write" => new Schema.AccessPolicy{ Writers = [allowedUser], Readers = [], Deleters = [], MetadataReaders = [], MetadataWriters = [] },
+			"delete" => new Schema.AccessPolicy{ Deleters = [allowedUser], Readers = [], Writers = [], MetadataReaders = [], MetadataWriters = [] },
+			"metadataRead" => new Schema.AccessPolicy{ MetadataReaders = [allowedUser], Readers = [], Writers = [], Deleters = [], MetadataWriters = [] },
+			"metadataWrite" => new Schema.AccessPolicy{ MetadataWriters = [allowedUser], Readers = [], Writers = [], Deleters = [], MetadataReaders = [] },
+			_ => new Schema.AccessPolicy()
+		};
+
+	public static AccessPolicy CreateAccessPolicyForAction(string allowedAction, string allowedUser) {
+		var dto = CreateAccessPolicyDtoForAction(allowedAction, allowedUser);
+		return new AccessPolicy(
+			dto.Readers,
+			dto.Writers,
+			dto.Deleters,
+			dto.MetadataReaders,
+			dto.MetadataWriters
+		);
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin.Tests/StreamPolicyAssertionTests.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin.Tests/StreamPolicyAssertionTests.cs
@@ -1,0 +1,236 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using EventStore.Core.Authorization;
+using EventStore.Core.Services;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Plugins.Authorization;
+using Xunit;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Tests;
+
+public class StreamPolicyAssertionTests {
+	private readonly PolicyInformation _policyInfo = new("fake", 1, DateTimeOffset.MinValue);
+	private const string _publicStream = "public-stream";
+	private const string _restrictedStream = "restricted-stream";
+	private const string _privilegedUser = "ouro";
+	private const string _nonPrivilegedUser = "test-user";
+
+	private (StreamPolicyAssertion, FakePolicyProvider) CreateSut() {
+		var policyProvider = new FakePolicyProvider(_restrictedStream, _privilegedUser);
+		return (new StreamPolicyAssertion(stream => policyProvider.GetAccessPolicyFor(stream)), policyProvider);
+	}
+
+	public static IEnumerable<object[]> ValidActionsData =>
+		PolicyTestHelpers.ValidActions.Select(x => new[] { (object)x });
+
+	[Fact]
+	public async Task unknown_action_throws_exception() {
+		var (sut, _) = CreateSut();
+		var user = SystemAccounts.System;
+
+		var operation = new Operation(new OperationDefinition("unknown", "unknown"))
+			.WithParameter(Operations.Streams.Parameters.StreamId(_publicStream));
+		var context = new EvaluationContext(operation, new CancellationToken());
+
+		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+			async () => await sut.Evaluate(user, operation, _policyInfo, context));
+	}
+
+	[Theory]
+	[MemberData(nameof(ValidActionsData))]
+	public async Task when_operation_has_no_stream_id_access_is_denied(string action) {
+		var (sut, _) = CreateSut();
+		var user = SystemAccounts.System;
+
+		var operation = new Operation(PolicyTestHelpers.ActionToOperationDefinition(action)); // No parameters added
+		var context = new EvaluationContext(operation, new CancellationToken());
+
+		var matchFound = await sut.Evaluate(user, operation, _policyInfo, context);
+		var matchResult = context.ToResult();
+
+		Assert.True(matchFound);
+		Assert.Equal(Grant.Deny, context.Grant);
+		Assert.Contains("streamId is null", matchResult.ToString());
+	}
+
+	[Theory]
+	[InlineData("read", "", Grant.Allow)] // "" translates to "$all"
+	[InlineData("read", "$all", Grant.Allow)]
+	[InlineData("metadataWrite", "", Grant.Allow)]
+	[InlineData("metadataWrite", "$all", Grant.Allow)]
+	[InlineData("write", "$$$all", Grant.Allow)]
+	[InlineData("write", "", Grant.Deny)]
+	[InlineData("write", "$all", Grant.Deny)]
+	[InlineData("delete", "", Grant.Deny)]
+	[InlineData("delete", "$all", Grant.Deny)]
+	public async Task actions_on_all_stream_with_system_user(string action, string stream, Grant expectedGrant) {
+		var (sut, _) = CreateSut();
+		var user = SystemAccounts.System;
+
+		var operation = new Operation(PolicyTestHelpers.ActionToOperationDefinition(action))
+			.WithParameter(Operations.Streams.Parameters.StreamId(stream));
+		var context = new EvaluationContext(operation, new CancellationToken());
+
+		var matchFound = await sut.Evaluate(user, operation, _policyInfo, context);
+		var matchResult = context.ToResult();
+
+		Assert.True(matchFound);
+		Assert.Equal(expectedGrant, context.Grant);
+		if (expectedGrant is Grant.Deny)
+			Assert.Contains("denied on $all", matchResult.ToString());
+	}
+
+	[Theory]
+	[InlineData(_publicStream, SystemUsers.Admin)]
+	[InlineData(_publicStream, "customAdmin")]
+	[InlineData(_restrictedStream, SystemUsers.Admin)]
+	[InlineData(_restrictedStream, "customAdmin")]
+	public async Task admin_is_always_granted_access(string stream, string username) {
+		var (sut, _) = CreateSut();
+		var user = PolicyTestHelpers.CreateUser(username, [SystemRoles.Admins]);
+
+		foreach (var action in PolicyTestHelpers.ValidActions) {
+			var operation = new Operation(PolicyTestHelpers.ActionToOperationDefinition(action))
+				.WithParameter(Operations.Streams.Parameters.StreamId(stream));
+			var context = new EvaluationContext(operation, new CancellationToken());
+
+			var matchFound = await sut.Evaluate(user, operation, _policyInfo, context);
+
+			Assert.True(matchFound);
+			Assert.Equal(Grant.Allow, context.Grant);
+		}
+	}
+
+	[Theory]
+	[InlineData(_restrictedStream, _privilegedUser, new string[] { }, Grant.Allow)]
+	[InlineData(_restrictedStream, "test-user", new[] { _privilegedUser }, Grant.Allow)]
+	[InlineData(_publicStream, _privilegedUser, new string[] { }, Grant.Allow)]
+	[InlineData(_publicStream, "test-user", new[] { _privilegedUser }, Grant.Allow)]
+	[InlineData(_restrictedStream, "test-user", new string[] { }, Grant.Deny)]
+	[InlineData(_restrictedStream, "test-user", new[] { "test-role" }, Grant.Deny)]
+	[InlineData(_publicStream, "test-user", new string[] { }, Grant.Allow)]
+	[InlineData(_publicStream, "test-user", new[] { "test-role" }, Grant.Allow)]
+	public async Task action_on_user_streams_with_custom_user(
+		string stream, string username, string[] role, Grant expectedGrant) {
+		var (sut, _) = CreateSut();
+		var user = PolicyTestHelpers.CreateUser(username, role);
+
+		foreach (var action in PolicyTestHelpers.ValidActions) {
+			var operation = new Operation(PolicyTestHelpers.ActionToOperationDefinition(action))
+				.WithParameter(Operations.Streams.Parameters.StreamId(stream));
+			var context = new EvaluationContext(operation, new CancellationToken());
+
+			var matchFound = await sut.Evaluate(user, operation, _policyInfo, context);
+
+			Assert.True(matchFound);
+			Assert.Equal(expectedGrant, context.Grant);
+		}
+	}
+
+	[Theory]
+	[InlineData(_restrictedStream, SystemUsers.Operations, new[] { SystemRoles.Operations }, Grant.Deny)]
+	[InlineData(_restrictedStream, "customOps", new[] { SystemRoles.Operations }, Grant.Deny)]
+	[InlineData(_publicStream, SystemUsers.Operations, new[] { SystemRoles.Operations }, Grant.Deny)]
+	[InlineData(_publicStream, "customOps", new[] { SystemRoles.Operations }, Grant.Deny)]
+	[InlineData(_publicStream, "customOps", new[] { SystemRoles.Operations, "customRole" }, Grant.Allow)]
+	public async Task users_with_only_the_ops_role_are_denied_access_to_public_and_restricted_streams(
+		string stream, string username, string[] roles, Grant expectedGrant) {
+		var (sut, _) = CreateSut();
+		var user = PolicyTestHelpers.CreateUser(username, roles);
+
+		foreach (var action in PolicyTestHelpers.ValidActions) {
+			var operation = new Operation(PolicyTestHelpers.ActionToOperationDefinition(action))
+				.WithParameter(Operations.Streams.Parameters.StreamId(stream));
+			var context = new EvaluationContext(operation, new CancellationToken());
+
+			var matchFound = await sut.Evaluate(user, operation, _policyInfo, context);
+
+			Assert.True(matchFound);
+			Assert.Equal(expectedGrant, context.Grant);
+		}
+	}
+
+	[Theory]
+	[InlineData("read", "custom-stream", Grant.Deny)]
+	[InlineData("write", "custom-stream", Grant.Deny)]
+	[InlineData("delete", "custom-stream", Grant.Deny)]
+	[InlineData("delete", "$$custom-stream", Grant.Deny)]
+	[InlineData("metadataRead", "custom-stream", Grant.Allow)]
+	[InlineData("metadataWrite", "custom-stream", Grant.Allow)]
+	[InlineData("read", "$$custom-stream", Grant.Allow)]
+	[InlineData("write", "$$custom-stream", Grant.Allow)]
+	[InlineData("metadataRead", "$$custom-stream", Grant.Deny)]
+	[InlineData("metadataWrite", "$$custom-stream", Grant.Deny)]
+	public async Task user_with_meta_access_only_does_not_have_normal_access(
+		string attemptedAction, string stream, Grant expectedGrant) {
+		var (sut, policyService) = CreateSut();
+		var user = PolicyTestHelpers.CreateUser(_nonPrivilegedUser, []);
+		var accessPolicy = new AccessPolicy([], [], [], [_nonPrivilegedUser], [_nonPrivilegedUser]);
+		policyService.SetCustomAccessPolicy(stream, accessPolicy);
+
+		var operation = new Operation(PolicyTestHelpers.ActionToOperationDefinition(attemptedAction))
+			.WithParameter(Operations.Streams.Parameters.StreamId(stream));
+		var context = new EvaluationContext(operation, new CancellationToken());
+
+		var matchFound = await sut.Evaluate(user, operation, _policyInfo, context);
+
+		Assert.True(matchFound);
+		Assert.Equal(expectedGrant, context.Grant);
+	}
+
+	[Theory]
+	[MemberData(nameof(ValidActionsData))]
+	public async Task user_is_restricted_to_allowed_actions(string allowedAction) {
+		var (sut, policyService) = CreateSut();
+		string stream = "custom-stream";
+		var user = PolicyTestHelpers.CreateUser(_nonPrivilegedUser, []);
+		var accessPolicy = PolicyTestHelpers.CreateAccessPolicyForAction(allowedAction, _nonPrivilegedUser);
+
+		policyService.SetCustomAccessPolicy(stream, accessPolicy);
+
+		foreach (var action in PolicyTestHelpers.ValidActions) {
+			var operation = new Operation(PolicyTestHelpers.ActionToOperationDefinition(action))
+				.WithParameter(Operations.Streams.Parameters.StreamId(stream));
+			var context = new EvaluationContext(operation, new CancellationToken());
+
+			var matchFound = await sut.Evaluate(user, operation, _policyInfo, context);
+
+			Assert.True(matchFound);
+			Assert.Equal(action == allowedAction ? Grant.Allow : Grant.Deny, context.Grant);
+		}
+	}
+
+	public static IEnumerable<object[]> UnauthenticatedUsers =>
+		new List<object[]> {
+			new object[] { new ClaimsPrincipal() }, // No identity
+			new object[] { // Admin claim, but authentication type is not set
+				new ClaimsPrincipal(new[] {
+					new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, SystemRoles.Admins) }, "")
+				})
+			},
+			new object[] { // Anonymous claim
+				new ClaimsPrincipal(
+					new ClaimsIdentity(new[] { new Claim(ClaimTypes.Anonymous, "") }))
+			}
+		};
+
+	[Theory]
+	[MemberData(nameof(UnauthenticatedUsers))]
+	public async Task unauthenticated_users_are_denied_access(ClaimsPrincipal user) {
+		var (sut, _) = CreateSut();
+		Assert.False(user.Identity?.IsAuthenticated ?? false);
+
+		foreach (var action in PolicyTestHelpers.ValidActions) {
+			var operation = new Operation(PolicyTestHelpers.ActionToOperationDefinition(action))
+				.WithParameter(Operations.Streams.Parameters.StreamId(_publicStream));
+			var context = new EvaluationContext(operation, new CancellationToken());
+
+			var matchFound = await sut.Evaluate(user, operation, _policyInfo, context);
+
+			Assert.True(matchFound);
+			Assert.Equal(Grant.Deny, context.Grant);
+		}
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin.Tests/StreamPolicySelectorFactoryTests.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin.Tests/StreamPolicySelectorFactoryTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Plugins.Licensing;
+using EventStore.Plugins;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Tests;
+
+public class StreamPolicySelectorFactoryTests {
+	[Theory]
+	[InlineData(true, "STREAM_POLICY_AUTHORIZATION", true)]
+	[InlineData(false, "STREAM_POLICY_AUTHORIZATION", false)]
+	[InlineData(true, "NONE", false)]
+	[InlineData(false, "NONE", false)]
+	public void respects_license(bool licensePresent, string entitlement, bool expectedIsLicensed) {
+		// given
+		using var sut = new StreamPolicySelectorFactory();
+
+		var config = new ConfigurationBuilder().Build();
+		var builder = WebApplication.CreateBuilder();
+		var licenseService = new FakeLicenseService(licensePresent, entitlement);
+		builder.Services.AddSingleton<ILicenseService>(licenseService);
+
+		((IPlugableComponent)sut).ConfigureServices(
+			builder.Services,
+			config);
+
+		var app = builder.Build();
+
+		// when
+		((IPlugableComponent)sut).ConfigureApplication(app, config);
+
+		// then
+		Assert.True(sut.IsLicensed == expectedIsLicensed);
+		Assert.Null(licenseService.RejectionException); // plugin can disable but never rejects the license
+	}
+
+	class FakeLicenseService : ILicenseService {
+		// there is tooling in CommercialHA FakeLicenseService to generate these
+		static readonly Dictionary<string, string> HardCodedTokens = new() {
+			{ "STREAM_POLICY_AUTHORIZATION", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJlc2RiIiwiaXNzIjoiZXNkYiIsImV4cCI6MTgyNDQ1NjgyOSwianRpIjoiMmIzMjlmOWMtNGFlZC00ZDlkLWJjOTEtYTQ4YWFkZWRiNTE0Iiwic3ViIjoiRVNEQiBUZXN0cyIsIklzVHJpYWwiOiJUcnVlIiwiSXNFeHBpcmVkIjoiRmFsc2UiLCJJc1ZhbGlkIjoiVHJ1ZSIsIklzRmxvYXRpbmciOiJUcnVlIiwiRGF5c1JlbWFpbmluZyI6IjEiLCJTdGFydERhdGUiOiIyNi8wNC8yMDI0IDAwOjAwOjAwICswMTowMCIsIlNUUkVBTV9QT0xJQ1lfQVVUSE9SSVpBVElPTiI6InRydWUiLCJpYXQiOjE3Mjk4NDg4MjksIm5iZiI6MTcyOTg0ODgyOX0.ZigSD46YoSWSiozvGQXJ7FXgtEallqyTSvfcywCO_Z_d8cRlCJRb27bzJ1q4UtrBP99SBbttN2etmzyCZhhASAH55W4oo1Vh9iEbBu3uiH8ZPdBD8_V4v83djh70Fux0JUpQWcFq8bBsscXdg7fE2MpaRU004Ei3C03P3Es8jtsXRJ6rkkFFsa0NIQtPnmj44lZfAnU5A_BgamW6_OoPHjB1vEA9LUquQ5p7ovZxK1cv2lgs0lh3drYFyflqI1sAqJof4HCmMV1oK4U-1j9UhGov6J7TWtvSfbpiRToQayGe8yKmYEqydhQhgFlNBfjvv11Z_1uWyVyItopl7W5o9g" },
+			{ "NONE", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJlc2RiIiwiaXNzIjoiZXNkYiIsImV4cCI6MTgyNDQ1NjgyOSwianRpIjoiOTVmZTY2YzAtMDRkMi00MjExLWI1ZGQtNTAyM2MyYTAxMGFiIiwic3ViIjoiRVNEQiBUZXN0cyIsIklzVHJpYWwiOiJUcnVlIiwiSXNFeHBpcmVkIjoiRmFsc2UiLCJJc1ZhbGlkIjoiVHJ1ZSIsIklzRmxvYXRpbmciOiJUcnVlIiwiRGF5c1JlbWFpbmluZyI6IjEiLCJTdGFydERhdGUiOiIyNi8wNC8yMDI0IDAwOjAwOjAwICswMTowMCIsIk5PTkUiOiJ0cnVlIiwiaWF0IjoxNzI5ODQ4ODI5LCJuYmYiOjE3Mjk4NDg4Mjl9.R24i-ZAow3BhRaST3n25Uc_nQ184k83YRZZ0oRcWbU9B9XNLRH0Iegj0HmkyzkT50I4gcIJOIfcO6mIPp4Y959CP7aTAlt7XEnXoGF0GwsfXatAxy4iXG8Gpya7INgMoWEeN0v8eDH8_OVmnieOxeba9ex5j1oAW_FtQDMzcFjAeErpW__8zmkCsn6GzvlhdLE4e3r2wjshvrTTcS_1fvSVjQZov5ce2sVBJPegjCLO_QGiIBK9QTnpHrhe6KCYje6fSTjgty0V1Qj22bftvrXreYzQijPrnC_ek1BwV-A1JvacZugMCPIy8WvE5jE3hVYRWGGUzQZ-CibPGsjudYA" },
+		};
+
+		public FakeLicenseService(bool createLicense = true, string? entitlement = null) {
+			var license = new License(new JsonWebToken(HardCodedTokens[entitlement ?? "NONE"]));
+			SelfLicense = license;
+
+			if (createLicense) {
+				CurrentLicense = license;
+				Licenses = new BehaviorSubject<License>(license);
+			} else {
+				var licenses = new Subject<License>();
+				licenses.OnError(new Exception("no license"));
+				Licenses = licenses;
+			}
+		}
+
+		public License SelfLicense { get; }
+
+		public License? CurrentLicense { get; }
+
+		public IObservable<License> Licenses { get; }
+
+		public void RejectLicense(Exception ex) {
+			RejectionException = ex;
+		}
+
+		public Exception? RejectionException { get; private set; }
+	}
+}
+

--- a/src/EventStore.Auth.StreamPolicyPlugin.Tests/StreamPolicySelectorTests.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin.Tests/StreamPolicySelectorTests.cs
@@ -1,0 +1,485 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using DotNext.Threading;
+using EventStore.Auth.StreamPolicyPlugin.Schema;
+using EventStore.Core.Authorization;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services;
+using EventStore.Core.Tests;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Plugins.Authorization;
+using Xunit;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Tests;
+
+public class StreamPolicySelectorTests {
+	private readonly SynchronousScheduler _bus = new("testBus");
+	private const string _userStream = "user-stream";
+	private const string _systemStream = "$system-stream";
+
+	private const string _customUser = "ouro";
+	private const string _customRole = "user-role";
+	private readonly CancellationTokenSource _cts = new ();
+
+	private readonly string[] _projectionStreamPrefixes = ["$et-", "$ce-,", "$bc-", "$category-", "$streams"];
+
+	private static string _customPolicyName => StreamPolicySelector.PolicyName;
+	private static string _customPolicyFallbackName => $"{StreamPolicySelector.PolicyName}-notready";
+
+	public static IEnumerable<object[]> ValidActionsData => PolicyTestHelpers.ValidActions.Select(x => new[] { (object)x });
+
+	private Schema.AccessPolicy AdminOnly => new() {
+		Readers = [SystemRoles.Admins],
+		Writers = [SystemRoles.Admins],
+		Deleters = [SystemRoles.Admins],
+		MetadataReaders = [SystemRoles.Admins],
+		MetadataWriters = [SystemRoles.Admins]
+	};
+
+	private StreamPolicySelector CreateSut() {
+		return new StreamPolicySelector(_bus, _cts.Token);
+	}
+
+	[Theory]
+	[InlineData(_systemStream, SystemUsers.Admin, SystemRoles.Admins, Grant.Allow)]
+	[InlineData(_userStream, SystemUsers.Admin, SystemRoles.Admins, Grant.Allow)]
+	[InlineData(_systemStream, SystemUsers.Operations, SystemRoles.Operations, Grant.Deny)]
+	[InlineData(_userStream, SystemUsers.Operations, SystemRoles.Operations, Grant.Deny)]
+	[InlineData(_systemStream, _customUser, _customRole, Grant.Deny)]
+	[InlineData(_userStream, _customUser, _customRole, Grant.Deny)]
+	public async Task when_policy_selector_is_not_ready_only_admin_users_have_access(
+		string stream, string username, string role, Grant expectedGrant) {
+		var sut = CreateSut();
+		var user = PolicyTestHelpers.CreateUser(username, [role]);
+		var policy = sut.Select();
+		Assert.Equal(_customPolicyFallbackName, policy.Information.Name);
+
+		await AssertAllActionsOnPolicy(policy, user, stream, expectedGrant);
+	}
+
+	[Fact]
+	public async Task when_policy_stream_is_empty_policy_selector_uses_not_ready_policy() {
+		var tcs = new TaskCompletionSource();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(NoStreamResponse(msg));
+				tcs.SetResult();
+			}));
+		var sut = CreateSut();
+		await tcs.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var policy = sut.Select();
+		Assert.Equal(_customPolicyFallbackName, policy.Information.Name);
+	}
+
+	[Fact]
+	public async Task when_policy_stream_contains_only_invalid_policy_events_policy_selector_uses_not_ready_policy() {
+		var tcs = new TaskCompletionSource();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(CreateReadCompleted(msg, [
+					CreateResolvedEvent("invalid", "invalid"u8.ToArray(), 0),
+					CreateResolvedEvent(StreamPolicySelector.PolicyEventType, "invalid"u8.ToArray(), 1),
+					CreateResolvedEvent("invalid", PolicyTestHelpers.SerializePolicy(StreamPolicySelector.DefaultPolicy),
+						2)
+				]));
+				tcs.SetResult();
+			}));
+		var sut = CreateSut();
+		await tcs.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var policy = sut.Select();
+		Assert.Equal(_customPolicyFallbackName, policy.Information.Name);
+	}
+
+	[Fact]
+	public async Task when_parsing_policy_with_multiple_rules_the_rules_are_applied_in_order() {
+		string username = _customUser;
+		string role = _customRole;
+		var tcs = new TaskCompletionSource();
+		var existingPolicy = new Schema.Policy {
+			StreamPolicies = new Dictionary<string, Schema.AccessPolicy>{
+				{ "systemDefault", new Schema.AccessPolicy{ Readers = [], Writers = [], Deleters = [], MetadataWriters = [], MetadataReaders = []}},
+				{ "userDefault", new Schema.AccessPolicy{ Readers = [role], Writers = [role], Deleters = [role], MetadataWriters = [], MetadataReaders = []}},
+				{ "customOne", new Schema.AccessPolicy{ Readers = [role], Writers = [], Deleters = [], MetadataWriters = [], MetadataReaders = [] }},
+				{ "customTwo", new Schema.AccessPolicy{ Readers = [role], Writers = [role], Deleters = [], MetadataWriters = [], MetadataReaders = [] }},
+			},
+			DefaultStreamRules = new Schema.DefaultStreamRules{ SystemStreams = "systemDefault", UserStreams = "userDefault"},
+			StreamRules = new Schema.StreamRule[] {
+				new StreamRule{ Policy = "customOne", StartsWith = "account-"},
+				new StreamRule {Policy = "customTwo", StartsWith = "account"}
+			}
+		};
+
+		var user = PolicyTestHelpers.CreateUser(username, [role]);
+
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(CreateReadCompleted(msg, [CreateResolvedEventForPolicy(existingPolicy, 0)]));
+				tcs.SetResult();
+			}));
+		var sut = CreateSut();
+		await tcs.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var policy = sut.Select();
+
+		await AssertAllowedStreamActionsOnPolicy(policy, user, "account-1", ["read"]);
+		await AssertAllowedSubscriptionActionsOnPolicy(policy, user, "account-1", ["read"]);
+
+		await AssertAllowedStreamActionsOnPolicy(policy, user, "account1", ["read", "write"]);
+		await AssertAllowedSubscriptionActionsOnPolicy(policy, user, "account1", ["read", "write"]);
+
+		await AssertAllowedStreamActionsOnPolicy(policy, user, "acc-3", ["read", "write", "delete"]);
+		await AssertAllowedSubscriptionActionsOnPolicy(policy, user, "acc-3", ["read", "write", "delete"]);
+
+		await AssertAllowedStreamActionsOnPolicy(policy, user, "$account", []);
+		await AssertAllowedSubscriptionActionsOnPolicy(policy, user, "$account", []);
+	}
+
+	[Theory]
+	[InlineData(SystemUsers.Admin, SystemRoles.Admins, Grant.Allow, Grant.Allow)]
+	[InlineData(SystemUsers.Operations, SystemRoles.Operations, Grant.Deny, Grant.Deny)]
+	[InlineData(_customUser, _customRole, Grant.Allow, Grant.Deny)]
+	public async Task when_using_the_default_policy_standard_projection_streams_are_read_only(
+		string username, string role, Grant expectedReadGrant, Grant expectedWriteGrant) {
+		var tcs = new TaskCompletionSource();
+		var existingPolicy = StreamPolicySelector.DefaultPolicy;
+		var user = PolicyTestHelpers.CreateUser(username, [role]);
+
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(CreateReadCompleted(msg, [CreateResolvedEventForPolicy(existingPolicy, 0)]));
+				tcs.SetResult();
+			}));
+		var sut = CreateSut();
+		await tcs.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var policy = sut.Select();
+		Assert.Equal(_customPolicyName, policy.Information.Name);
+		string[] allowedActions;
+		if (expectedReadGrant == Grant.Allow) {
+			allowedActions = expectedWriteGrant == Grant.Allow
+				? PolicyTestHelpers.ValidActions
+				: ["read", "metadataRead"];
+		} else {
+			allowedActions = [];
+		}
+
+		foreach (var prefix in _projectionStreamPrefixes) {
+			var stream = $"{prefix}test";
+			await AssertAllowedStreamActionsOnPolicy(policy, user, stream, allowedActions);
+			await AssertAllowedSubscriptionActionsOnPolicy(policy, user, stream, allowedActions);
+		}
+	}
+
+	[Theory]
+	[InlineData(_systemStream, SystemUsers.Admin, SystemRoles.Admins, Grant.Allow)]
+	[InlineData(_userStream, SystemUsers.Admin, SystemRoles.Admins, Grant.Allow)]
+	[InlineData(_systemStream, SystemUsers.Operations, SystemRoles.Operations, Grant.Deny)]
+	[InlineData(_userStream, SystemUsers.Operations, SystemRoles.Operations, Grant.Deny)]
+	[InlineData(_systemStream, _customUser, _customRole, Grant.Deny)]
+	[InlineData(_userStream, _customUser, _customRole, Grant.Allow)]
+	public async Task when_policy_stream_contains_a_valid_policy_that_policy_is_used(
+		string stream, string username, string role, Grant expectedGrant) {
+		var tcs = new TaskCompletionSource();
+		var existingPolicy = StreamPolicySelector.DefaultPolicy;
+		var user = PolicyTestHelpers.CreateUser(username, [role]);
+
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(CreateReadCompleted(msg, [CreateResolvedEventForPolicy(existingPolicy, 0)]));
+				tcs.SetResult();
+			}));
+		var sut = CreateSut();
+		await tcs.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var policy = sut.Select();
+		Assert.Equal(_customPolicyName, policy.Information.Name);
+
+		await AssertAllActionsOnPolicy(policy, user, stream, expectedGrant);
+	}
+
+	[Theory]
+	[MemberData(nameof(ValidActionsData))]
+	public async Task
+		when_policy_stream_contains_multiple_policies_the_most_recent_policy_is_used(string allowedAction) {
+		var tcs = new TaskCompletionSource();
+		var user = PolicyTestHelpers.CreateUser(SystemUsers.Operations, [SystemRoles.Operations]);
+		var stream = _systemStream;
+
+		var policy1 = StreamPolicySelector.DefaultPolicy;
+		var policy2 = new Schema.Policy {
+			StreamPolicies = new Dictionary<string, Schema.AccessPolicy> {
+				{ "NewPolicy", PolicyTestHelpers.CreateAccessPolicyDtoForAction(allowedAction, SystemUsers.Operations) },
+				{ "DefaultPolicy", AdminOnly }
+			},
+			DefaultStreamRules = new Schema.DefaultStreamRules
+				{ SystemStreams = "DefaultPolicy", UserStreams = "DefaultPolicy" },
+			StreamRules = [new Schema.StreamRule { Policy = "NewPolicy", StartsWith = stream }]
+		};
+
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(CreateReadCompleted(msg, [
+					CreateResolvedEventForPolicy(policy2, 1),
+					CreateResolvedEventForPolicy(policy1, 0)
+				]));
+				tcs.SetResult();
+			}));
+		var sut = CreateSut();
+		await tcs.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var policy = sut.Select();
+		Assert.Equal(_customPolicyName, policy.Information.Name);
+
+		await AssertAllowedStreamActionsOnPolicy(policy, user, stream, [allowedAction]);
+		await AssertAllowedSubscriptionActionsOnPolicy(policy, user, stream, [allowedAction]);
+	}
+
+	[Theory]
+	[MemberData(nameof(ValidActionsData))]
+	public async Task when_policy_stream_contains_an_invalid_policy_the_most_recent_valid_policy_is_used(
+		string allowedAction) {
+		var tcs = new TaskCompletionSource();
+		var user = PolicyTestHelpers.CreateUser(SystemUsers.Operations, [SystemRoles.Operations]);
+		var stream = _systemStream;
+
+		var policy1 = StreamPolicySelector.DefaultPolicy;
+		var policy2 = new Schema.Policy {
+			StreamPolicies = new Dictionary<string, Schema.AccessPolicy> {
+				{ "NewPolicy", PolicyTestHelpers.CreateAccessPolicyDtoForAction(allowedAction, SystemUsers.Operations) },
+				{ "DefaultPolicy", AdminOnly }
+			},
+			DefaultStreamRules = new Schema.DefaultStreamRules
+				{ SystemStreams = "DefaultPolicy", UserStreams = "DefaultPolicy" },
+			StreamRules = [new Schema.StreamRule { Policy = "NewPolicy", StartsWith = stream }]
+		};
+
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(CreateReadCompleted(msg, [
+					CreateResolvedEvent("invalid", "invalid"u8.ToArray(), 2),
+					CreateResolvedEventForPolicy(policy2, 1),
+					CreateResolvedEventForPolicy(policy1, 0)
+				]));
+				tcs.SetResult();
+			}));
+		var sut = CreateSut();
+		await tcs.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var policy = sut.Select();
+		Assert.Equal(_customPolicyName, policy.Information.Name);
+
+		await AssertAllowedStreamActionsOnPolicy(policy, user, stream, [allowedAction]);
+		await AssertAllowedSubscriptionActionsOnPolicy(policy, user, stream, [allowedAction]);
+	}
+
+	[Theory]
+	[MemberData(nameof(ValidActionsData))]
+	public async Task when_a_new_policy_event_is_written_the_new_policy_is_applied(string allowedAction) {
+		var user = PolicyTestHelpers.CreateUser(SystemUsers.Operations, [SystemRoles.Operations]);
+		var stream = _systemStream;
+
+		var policy1 = StreamPolicySelector.DefaultPolicy;
+		var policy2 = new Schema.Policy {
+			StreamPolicies = new Dictionary<string, Schema.AccessPolicy> {
+				{ "NewPolicy", PolicyTestHelpers.CreateAccessPolicyDtoForAction(allowedAction, SystemUsers.Operations)},
+				{ "DefaultPolicy", AdminOnly }
+			},
+			DefaultStreamRules = new Schema.DefaultStreamRules{ SystemStreams = "DefaultPolicy", UserStreams = "DefaultPolicy"},
+			StreamRules = [new Schema.StreamRule{ Policy = "NewPolicy", StartsWith = stream}]
+		};
+
+		var subscribeSource = new TaskCompletionSource<ClientMessage.SubscribeToStream>();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.SubscribeToStream>(msg => {
+			subscribeSource.TrySetResult(msg);
+		}));
+
+		var readCompletionSource = new TaskCompletionSource();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(CreateReadCompleted(msg, [CreateResolvedEventForPolicy(policy1, 0)]));
+				readCompletionSource.SetResult();
+			}));
+		var sut = CreateSut();
+		await readCompletionSource.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var initialPolicy = sut.Select();
+		Assert.Equal(_customPolicyName, initialPolicy.Information.Name);
+
+		// Test that the old policy is in effect
+		await AssertAllActionsOnPolicy(initialPolicy, user, stream, Grant.Deny);
+
+		// Write a new policy event
+		var subscribeMsg = await subscribeSource.Task.WithTimeout();
+		subscribeMsg.Envelope.ReplyWith(new ClientMessage.SubscriptionConfirmation(subscribeMsg.CorrelationId, 0, 0));
+		subscribeMsg.Envelope.ReplyWith(new ClientMessage.StreamEventAppeared(
+			subscribeMsg.CorrelationId, CreateResolvedEventForPolicy(policy2, 1)));
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var newPolicy = sut.Select();
+		Assert.Equal(_customPolicyName, newPolicy.Information.Name);
+		await AssertAllowedStreamActionsOnPolicy(newPolicy, user, stream, [allowedAction]);
+		await AssertAllowedSubscriptionActionsOnPolicy(newPolicy, user, stream, [allowedAction]);
+	}
+
+	[Theory]
+	[MemberData(nameof(ValidActionsData))]
+	public async Task when_an_invalid_policy_event_is_written_the_previous_policy_is_used(string allowedAction) {
+		var user = PolicyTestHelpers.CreateUser(SystemUsers.Operations, [SystemRoles.Operations]);
+		var stream = _systemStream;
+
+		var policy1 = new Schema.Policy {
+			StreamPolicies = new Dictionary<string, Schema.AccessPolicy> {
+				{ "NewPolicy", PolicyTestHelpers.CreateAccessPolicyDtoForAction(allowedAction, SystemUsers.Operations)},
+				{ "DefaultPolicy", AdminOnly }
+			},
+			DefaultStreamRules = new Schema.DefaultStreamRules{ SystemStreams = "DefaultPolicy", UserStreams = "DefaultPolicy"},
+			StreamRules = [new Schema.StreamRule{ Policy = "NewPolicy", StartsWith = stream}]
+		};
+
+		var subscribeSource = new TaskCompletionSource<ClientMessage.SubscribeToStream>();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.SubscribeToStream>(msg => {
+			subscribeSource.TrySetResult(msg);
+		}));
+
+		var readCompletionSource = new TaskCompletionSource();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(CreateReadCompleted(msg, [CreateResolvedEventForPolicy(policy1, 0)]));
+				readCompletionSource.SetResult();
+			}));
+		var sut = CreateSut();
+		await readCompletionSource.Task.WithTimeout();
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var initialPolicy = sut.Select();
+		Assert.Equal(_customPolicyName, initialPolicy.Information.Name);
+
+		// Write an invalid policy event
+		var subscribeMsg = await subscribeSource.Task.WithTimeout();
+		subscribeMsg.Envelope.ReplyWith(new ClientMessage.SubscriptionConfirmation(subscribeMsg.CorrelationId, 0, 0));
+		subscribeMsg.Envelope.ReplyWith(new ClientMessage.StreamEventAppeared(
+			subscribeMsg.CorrelationId, CreateResolvedEvent("invalid", "invalid"u8.ToArray(), 1)));
+		await Task.Delay(100); // Wait for the policy to appear in the selector
+
+		var policy = sut.Select();
+		Assert.Equal(_customPolicyName, policy.Information.Name);
+
+		await AssertAllowedStreamActionsOnPolicy(policy, user, stream, [allowedAction]);
+		await AssertAllowedSubscriptionActionsOnPolicy(policy, user, stream, [allowedAction]);
+	}
+
+	[Theory]
+	[InlineData(ClientMessage.NotHandled.Types.NotHandledReason.NotReady)]
+	[InlineData(ClientMessage.NotHandled.Types.NotHandledReason.TooBusy)]
+	public async Task when_the_policy_subscription_is_not_handled_it_is_retried_when_recoverable(
+		ClientMessage.NotHandled.Types.NotHandledReason notHandledReason) {
+		var subscriptionMessages = new List<ClientMessage.SubscribeToStream>();
+		var subscribeEvent = new ManualResetEvent(false);
+		_bus.Subscribe(new AdHocHandler<ClientMessage.SubscribeToStream>(msg => {
+			subscriptionMessages.Add(msg);
+			subscribeEvent.Set();
+		}));
+		// Respond to the initial read with empty stream
+		_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsBackward>(
+			msg => {
+				msg.Envelope.ReplyWith(NoStreamResponse(msg));
+			}));
+
+		var sut = CreateSut();
+		await subscribeEvent.WaitAsync().AsTask().WithTimeout();
+		subscribeEvent.Reset();
+
+		var initialSubscription = subscriptionMessages.FirstOrDefault();
+		Assert.NotNull(initialSubscription);
+
+		// Fail the subscription attempt
+		initialSubscription.Envelope.ReplyWith(
+			new ClientMessage.NotHandled(initialSubscription.CorrelationId, notHandledReason, ""));
+
+		// It should attempt to resubscribe
+		await subscribeEvent.WaitAsync().AsTask().WithTimeout();
+		Assert.Equal(2, subscriptionMessages.Count);
+	}
+
+	private static async Task AssertAllActionsOnPolicy(
+		ReadOnlyPolicy policy, ClaimsPrincipal user, string stream, Grant expectedGrant) {
+		var allowedActions = expectedGrant == Grant.Allow ? PolicyTestHelpers.ValidActions : [];
+		await AssertAllowedStreamActionsOnPolicy(policy, user, stream, allowedActions);
+		await AssertAllowedSubscriptionActionsOnPolicy(policy, user, stream, allowedActions);
+	}
+
+	private static async Task AssertAllowedStreamActionsOnPolicy(
+		ReadOnlyPolicy policy, ClaimsPrincipal user, string stream, string[] allowedActions) {
+		foreach (var action in PolicyTestHelpers.ValidActions) {
+			var operationDefinition = PolicyTestHelpers.ActionToOperationDefinition(action);
+			var operation = new Operation(operationDefinition)
+				.WithParameter(Operations.Streams.Parameters.StreamId(stream));
+			Assert.True(policy.TryGetAssertions(operationDefinition, out var assertions));
+			Assert.Single(assertions.ToArray());
+
+			var assertion = assertions.ToArray()[0];
+			var evaluationContext = new EvaluationContext(operation, CancellationToken.None);
+			await assertion.Evaluate(user, operation, policy.Information, evaluationContext);
+			Assert.Equal(allowedActions.Contains(action) ? Grant.Allow : Grant.Deny, evaluationContext.Grant);
+		}
+	}
+
+	private static async Task AssertAllowedSubscriptionActionsOnPolicy(
+		ReadOnlyPolicy policy, ClaimsPrincipal user, string stream, string[] allowedActions) {
+		var operationDefinition = Operations.Subscriptions.ProcessMessages;
+		var operation = new Operation(operationDefinition)
+			.WithParameter(Operations.Subscriptions.Parameters.StreamId(stream));
+		Assert.True(policy.TryGetAssertions(operationDefinition, out var assertions));
+		Assert.Single(assertions.ToArray());
+
+		var assertion = assertions.ToArray()[0];
+		var evaluationContext = new EvaluationContext(operation, CancellationToken.None);
+		await assertion.Evaluate(user, operation, policy.Information, evaluationContext);
+		Assert.Equal(allowedActions.Contains("read") ? Grant.Allow : Grant.Deny, evaluationContext.Grant);
+	}
+
+	private static ClientMessage.ReadStreamEventsBackwardCompleted
+		NoStreamResponse(ClientMessage.ReadStreamEventsBackward msg) =>
+		new(
+			msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount,
+			ReadStreamResult.NoStream, [], StreamMetadata.Empty, true, "",
+			msg.FromEventNumber, msg.FromEventNumber, true, 0L);
+
+	private ResolvedEvent CreateResolvedEventForPolicy(Schema.Policy policy, long eventNumber) {
+		var data = PolicyTestHelpers.SerializePolicy(policy);
+		return CreateResolvedEvent(StreamPolicySelector.PolicyEventType, data, eventNumber);
+	}
+
+	private ResolvedEvent CreateResolvedEvent(string eventType, byte[] data, long eventNumber) {
+		var logPosition = eventNumber * 100;
+		var prepare = new PrepareLogRecord(logPosition, Guid.NewGuid(), Guid.NewGuid(),
+			transactionPosition: logPosition,
+			transactionOffset: 0,
+			StreamPolicySelector.PolicyStream,
+			eventStreamIdSize: null,
+			expectedVersion: eventNumber, DateTime.Now, PrepareFlags.Data,
+			eventType, eventTypeSize: null, data, ReadOnlyMemory<byte>.Empty);
+		var eventRecord = new EventRecord(eventNumber, prepare, StreamPolicySelector.PolicyStream, eventType);
+		return ResolvedEvent.ForUnresolvedEvent(eventRecord, logPosition);
+	}
+
+	private ClientMessage.ReadStreamEventsBackwardCompleted CreateReadCompleted(
+		ClientMessage.ReadStreamEventsBackward msg, ResolvedEvent[] events) =>
+		new(msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount,
+			ReadStreamResult.Success, events, StreamMetadata.Empty, true, "",
+			msg.FromEventNumber, msg.FromEventNumber, true, 1000L);
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin.Tests/StreamPolicyWriterTests.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin.Tests/StreamPolicyWriterTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using DotNext.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Tests;
+using Xunit;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Tests;
+
+public class StreamPolicyWriterTests {
+	private readonly SynchronousScheduler _bus = new("testBus");
+
+	private StreamPolicyWriter CreateSut() {
+		return new StreamPolicyWriter(
+			_bus,
+			StreamPolicySelector.PolicyStream,
+			StreamPolicySelector.PolicyEventType,
+			PolicyTestHelpers.SerializePolicy);
+	}
+
+	[Fact]
+	public async Task when_writing_the_default_policy() {
+		var tcs = new TaskCompletionSource<ClientMessage.WriteEvents>();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.WriteEvents>(msg => {
+			tcs.TrySetResult(msg);
+		}));
+
+		var sut = CreateSut();
+		var writeRequest = sut.WriteDefaultPolicy(StreamPolicySelector.DefaultPolicy, CancellationToken.None);
+		var writeMessage = await tcs.Task.WithTimeout();
+
+		// The write succeeds
+		writeMessage.Envelope.ReplyWith(
+			new ClientMessage.WriteEventsCompleted(writeMessage.CorrelationId, 0, 0, 100, 100));
+
+		// It attempts to write an event with a known id to the start of the stream
+		Assert.Equal(StreamPolicyWriter.DefaultStreamPolicyEventId, writeMessage.Events[0].EventId.ToString());
+		Assert.Equal(ExpectedVersion.NoStream, writeMessage.ExpectedVersion);
+
+		// It does not require leader
+		Assert.False(writeMessage.RequireLeader);
+
+		// The request should complete
+		await writeRequest.WithTimeout();
+	}
+
+	[Theory]
+	[InlineData(ClientMessage.NotHandled.Types.NotHandledReason.NotReady)]
+	[InlineData(ClientMessage.NotHandled.Types.NotHandledReason.NotLeader)]
+	[InlineData(ClientMessage.NotHandled.Types.NotHandledReason.TooBusy)]
+	public async Task when_the_default_policy_write_request_is_not_handled_and_can_be_retried(
+		ClientMessage.NotHandled.Types.NotHandledReason notHandledReason) {
+		var writeMessages = new List<ClientMessage.WriteEvents>();
+		var mre = new ManualResetEvent(false);
+		_bus.Subscribe(new AdHocHandler<ClientMessage.WriteEvents>(msg => {
+			writeMessages.Add(msg);
+			mre.Set();
+		}));
+
+		var sut = CreateSut();
+		var writeRequest = sut.WriteDefaultPolicy(StreamPolicySelector.DefaultPolicy, CancellationToken.None);
+		await mre.WaitAsync().AsTask().WithTimeout();
+		mre.Reset();
+
+		Assert.Single(writeMessages);
+		writeMessages[0].Envelope.ReplyWith(new ClientMessage.NotHandled(writeMessages[0].CorrelationId, notHandledReason, ""));
+
+		await mre.WaitAsync().AsTask().WithTimeout();
+		Assert.Equal(2, writeMessages.Count);
+		writeMessages[1].Envelope.ReplyWith(CreateWriteEventsSuccessfullyCompleted(writeMessages[1]));
+
+		// The request should now complete
+		await writeRequest.WithTimeout();
+	}
+
+	[Theory]
+	[InlineData(ClientMessage.NotHandled.Types.NotHandledReason.IsReadOnly)]
+	public async Task when_the_default_policy_write_request_is_not_handled_and_cannot_be_retried(
+		ClientMessage.NotHandled.Types.NotHandledReason notHandledReason) {
+		var tcs = new TaskCompletionSource<ClientMessage.WriteEvents>();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.WriteEvents>(msg => {
+			tcs.TrySetResult(msg);
+		}));
+
+		var sut = CreateSut();
+		var writeRequest = sut.WriteDefaultPolicy(StreamPolicySelector.DefaultPolicy, CancellationToken.None);
+		var writeMessage = await tcs.Task.WithTimeout();
+
+		writeMessage.Envelope.ReplyWith(new ClientMessage.NotHandled(writeMessage.CorrelationId, notHandledReason, ""));
+
+		// The request should now complete
+		await writeRequest.WithTimeout();
+	}
+
+	[Theory]
+	[InlineData(OperationResult.CommitTimeout)]
+	[InlineData(OperationResult.PrepareTimeout)]
+	[InlineData(OperationResult.ForwardTimeout)]
+	[InlineData(OperationResult.AccessDenied)]
+	[InlineData(OperationResult.InvalidTransaction)]
+	public async Task when_the_default_policy_write_request_fails_and_can_be_retried(
+		OperationResult operationResult) {
+		var writeMessages = new List<ClientMessage.WriteEvents>();
+		var mre = new ManualResetEvent(false);
+		_bus.Subscribe(new AdHocHandler<ClientMessage.WriteEvents>(msg => {
+			writeMessages.Add(msg);
+			mre.Set();
+		}));
+
+		var sut = CreateSut();
+		var writeRequest = sut.WriteDefaultPolicy(StreamPolicySelector.DefaultPolicy, CancellationToken.None);
+		await mre.WaitAsync().AsTask().WithTimeout();
+		mre.Reset();
+
+		Assert.Single(writeMessages);
+		writeMessages[0].Envelope.ReplyWith(
+			new ClientMessage.WriteEventsCompleted(writeMessages[0].CorrelationId, operationResult, ""));
+
+		await mre.WaitAsync().AsTask().WithTimeout();
+		Assert.Equal(2, writeMessages.Count);
+		writeMessages[1].Envelope.ReplyWith(CreateWriteEventsSuccessfullyCompleted(writeMessages[1]));
+
+		// The request should now complete
+		await writeRequest.WithTimeout();
+	}
+
+	[Theory]
+	[InlineData(OperationResult.WrongExpectedVersion)]
+	[InlineData(OperationResult.StreamDeleted)]
+	public async Task when_the_default_policy_write_request_fails_and_cannot_be_retried(
+		OperationResult operationResult) {
+		var tcs = new TaskCompletionSource<ClientMessage.WriteEvents>();
+		_bus.Subscribe(new AdHocHandler<ClientMessage.WriteEvents>(msg => {
+			tcs.TrySetResult(msg);
+		}));
+
+		var sut = CreateSut();
+		var writeRequest = sut.WriteDefaultPolicy(StreamPolicySelector.DefaultPolicy, CancellationToken.None);
+		var writeMessage = await tcs.Task.WithTimeout();
+
+		writeMessage.Envelope.ReplyWith(
+			new ClientMessage.WriteEventsCompleted(writeMessage.CorrelationId, operationResult, ""));
+
+		// The request should complete
+		await writeRequest.WithTimeout();
+	}
+
+	private ClientMessage.WriteEventsCompleted CreateWriteEventsSuccessfullyCompleted(ClientMessage.WriteEvents msg) =>
+		new (msg.CorrelationId, 0, 0, 1000L, 1000L);
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/AccessPolicy.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/AccessPolicy.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.Auth.StreamPolicyPlugin;
+
+public class AccessPolicy {
+	public readonly string[] Readers;
+	public readonly string[] Writers;
+	public readonly string[] Deleters;
+	public readonly string[] MetadataReaders;
+	public readonly string[] MetadataWriters;
+
+	private AccessPolicy() {
+		Readers = [];
+		Writers = [];
+		Deleters = [];
+		MetadataReaders = [];
+		MetadataWriters = [];
+	}
+
+	public AccessPolicy(
+		string[] readers, string[] writers, string[] deleters, string[] metadataReaders, string[] metadataWriters) {
+		Readers = readers ?? [];
+		Writers = writers ?? [];
+		Deleters = deleters ?? [];
+		MetadataReaders = metadataReaders ?? [];
+		MetadataWriters = metadataWriters ?? [];
+	}
+	public static AccessPolicy None => new();
+
+	public override string ToString() {
+		return $"$r: {string.Join(',', Readers)}\n" +
+		       $"$w: {string.Join(',', Writers)}\n" +
+		       $"$d: {string.Join(',', Deleters)}\n" +
+		       $"$mr: {string.Join(',', MetadataReaders)}\n" +
+		       $"$mw: {string.Join(',', MetadataWriters)}\n";
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/EventStore.Auth.StreamPolicyPlugin.csproj
+++ b/src/EventStore.Auth.StreamPolicyPlugin/EventStore.Auth.StreamPolicyPlugin.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\EventStore\src\EventStore.Core\EventStore.Core.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="EventStore.Plugins" Version="25.2.5" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+	</ItemGroup>
+
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<ItemGroup>
+			<PluginReferences Include="$(OutDir)\EventStore.Auth.StreamPolicyPlugin.deps.json" />
+			<PluginReferences Include="$(OutDir)\EventStore.Auth.StreamPolicyPlugin.dll" />
+			<PluginReferences Include="$(OutDir)\EventStore.Auth.StreamPolicyPlugin.pdb" />
+		</ItemGroup>
+		<Copy SourceFiles="@(PluginReferences)" DestinationFolder="..\..\EventStore\src\KurrentDB\$(OutDir)\plugins\$(ProjectName)" />
+		<Copy SourceFiles="@(PluginRuntimeDependencies)" DestinationFolder="..\..\EventStore\src\KurrentDB\$(OutDir)\plugins\$(ProjectName)\runtimes\%(RecursiveDir)" />
+	</Target>
+
+	<Target Name="PublishPlugin" AfterTargets="Publish">
+		<ItemGroup>
+			<PluginOutputFiles Include="$(PublishDir)\LICENSE.md" />
+			<PluginOutputFiles Include="$(PublishDir)\NOTICE.html" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.Auth.StreamPolicyPlugin.deps.json" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.Auth.StreamPolicyPlugin.dll" />
+		</ItemGroup>
+		<Copy SourceFiles="@(PluginOutputFiles)" DestinationFolder="$(PublishDir)/package" />
+	</Target>
+</Project>

--- a/src/EventStore.Auth.StreamPolicyPlugin/README.md
+++ b/src/EventStore.Auth.StreamPolicyPlugin/README.md
@@ -1,0 +1,241 @@
+# Stream Policy Plugin
+
+This plugin allows administrators to define stream access policies for EventStoreDB based on stream prefix.
+
+## Enabling the plugin
+
+The plugin can be enabled by setting the `Authorization:PolicyType` option to `streampolicy`.
+
+You can do this by adding the following config to the `config` folder in the installation directory:
+
+```
+{
+  "EventStore": {
+    "Authorization": {
+      "PolicyType": "streampolicy"
+    }
+  }
+}
+```
+
+or by setting the environment variable:
+
+```
+EVENTSTORE__AUTHORIZATION__POLICY_TYPE="streampolicy"
+```
+
+You can check that the plugin is enabled by searching for the following log at startup:
+
+```
+[15708, 1,14:58:15.570,INF] "PolicyAuthorizationProvider" "24.6.0.0" plugin enabled.
+```
+
+## Stream Policies and Rules
+
+Stream policies and Stream Rules are configured by events written to the `$policies` stream.
+
+### Default Stream Policy
+
+When the Stream Policy Plugin is run for the first time, it will create a default policy in the `$policies` stream.
+The default policy does the following
+- Grants public access to user streams (this excludes users in the `$ops` group).
+- Restricts system streams to the `$admins` group.
+- Grants public read and metadata read access to the default projection streams (`$ce`, `$et`, `$bc`, `$category`, `$streams`).
+
+```
+{
+	"streamPolicies": {
+		"publicDefault": {
+			"$r": ["$all"],
+			"$w": ["$all"],
+			"$d": ["$all"],
+			"$mr": ["$all"],
+			"$mw": ["$all"]
+		},
+		"adminsDefault": {
+			"$r": ["$admins"],
+			"$w": ["$admins"],
+			"$d": ["$admins"],
+			"$mr": ["$admins"],
+			"$mw": ["$admins"]
+		},
+		"projectionsDefault": {
+			"$r": ["$all"],
+			"$w": ["$admins"],
+			"$d": ["$admins"],
+			"$mr": ["$all"],
+			"$mw": ["$admins"]
+		}
+	},
+	"streamRules": [
+		{
+			"startsWith": "$et-",
+			"policy": "projectionsDefault"
+		},
+		{
+			"startsWith": "$ce-",
+			"policy": "projectionsDefault"
+		},
+		{
+			"startsWith": "$bc-",
+			"policy": "projectionsDefault"
+		},
+		{
+			"startsWith": "$category-",
+			"policy": "projectionsDefault"
+		},
+		{
+			"startsWith": "$streams",
+			"policy": "projectionsDefault"
+		}
+	],
+	"defaultStreamRules": {
+		"userStreams": "publicDefault",
+		"systemStreams": "adminsDefault"
+	}
+}
+```
+
+**Note:** Operations users in the `$ops` group are excluded from the `$all` group and does not have access to user streams by default.
+
+### Custom Stream Policies
+
+You can create a custom stream policy by writing an event with event type `$policy-updated` to the `$policies` stream.
+
+Define your custom policy in the `streamPolicies`, e.g:
+
+```
+"streamPolicies": {
+    "customPolicy": {
+        "$r": ["ouro", "readers"],
+        "$w": ["ouro"],
+        "$d": ["ouro"],
+        "$mr": ["ouro"],
+        "$mw": ["ouro"]
+    },
+    // Default policies truncated (full version defined below)
+}
+```
+
+And then add an entry to `streamRules` to specify the stream prefixes which should use the custom policy. You can apply the same policy to multiple streams by defining multiple stream rules. e.g:
+
+```
+"streamRules": [{
+    "startsWith": "account",
+    "policy": "customPolicy"
+}, {
+    "startsWith": "customer",
+    "policy": "customPolicy"
+}]
+```
+
+You still need to specify default stream rules when you update the `$policies` stream. So the above example would look like this in full:
+
+```
+{
+    "streamPolicies": {
+        "publicDefault": {
+            "$r": ["$all"],
+            "$w": ["$all"],
+            "$d": ["$all"],
+            "$mr": ["$all"],
+            "$mw": ["$all"]
+        },
+        "adminsDefault": {
+            "$r": ["$admins"],
+            "$w": ["$admins"],
+            "$d": ["$admins"],
+            "$mr": ["$admins"],
+            "$mw": ["$admins"]
+        },
+        {
+            "projectionsDefault": {
+			"$r": ["$all"],
+			"$w": ["$admins"],
+			"$d": ["$admins"],
+			"$mr": ["$all"],
+			"$mw": ["$admins"]
+		},
+        "customPolicy": {
+            "$r": ["$all"],
+            "$w": ["$all"],
+            "$d": ["$all"],
+            "$mr": ["$all"],
+            "$mw": ["$all"]
+        }
+    },
+    "streamRules": [
+		{
+            "startsWith": "account",
+            "policy": "customPolicy"
+        },
+        {
+            "startsWith": "customer",
+            "policy": "customPolicy"
+        },
+        {
+			"startsWith": "$et-",
+			"policy": "projectionsDefault"
+		},
+		{
+			"startsWith": "$ce-",
+			"policy": "projectionsDefault"
+		},
+		{
+			"startsWith": "$bc-",
+			"policy": "projectionsDefault"
+		},
+		{
+			"startsWith": "$category-",
+			"policy": "projectionsDefault"
+		},
+		{
+			"startsWith": "$streams",
+			"policy": "projectionsDefault"
+		}
+    ],
+    "defaultStreamRules": {
+        "userStreams": "publicDefault",
+        "systemStreams": "adminsDefault"
+    }
+}
+```
+
+**Note:** If a policy update is invalid, it will not be applied and an error will be logged. EventStoreDB will continue running with the previous valid policy in place.
+
+### Stream Policy Schema
+
+#### Policy
+
+| Key                   | Type                                  | Description | Required |
+|-----------------------|---------------------------------------|-------------|----------|
+| `streamPolicies`      | `Dictionary<string, AccessPolicy>`    | The named policies which can be applied to streams. | Yes |
+| `streamRules`         | `StreamRule[]`                        | An array of rules to apply for stream access.  The ordering is important, and the first match wins. | Yes |
+| `defaultStreamRules`  | `DefaultStreamRules`                  | The default policies to apply if no other policies are defined for a stream | Yes |
+
+#### AccessPolicy
+
+| Key   | Type	    | Description	| Required |
+|-------|-----------|---------------|----------|
+| `$r`  | string[]  | User and group names that are granted stream read access. | Yes |
+| `$w`  | string[]  | User and group names that are granted stream write access. | Yes |
+| `$d`  | string[]  | User and group names that are granted stream delete access. | Yes |
+| `$mr` | string[]  | User and group names that are granted metadata stream read access. | Yes |
+| `$mw` | string[]  | User and group names that are granted metadata stream write access. | Yes |
+
+**Note:** Having metadata read or metadata write access to a stream does not grant read or write access to that stream.
+
+#### DefaultStreamRules
+
+|Key                | Type           | Description   | Required |
+|-------------------|----------------|---------------|----------|
+| `userStreams`     | `AccessPolicy` | The default policy to apply for non-system streams. | Yes |
+| `systemStreams`   | `AccessPolicy` | The default policy to apply for system streams. | Yes |
+
+#### StreamRule
+
+| Key           | Type     | Description   | Required |
+|---------------|----------|---------------|----------|
+| `startsWith`  | `string` | The stream prefix to apply the rule to. | Yes |
+| `policy`      | `string` | The name of the policy to enforce for streams that match this prefix. | Yes |
+

--- a/src/EventStore.Auth.StreamPolicyPlugin/Schema/AccessPolicy.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/Schema/AccessPolicy.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json.Serialization;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Schema;
+
+public class AccessPolicy : IJsonOnDeserialized {
+	[JsonRequired]
+	[JsonPropertyName("$r")]
+	public string[] Readers { get; init; } = default!;
+
+	[JsonRequired]
+	[JsonPropertyName("$w")]
+	public string[] Writers { get; init; } = default!;
+
+	[JsonRequired]
+	[JsonPropertyName("$d")]
+	public string[] Deleters { get; init; } = default!;
+
+	[JsonRequired]
+	[JsonPropertyName("$mr")]
+	public string[] MetadataReaders { get; init; } = default!;
+
+	[JsonRequired]
+	[JsonPropertyName("$mw")]
+	public string[] MetadataWriters { get; init; } = default!;
+
+	public void OnDeserialized() {
+		if (Readers is null)
+			throw new ArgumentNullException($"{nameof(Readers)} cannot be null");
+		if (Writers is null)
+			throw new ArgumentNullException($"{nameof(Writers)} cannot be null");
+		if (Deleters is null)
+			throw new ArgumentNullException($"{nameof(Deleters)} cannot be null");
+		if (MetadataReaders is null)
+			throw new ArgumentNullException($"{nameof(MetadataReaders)} cannot be null");
+		if (MetadataWriters is null)
+			throw new ArgumentNullException($"{nameof(MetadataWriters)} cannot be null");
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/Schema/DefaultStreamRules.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/Schema/DefaultStreamRules.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json.Serialization;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Schema;
+
+public class DefaultStreamRules : IJsonOnDeserialized {
+	[JsonRequired]
+	public string UserStreams { get; init; } = default!;
+
+	[JsonRequired]
+	public string SystemStreams { get; init; } = default!;
+
+	public void OnDeserialized() {
+		if (string.IsNullOrEmpty(UserStreams))
+			throw new ArgumentNullException($"{nameof(UserStreams)} cannot be null or empty");
+		if (string.IsNullOrEmpty(SystemStreams))
+			throw new ArgumentNullException($"{nameof(SystemStreams)} cannot be null or empty");
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/Schema/Policy.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/Schema/Policy.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json.Serialization;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Schema;
+
+public class Policy : IJsonOnDeserialized {
+	[JsonRequired]
+	public Dictionary<string, AccessPolicy> StreamPolicies { get; init; } = default!;
+
+	[JsonRequired]
+	public StreamRule[] StreamRules { get; init; } = default!;
+
+	[JsonRequired]
+	public DefaultStreamRules DefaultStreamRules { get; init; } = default!;
+
+	public void OnDeserialized() {
+		if (StreamPolicies is null)
+			throw new ArgumentNullException($"{nameof(StreamPolicies)} cannot be null");
+		if (StreamRules is null)
+			throw new ArgumentNullException($"{nameof(StreamRules)} cannot be null");
+		if (DefaultStreamRules is null)
+			throw new ArgumentNullException($"{nameof(DefaultStreamRules)} cannot be null");
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/Schema/StreamRule.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/Schema/StreamRule.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json.Serialization;
+
+namespace EventStore.Auth.StreamPolicyPlugin.Schema;
+
+public class StreamRule : IJsonOnDeserialized {
+	[JsonRequired]
+	public string StartsWith { get; init; } = default!;
+
+	[JsonRequired]
+	public string Policy { get; init; } = default!;
+	public void OnDeserialized() {
+		if (string.IsNullOrEmpty(StartsWith))
+			throw new ArgumentNullException($"{nameof(StartsWith)} cannot be null or empty");
+		if (string.IsNullOrEmpty(Policy))
+			throw new ArgumentNullException($"{nameof(Policy)} cannot be null or empty");
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/StreamBasedPolicySelector.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/StreamBasedPolicySelector.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using EventStore.Core.Authorization;
+using EventStore.Core.Authorization.AuthorizationPolicies;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Services.Transport.Common;
+using EventStore.Core.Services.Transport.Enumerators;
+using Serilog;
+
+namespace EventStore.Auth.StreamPolicyPlugin;
+
+public delegate bool TryParsePolicy(string eventType, ReadOnlySpan<byte> eventData, out ReadOnlyPolicy policy);
+
+// TODO: use the IClient interface instead of enumerators to read streams
+public abstract class StreamBasedPolicySelector : IPolicySelector {
+	private readonly IPublisher _publisher;
+	private readonly string _stream;
+	private readonly ClaimsPrincipal _user;
+	private readonly TryParsePolicy _tryParsePolicy;
+
+	private ReadOnlyPolicy _currentPolicy;
+
+	private static readonly ILogger Logger = Log.ForContext<StreamBasedPolicySelector>();
+
+	protected StreamBasedPolicySelector(
+		IPublisher publisher,
+		string stream,
+		ClaimsPrincipal user,
+		TryParsePolicy tryParsePolicy,
+		ReadOnlyPolicy notReadyPolicy,
+		CancellationToken ct) {
+		_publisher = publisher;
+		_stream = stream;
+		_user = user;
+		_tryParsePolicy = tryParsePolicy;
+
+		_currentPolicy = notReadyPolicy;
+		Task.Factory.StartNew(() => StartAsync(ct));
+	}
+
+	private async Task StartAsync(CancellationToken ct) {
+		do {
+			try {
+				var checkpoint = await TryGetSubscriptionCheckpoint(ct);
+				await StartSubscription(checkpoint, ct);
+				return;
+			} catch (ReadResponseException.NotHandled.ServerNotReady) {
+				Logger.Verbose("Subscription to {policyStream}: server is not ready, retrying...", _stream);
+				await Task.Delay(TimeSpan.FromSeconds(3), ct);
+			} catch (ReadResponseException.NotHandled.ServerBusy) {
+				Logger.Verbose("Subscription to {policyStream}: server is too busy, retrying...", _stream);
+				await Task.Delay(TimeSpan.FromSeconds(3), ct);
+			} catch (OperationCanceledException) {
+				// ignore
+			} catch (Exception exc) {
+				Logger.Fatal(exc, "Fatal error in subscription to {policyStream}", _stream);
+				return;
+			}
+		} while (true);
+	}
+
+	private async Task StartSubscription(StreamRevision? checkpoint, CancellationToken ct) {
+		Logger.Information("Subscribing to {policyStream} at {checkpoint}", _stream, checkpoint);
+		await using var sub = new Enumerator.StreamSubscription<string>(
+			bus: _publisher,
+			expiryStrategy: new DefaultExpiryStrategy(),
+			streamName: _stream,
+			resolveLinks: false,
+			user: _user,
+			checkpoint: checkpoint,
+			requiresLeader: false,
+			cancellationToken: ct);
+
+		while (await sub.MoveNextAsync()) {
+			var response = sub.Current;
+			switch (response) {
+				case ReadResponse.EventReceived evt:
+					Logger.Information("New policy found in {policyStream} stream ({eventNumber})", _stream,
+						evt.Event.OriginalEventNumber);
+					TryApplyPolicy(evt.Event);
+					break;
+			}
+		}
+	}
+
+	private bool TryApplyPolicy(ResolvedEvent evt) {
+		if (_tryParsePolicy(evt.Event.EventType, evt.Event.Data.Span, out var policy)) {
+			_currentPolicy = policy;
+			Logger.Information("Successfully applied policy");
+			return true;
+		}
+		Logger.Error("Could not parse policy");
+		return false;
+	}
+
+	private async Task<StreamRevision?> TryGetSubscriptionCheckpoint(CancellationToken ct) {
+		Logger.Verbose("Determining subscription checkpoint for stream {policyStream}", _stream);
+		await using var enumerator = new Enumerator.ReadStreamBackwards(
+			bus: _publisher,
+			streamName: _stream,
+			startRevision: StreamRevision.End,
+			maxCount: ulong.MaxValue,
+			resolveLinks: false,
+			user: _user,
+			requiresLeader: false,
+			deadline: DateTime.MaxValue,
+			compatibility: 0,
+			cancellationToken: ct);
+
+		StreamRevision? checkpoint = null;
+		while (await enumerator.MoveNextAsync()) {
+			var response = enumerator.Current;
+			switch (response) {
+				case ReadResponse.StreamNotFound:
+					Log.Information("{policyStream} stream not found", _stream);
+					return null;
+				case ReadResponse.EventReceived evt:
+					Logger.Information("Existing policy found in {policyStream} stream ({eventNumber})", _stream, evt.Event.OriginalEventNumber);
+
+					// assign the checkpoint only for the first event we find as we want to subscribe from there
+					checkpoint ??= StreamRevision.FromInt64(evt.Event.OriginalEventNumber);
+
+					if (!TryApplyPolicy(evt.Event)) {
+						// we haven't been able to apply the policy we found since it's invalid.
+						// let's continue reading events until we find a valid one, otherwise
+						// we'll default to the not ready policy
+						continue;
+					}
+
+					return checkpoint;
+			}
+		}
+		// all the policies are invalid
+		// we subscribe anyway and remain on the not ready policy
+		Logger.Warning("No valid policy found in {policyStream} stream", _stream);
+		return checkpoint;
+	}
+
+	public ReadOnlyPolicy Select() => _currentPolicy;
+}
+

--- a/src/EventStore.Auth.StreamPolicyPlugin/StreamPolicyAssertion.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/StreamPolicyAssertion.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using EventStore.Core.Authorization;
+using EventStore.Core.Services;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Auth.StreamPolicyPlugin;
+
+public class StreamPolicyAssertion(Func<string, AccessPolicy> getAccessPolicyForStream) : IStreamPermissionAssertion {
+	public Grant Grant { get; } = Grant.Unknown;
+	public AssertionInformation Information { get; } = new("starts with", "stream prefix", Grant.Unknown);
+
+	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context) {
+		var streamId = FindStreamId(operation.Parameters.Span);
+
+		return CheckStreamAccess(cp, operation, policy, context, streamId);
+	}
+
+	private async ValueTask<bool> CheckStreamAccess(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+		EvaluationContext context, string? streamId) {
+		if (cp.Identity is null || !cp.Identity.IsAuthenticated) {
+			context.Add(new AssertionMatch(policy,
+				new AssertionInformation("unauthenticated", "unauthenticated/anonymous user denied access", Grant.Deny)));
+			return true;
+		}
+
+		if (streamId is null) {
+			context.Add(new AssertionMatch(policy,
+				new AssertionInformation("streamId", "streamId is null", Grant.Deny)));
+			return true;
+		}
+
+		if (streamId == string.Empty)
+			streamId = SystemStreams.AllStream;
+		if (streamId == SystemStreams.AllStream &&
+		    (operation == Operations.Streams.Delete || operation == Operations.Streams.Write)) {
+			context.Add(new AssertionMatch(policy,
+				new AssertionInformation("streamId", $"{operation.Action} denied on $all", Grant.Deny)));
+			return true;
+		}
+
+		var action = operation.Action;
+		if (SystemStreams.IsMetastream(streamId)) {
+			action = operation.Action switch {
+				"read" => "metadataRead",
+				"write" => "metadataWrite",
+				_ => null
+			};
+			if (action == null)
+				return InvalidMetadataOperation(operation, policy, context);
+			streamId = SystemStreams.OriginalStreamOf(streamId);
+		}
+
+		return action switch {
+			"read" => await Check(cp, operation, action, streamId, policy, context),
+			"write" => await Check(cp, operation, action, streamId, policy, context),
+			"delete" => await Check(cp, operation, action, streamId, policy, context),
+			"metadataWrite" => await Check(cp, operation, action, streamId, policy, context),
+			"metadataRead" => await Check(cp, operation, action, streamId, policy, context),
+			_ => throw new ArgumentOutOfRangeException(nameof(operation.Action), action)
+		};
+	}
+
+	private async ValueTask<bool> Check(ClaimsPrincipal cp, Operation operation, string action,
+		string streamId, PolicyInformation policy, EvaluationContext context) {
+		if (await IsSystemOrAdmin(cp, operation, policy, context)) {
+			return true;
+		}
+
+		var permissions = getAccessPolicyForStream(streamId);
+
+		var roles = action switch {
+			"read" => permissions.Readers,
+			"write" => permissions.Writers,
+			"delete" => permissions.Deleters,
+			"metadataRead" => permissions.MetadataReaders,
+			"metadataWrite" => permissions.MetadataWriters,
+			_ => []
+		};
+
+		var isOpsUser = IsOpsUser(cp);
+		var isPublicStream = roles.Any(x => x == SystemRoles.All);
+		if (isPublicStream && !isOpsUser) {
+			context.Add(new AssertionMatch(policy, new AssertionInformation("stream prefix", "public stream", Grant.Allow)));
+			return true;
+		}
+
+		for (int i = 0; i < roles.Length; i++) {
+			var role = roles[i];
+			if (cp.FindFirst(x => (x.Type == ClaimTypes.Name || x.Type == ClaimTypes.Role) && x.Value == role)
+				is { } matched) {
+				context.Add(new AssertionMatch(policy, new AssertionInformation("role match", role, Grant.Allow),
+					matched));
+				return true;
+			}
+		}
+
+		if (isPublicStream && isOpsUser) {
+			context.Add(new AssertionMatch(policy,
+				new AssertionInformation("$ops user denied access", "public stream", Grant.Deny)));
+			return true;
+		}
+
+		context.Add(new AssertionMatch(policy, new AssertionInformation("denied access", "stream prefix", Grant.Deny)));
+		return true;
+	}
+
+	private async ValueTask<bool> IsSystemOrAdmin(ClaimsPrincipal cp, Operation operation,
+		PolicyInformation policy, EvaluationContext context) {
+		return await WellKnownAssertions.System.Evaluate(cp, operation, policy, context)
+		       || await WellKnownAssertions.Admin.Evaluate(cp, operation, policy, context);
+	}
+
+	private bool IsOpsUser(ClaimsPrincipal cp) {
+		var roles = cp.FindAll(x => x.Type == ClaimTypes.Role).ToArray();
+		return roles.Length > 0
+		       && roles.All(x => x.Value == SystemRoles.Operations);
+	}
+
+	private string? FindStreamId(ReadOnlySpan<Parameter> parameters) {
+		for (int i = 0; i < parameters.Length; i++) {
+			if (parameters[i].Name == "streamId")
+				return parameters[i].Value;
+		}
+		return null;
+	}
+
+	private bool InvalidMetadataOperation(Operation operation, PolicyInformation policy,
+		EvaluationContext result) {
+		result.Add(new AssertionMatch(policy,
+			new AssertionInformation("metadata", $"invalid metadata operation {operation.Action}",
+				Grant.Deny)));
+		return true;
+	}
+}
+

--- a/src/EventStore.Auth.StreamPolicyPlugin/StreamPolicySelector.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/StreamPolicySelector.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json;
+using EventStore.Auth.StreamPolicyPlugin.Schema;
+using EventStore.Core.Authorization;
+using EventStore.Core.Bus;
+using EventStore.Core.Services;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Plugins.Authorization;
+using Serilog;
+using Policy = EventStore.Core.Authorization.Policy;
+
+namespace EventStore.Auth.StreamPolicyPlugin;
+
+public sealed class StreamPolicySelector : StreamBasedPolicySelector {
+	public const string PolicyName = "custom-stream-policy";
+	public const string PolicyStream = "$policies";
+	public const string PolicyEventType = "$policy-updated";
+	private static readonly ILogger Logger = Log.ForContext<StreamPolicySelector>();
+
+	public StreamPolicySelector(IPublisher publisher, CancellationToken ct) : base(
+		publisher: publisher,
+		stream: PolicyStream,
+		user: SystemAccounts.System,
+		tryParsePolicy: TryParsePolicy,
+		notReadyPolicy: BuildNotReadyPolicy(),
+		ct: ct) {
+	}
+
+	private static ReadOnlyPolicy BuildNotReadyPolicy() {
+		// we build a policy that denies all stream access as we don't want any stream operation to seep through while
+		// we're setting things up. note that system or admin users will still be able to get through as there are some
+		// preliminary checks prior to applying the rules.
+		var streamAssertion = new StreamPolicyAssertion(_ => AccessPolicy.None);
+		var policy = new Policy($"{PolicyName}-notready", 1, DateTimeOffset.MinValue);
+		policy.Add(Operations.Streams.Read, streamAssertion);
+		policy.Add(Operations.Streams.Write, streamAssertion);
+		policy.Add(Operations.Streams.Delete, streamAssertion);
+		policy.Add(Operations.Streams.MetadataRead, streamAssertion);
+		policy.Add(Operations.Streams.MetadataWrite, streamAssertion);
+		// Persistent Subscriptions
+		var subscriptionAccess = new RequireStreamReadAssertion(streamAssertion);
+		policy.Add(Operations.Subscriptions.ProcessMessages, subscriptionAccess);
+		return policy.AsReadOnly();
+	}
+
+	// The default policy allows:
+	// - User access to public streams
+	// - Admin only access to system streams
+	// - User read-only access to standard projection streams
+	public static Schema.Policy DefaultPolicy =
+		new() {
+			StreamPolicies = new Dictionary<string, Schema.AccessPolicy> {
+				{
+					"publicDefault", new Schema.AccessPolicy {
+						Readers = [SystemRoles.All],
+						Writers = [SystemRoles.All],
+						Deleters = [SystemRoles.All],
+						MetadataReaders = [SystemRoles.All],
+						MetadataWriters = [SystemRoles.All],
+					}
+				}, {
+					"adminsDefault", new Schema.AccessPolicy {
+						Readers = [SystemRoles.Admins],
+						Writers = [SystemRoles.Admins],
+						Deleters = [SystemRoles.Admins],
+						MetadataReaders = [SystemRoles.Admins],
+						MetadataWriters = [SystemRoles.Admins],
+					}
+				}, {
+					"projectionsDefault", new Schema.AccessPolicy {
+						Readers = [SystemRoles.All],
+						Writers = [SystemRoles.Admins],
+						Deleters = [SystemRoles.Admins],
+						MetadataReaders = [SystemRoles.All],
+						MetadataWriters = [SystemRoles.Admins],
+					}
+				}
+			},
+			DefaultStreamRules = new DefaultStreamRules {
+				SystemStreams = "adminsDefault",
+				UserStreams = "publicDefault"
+			},
+			StreamRules = [
+				new StreamRule {
+					StartsWith = "$et-",
+					Policy = "projectionsDefault",
+				},
+				new StreamRule {
+					StartsWith = "$ce-",
+					Policy = "projectionsDefault",
+				},
+				new StreamRule {
+					StartsWith = "$bc-",
+					Policy = "projectionsDefault",
+				},
+				new StreamRule {
+					StartsWith = "$category-",
+					Policy = "projectionsDefault",
+				},
+				new StreamRule {
+					StartsWith = "$streams",
+					Policy = "projectionsDefault",
+				}
+			],
+		};
+
+	private static readonly JsonSerializerOptions SerializeOptions = new() {
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+	};
+
+	private static bool TryParsePolicy(string eventType, ReadOnlySpan<byte> eventData, out ReadOnlyPolicy readOnlyPolicy) {
+		if (eventType != PolicyEventType) {
+			Logger.Error("Expected event type: {expectedEventType} but was {actualEventType}", PolicyEventType, eventType);
+			readOnlyPolicy = default!;
+			return false;
+		}
+
+		if (!TryParseStreamRules(eventData, out var streamRules)) {
+			readOnlyPolicy = default!;
+			return false;
+		}
+
+		var streamAssertion = new StreamPolicyAssertion(streamRules);
+		var policy = new Policy(PolicyName, 1, DateTimeOffset.MinValue);
+		// Streams
+		policy.Add(Operations.Streams.Read, streamAssertion);
+		policy.Add(Operations.Streams.Write, streamAssertion);
+		policy.Add(Operations.Streams.Delete, streamAssertion);
+		policy.Add(Operations.Streams.MetadataRead, streamAssertion);
+		policy.Add(Operations.Streams.MetadataWrite, streamAssertion);
+		// Persistent Subscriptions
+		var subscriptionAccess = new RequireStreamReadAssertion(streamAssertion);
+		policy.Add(Operations.Subscriptions.ProcessMessages, subscriptionAccess);
+		readOnlyPolicy = policy.AsReadOnly();
+		return true;
+	}
+
+	public static byte[] SerializePolicy(Schema.Policy policy) => JsonSerializer.SerializeToUtf8Bytes(policy, SerializeOptions);
+
+	private static bool TryParseStreamRules(ReadOnlySpan<byte> data, out Func<string, AccessPolicy> streamRules) {
+		streamRules = default!;
+
+		try {
+			var policy = JsonSerializer.Deserialize<Schema.Policy>(data, SerializeOptions)!;
+
+			var streamPolicies = new Dictionary<string, AccessPolicy>();
+			foreach (var (name, accessPolicy) in policy.StreamPolicies) {
+				streamPolicies[name] = new AccessPolicy(
+					readers: accessPolicy.Readers,
+					writers: accessPolicy.Writers,
+					deleters: accessPolicy.Deleters,
+					metadataReaders: accessPolicy.MetadataReaders,
+					metadataWriters: accessPolicy.MetadataWriters);
+			}
+
+			var streamPrefixRules = new List<StreamPrefixRule>();
+			foreach (var streamRule in policy.StreamRules) {
+				if (string.IsNullOrEmpty(streamRule.StartsWith)) {
+					Logger.Error("Stream rule at index: {streamRuleIndex} and referring to policy: {policy} has an empty prefix",
+						Array.IndexOf(policy.StreamRules, streamRule), streamRule.Policy);
+					return false;
+				}
+				if (!streamPolicies.TryGetValue(streamRule.Policy, out var accessPolicy)) {
+					Logger.Error("Stream rule for prefix: {streamPrefix} refers to an undefined policy: {policy}", streamRule.StartsWith, streamRule.Policy);
+					return false;
+				}
+				streamPrefixRules.Add(new StreamPrefixRule(streamRule.StartsWith, accessPolicy));
+			}
+
+			if (!streamPolicies.TryGetValue(policy.DefaultStreamRules.SystemStreams, out var systemStreamsPolicy)) {
+				Logger.Error("Default {streamType} stream rule refers to an undefined policy: {policy}", "system", policy.DefaultStreamRules.SystemStreams);
+				return false;
+			}
+
+			if (!streamPolicies.TryGetValue(policy.DefaultStreamRules.UserStreams, out var userStreamsPolicy)) {
+				Logger.Error("Default {streamType} stream rule refers to an undefined policy: {policy}", "user", policy.DefaultStreamRules.UserStreams);
+				return false;
+			}
+
+			var rules = streamPrefixRules.ToArray();
+			streamRules = streamId => {
+				foreach (var rule in rules)
+					if (rule.TryHandle(streamId, out var permissions))
+						return permissions;
+				return SystemStreams.IsSystemStream(streamId) ? systemStreamsPolicy : userStreamsPolicy;
+			};
+			return true;
+		} catch (JsonException exc) {
+			Logger.Error(exc, "Error while deserializing new policy");
+			return false;
+		} catch (ArgumentNullException exc) {
+			Logger.Error(exc, "Error while deserializing new policy");
+			return false;
+		}
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/StreamPolicySelectorFactory.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/StreamPolicySelectorFactory.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.ComponentModel.Composition;
+using EventStore.Core.Authorization.AuthorizationPolicies;
+using EventStore.Core.Bus;
+using EventStore.Plugins;
+using EventStore.Plugins.Subsystems;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.Auth.StreamPolicyPlugin;
+
+[Export(typeof(IPolicySelectorFactory))]
+public class StreamPolicySelectorFactory : Plugin, IPolicySelectorFactory, ISubsystem {
+	public string CommandLineName => Name.Replace("Plugin", "").ToLowerInvariant();
+	private static readonly ILogger Logger = Log.ForContext<StreamPolicySelector>();
+	private IPolicySelector? _policySelector;
+	private bool _enabled;
+	private bool _licensed = true;
+	private CancellationTokenSource _cts = new();
+
+	public StreamPolicySelectorFactory()
+		: base(
+			name: "StreamPolicyPlugin",
+			requiredEntitlements: ["STREAM_POLICY_AUTHORIZATION"]) {
+	}
+
+	protected override void OnLicenseException(Exception ex, Action<Exception> shutdown) {
+		Logger.Information("Stream Policies plugin is not licensed, stream policy authorization cannot be enabled.");
+		_licensed = false;
+	}
+
+	public bool IsLicensed => _licensed; // temporary
+
+	public IPolicySelector Create(IPublisher publisher) {
+		if (!_enabled) {
+			throw new InvalidOperationException(
+				$"Cannot create a {nameof(StreamPolicySelector)} while the Stream Policies plugin is disabled.");
+		}
+		// Always try to create the default policy
+		// This should result in WrongExpectedVersion if the default policy already exists
+		var writer = new StreamPolicyWriter(publisher, StreamPolicySelector.PolicyStream,
+			StreamPolicySelector.PolicyEventType, StreamPolicySelector.SerializePolicy);
+		_ = writer?.WriteDefaultPolicy(StreamPolicySelector.DefaultPolicy, _cts.Token);
+		return _policySelector ??= new StreamPolicySelector(publisher, _cts.Token);
+	}
+
+	public Task<bool> Enable() {
+		if (_enabled) return Task.FromResult(_enabled);
+
+		if (!_licensed) {
+			Logger.Error("Stream Policies plugin is not licensed, cannot enable Stream policies");
+			_enabled = false;
+		} else {
+			_enabled = true;
+			_cts = new CancellationTokenSource();
+		}
+		return Task.FromResult(_enabled);
+	}
+
+	public async Task Disable() {
+		if (_enabled) {
+			await _cts.CancelAsync();
+			_policySelector = null;
+		}
+		_enabled = false;
+	}
+
+	public Task Start() => Task.CompletedTask;
+
+	public Task Stop() => Task.CompletedTask;
+}
+

--- a/src/EventStore.Auth.StreamPolicyPlugin/StreamPolicyWriter.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/StreamPolicyWriter.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Auth.StreamPolicyPlugin.Schema;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.UserManagement;
+using Serilog;
+
+namespace EventStore.Auth.StreamPolicyPlugin;
+
+public interface IPolicyWriter {
+	public Task WriteDefaultPolicy(Policy policy, CancellationToken ct);
+}
+
+// TODO: use the IClient interface instead to write to streams
+public class StreamPolicyWriter : IPolicyWriter {
+	private readonly IPublisher _bus;
+	private readonly string _policyStream;
+	private readonly string _policyEventType;
+	private readonly TimeSpan _retryDelay = TimeSpan.FromSeconds(2);
+
+	private static readonly ILogger Logger = Log.ForContext<StreamBasedPolicySelector>();
+	private readonly Func<Policy, byte[]> _serializePolicy;
+	public const string DefaultStreamPolicyEventId = "ff8b943c-60f5-49af-845c-ab7150be91d0";
+
+	public StreamPolicyWriter(
+		IPublisher bus, string policyStream, string policyEventType, Func<Schema.Policy, byte[]> serializePolicy) {
+		_bus = bus;
+		_policyStream = policyStream;
+		_policyEventType = policyEventType;
+		_serializePolicy = serializePolicy;
+	}
+
+	public Task WriteDefaultPolicy(Policy defaultPolicy, CancellationToken ct) {
+		var defaultId = Guid.Parse(DefaultStreamPolicyEventId);
+		return WritePolicyWithRetry(defaultPolicy, defaultId, ExpectedVersion.NoStream, ct);
+	}
+
+	private async Task WritePolicyWithRetry(Policy policy, Guid eventId, long expectedVersion, CancellationToken ct) {
+		var policyEvent = new Event(eventId, _policyEventType, isJson: true, _serializePolicy(policy), []);
+		var attempt = 0;
+		while (true) {
+			try {
+				if (attempt > 0) {
+					await Task.Delay(_retryDelay, ct);
+					Logger.Debug(
+						"Retrying to write default policy to stream {stream} with expected version {expectedVersion}. Attempt {attempt}",
+						_policyStream, expectedVersion, attempt + 1);
+				}
+
+				var result = await WriteEvents(_policyStream, [policyEvent], expectedVersion, ct);
+				if (result is RetryAction.None or RetryAction.NoRetry)
+					return;
+
+			} catch (Exception ex) {
+				Logger.Error(ex, "Failed to write default policy to stream {stream}", _policyStream);
+			}
+
+			attempt++;
+		}
+	}
+
+	private async Task<RetryAction> WriteEvents(string streamName, Event[] events, long expectedVersion,
+		CancellationToken ct) {
+		var correlationId = Guid.NewGuid();
+		var appendResponseSource =
+			new TaskCompletionSource<RetryAction>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var envelope = new CallbackEnvelope(HandleWriteEventsCallback);
+
+		_bus.Publish(new ClientMessage.WriteEvents(
+			correlationId,
+			correlationId,
+			envelope,
+			requireLeader: false,
+			streamName,
+			expectedVersion,
+			events,
+			SystemAccounts.System,
+			cancellationToken: ct));
+
+		return await appendResponseSource.Task;
+
+
+		void HandleWriteEventsCallback(Message message) {
+			if (message is ClientMessage.NotHandled notHandled) {
+				appendResponseSource.TrySetResult(HandleNotHandled(notHandled));
+				return;
+			}
+
+			if (!(message is ClientMessage.WriteEventsCompleted completed)) {
+				Logger.Error("Unknown response {response}. Expected {expected}", message.GetType().Name,
+					nameof(ClientMessage.WriteEventsCompleted));
+				appendResponseSource.TrySetResult(RetryAction.Retry);
+				return;
+			}
+
+			appendResponseSource.TrySetResult(HandleWriteEventsCompleted(completed, expectedVersion));
+		}
+	}
+
+	private RetryAction HandleWriteEventsCompleted(ClientMessage.WriteEventsCompleted completed, long expectedVersion) {
+		switch (completed.Result) {
+			case OperationResult.Success:
+				Logger.Debug("Successfully wrote default policy to stream {stream}.", _policyStream);
+				return RetryAction.NoRetry;
+			case OperationResult.PrepareTimeout:
+			case OperationResult.CommitTimeout:
+			case OperationResult.ForwardTimeout:
+				Logger.Error("Timed out while writing default policy to stream {stream}", _policyStream);
+				return RetryAction.Retry;
+			case OperationResult.StreamDeleted:
+				Logger.Error(
+					"Could not write default policy to stream {stream} because it has been deleted", _policyStream);
+				return RetryAction.NoRetry;
+			case OperationResult.WrongExpectedVersion:
+				Logger.Debug(
+					"A policy event already exists in the stream {stream}. Skipping write of the default policy.",
+					_policyStream);
+				return RetryAction.NoRetry;
+			case OperationResult.AccessDenied:
+			case OperationResult.InvalidTransaction:
+			default:
+				Logger.Error("Failed to write default policy to stream {stream} because of unexpected result: {result}",
+					_policyStream, completed.Result);
+				return RetryAction.Retry;
+		}
+	}
+
+	private RetryAction HandleNotHandled(ClientMessage.NotHandled notHandled) {
+		switch (notHandled.Reason) {
+			case ClientMessage.NotHandled.Types.NotHandledReason.IsReadOnly:
+				Logger.Debug("Could not write default policy to stream {stream} as we are readonly",
+					_policyStream);
+				return RetryAction.NoRetry;
+			case ClientMessage.NotHandled.Types.NotHandledReason.NotLeader:
+				Logger.Debug("Could not write default policy to stream {stream} as we are not leader",
+					_policyStream);
+				return RetryAction.Retry;
+			case ClientMessage.NotHandled.Types.NotHandledReason.TooBusy:
+				Logger.Debug("Could not write default policy to stream {stream} as the server is too busy",
+					_policyStream);
+				return RetryAction.Retry;
+			case ClientMessage.NotHandled.Types.NotHandledReason.NotReady:
+				Logger.Debug("Could not write default policy to stream {stream} as the server is not ready",
+					_policyStream);
+				return RetryAction.Retry;
+		}
+
+		return RetryAction.None;
+	}
+
+	private enum RetryAction {
+		None = 0,
+		NoRetry = 1,
+		Retry = 2,
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/StreamPrefixRule.cs
+++ b/src/EventStore.Auth.StreamPolicyPlugin/StreamPrefixRule.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.Auth.StreamPolicyPlugin;
+public class StreamPrefixRule {
+	private readonly string _startsWith;
+	private readonly AccessPolicy _streamAccessPolicy;
+
+	public StreamPrefixRule(string startsWith, AccessPolicy streamAccessPolicy) {
+		if (string.IsNullOrEmpty(startsWith))
+			throw new ArgumentNullException(nameof(startsWith));
+		_startsWith = startsWith;
+		_streamAccessPolicy = streamAccessPolicy;
+	}
+
+	public bool TryHandle(string streamId, out AccessPolicy policy) {
+		if (!streamId.StartsWith(_startsWith)) {
+			policy = default!;
+			return false;
+		}
+
+		policy = _streamAccessPolicy;
+		return true;
+	}
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/sample-requests.http
+++ b/src/EventStore.Auth.StreamPolicyPlugin/sample-requests.http
@@ -1,0 +1,107 @@
+### Configure cluster to use stream policies
+POST https://localhost:2113/streams/$authorization-policy-settings
+Authorization: Basic admin changeit
+Content-Type: application/json
+ES-EventId: 11887e82-9fb4-4112-b937-aea895b32a4a
+ES-EventType: $authorization-policy-changed
+
+{
+    "streamAccessPolicyType": "streampolicy"
+}
+
+### Configure cluster to use acls
+POST https://localhost:2113/streams/$authorization-policy-settings
+Authorization: Basic admin changeit
+Content-Type: application/json
+ES-EventId: d07a6637-d9d0-43b7-8f48-6a9a8800af12
+ES-EventType: $authorization-policy-changed
+
+{
+    "streamAccessPolicyType": "acl"
+}
+
+### GET latest stream policy
+GET https://localhost:2113/streams/$policies/head/backward/1?embed=body
+Accept: application/json
+Authorization: Basic admin changeit
+
+### POST a new stream policy
+POST https://localhost:2113/streams/$policies
+Authorization: Basic admin changeit
+Content-Type: application/json
+ES-EventId: ae819cd9-2909-4023-af1f-9190ff042c2b
+ES-EventType: $policy-updated
+
+{
+    "streamPolicies": {
+        "customPolicy": {
+            "$r": ["$all","ouro"],
+            "$w": ["ouro"],
+            "$d": ["ouro"],
+            "$mr": ["$all","ouro"],
+            "$mw": ["ouro"]
+        },
+        "opsPolicy": {
+            "$r": ["$ops"],
+            "$w": ["$ops"],
+            "$d": ["$admins"],
+            "$mr": ["$ops"],
+            "$mw": ["$admins"]
+        },
+        "publicDefault": {
+            "$r": ["$all"],
+            "$w": ["$all"],
+            "$d": ["$all"],
+            "$mr": ["$all"],
+            "$mw": ["$all"]
+        },
+        "adminsDefault": {
+            "$r": ["$admins"],
+            "$w": ["$admins"],
+            "$d": ["$admins"],
+            "$mr": ["$admins"],
+            "$mw": ["$admins"]
+        },
+        "projectionsDefault": {
+            "$r": ["$all"],
+            "$w": ["$admins"],
+            "$d": ["$admins"],
+            "$mr": ["$all"],
+            "$mw": ["$admins"]
+        }
+    },
+    "streamRules": [
+        {
+            "startsWith": "customer-",
+            "policy": "customPolicy"
+        },
+        {
+            "startsWith": "$scavenges",
+            "policy": "opsPolicy"
+        },
+        {
+            "startsWith": "$et-",
+            "policy": "projectionsDefault"
+        },
+        {
+            "startsWith": "$ce-",
+            "policy": "projectionsDefault"
+        },
+        {
+            "startsWith": "$bc-",
+            "policy": "projectionsDefault"
+        },
+        {
+            "startsWith": "$category-",
+            "policy": "projectionsDefault"
+        },
+        {
+            "startsWith": "$streams",
+            "policy": "projectionsDefault"
+        }
+    ],
+    "defaultStreamRules": {
+        "userStreams": "publicDefault",
+        "systemStreams": "adminsDefault"
+    }
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/stream-policy-plugin-example.json
+++ b/src/EventStore.Auth.StreamPolicyPlugin/stream-policy-plugin-example.json
@@ -1,0 +1,7 @@
+{
+  "EventStore": {
+    "Authorization": {
+      "PolicyType": "streampolicy"
+    }
+  }
+}

--- a/src/EventStore.Auth.StreamPolicyPlugin/stream-policy-plugin-example.yaml
+++ b/src/EventStore.Auth.StreamPolicyPlugin/stream-policy-plugin-example.yaml
@@ -1,0 +1,2 @@
+Authorization:
+  PolicyType: streampolicy

--- a/src/EventStore.Auth.UserCertificates.Tests/CertificateExtensionsTests.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/CertificateExtensionsTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+public class CertificateExtensionsTests {
+	private readonly Oid _serverAuth = Oid.FromOidValue("1.3.6.1.5.5.7.3.1", OidGroup.EnhancedKeyUsage);
+	private readonly Oid _clientAuth = Oid.FromOidValue("1.3.6.1.5.5.7.3.2", OidGroup.EnhancedKeyUsage);
+	private const X509KeyUsageFlags DefaultKeyUsages = X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment;
+
+	private static X509Certificate2 GenSut(X509KeyUsageFlags keyUsages, OidCollection extendedKeyUsages) {
+		using (RSA rsa = RSA.Create()) {
+			var certReq =
+				new CertificateRequest("CN=hello", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+			var keyUsageExtension = new X509KeyUsageExtension(keyUsages, false);
+			var extendedKeyUsageExtension = new X509EnhancedKeyUsageExtension(extendedKeyUsages, false);
+
+			certReq.CertificateExtensions.Add(keyUsageExtension);
+
+			if (extendedKeyUsages.Count != 0)
+				certReq.CertificateExtensions.Add(extendedKeyUsageExtension);
+
+			return certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddMonths(-1),
+				DateTimeOffset.UtcNow.AddMonths(1));
+		}
+	}
+
+	private static OidCollection GenOids(params Oid[] oids) {
+		var oidCollection = new OidCollection();
+		foreach (var oid in oids) {
+			oidCollection.Add(oid);
+		}
+
+		return oidCollection;
+	}
+
+	[Fact]
+	public void certificate_with_client_auth_eku() {
+		var sut = GenSut(
+			keyUsages: DefaultKeyUsages,
+			extendedKeyUsages: GenOids(_clientAuth));
+
+		Assert.True(sut.IsClientCertificate(out _));
+		Assert.False(sut.IsServerCertificate(out _));
+	}
+
+	[Fact]
+	public void certificate_with_client_and_server_auth_eku() {
+		var sut = GenSut(
+			keyUsages: DefaultKeyUsages,
+			extendedKeyUsages: GenOids(_clientAuth, _serverAuth));
+
+		Assert.True(sut.IsServerCertificate(out _));
+		Assert.True(sut.IsClientCertificate(out _));
+	}
+
+	[Fact]
+	public void certificate_with_server_auth_eku_only() {
+		var sut = GenSut(
+			keyUsages: DefaultKeyUsages,
+			extendedKeyUsages: GenOids(_serverAuth));
+
+		// historically, server certificates also have the clientAuth EKU
+		Assert.False(sut.IsServerCertificate(out _));
+		Assert.False(sut.IsClientCertificate(out _));
+	}
+
+	[Fact]
+	public void certificate_with_no_ekus() {
+		var sut = GenSut(
+			keyUsages: DefaultKeyUsages,
+			extendedKeyUsages: GenOids());
+
+		Assert.True(sut.IsServerCertificate(out _));
+		Assert.False(sut.IsClientCertificate(out _));
+	}
+
+	[Fact]
+	public void certificate_with_no_key_usage() {
+		var sut = GenSut(
+			keyUsages: X509KeyUsageFlags.None,
+			extendedKeyUsages: GenOids(_clientAuth, _serverAuth));
+
+		Assert.False(sut.IsClientCertificate(out _));
+		Assert.False(sut.IsServerCertificate(out _));
+	}
+
+	[Fact]
+	public void certificate_with_missing_key_usage() {
+		var sut = GenSut(
+			keyUsages: X509KeyUsageFlags.KeyEncipherment,
+			extendedKeyUsages: GenOids(_clientAuth, _serverAuth));
+
+		Assert.False(sut.IsClientCertificate(out _));
+		Assert.False(sut.IsServerCertificate(out _));
+	}
+
+	[Fact]
+	public void certificate_with_key_agreement_instead_of_key_encipherment_key_usage() {
+		var sut = GenSut(
+			keyUsages: X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyAgreement,
+			extendedKeyUsages: GenOids(_clientAuth, _serverAuth));
+
+		Assert.True(sut.IsClientCertificate(out _));
+		Assert.True(sut.IsServerCertificate(out _));
+	}
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/EventStore.Auth.UserCertificates.Tests.csproj
+++ b/src/EventStore.Auth.UserCertificates.Tests/EventStore.Auth.UserCertificates.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsPublishable>false</IsPublishable>
+		<IsTestProject>true</IsTestProject>
+		<Platforms>x64</Platforms>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+		<PackageReference Include="xunit" Version="2.4.2"/>
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.Auth.UserCertificates\EventStore.Auth.UserCertificates.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/EventStore.Auth.UserCertificates.Tests/FakeAnonymousHttpAuthenticationProvider.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/FakeAnonymousHttpAuthenticationProvider.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+// grants anonymous claims to anyone
+internal class FakeAnonymousHttpAuthenticationProvider : IHttpAuthenticationProvider {
+	public static readonly ClaimsPrincipal Anonymous = new(new ClaimsIdentity(new Claim[] { new(ClaimTypes.Anonymous, ""), }));
+	public string Name => "anonymous";
+
+	public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
+		request = new HttpAuthenticationRequest(context, "", "");
+		request.Authenticated(Anonymous);
+		return true;
+	}
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/FakeAuthenticationHandler.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/FakeAuthenticationHandler.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Encodings.Web;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+// authenticates according to the httpAuthenticationProviders
+// similar to EventStore.Core.Services.Transport.Http.AuthenticationMiddleware
+public class FakeAuthenticationHandler(
+	IOptionsMonitor<AuthenticationSchemeOptions> options,
+	IReadOnlyList<IHttpAuthenticationProvider> httpAuthenticationProviders,
+	ILoggerFactory logger,
+	UrlEncoder encoder)
+	: AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder) {
+
+	protected override async Task<AuthenticateResult> HandleAuthenticateAsync() {
+		if (!TrySelectProvider(Context, out var authenticationRequest)) {
+			return AuthenticateResult.Fail("No provider");
+		}
+
+		var (status, principal) = await authenticationRequest!.AuthenticateAsync();
+
+		if (status != HttpAuthenticationRequestStatus.Authenticated) {
+			return AuthenticateResult.Fail("Not authenticated");
+		}
+
+		var ticket = new AuthenticationTicket(
+			principal: principal!,
+			authenticationScheme: "fake");
+
+		return AuthenticateResult.Success(ticket);
+	}
+
+	private bool TrySelectProvider(HttpContext context, out HttpAuthenticationRequest? authenticationRequest) {
+		foreach (var provider in httpAuthenticationProviders) {
+			if (provider.Authenticate(context, out authenticationRequest)) {
+				return true;
+			}
+		}
+
+		authenticationRequest = default;
+		return false;
+	}
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/FakeAuthenticationProvider.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/FakeAuthenticationProvider.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Claims;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Routing;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+// pretends any user that the valid certificate names is in the database
+internal class FakeAuthenticationProvider(string scheme) : AuthenticationProviderBase(name: "fake") {
+	public override void Authenticate(AuthenticationRequest authenticationRequest) {
+		if (!authenticationRequest.HasValidClientCertificate) {
+			authenticationRequest.Unauthorized();
+			return;
+		}
+
+		authenticationRequest.Authenticated(new ClaimsPrincipal(new ClaimsIdentity(
+			new[] {
+				new Claim(ClaimTypes.Name, authenticationRequest.Name),
+			},
+			"fake")));
+	}
+
+	public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => [scheme];
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/FakeLogger.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/FakeLogger.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Serilog;
+using Serilog.Events;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+public class FakeLogger : ILogger {
+	public List<LogEvent> LogMessages { get; } = new();
+
+	public void Write(LogEvent logEvent) {
+		LogMessages.Add(logEvent);
+	}
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/FindRootsTests.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/FindRootsTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+using static EventStore.Auth.UserCertificates.Tests.TestUtils;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+public class FindRootsTests {
+	private static string[] FindRoots(X509Certificate2 leaf, X509Certificate2[]? intermediates, X509Certificate2[]? roots) {
+		var intermediatesCollection = intermediates is null ? null : new X509Certificate2Collection(intermediates);
+		var rootsCollection = roots is null ? null : new X509Certificate2Collection(roots);
+		var rootCAs = CertificateUtils
+			.FindRoots(
+				leaf,
+				intermediatesCollection,
+				rootsCollection)
+			.Select(x => x.Thumbprint)
+			.Order()
+			.ToArray();
+
+		// verify that the collections haven't changed
+		if (intermediates != null)
+			Assert.Equal(new X509Certificate2Collection(intermediates), intermediatesCollection);
+
+		if (roots != null)
+			Assert.Equal(new X509Certificate2Collection(roots), rootsCollection);
+
+		return rootCAs;
+	}
+
+	[Fact]
+	public void with_untrusted_self_signed() {
+		var someRoot = CreateCertificate(ca: true);
+		var leaf = CreateCertificate(ca: false, parent: null);
+		Assert.Empty(
+			FindRoots(leaf, null, [someRoot]));
+	}
+
+	[Fact]
+	public void with_trusted_self_signed() {
+		var someRoot = CreateCertificate(ca: true);
+		var leaf = CreateCertificate(ca: false, parent: null);
+		Assert.Equal(
+			[leaf.Thumbprint],
+			FindRoots(leaf, null, [leaf, someRoot]));
+	}
+
+	[Fact]
+	public void with_root() {
+		var root = CreateCertificate(ca: true);
+		var leaf = CreateCertificate(ca: false, parent: root);
+		Assert.Equal(
+			[root.Thumbprint],
+			FindRoots(leaf, null, [root]));
+	}
+
+	[Fact]
+	public void with_root_having_same_issuer_name_but_different_keypair() {
+		var root = CreateCertificate(ca: true, subject: "CN=root");
+		var differentRoot = CreateCertificate(ca: true, subject: "CN=root");
+		var leaf = CreateCertificate(ca: false, parent: root);
+		Assert.Equal(
+			[root.Thumbprint],
+			FindRoots(leaf, null, [root, differentRoot]));
+	}
+
+	[Fact]
+	public void with_expired_root() {
+		var root = CreateCertificate(ca: true, expired: true);
+		var leaf = CreateCertificate(ca: false, parent: root);
+		Assert.Empty(
+			FindRoots(leaf, null, [root]));
+	}
+
+	[Fact]
+	public void with_intermediate() {
+		var root = CreateCertificate(ca: true);
+		var intermediate = CreateCertificate(ca: true, parent: root);
+		var leaf = CreateCertificate(ca: false, parent: intermediate);
+		Assert.Equal(
+			[root.Thumbprint],
+			FindRoots(leaf, [intermediate], [root]));
+	}
+
+	[Fact]
+	public void with_expired_intermediate() {
+		var root = CreateCertificate(ca: true);
+		var intermediate = CreateCertificate(ca: true, parent: root, expired: true);
+		var leaf = CreateCertificate(ca: false, parent: intermediate);
+		Assert.Empty(
+			FindRoots(leaf, [intermediate], [root]));
+	}
+
+	[Fact]
+	public void with_expired_leaf() {
+		var root = CreateCertificate(ca: true);
+		var intermediate = CreateCertificate(ca: true, parent: root);
+		var leaf = CreateCertificate(ca: false, parent: intermediate, expired: true);
+		Assert.Empty(
+			FindRoots(leaf, [intermediate], [root]));
+	}
+
+	[Fact]
+	public void with_two_equivalent_roots() {
+		using var rsa = RSA.Create();
+		var root1 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rsa);
+		var root2 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rsa);
+		var leaf = CreateCertificate(ca: false, parent: root1);
+
+		Assert.Equal(
+			new[] { root1.Thumbprint, root2.Thumbprint }.Order(),
+			FindRoots(leaf, null, [root1, root2]));
+	}
+
+	[Fact]
+	public void with_two_equivalent_roots_and_intermediates() {
+		using var rootRsa = RSA.Create();
+		var root1 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rootRsa);
+		var root2 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rootRsa);
+
+		using var intermediateRsa = RSA.Create();
+		var intermediate1 = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate",
+			keyPair: intermediateRsa);
+		var intermediate2 = CreateCertificate(ca: true, parent: root2, subject: "CN=intermediate",
+			keyPair: intermediateRsa);
+
+		var leaf = CreateCertificate(ca: false, parent: intermediate1);
+
+		Assert.Equal(
+			new[] { root1.Thumbprint, root2.Thumbprint }.Order(),
+			FindRoots(leaf, [intermediate1, intermediate2], [root1, root2]));
+	}
+
+	// https://github.com/dotnet/runtime/issues/98921
+	[Fact(Skip = "failing on linux due to the above issue")]
+	public void with_two_different_roots_but_equivalent_intermediates() {
+		var root1 = CreateCertificate(ca: true, subject: "CN=root1");
+		var root2 = CreateCertificate(ca: true, subject: "CN=root2");
+
+		using var intermediateRsa = RSA.Create();
+		var intermediate1 = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate",
+			keyPair: intermediateRsa);
+		var intermediate2 = CreateCertificate(ca: true, parent: root2, subject: "CN=intermediate",
+			keyPair: intermediateRsa);
+
+		var leaf = CreateCertificate(ca: false, parent: intermediate1);
+
+		Assert.Equal(
+			new[] { root1.Thumbprint, root2.Thumbprint }.Order(),
+			FindRoots(leaf, [intermediate1, intermediate2], [root1, root2]));
+	}
+
+	[Fact]
+	public void with_cycle_between_leaf_and_root() {
+		using var rootRsa = RSA.Create();
+		using var leafRsa = RSA.Create();
+		const string leafSubject = "CN=leaf";
+
+		var root = CreateCertificate(
+			ca: true,
+			subject: TestUtils.GenerateSubject(),
+			keyPair: rootRsa,
+			parentInfo: (leafRsa, new X500DistinguishedName(leafSubject)),
+			expired: false);
+
+		var intermediate = CreateCertificate(ca: true, parent: root);
+		var leaf = CreateCertificate(ca: false, parent: intermediate, subject: leafSubject, keyPair: leafRsa);
+
+		Assert.Empty(
+			FindRoots(leaf, [intermediate], [root]));
+	}
+
+	[Fact]
+	public void with_cycle_between_intermediate_and_root() {
+		using var rootRsa = RSA.Create();
+		using var intermediateRsa = RSA.Create();
+		const string intermediateSubject = "CN=intermediate";
+
+		var root = CreateCertificate(
+			ca: true,
+			subject: TestUtils.GenerateSubject(),
+			keyPair: rootRsa,
+			parentInfo: (intermediateRsa, new X500DistinguishedName(intermediateSubject)),
+			expired: false);
+
+		var intermediate = CreateCertificate(ca: true, subject: intermediateSubject, parent: root,
+			keyPair: intermediateRsa);
+		var leaf = CreateCertificate(ca: false, parent: intermediate);
+
+		Assert.Empty(
+			FindRoots(leaf, [intermediate], [root]));
+	}
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/ShareARootTests.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/ShareARootTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+using static EventStore.Auth.UserCertificates.Tests.TestUtils;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+public class ShareARootTests {
+	private static bool ShareARoot(
+		X509Certificate2 leaf1,
+		X509Certificate2 leaf2,
+		X509Certificate2[]? intermediates,
+		X509Certificate2[]? roots) =>
+		CertificateUtils.ShareARoot(
+			leaf1,
+			leaf2,
+			intermediates is null ? null : new (intermediates),
+			roots is null ? null : new (roots),
+			out _,
+			out _);
+
+	[Fact]
+	public void with_same_root() {
+		var root = CreateCertificate(ca: true);
+		var leaf1 = CreateCertificate(ca: false, parent: root);
+		var leaf2 = CreateCertificate(ca: false, parent: root);
+		Assert.True(ShareARoot(leaf1, leaf2, null, [root]));
+	}
+
+	[Fact]
+	public void with_same_self_signed_root() {
+		var selfSignedLeaf = CreateCertificate(ca: true, parent: null);
+		var otherLeaf = CreateCertificate(ca: false, parent: selfSignedLeaf);
+		Assert.True(ShareARoot(selfSignedLeaf, otherLeaf, null, [selfSignedLeaf]));
+	}
+
+	[Fact]
+	public void with_different_root() {
+		var root1 = CreateCertificate(ca: true);
+		var root2 = CreateCertificate(ca: true);
+		var leaf1 = CreateCertificate(ca: false, parent: root1);
+		var leaf2 = CreateCertificate(ca: false, parent: root2);
+		Assert.False(ShareARoot(leaf1, leaf2, null, [root1, root2]));
+	}
+
+	[Fact]
+	public void with_expired_root() {
+		var root = CreateCertificate(ca: true, expired: true);
+		var leaf1 = CreateCertificate(ca: false, parent: root);
+		var leaf2 = CreateCertificate(ca: false, parent: root);
+		Assert.False(ShareARoot(leaf1, leaf2, null, [root]));
+	}
+
+	[Fact]
+	public void with_same_root_and_intermediate() {
+		var root = CreateCertificate(ca: true);
+		var intermediate = CreateCertificate(ca: true, parent: root);
+		var leaf1 = CreateCertificate(ca: false, parent: intermediate);
+		var leaf2 = CreateCertificate(ca: false, parent: intermediate);
+		Assert.True(ShareARoot(leaf1, leaf2, [intermediate], [root]));
+	}
+
+	[Fact]
+	public void with_same_root_and_expired_intermediate() {
+		var root = CreateCertificate(ca: true);
+		var intermediate = CreateCertificate(ca: true, parent: root, expired: true);
+		var leaf1 = CreateCertificate(ca: false, parent: intermediate);
+		var leaf2 = CreateCertificate(ca: false, parent: intermediate);
+		Assert.False(ShareARoot(leaf1, leaf2, [intermediate], [root]));
+	}
+
+	[Fact]
+	public void with_same_root_but_different_intermediate() {
+		var root = CreateCertificate(ca: true);
+		var intermediate1 = CreateCertificate(ca: true, parent: root);
+		var intermediate2 = CreateCertificate(ca: true, parent: root);
+		var leaf1 = CreateCertificate(ca: false, parent: intermediate1);
+		var leaf2 = CreateCertificate(ca: false, parent: intermediate2);
+		Assert.True(ShareARoot(leaf1, leaf2, [intermediate1, intermediate2], [root]));
+	}
+
+	[Fact]
+	public void with_equivalent_roots() {
+		using var rsa = RSA.Create();
+		var root1 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rsa);
+		var root2 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rsa);
+		var leaf1 = CreateCertificate(ca: false, parent: root1);
+		var leaf2 = CreateCertificate(ca: false, parent: root2);
+		Assert.True(ShareARoot(leaf1, leaf2, null, [root1, root2]));
+	}
+
+	[Fact]
+	public void with_equivalent_roots_and_intermediates() {
+		using var rootRsa = RSA.Create();
+		var root1 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rootRsa);
+		var root2 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rootRsa);
+
+		using var intermediateRsa = RSA.Create();
+		var intermediate1 = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate",
+			keyPair: intermediateRsa);
+		var intermediate2 = CreateCertificate(ca: true, parent: root2, subject: "CN=intermediate",
+			keyPair: intermediateRsa);
+
+		var leaf1 = CreateCertificate(ca: false, parent: intermediate1);
+		var leaf2 = CreateCertificate(ca: false, parent: intermediate2);
+
+		Assert.True(ShareARoot(leaf1, leaf2, [intermediate1, intermediate2], [root1, root2]));
+	}
+
+	[Fact]
+	public void with_equivalent_roots_and_intermediates_but_some_have_expired() {
+		using var rootRsa = RSA.Create();
+		var root1 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rootRsa);
+		var root2 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rootRsa, expired: true);
+
+		using var intermediateRsa = RSA.Create();
+		var intermediate1 = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate",
+			keyPair: intermediateRsa, expired: true);
+		var intermediate2 = CreateCertificate(ca: true, parent: root2, subject: "CN=intermediate",
+			keyPair: intermediateRsa);
+
+		var leaf1 = CreateCertificate(ca: false, parent: intermediate1);
+		var leaf2 = CreateCertificate(ca: false, parent: intermediate2);
+
+		Assert.True(ShareARoot(leaf1, leaf2, [intermediate1, intermediate2], [root1, root2]));
+	}
+
+	[Fact]
+	public void with_equivalent_roots_and_intermediates_but_all_have_expired() {
+		using var rootRsa = RSA.Create();
+		var root1 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rootRsa, expired: true);
+		var root2 = CreateCertificate(ca: true, subject: "CN=root", keyPair: rootRsa, expired: true);
+
+		using var intermediateRsa = RSA.Create();
+		var intermediate1 = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate",
+			keyPair: intermediateRsa, expired: true);
+		var intermediate2 = CreateCertificate(ca: true, parent: root2, subject: "CN=intermediate",
+			keyPair: intermediateRsa, expired: true);
+
+		var leaf1 = CreateCertificate(ca: false, parent: intermediate1);
+		var leaf2 = CreateCertificate(ca: false, parent: intermediate2);
+
+		Assert.False(ShareARoot(leaf1, leaf2, [intermediate1, intermediate2], [root1, root2]));
+	}
+
+	[Fact]
+	public void with_a_shared_root_and_a_non_shared_root() {
+		var root1 = CreateCertificate(ca: true, subject: "CN=root1");
+		var root2 = CreateCertificate(ca: true, subject: "CN=root2");
+
+		using var intermediateRsa = RSA.Create();
+		var intermediate1a = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate1",
+			keyPair: intermediateRsa);
+		var intermediate1b = CreateCertificate(ca: true, parent: root2, subject: "CN=intermediate1",
+			keyPair: intermediateRsa);
+		var intermediate2 = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate2");
+
+		var leaf1 = CreateCertificate(ca: false, parent: intermediate1a);
+		var leaf2 = CreateCertificate(ca: false, parent: intermediate2);
+
+		Assert.True(ShareARoot(leaf1, leaf2, [intermediate1a, intermediate1b, intermediate2], [root1, root2]));
+	}
+
+
+	[Fact]
+	public void with_a_shared_root_having_an_expired_chain_and_a_non_shared_root() {
+		var root1 = CreateCertificate(ca: true, subject: "CN=root1");
+		var root2 = CreateCertificate(ca: true, subject: "CN=root2");
+
+		using var intermediateRsa = RSA.Create();
+		var intermediate1a = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate1",
+			keyPair: intermediateRsa, expired: true);
+		var intermediate1b = CreateCertificate(ca: true, parent: root2, subject: "CN=intermediate1",
+			keyPair: intermediateRsa);
+		var intermediate2 = CreateCertificate(ca: true, parent: root1, subject: "CN=intermediate2");
+
+		var leaf1 = CreateCertificate(ca: false, parent: intermediate1a);
+		var leaf2 = CreateCertificate(ca: false, parent: intermediate2);
+
+		Assert.False(ShareARoot(leaf1, leaf2, [intermediate1a, intermediate1b, intermediate2], [root1, root2]));
+	}
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/TestUtils.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/TestUtils.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+public static class TestUtils {
+	private static readonly Random Random = new();
+	private static string GetCharset() {
+		var charset = "";
+		for (var c = 'a'; c <= 'z'; c++) {
+			charset += c;
+		}
+		for (var c = 'A'; c <= 'Z'; c++) {
+			charset += c;
+		}
+		for (var c = '0'; c <= '9'; c++) {
+			charset += c;
+		}
+		return charset;
+	}
+
+	public static string GenerateSubject() {
+		var charset = GetCharset();
+		string s = "";
+		for (var j = 0; j < 10; j++) {
+			s += charset[Random.Next() % charset.Length];
+		}
+
+		return $"CN={s}";
+	}
+
+	private static byte[] GenerateSerialNumber() {
+		var charset = GetCharset();
+		string s = "";
+		for (var j = 0; j < 10; j++) {
+			s += charset[Random.Next() % charset.Length];
+		}
+
+		var utf8Encoding = new UTF8Encoding(false);
+		return utf8Encoding.GetBytes(s);
+	}
+
+	public static X509Certificate2 CreateCertificate(
+		bool ca,
+		RSA keyPair,
+		string subject,
+		(RSA keyPair, X500DistinguishedName subjectName)? parentInfo,
+		bool expired,
+		bool unready,
+		bool serverAuthEKU,
+		bool clientAuthEKU) {
+
+		var certReq = new CertificateRequest(subject, keyPair, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+		var now = DateTimeOffset.UtcNow;
+		now = new DateTime(now.Year, now.Month, now.Day); // round to nearest day
+		var startDate = !unready ? now.AddMonths(-1) : now.AddDays(1);
+		var endDate = !expired ? now.AddMonths(1) : now.AddDays(-1);
+
+		if (ca) {
+			certReq.CertificateExtensions.Add(new X509BasicConstraintsExtension(
+				certificateAuthority: true,
+				hasPathLengthConstraint: false,
+				pathLengthConstraint: 0,
+				critical: true));
+		}
+
+		if (serverAuthEKU || clientAuthEKU) {
+			certReq.CertificateExtensions.Add(new X509KeyUsageExtension(
+				keyUsages: X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+				critical: false));
+
+			var oids = new OidCollection();
+
+			if (serverAuthEKU)
+				oids.Add(new Oid("1.3.6.1.5.5.7.3.1"));
+
+			if (clientAuthEKU)
+				oids.Add(new Oid("1.3.6.1.5.5.7.3.2"));
+
+			certReq.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(oids, critical: false));
+		}
+
+		if (parentInfo == null) {
+			return certReq.CreateSelfSigned(startDate, endDate);
+		}
+
+		var parentKey = parentInfo.Value.keyPair;
+		var signatureGenerator = X509SignatureGenerator.CreateForRSA(parentKey!, RSASignaturePadding.Pkcs1);
+		return certReq.Create(parentInfo.Value.subjectName, signatureGenerator, startDate, endDate, GenerateSerialNumber()).CopyWithPrivateKey(keyPair);
+	}
+
+	public static X509Certificate2 CreateCertificate(
+		bool ca,
+		RSA keyPair,
+		string subject,
+		(RSA keyPair, X500DistinguishedName subjectName)? parentInfo,
+		bool expired,
+		bool serverAuthEKU = false,
+		bool clientAuthEKU = false) =>
+
+		CreateCertificate(
+			ca, keyPair, subject, parentInfo, expired,
+			unready: false, serverAuthEKU: serverAuthEKU, clientAuthEKU: clientAuthEKU);
+
+	public static X509Certificate2 CreateCertificate(
+		bool ca = false,
+		X509Certificate2? parent = null,
+		bool expired = false,
+		string? subject = null,
+		RSA? keyPair = null,
+		bool serverAuthEKU = false,
+		bool clientAuthEKU = false) {
+
+		using var rsa = RSA.Create();
+		subject ??= GenerateSubject();
+
+		(RSA, X500DistinguishedName)? parentInfo = null;
+		if (parent != null) {
+			parentInfo = (parent.GetRSAPrivateKey()!, parent.SubjectName);
+		}
+
+		return CreateCertificate(ca, keyPair ?? rsa, subject, parentInfo, expired,
+			serverAuthEKU: serverAuthEKU,
+			clientAuthEKU: clientAuthEKU);
+	}
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/UserCertificateAuthenticationProviderTests.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/UserCertificateAuthenticationProviderTests.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+public class UserCertificateAuthenticationProviderTests {
+	private readonly X509Certificate2 _root, _intermediate, _node;
+	private readonly UserCertificateAuthenticationProvider _provider;
+
+	public UserCertificateAuthenticationProviderTests() {
+		_root = CreateRoot();
+		_intermediate = CreateIntermediate(parent: _root);
+		_node = CreateNode(parent: _intermediate);
+		_provider = new UserCertificateAuthenticationProvider(
+			authenticationProvider: new FakeAuthenticationProvider("UserCertificate"),
+			getCertificates: () => (
+				Node: _node,
+				Intermediates: new X509Certificate2Collection(_intermediate),
+				Roots: new X509Certificate2Collection(_root)),
+			configuration: new ConfigurationBuilder().Build());
+	}
+
+	private static X509Certificate2 CreateCertificate(
+		bool ca = false,
+		X509Certificate2? parent = null,
+		bool expired = false,
+		bool unready = false,
+		string? subject = null,
+		bool serverAuthEKU = false,
+		bool clientAuthEKU = false) {
+		using var rsa = RSA.Create();
+		subject ??= TestUtils.GenerateSubject();
+
+		(RSA, X500DistinguishedName)? parentInfo = null;
+		if (parent != null) {
+			parentInfo = (parent.GetRSAPrivateKey()!, parent.SubjectName);
+		}
+
+		return TestUtils.CreateCertificate(ca, rsa, subject, parentInfo, expired, unready,
+			serverAuthEKU: serverAuthEKU, clientAuthEKU: clientAuthEKU);
+	}
+
+	private static X509Certificate2 CreateRoot() =>
+		CreateCertificate(ca: true, parent: null);
+
+	private static X509Certificate2 CreateIntermediate(X509Certificate2 parent) =>
+		CreateCertificate(ca: true, parent: parent);
+
+	private static X509Certificate2 CreateNode(X509Certificate2 parent) =>
+		CreateCertificate(
+			parent: parent,
+			serverAuthEKU: true,
+			clientAuthEKU: true);
+
+	private static X509Certificate2 CreateClient(X509Certificate2 parent, string userId,
+		bool expired = false, bool unready = false) =>
+
+		CreateCertificate(
+			parent: parent,
+			subject: $"CN={userId}",
+			serverAuthEKU: false,
+			clientAuthEKU: true,
+			expired: expired,
+			unready: unready);
+
+	private static X509Certificate2 CreateClientNoEKU(X509Certificate2 parent, string userId) =>
+		CreateCertificate(
+			parent: parent,
+			subject: $"CN={userId}",
+			serverAuthEKU: false,
+			clientAuthEKU: false);
+
+	[Fact]
+	public void with_no_user_certificate() {
+		Assert.False(_provider.Authenticate(new DefaultHttpContext(), out _));
+	}
+
+	[Fact]
+	public void with_proper_user_certificate() {
+		var ctx = new DefaultHttpContext {
+			Connection = {
+				ClientCertificate = CreateClient(_root, "bob")
+			}
+		};
+
+		Assert.True(_provider.Authenticate(ctx, out _));
+	}
+
+	[Fact]
+	public void with_user_certificate_having_different_root_ca_than_node() {
+		var ctx = new DefaultHttpContext {
+			Connection = {
+				ClientCertificate = CreateClient(CreateRoot(), "bob")
+			}
+		};
+
+		Assert.False(_provider.Authenticate(ctx, out _));
+	}
+
+	[Fact]
+	public void with_user_certificate_having_no_client_auth_eku() {
+		var ctx = new DefaultHttpContext {
+			Connection = {
+				ClientCertificate = CreateClientNoEKU(_root, "bob")
+			}
+		};
+
+		Assert.False(_provider.Authenticate(ctx, out _));
+	}
+
+	[Fact]
+	public void with_user_certificate_having_both_server_and_client_auth_eku() {
+		var ctx = new DefaultHttpContext {
+			Connection = {
+				ClientCertificate = CreateNode(_root)
+			}
+		};
+
+		Assert.False(_provider.Authenticate(ctx, out _));
+	}
+
+	[Fact]
+	public void with_expired_user_certificate() {
+		var ctx = new DefaultHttpContext {
+			Connection = {
+				ClientCertificate = CreateClient(_root, "bob", expired: true)
+			}
+		};
+
+		Assert.False(_provider.Authenticate(ctx, out _));
+	}
+
+	[Fact]
+	public void with_unready_user_certificate() {
+		var ctx = new DefaultHttpContext {
+			Connection = {
+				ClientCertificate = CreateClient(_root, "bob", unready: true)
+			}
+		};
+
+		Assert.False(_provider.Authenticate(ctx, out _));
+	}
+
+	[Fact]
+	public void with_proper_user_certificate_and_cache() {
+		var ctx = new DefaultHttpContext {
+			Connection = {
+				ClientCertificate = CreateClient(_root, "bob")
+			}
+		};
+		ctx.Features.Set<IConnectionItemsFeature>(new DefaultConnectionContext());
+
+		Assert.True(_provider.Authenticate(ctx, out _));
+
+		var items = ctx.Features.Get<IConnectionItemsFeature>()?.Items;
+		Assert.NotNull(items);
+		Assert.True(items.TryGetValue("UserCertificateAuthenticationStatus", out var cachedValue));
+		var (authenticated, userId) = Assert.IsType<(bool, string)>(cachedValue);
+		Assert.True(authenticated);
+		Assert.Equal("bob", userId);
+		Assert.True(_provider.Authenticate(ctx, out _));
+	}
+
+	[Fact]
+	public void with_invalid_user_certificate_and_cache() {
+		var ctx = new DefaultHttpContext {
+			Connection = {
+				ClientCertificate = CreateNode(parent: _root)
+			}
+		};
+		ctx.Features.Set<IConnectionItemsFeature>(new DefaultConnectionContext());
+
+		Assert.False(_provider.Authenticate(ctx, out _));
+
+		var items = ctx.Features.Get<IConnectionItemsFeature>()?.Items;
+		Assert.NotNull(items);
+		Assert.True(items.TryGetValue("UserCertificateAuthenticationStatus", out var cachedValue));
+		var (authenticated, userId) = Assert.IsType<(bool, string)>(cachedValue);
+		Assert.False(authenticated);
+		Assert.Null(userId);
+		Assert.False(_provider.Authenticate(ctx, out _));
+	}
+}

--- a/src/EventStore.Auth.UserCertificates.Tests/UserCertificatesPluginTests.cs
+++ b/src/EventStore.Auth.UserCertificates.Tests/UserCertificatesPluginTests.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Plugins;
+using EventStore.Plugins.Authentication;
+using EventStore.Plugins.Diagnostics;
+using EventStore.Plugins.Licensing;
+using EventStore.Plugins.Tests;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EventStore.Auth.UserCertificates.Tests;
+
+public class UserCertificatesPluginTests {
+	private readonly FakeLogger _logger = new();
+	private readonly X509Certificate2 _rootCert;
+	private readonly X509Certificate2 _nodeCert;
+	private readonly X509Certificate2 _userCert;
+
+	public UserCertificatesPluginTests() {
+		_rootCert = TestUtils.CreateCertificate(ca: true, parent: null);
+		_nodeCert = TestUtils.CreateCertificate(ca: false, parent: _rootCert, clientAuthEKU: true, serverAuthEKU: true);
+		_userCert = TestUtils.CreateCertificate(ca: false, parent: _rootCert, clientAuthEKU: true);
+		_userCert = new X509Certificate2(_userCert.Export(X509ContentType.Pfx));
+	}
+
+	[Fact]
+	public void has_parameterless_constructor() {
+		// needed for all plugins
+		Activator.CreateInstance<UserCertificatesPlugin>();
+	}
+
+	[Fact]
+	public async Task works() {
+		await using var app = await CreateServer(
+			new Dictionary<string, string?> {
+				{ $"{KurrentConfigurationConstants.Prefix}:UserCertificates:Enabled", "true" }
+			},
+			ConfigureServicesCorrectly);
+
+		var client = CreateClient(app, _userCert);
+		var result = await client.GetAsync("/test");
+		Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+		var log = Assert.Single(_logger.LogMessages);
+		Assert.Equal("UserCertificatesPlugin: user X.509 certificate authentication is enabled", log.RenderMessage());
+	}
+
+	[Fact]
+	public async Task disabled_by_default() {
+		using var collector = PluginDiagnosticsDataCollector.Start("UserCertificates");
+		await using var app = await CreateServer([], ConfigureServicesCorrectly);
+
+		var client = CreateClient(app, _userCert);
+		var result = await client.GetAsync("/test");
+		Assert.Equal(HttpStatusCode.Forbidden, result.StatusCode);
+
+		collector.CollectedEvents("UserCertificates").Should().ContainSingle().Which
+			.Data["enabled"].Should().Be(false);
+	}
+
+	[Fact]
+	public async Task can_be_disabled() {
+		using var collector = PluginDiagnosticsDataCollector.Start("UserCertificates");
+		await using var app = await CreateServer(
+			new Dictionary<string, string?> {
+				{ $"{KurrentConfigurationConstants.Prefix}:UserCertificates:Enabled", "false" }
+			},
+			ConfigureServicesCorrectly);
+
+		var client = CreateClient(app, _userCert);
+		var result = await client.GetAsync("/test");
+		Assert.Equal(HttpStatusCode.Forbidden, result.StatusCode);
+
+		collector.CollectedEvents("UserCertificates").Should().ContainSingle().Which
+			.Data["enabled"].Should().Be(false);
+	}
+
+	[Fact]
+	public async Task requires_user_certificate_scheme() {
+		await using var app = await CreateServer(
+			new Dictionary<string, string?> {
+				{ $"{KurrentConfigurationConstants.Prefix}:UserCertificates:Enabled", "true" }
+			},
+			services => services
+				.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService())
+				.AddSingleton<IReadOnlyList<IHttpAuthenticationProvider>>([new FakeAnonymousHttpAuthenticationProvider()])
+				.AddSingleton<IAuthenticationProvider>(new FakeAuthenticationProvider("Basic"))
+				.AddSingleton<Func<(X509Certificate2? Node, X509Certificate2Collection? Intermediates, X509Certificate2Collection? Roots)>>(
+				() => (_nodeCert, null, new(_rootCert))));
+
+		var client = CreateClient(app, _userCert);
+		var result = await client.GetAsync("/test");
+		Assert.Equal(HttpStatusCode.Forbidden, result.StatusCode);
+
+		var log = Assert.Single(_logger.LogMessages);
+		Assert.Equal("UserCertificatesPlugin is not compatible with the current authentication provider", log.RenderMessage());
+	}
+
+	[Fact]
+	public async Task requires_anonymous_http_provider() {
+		await using var app = await CreateServer(
+			new Dictionary<string, string?> {
+				{ $"{KurrentConfigurationConstants.Prefix}:UserCertificates:Enabled", "true" }
+			},
+			services => services
+				.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService())
+				.AddSingleton<IReadOnlyList<IHttpAuthenticationProvider>>([])
+				.AddSingleton<IAuthenticationProvider>(new FakeAuthenticationProvider("UserCertificate"))
+				.AddSingleton<Func<(X509Certificate2? Node, X509Certificate2Collection? Intermediates, X509Certificate2Collection? Roots)>>(
+				() => (_nodeCert, null, new(_rootCert))));
+
+		var client = CreateClient(app, _userCert);
+		var result = await client.GetAsync("/test");
+		// since there is no anonymous provider we do not get authenticated at all, hence different code
+		Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+
+		var log = Assert.Single(_logger.LogMessages);
+		Assert.Equal("UserCertificatesPlugin failed to load as the conditions required to load the plugin were not met", log.RenderMessage());
+	}
+
+	private async Task<WebApplication> CreateServer(
+		Dictionary<string, string?> configuration,
+		Action<IServiceCollection>? configureServices = null) {
+
+		var builder = WebApplication.CreateBuilder();
+		builder.Configuration.AddInMemoryCollection(configuration);
+		builder.WebHost
+			.UseUrls("https://127.0.0.1:0")
+			.ConfigureKestrel(x => x
+				.ConfigureHttpsDefaults(y => {
+					y.ClientCertificateMode = ClientCertificateMode.AllowCertificate;
+					y.ClientCertificateValidation = (certificate, chain, errors) => true;
+				}));
+		builder.Services.AddAuthorizationBuilder()
+			.SetDefaultPolicy(new AuthorizationPolicyBuilder()
+				.RequireAuthenticatedUser()
+				.Build());
+		builder.Services.AddAuthentication(o => {
+			o.AddScheme<FakeAuthenticationHandler>("fake", "fake");
+		});
+
+		configureServices?.Invoke(builder.Services);
+
+		var sut = new UserCertificatesPlugin(_logger);
+		((IPlugableComponent)sut).ConfigureServices(builder.Services, builder.Configuration);
+
+		var app = builder.Build();
+		((IPlugableComponent)sut).ConfigureApplication(app, builder.Configuration);
+
+		app.MapGet("/test", () => "Hello World!").RequireAuthorization();
+
+		await app.StartAsync();
+		return app;
+	}
+
+	void ConfigureServicesCorrectly(IServiceCollection services) => services
+			.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService())
+			.AddSingleton<IReadOnlyList<IHttpAuthenticationProvider>>([new FakeAnonymousHttpAuthenticationProvider()])
+			.AddSingleton<IAuthenticationProvider>(new FakeAuthenticationProvider("UserCertificate"))
+			.AddSingleton<Func<(X509Certificate2? Node, X509Certificate2Collection? Intermediates, X509Certificate2Collection? Roots)>>(
+				() => (_nodeCert, null, new(_rootCert)));
+
+	private static HttpClient CreateClient(WebApplication app, X509Certificate2? userCert) {
+		var handler = new HttpClientHandler {
+			ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true
+		};
+
+		if (userCert != null)
+			handler.ClientCertificates.Add(userCert);
+
+		var client = new HttpClient(handler, disposeHandler: true) {
+			BaseAddress = new Uri(app.Urls.First())
+		};
+
+		return client;
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void can_collect_telemetry(bool enabled) {
+		// given
+		using var sut = new UserCertificatesPlugin();
+		using var collector = PluginDiagnosticsDataCollector.Start(sut.DiagnosticsName);
+
+		var config = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?> {
+				{$"{KurrentConfigurationConstants.Prefix}:UserCertificates:Enabled", $"{enabled}"},
+			})
+			.Build();
+
+		var builder = WebApplication.CreateBuilder();
+		builder.Services.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService(true, "USER_CERTIFICATES"));
+		builder.Services.AddSingleton<IReadOnlyList<IHttpAuthenticationProvider>>([]);
+
+		// when
+		((IPlugableComponent)sut).ConfigureServices(
+			builder.Services,
+			config);
+
+		var app = builder.Build();
+		((IPlugableComponent)sut).ConfigureApplication(app, config);
+
+		// then
+		collector.CollectedEvents(sut.DiagnosticsName).Should().ContainSingle().Which
+			.Data["enabled"].Should().Be(enabled);
+	}
+
+	[Theory]
+	[InlineData(true, true, "USER_CERTIFICATES", false)]
+	[InlineData(true, false, "USER_CERTIFICATES", true)]
+	[InlineData(false, true, "USER_CERTIFICATES", false)]
+	[InlineData(false, false, "USER_CERTIFICATES", false)]
+	[InlineData(true, true, "NONE", true)]
+	[InlineData(true, false, "NONE", true)]
+	[InlineData(false, true, "NONE", false)]
+	[InlineData(false, false, "NONE", false)]
+	public void respects_license(bool enabled, bool licensePresent, string entitlement, bool expectedException) {
+		// given
+		using var sut = new UserCertificatesPlugin();
+
+		var config = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?> {
+				{$"{KurrentConfigurationConstants.Prefix}:UserCertificates:Enabled", $"{enabled}"},
+			})
+			.Build();
+
+		var builder = WebApplication.CreateBuilder();
+
+		if (enabled)
+			builder.Services.AddSingleton<IReadOnlyList<IHttpAuthenticationProvider>>([]);
+
+		var licenseService = new Fixtures.FakeLicenseService(licensePresent, entitlement);
+		builder.Services.AddSingleton<ILicenseService>(licenseService);
+
+		((IPlugableComponent)sut).ConfigureServices(
+			builder.Services,
+			config);
+
+		var app = builder.Build();
+
+		// when
+		((IPlugableComponent)sut).ConfigureApplication(app, config);
+
+		// then
+		if (expectedException) {
+			Assert.NotNull(licenseService.RejectionException);
+		} else {
+			Assert.Null(licenseService.RejectionException);
+		}
+	}
+}

--- a/src/EventStore.Auth.UserCertificates/CertificateExtensions.cs
+++ b/src/EventStore.Auth.UserCertificates/CertificateExtensions.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EventStore.Auth.UserCertificates;
+
+public static class CertificateExtensions {
+	private static bool TryGetKeyUsages(
+		this X509Certificate2 certificate,
+		out X509KeyUsageFlags keyUsages,
+		out bool hasExtendedKeyUsage,
+		out Oid[] extKeyUsages,
+		out string failReason) {
+
+		keyUsages = X509KeyUsageFlags.None;
+		hasExtendedKeyUsage = false;
+		extKeyUsages = [];
+		failReason = "";
+
+		X509ExtensionCollection extensions;
+		try {
+			extensions = certificate.Extensions;
+		} catch (CryptographicException ex) {
+			failReason = ex.Message;
+			return false;
+		}
+
+		foreach (var extension in extensions) {
+			switch (extension.Oid?.Value)
+			{
+				case "2.5.29.15": // Oid for Key Usage extension
+					var keyUsageExt = (X509KeyUsageExtension)extension;
+					keyUsages |= keyUsageExt.KeyUsages;
+					break;
+				case "2.5.29.37": // Oid for Extended Key Usage extension
+					hasExtendedKeyUsage = true;
+					var enhancedKeyUsageExt = (X509EnhancedKeyUsageExtension)extension;
+					extKeyUsages = new Oid[enhancedKeyUsageExt.EnhancedKeyUsages.Count];
+					if (extKeyUsages.Length > 0)
+						enhancedKeyUsageExt.EnhancedKeyUsages.CopyTo(extKeyUsages, 0);
+					break;
+			}
+		}
+
+		return true;
+	}
+
+	private static bool HasCorrectKeyUsages(X509KeyUsageFlags keyUsageFlags, out string failReason) {
+		if (!keyUsageFlags.HasFlag(X509KeyUsageFlags.DigitalSignature)) {
+			failReason = "Missing key usage: Digital Signature";
+			return false;
+		}
+
+		if (!keyUsageFlags.HasFlag(X509KeyUsageFlags.KeyEncipherment) &&
+		    !keyUsageFlags.HasFlag(X509KeyUsageFlags.KeyAgreement)) {
+			failReason = "Missing key usage: Key Encipherment and/or Key Agreement";
+			return false;
+		}
+
+		failReason = string.Empty;
+		return true;
+	}
+
+	private static bool HasServerAuthExtendedKeyUsage(IEnumerable<Oid> extendedKeyUsages, out string failReason) {
+		if (extendedKeyUsages.All(oid => oid.Value != "1.3.6.1.5.5.7.3.1")) { // serverAuth
+			failReason = "Missing extended key usage: Server Authentication";
+			return false;
+		}
+
+		failReason = string.Empty;
+		return true;
+	}
+
+	private static bool HasClientAuthExtendedKeyUsage(IEnumerable<Oid> extendedKeyUsages, out string failReason) {
+		if (extendedKeyUsages.All(oid => oid.Value != "1.3.6.1.5.5.7.3.2")) { // clientAuth
+			failReason = "Missing extended key usage: Client Authentication";
+			return false;
+		}
+
+		failReason = string.Empty;
+		return true;
+	}
+
+	public static bool IsServerCertificate(this X509Certificate2 certificate, out string failReason) {
+		if (!certificate.TryGetKeyUsages(out var keyUsages, out var hasExtKeyUsagesExtension, out var extKeyUsages, out failReason))
+			return false;
+
+		if (!HasCorrectKeyUsages(keyUsages, out failReason))
+			return false;
+
+		// rfc5280 section-4.2.1.12: extended key usages (EKUs) only have to be enforced
+		// if the extension is present at all. here, we don't enforce them for server
+		// certificates for backwards compatibility. however, this also implies that we
+		// _need_ the EKUs to be present for other types of certificates (e.g user certificates)
+		// as otherwise it would cause ambiguity when trying to determine the certificate type.
+		if (hasExtKeyUsagesExtension) {
+			if (!HasServerAuthExtendedKeyUsage(extKeyUsages, out failReason))
+				return false;
+
+			// historically, server certificates also have the clientAuth EKU
+			if (!HasClientAuthExtendedKeyUsage(extKeyUsages, out failReason))
+				return false;
+		}
+
+		failReason = string.Empty;
+		return true;
+	}
+
+	public static bool IsClientCertificate(this X509Certificate2 certificate, out string failReason) {
+		if (!certificate.TryGetKeyUsages(out var keyUsages, out _, out var extKeyUsages, out failReason))
+			return false;
+
+		if (!HasCorrectKeyUsages(keyUsages, out failReason))
+			return false;
+
+		if (!HasClientAuthExtendedKeyUsage(extKeyUsages, out failReason))
+			return false;
+
+		failReason = string.Empty;
+		return true;
+	}
+
+	public static string GetCommonName(this X509Certificate2 certificate) => certificate.GetNameInfo(X509NameType.SimpleName, false);
+}

--- a/src/EventStore.Auth.UserCertificates/CertificateUtils.cs
+++ b/src/EventStore.Auth.UserCertificates/CertificateUtils.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EventStore.Auth.UserCertificates;
+
+public static class CertificateUtils {
+	// returns true iff there exists a root in `roots` that begins a valid chain of
+	// trust to both `certificate1` and `certificate2`.
+	public static bool ShareARoot(
+		X509Certificate2 certificate1,
+		X509Certificate2 certificate2,
+		X509Certificate2Collection intermediates,
+		X509Certificate2Collection roots,
+		out string[] certificate1Roots,
+		out string[] certificate2Roots) {
+
+		certificate1Roots = FindRoots(certificate1, intermediates, roots).Select(x => x.Thumbprint).ToArray();
+		certificate2Roots = FindRoots(certificate2, intermediates, roots).Select(x => x.Thumbprint).ToArray();
+
+		return certificate1Roots.Intersect(certificate2Roots).Any();
+	}
+
+	// finds every root in `roots` that begins a valid chain of trust to `leaf`
+	public static X509Certificate2[] FindRoots(
+		X509Certificate2 leaf,
+		X509Certificate2Collection intermediates,
+		X509Certificate2Collection roots) {
+
+		var candidateRoots = new HashSet<X509Certificate2>();
+		FindCandidateRoots(leaf, intermediates, roots, visited: [], candidateRoots);
+
+		return candidateRoots
+			.Where(root => IsValidRoot(leaf, intermediates, root))
+			.ToArray();
+	}
+
+	// returns true iff there is a valid chain from the root to the leaf
+	private static bool IsValidRoot(X509Certificate2 leaf, X509Certificate2Collection intermediates, X509Certificate2 root) {
+		var chain = new X509Chain {
+			ChainPolicy = {
+				TrustMode = X509ChainTrustMode.CustomRootTrust,
+				RevocationMode = X509RevocationMode.NoCheck,
+				DisableCertificateDownloads = true
+			}
+		};
+
+		if (intermediates != null)
+			foreach (var intermediate in intermediates)
+				chain.ChainPolicy.ExtraStore.Add(intermediate);
+
+		chain.ChainPolicy.CustomTrustStore.Add(root);
+
+		return chain.Build(leaf);
+	}
+
+	// DFS. finds every root in `roots` with a issuer/subject chain down to `certificate`
+	private static void FindCandidateRoots(
+		X509Certificate2 certificate,
+		X509Certificate2Collection intermediates,
+		X509Certificate2Collection roots,
+		HashSet<string> visited,
+		HashSet<X509Certificate2> results) {
+
+		if (!visited.Add(certificate.Thumbprint))
+			return;
+
+		if (certificate.Issuer == certificate.Subject) {
+			// we've reached a root certificate - check if it's a trusted root
+			if (roots.Contains(certificate))
+				results.Add(certificate);
+		}
+
+		if (intermediates != null)
+			foreach (var intermediate in intermediates)
+				if (certificate.Issuer == intermediate.Subject)
+					FindCandidateRoots(intermediate, intermediates, roots, visited, results);
+
+		if (roots != null)
+			foreach (var root in roots)
+				if (certificate.Issuer == root.Subject)
+					FindCandidateRoots(root, intermediates, roots, visited, results);
+	}
+}

--- a/src/EventStore.Auth.UserCertificates/EventStore.Auth.UserCertificates.csproj
+++ b/src/EventStore.Auth.UserCertificates/EventStore.Auth.UserCertificates.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Platforms>x64</Platforms>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+	</PropertyGroup>
+	<PropertyGroup>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Scrutor" Version="4.2.2" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="user-certificates-plugin-example.yaml">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="user-certificates-plugin-example.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Auth.UserCertificates/README.md
+++ b/src/EventStore.Auth.UserCertificates/README.md
@@ -1,0 +1,215 @@
+# User Certificates Plugin
+The User Certificates plugin allows users to provide an x509 user certificate for authentication in addition to username and password.
+
+A user certificate is valid on any cluster where the user exists and where the node certificates for the cluster share a common root CA with the user certificate. This means that you can have a single user certificate that is valid across multiple clusters.
+
+To enable user certificate authentication you will need to download the plugin and add it to the `.\plugins` folder in your EventStoreDB installation directory.
+
+You then need to add the configuration to enable the plugin to a json file in the `.\config` directory. For example, add the following configuration to `.\config\plugin-config.json` within the EventStoreDB installation directory:
+
+```
+{
+  "EventStore": {
+    "UserCertificates": {
+      "Enabled": true
+    }
+  }
+}
+```
+
+Once the plugin is installed and enabled the server should log a similar message to the one below:
+
+```
+[13260, 8,13:59:10.445,INF] UserCertificatesPlugin: user X.509 certificate authentication is enabled
+```
+
+You can then connect to the server with a user certificate. For example, in curl:
+
+```
+curl -i https://localhost:2113/streams/%24all --cert user-admin.crt --key user-admin.key
+```
+
+## Creating a user certificate
+
+The user certificate has to meet the following requirements:
+- The certificate has a root CA in common with the node certificate
+- The root CA that they have in common is trusted by the node
+- The CN of the certificate is the same as the username
+- The certificate has the ClientAuth EKU, and not the ServerAuth EKU
+- The certificate must be in date
+- The CN is the username of a user that exists in the database
+
+> Note: User certificates may also be used for the `admin` and `ops` users.
+
+You can generate a user certificate with the [es-gencert-cli](https://github.com/EventStore/es-gencert-cli/pull/23) (currently in a branch):
+
+For example, to generate a user certificate with the username `ouro`:
+
+```
+./es-gencert-cli.exe create-user -username ouro -ca-certificate ca.crt -ca-key ca.key -days 10
+```
+
+The resulting certificate looks like this:
+
+<details>
+    <summary>Example Certificate</summary>
+
+```
+X509 Certificate:
+Version: 3
+Serial Number: 6339e77cacd508002e45cf38418e4f69
+Signature Algorithm:
+    Algorithm ObjectId: 1.2.840.113549.1.1.11 sha256RSA
+    Algorithm Parameters:
+    05 00
+Issuer:
+    CN=EventStoreDB CA f2993c31201bd4bb5a59f3e580d32865
+    O=Event Store Ltd
+    C=UK
+  Name Hash(sha1): cd4323cbb5259cfee1e1e01aaf472552cf18cbf2
+  Name Hash(md5): 993adcf28aa235c593611234e6abc1fc
+
+ NotBefore: 2024-02-26 5:24 PM
+ NotAfter: 2024-03-07 5:24 PM
+
+Subject:
+    CN=ouro
+  Name Hash(sha1): fe1463b6b0edf7f66dd22101c7d1c38f14d1292e
+  Name Hash(md5): f40719c54125d3a27290bb48d6f73b15
+
+Public Key Algorithm:
+    Algorithm ObjectId: 1.2.840.113549.1.1.1 RSA
+    Algorithm Parameters:
+    05 00
+Public Key Length: 2048 bits
+Public Key: UnusedBits = 0
+    0000  30 82 01 0a 02 82 01 01  00 9d 7b f2 25 72 0c b6
+    0010  65 01 02 16 37 60 b9 22  14 04 bf fc 54 b2 e9 6f
+    0020  c7 bc 43 8d c0 ca 3d 55  86 b4 3e 24 88 fc 70 7e
+    0030  f6 f4 38 d3 52 2d 57 a0  48 8e 91 7b f4 10 8b fd
+    0040  95 6b 41 99 d7 9b e4 d9  42 c8 c5 47 5e d1 0c 4c
+    0050  3a 5a ff a3 db ea 0d 11  89 0c 3d 7f fb 9c e5 6c
+    0060  4a 04 e7 f7 48 ff 0f 2f  63 fa be bf f5 f3 76 a1
+    0070  ea 02 27 4c ca 27 82 64  40 b5 ef f6 6f fe f2 02
+    0080  8b 16 ea 45 54 fd ba 80  2c 72 02 d0 14 41 d5 cd
+    0090  db ae 6e 4d 9b 67 60 63  ae 92 ab 2d f4 8b 70 70
+    00a0  d0 4f b1 97 66 71 9b c9  2a 5e 7a e3 d0 f5 0b eb
+    00b0  9e 37 81 09 75 fa 81 d6  3c 9f 6a e6 56 8b 1f 73
+    00c0  d0 61 4c f5 51 16 44 da  dd 3b b1 2b b9 f2 44 94
+    00d0  53 a2 08 5a 8d 4a 4e cb  d7 cb f7 0c ca 7a 1a fb
+    00e0  21 db 00 3e 75 85 c6 d3  95 bd 39 61 d1 ff 89 e7
+    00f0  88 ab b0 58 ff ce e8 d7  19 a9 75 62 dc 98 a8 8f
+    0100  58 31 a7 7c 1d 88 ba 51  5d 02 03 01 00 01
+Certificate Extensions: 5
+    2.5.29.15: Flags = 1(Critical), Length = 4
+    Key Usage
+        Digital Signature, Key Encipherment (a0)
+
+    2.5.29.37: Flags = 0, Length = c
+    Enhanced Key Usage
+        Client Authentication (1.3.6.1.5.5.7.3.2)
+
+    2.5.29.19: Flags = 1(Critical), Length = 2
+    Basic Constraints
+        Subject Type=End Entity
+        Path Length Constraint=None
+
+    2.5.29.14: Flags = 0, Length = 22
+    Subject Key Identifier
+        01fc7f1e364f1767b759dae23d43bbb1cbf2d75deabe605737969489b8de201d
+
+    2.5.29.35: Flags = 0, Length = 24
+    Authority Key Identifier
+        KeyID=5e13f92550df9af08cdab327161ef2d2ef764b77fc4246bc2b172e1d9ed81b2f
+
+Signature Algorithm:
+    Algorithm ObjectId: 1.2.840.113549.1.1.11 sha256RSA
+    Algorithm Parameters:
+    05 00
+Signature: UnusedBits=0
+    0000  8f a4 00 65 f1 a5 53 54  a8 ed de 98 cc 51 f9 1c
+    0010  49 7d f0 7c d6 9f 14 fa  13 b4 db b3 8b 56 59 6a
+    0020  d1 67 a7 e3 21 d5 2d e3  c9 73 9b 09 a9 25 74 35
+    0030  79 16 a2 ce 62 ff fd f1  5e 05 0c b6 29 3d c8 ab
+    0040  1f 7f 87 66 d3 a1 a1 23  7e 11 03 1f 28 eb af d2
+    0050  ac ef 7b 2c 0f b2 18 b4  59 b1 5a ba c9 35 5a b6
+    0060  58 ef 55 4f e7 8c 43 35  1f 22 5c 6d 65 ff 6d 7c
+    0070  af 32 3c b5 ba 00 c4 74  91 73 32 54 22 4c 52 f5
+    0080  de cf f4 ed 71 37 f6 4a  5f 3b ba 37 2c 29 77 9a
+    0090  ad a0 6f c9 a0 26 b3 a6  d3 0c 99 d6 1c f2 f0 b9
+    00a0  29 51 c7 cc 8e 47 2c 04  0f b4 6f aa 09 5b c6 a4
+    00b0  e3 b9 0b 07 3c 49 e6 62  b7 78 3b ff 81 d1 8c 26
+    00c0  3e af 24 ae 01 54 91 33  96 a1 aa 14 05 b4 0a 5b
+    00d0  42 3c 11 f1 f1 2c 93 9d  6d 8b b8 ec eb c6 e5 e7
+    00e0  a4 9a d4 59 fb ff b7 ba  e1 33 c2 f8 09 52 80 c6
+    00f0  95 95 51 35 08 1a 65 41  76 bc c2 62 2b 71 b3 65
+Non-root Certificate
+Key Id Hash(rfc-sha1): 8a3c17e6662711175142740cfeb0f52d2bdd3596
+Key Id Hash(sha1): 87a30feaaeabd616f4dad92a9f1b44a43e2d0b52
+Subject Key Id (precomputed): 01fc7f1e364f1767b759dae23d43bbb1cbf2d75deabe605737969489b8de201d
+Key Id Hash(bcrypt-sha1): b808b4e710e4f6f158a837155838a295cfbb17bf
+Key Id Hash(bcrypt-sha256): eaf799bb5f3d57dbb3afc0f5357a8723574c8c254bf159fce1c95d76f6085ae5
+Key Id Hash(md5): fbb024d546e2039af7f3e01c71278313
+Key Id Hash(sha256): ca10f7cb5af9bf9dff8f2ad43c3cbdb0647da1173631018cb8551812c425d575
+Key Id Hash(pin-sha256): MZu7Waanp4kbJ/Hx3/tpgMb6L3GnXB3PrMY+9MDBmSg=
+Key Id Hash(pin-sha256-hex): 319bbb59a6a7a7891b27f1f1dffb6980c6fa2f71a75c1dcfacc63ef4c0c19928
+Cert Hash(md5): 1719850bd6f5f09c3610e4c33d13f7c2
+Cert Hash(sha1): 12c5293973bda1df2c74ab280d492135171c8ab6
+Cert Hash(sha256): a37767096f10697fb0fcf94a3872d0984aeed4754a295c5320679876e00def32
+Signature Hash: 6d922badaba2372070f13c69b620286262eab1d8d2d2156a271a1d73aaaf64e4
+```
+
+</details>
+
+
+## Restrictions
+
+There is currently a limitation with this plugin that requests authenticated with user certificates cannot be forwarded between nodes.
+
+This affects Writes, Persistent Subscription operations, and Projections operations. These requests will need to be performed on the Leader node only.
+
+The User Certificates plugin cannot be used alongside any of the other authentication plugins, such as the LDAPS plugin or the OAuth plugin.
+
+## Troubleshooting
+
+### Plugin not loaded
+The plugin has to be located in a subdirectory of the server's `plugins` directory.
+To check this:
+1. Go to the installation directory of the server, the directory containing the EventStoreDb executable.
+1. In this directory there should be a directoy called `plugins`, create it if this is not the case.
+1. The `plugins` directory should have a subdirectoy for the plugin, for instance called `EventStore.Auth.UserCertificates` but this could be any name. Create it if it doesn't exist.
+1. The binaries of the plugin should be located in the subdirectory which was checked in the previous step.
+
+You can verify which plugins have been found and loaded by looking for the following logs:
+
+```
+[12824, 1,17:30:04.921,INF] Plugins path: "C:\eventstoredb-24.2.0-rc.1-ce-windows.x64\plugins"
+[12824, 1,17:30:04.922,INF] Adding: "C:\eventstoredb-24.2.0-rc.1-ce-windows.x64\plugins" to the plugin catalog.
+[12824, 1,17:30:04.924,INF] Adding: "C:\eventstoredb-24.2.0-rc.1-ce-windows.x64\plugins\EventStore.Auth.UserCertificates" to the plugin catalog.
+[12824, 1,17:30:05.253,INF] Loaded SubsystemsPlugin plugin: "user-certificates" "24.2.0.1".
+```
+
+### Plugin not started
+The plugin has to be configured to start in order to authenticate user requests.
+
+If you see the following log it means the plugin was found but was not started:
+
+```
+[28056, 1,11:44:52.441,INF] UserCertificatesPlugin is not enabled
+```
+
+Ensure the plugin is enabled in the EventStoreDB configuration.
+
+When the plugin starts correctly you should see the following log:
+
+```
+[13260, 8,13:59:10.445,INF] UserCertificatesPlugin: user X.509 certificate authentication is enabled
+```
+
+### The plugin is enabled but the user is not authenticated
+If the plugin has been enabled but you are still getting access denied errors, check the following:
+
+1. The user exists and is enabled in the EventStoreDB database. Can you log in with the username and password?
+1. The user certificate is valid, and has a valid chain up to a trusted root CA.
+1. The user certificate and node certificate share a common root CA.
+1. Use 'requires leader' (which is the default) in your client configuration to rule out issues with forwarding requests.

--- a/src/EventStore.Auth.UserCertificates/UserCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Auth.UserCertificates/UserCertificateAuthenticationProvider.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+
+namespace EventStore.Auth.UserCertificates;
+
+public class UserCertificateAuthenticationProvider(
+	IAuthenticationProvider authenticationProvider,
+	Func<(X509Certificate2 Node, X509Certificate2Collection Intermediates, X509Certificate2Collection Roots)> getCertificates,
+	IConfiguration configuration) :
+	IHttpAuthenticationProvider {
+
+	private static readonly ILogger Logger = Log.ForContext<UserCertificateAuthenticationProvider>();
+	private readonly bool _logFailedAuthenticationAttempts = configuration.GetValue<bool>(
+		$"{UserCertificatesPlugin.KurrentConfigurationPrefix}:LogFailedAuthenticationAttempts");
+
+	public string Name => "user-certificate";
+
+	public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
+		return AuthenticateCached(context, out request);
+	}
+
+	private bool AuthenticateCached(HttpContext context, out HttpAuthenticationRequest request) {
+		// we cache the authentication result as the same TLS connection may be used for multiple HTTP requests.
+		// performance aside, the cache also ensures that authentication requests that were successful in the past
+		// will succeed in the future for the same TLS connection even if certificates are rotated.
+
+		request = null;
+
+		// if the connection doesn't have a client certificate, take a shortcut
+		var clientCertificate = context.Connection.ClientCertificate;
+		if (clientCertificate is null)
+			return false;
+
+		bool authenticated;
+		string userId;
+
+		var connectionItems = context.Features.Get<IConnectionItemsFeature>()?.Items;
+		const string connectionItemsKey = "UserCertificateAuthenticationStatus";
+		if (TryGetDictionaryValue(connectionItems, connectionItemsKey, out var cached)) {
+			(authenticated, userId) = ((bool, string)) cached;
+		} else {
+			authenticated = AuthenticateUncached(context, clientCertificate, out userId);
+			TrySetDictionaryValue(connectionItems, connectionItemsKey, (authenticated, userId));
+		}
+
+		// todo: consider not falling through if we have a cert but fail to authenticate it
+		if (!authenticated)
+			return false;
+
+		if (!IsTimeValid(clientCertificate, userId))
+			return false;
+
+		request = HttpAuthenticationRequest.CreateWithValidCertificate(context, userId, clientCertificate);
+		authenticationProvider.Authenticate(request);
+
+		return true;
+	}
+
+	private bool IsTimeValid(X509Certificate2 clientCertificate, string userId) {
+		var now = DateTime.Now;
+
+		if (now < clientCertificate.NotBefore) {
+			if (_logFailedAuthenticationAttempts)
+				Logger.Warning("Connection from user: {user} was denied because its certificate's effective start time hasn't been reached yet.", userId);
+			return false;
+		}
+
+		if (now > clientCertificate.NotAfter) {
+			if (_logFailedAuthenticationAttempts)
+				Logger.Warning("Connection from user: {user} was denied because its certificate has expired.", userId);
+			return false;
+		}
+
+		return true;
+	}
+
+	private static bool TryGetDictionaryValue(IDictionary<object, object> dictionary, string key, out object value) {
+		if (dictionary == null) {
+			value = null;
+			return false;
+		}
+
+		lock (dictionary) {
+			return dictionary.TryGetValue(key, out value);
+		}
+	}
+
+	private static bool TrySetDictionaryValue(IDictionary<object, object> dictionary, string key, object value) {
+		if (dictionary == null)
+			return false;
+
+		lock (dictionary) {
+			return dictionary.TryAdd(key, value);
+		}
+	}
+
+	private bool AuthenticateUncached(HttpContext context, X509Certificate2 clientCertificate, out string userId) {
+		userId = null;
+
+		if (!clientCertificate.IsClientCertificate(out _))
+			return false;
+
+		if (clientCertificate.IsServerCertificate(out _))
+			return false;
+
+		userId = clientCertificate.GetCommonName();
+
+		// currently, we restrict user certificates to have the same root CA as the node certificate
+		// however, this may not suit all use cases and can be expanded later based on feedback from users.
+		if (!HasSameRootAsNodeCertificate(clientCertificate)) {
+			if (_logFailedAuthenticationAttempts)
+				Logger.Warning("Connection from user: {user} was denied because its certificate's root CA does not match with the node's certificate's root CA", userId);
+			return false;
+		}
+
+		return true;
+	}
+
+	private bool HasSameRootAsNodeCertificate(X509Certificate2 user) {
+		var (node, intermediates, roots) = getCertificates();
+		var shareARoot = CertificateUtils.ShareARoot(
+			certificate1: user,
+			certificate2: node,
+			intermediates: intermediates,
+			roots: roots,
+			out var userRoots,
+			out var nodeRoots);
+
+		Logger.Verbose("User certificate's root CA thumbprint(s): {roots}", string.Join(",", userRoots));
+		Logger.Verbose("Node certificate's root CA thumbprint(s): {roots}", string.Join(",", nodeRoots));
+
+		return shareARoot;
+	}
+}

--- a/src/EventStore.Auth.UserCertificates/UserCertificatesPlugin.cs
+++ b/src/EventStore.Auth.UserCertificates/UserCertificatesPlugin.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Plugins;
+using EventStore.Plugins.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
+namespace EventStore.Auth.UserCertificates;
+
+public class UserCertificatesPlugin : SubsystemsPlugin {
+	public const string KurrentConfigurationPrefix = "KurrentDB";
+	private static readonly ILogger _staticLogger = Log.ForContext<UserCertificatesPlugin>();
+	private readonly ILogger _logger;
+
+	private const string AnonymousProvider = "anonymous";
+
+	public UserCertificatesPlugin() : this(_staticLogger) {
+	}
+
+	public UserCertificatesPlugin(ILogger logger)
+		: base(
+			requiredEntitlements: ["USER_CERTIFICATES"]) {
+
+		_logger = logger;
+	}
+
+	public override (bool Enabled, string EnableInstructions) IsEnabled(IConfiguration configuration) {
+		var enabled = configuration.GetValue($"{KurrentConfigurationPrefix}:UserCertificates:Enabled", defaultValue: false);
+		return (enabled, $"Set '{KurrentConfigurationPrefix}:UserCertificates:Enabled' to 'true' to enable user X.509 certificate authentication");
+	}
+
+	public override void ConfigureServices(IServiceCollection services, IConfiguration configuration) {
+		services
+			.AddSingleton<UserCertificateAuthenticationProvider>()
+			.Decorate<IReadOnlyList<IHttpAuthenticationProvider>>(Decorate);
+	}
+
+	// inject the user certificate authentication provider just before the anonymous provider -
+	// its order w.r.t the node certificate authentication provider is unimportant because they accept disjoint sets of certificates
+	private IReadOnlyList<IHttpAuthenticationProvider> Decorate(
+		IReadOnlyList<IHttpAuthenticationProvider> authProviders,
+		IServiceProvider serviceProvider) {
+
+		var authenticationProvider = serviceProvider.GetRequiredService<IAuthenticationProvider>();
+		if (!authenticationProvider.GetSupportedAuthenticationSchemes().Contains("UserCertificate")) {
+			_logger.Information($"{nameof(UserCertificatesPlugin)} is not compatible with the current authentication provider");
+			return authProviders;
+		}
+
+		var newAuthProviders = authProviders.ToList();
+		var anonymousProviderIndex = newAuthProviders.FindIndex(x => x.Name == AnonymousProvider);
+
+		if (anonymousProviderIndex == -1) {
+			_logger.Error($"{nameof(UserCertificatesPlugin)} failed to load as the conditions required to load the plugin were not met");
+			return authProviders;
+		}
+
+		var userCertAuthProvider = serviceProvider.GetService<UserCertificateAuthenticationProvider>();
+		newAuthProviders.Insert(anonymousProviderIndex, userCertAuthProvider);
+
+		_logger.Information($"{nameof(UserCertificatesPlugin)}: user X.509 certificate authentication is enabled");
+		return newAuthProviders;
+	}
+}

--- a/src/EventStore.Auth.UserCertificates/user-certificates-plugin-example.json
+++ b/src/EventStore.Auth.UserCertificates/user-certificates-plugin-example.json
@@ -1,0 +1,7 @@
+{
+  "KurrentDB": {
+    "UserCertificates": {
+      "Enabled": true
+    }
+  }
+}

--- a/src/EventStore.Auth.UserCertificates/user-certificates-plugin-example.yaml
+++ b/src/EventStore.Auth.UserCertificates/user-certificates-plugin-example.yaml
@@ -1,0 +1,2 @@
+UserCertificates:
+  Enabled: true

--- a/src/EventStore.AutoScavenge.Tests/ClusterFixtures.cs
+++ b/src/EventStore.AutoScavenge.Tests/ClusterFixtures.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Bogus;
+using EventStore.AutoScavenge.Domain;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class ClusterFixtures {
+	public static readonly Faker<ClusterMember> ClusterMembers =
+		new Faker<ClusterMember>()
+			.RuleFor(m => m.InstanceId, f => f.Random.Guid())
+			.RuleFor(m => m.State, _ => "Follower")
+			.RuleFor(m => m.InternalHttpEndPointIp, f => f.Internet.Ip())
+			.RuleFor(m => m.InternalHttpEndPointPort, f => f.Random.Int(1_024, 65_535))
+			.RuleFor(m => m.IsAlive, f => f.Random.Bool())
+			.RuleFor(m => m.WriterCheckpoint, f => f.Random.Long(0, 8_192));
+
+	public static Dictionary<Guid, ClusterMember> Generate3NodesCluster() {
+		var members = ClusterMembers.Generate(3);
+
+		long maxWriterCheckpoint = 0;
+		ClusterMember? leader = null;
+
+		foreach (var member in members) {
+			if (member.WriterCheckpoint <= maxWriterCheckpoint)
+				continue;
+
+			leader = member;
+			maxWriterCheckpoint = member.WriterCheckpoint;
+		}
+
+		leader!.State = "Leader";
+
+		Assert.Single(members.Where(m => m.State == "Leader"));
+		Assert.Equal(leader.WriterCheckpoint, members.Max(m => m.WriterCheckpoint));
+
+		return members.ToDictionary(m => m.InstanceId);
+	}
+
+	public static Dictionary<Guid, ClusterMember> Generate3NodesClusterWith2RoRs() {
+		var members = ClusterMembers.Generate(5);
+
+		long maxWriterCheckpoint = 0;
+		ClusterMember? leader = null;
+
+		foreach (var member in members) {
+			if (member.WriterCheckpoint <= maxWriterCheckpoint)
+				continue;
+
+			leader = member;
+			maxWriterCheckpoint = member.WriterCheckpoint;
+		}
+
+		leader!.State = "Leader";
+
+		var rorCount = 0;
+		foreach (var member in members) {
+			if (member.InstanceId == leader.InstanceId)
+				continue;
+
+			member.IsReadOnlyReplica = true;
+			rorCount++;
+			if (rorCount >= 2)
+				break;
+		}
+
+		Assert.Equal(2, members.Count(m => m.IsReadOnlyReplica));
+		Assert.Single(members.Where(m => m.State == "Leader"));
+		Assert.Equal(leader.WriterCheckpoint, members.Max(m => m.WriterCheckpoint));
+
+		return members.ToDictionary(m => m.InstanceId);
+	}
+
+	public static NodeId GenerateNodeId(int nodeNumber) =>
+		new($"https://node{nodeNumber}", 2113);
+
+	public static ClusterMember GenerateSingleNode() {
+		var node = ClusterMembers.Generate(1).Single()!;
+		node.State = "Leader";
+		return node;
+	}
+
+	public static ClusterMember GetLeader(IEnumerable<ClusterMember> members) {
+		return members.Single(m => m.State == "Leader");
+	}
+
+	// Returns the first follower we found in the cluster.
+	public static ClusterMember GetFollower(IEnumerable<ClusterMember> members) {
+		return members.First(m => m.State == "Follower");
+	}
+
+	// FIXME: This approach won't work if another node is on part with the leader. We ought to prioritize the follower
+	// node in that case.
+	public static ClusterMember GetFarthestNodeInReplication(IEnumerable<ClusterMember> members) {
+		return members.OrderBy(m => m.WriterCheckpoint).First();
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/Command.cs
+++ b/src/EventStore.AutoScavenge.Tests/Command.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public static class Command {
+	public static ICommand FastForward(TimeSpan time) => new SimulatorCommands.FastForward(time);
+	public static ICommand ReceiveGossip(Guid nodeId, List<ClusterMember> members) =>
+		new Commands.ReceiveGossip(new GossipMessage { NodeId = nodeId, Members = members });
+
+	public static ICommand Configure(CrontabSchedule schedule, Action<Response<Unit>>? callback = null) =>
+		new Commands.Configure(schedule, resp => callback?.Invoke(resp));
+
+	public static ICommand Suspend { get; } = new SimulatorCommands.Suspend();
+
+	public static ICommand PauseProcess(Action<Response<Unit>> callback) =>
+		new Commands.PauseProcess(callback);
+
+	public static ICommand ResumeProcess(Action<Response<Unit>> callback) =>
+		new Commands.ResumeProcess(callback);
+
+	public static ICommand GetStatus(TaskCompletionSource<Response<AutoScavengeStatusResponse>> source) =>
+		new Commands.GetStatus(source.SetResult);
+}

--- a/src/EventStore.AutoScavenge.Tests/ConfigurationTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/ConfigurationTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Core.Configuration.Sources;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class ConfigurationTests {
+	public enum EnabledStatus {
+		True,
+		False,
+		Exception,
+	}
+
+	[Theory]
+	[InlineData("true", "true", EnabledStatus.Exception)]
+	[InlineData("true", "false", EnabledStatus.True)]
+	[InlineData("", "true", EnabledStatus.False)]
+	[InlineData("", "false", EnabledStatus.True)]
+	[InlineData("false", "true", EnabledStatus.False)]
+	[InlineData("false", "false", EnabledStatus.False)]
+	public void enables_correctly_according_to_configuration(string enabledValue, string devModeValue, EnabledStatus expected) {
+		var startup = new DummyStartup(
+			new ConfigurationBuilder()
+				.AddInMemoryCollection([
+					new($"{KurrentConfigurationKeys.Prefix}:AutoScavenge:Enabled", enabledValue),
+					new($"{KurrentConfigurationKeys.Prefix}:Dev", devModeValue),
+				])
+				.Build());
+
+		var sut = startup.AutoScavengePlugin;
+
+		var builder = WebApplication.CreateBuilder();
+
+		void When() {
+			startup.ConfigureServices(builder.Services);
+			startup.Configure(builder.Build());
+		}
+
+		if (expected == EnabledStatus.Exception) {
+			Assert.Throws<Exception>(When);
+		} else {
+			When();
+
+			if (expected == EnabledStatus.True) {
+				Assert.True(sut.Enabled);
+			} else if (expected == EnabledStatus.False) {
+				Assert.False(sut.Enabled);
+			}
+		}
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/CrashTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/CrashTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using EventStore.POC.IO.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class CrashTests: IClassFixture<DummyWebApplicationFactory> {
+	private readonly HttpClient _client;
+
+	public CrashTests(DummyWebApplicationFactory factory) {
+		_client = factory.CreateClient();
+		((DummyClient)factory.Services.GetRequiredService<IClient>()).BeNaughty = true;
+	}
+
+	[Fact]
+	public async Task ShouldReturnResponseEvenWhenCrashing() {
+		var attempt = 0;
+		HttpResponseMessage resp;
+		HttpRequestMessage msg;
+
+		// We make sure the server is ready to accept configure request first.
+		do {
+			msg = new HttpRequestMessage(HttpMethod.Get, "/auto-scavenge/status");
+			msg.Headers.Authorization =
+				new AuthenticationHeaderValue("dummy", Convert.ToBase64String("ouro:changeit"u8.ToArray()));
+			resp = await _client.SendAsync(msg);
+			attempt++;
+
+			var code = (int)resp.StatusCode;
+			if (code < 500)
+				break;
+			await Task.Delay(TimeSpan.FromSeconds(1));
+		} while (attempt < 30);
+
+		resp.EnsureSuccessStatusCode();
+
+		msg = new HttpRequestMessage(HttpMethod.Post, "/auto-scavenge/configure");
+		msg.Headers.Authorization =
+			new AuthenticationHeaderValue("dummy", Convert.ToBase64String("ouro:changeit"u8.ToArray()));
+		msg.Content = JsonContent.Create(new JsonObject {
+			["schedule"] = "* * * * 1",
+		});
+
+
+		resp = await _client.SendAsync(msg);
+		Assert.Equal(HttpStatusCode.InternalServerError, resp.StatusCode);
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/DummyAuthHandler.cs
+++ b/src/EventStore.AutoScavenge.Tests/DummyAuthHandler.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class DummyAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions> {
+	private static readonly Claim[] AdminClaims = new[] {
+		new Claim(ClaimTypes.Name, "ouro"),
+		new Claim(ClaimTypes.Role, "$admins")
+	};
+
+	private static readonly Claim[] UserClaims = new[] {
+		new Claim(ClaimTypes.Name, "johndoe"),
+	};
+
+	public DummyAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger,
+		UrlEncoder encoder) : base(options, logger, encoder) {
+	}
+
+	protected override Task<AuthenticateResult> HandleAuthenticateAsync() {
+		try {
+			if (!Request.Headers.TryGetValue("Authorization", out var authHeader))
+				return Task.FromResult(AuthenticateResult.Fail("Missing Authorization Header"));
+
+			var authHeaderVal = AuthenticationHeaderValue.Parse(authHeader!);
+
+			if (authHeaderVal.Scheme.Equals("dummy", StringComparison.OrdinalIgnoreCase)) {
+				var credentials = Encoding.UTF8
+					.GetString(Convert.FromBase64String(authHeaderVal.Parameter!))
+					.Split(':');
+
+				if (credentials.Length == 2) {
+					var username = credentials[0];
+					var password = credentials[1];
+
+					if (username == "ouro" && password == "changeit") {
+						var identity = new ClaimsIdentity(AdminClaims, Scheme.Name);
+						var principal = new ClaimsPrincipal(identity);
+						var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+						return Task.FromResult(AuthenticateResult.Success(ticket));
+					}
+
+					if (username == "johndoe" && password == "1234") {
+						var identity = new ClaimsIdentity(UserClaims, Scheme.Name);
+						var principal = new ClaimsPrincipal(identity);
+						var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+						return Task.FromResult(AuthenticateResult.Success(ticket));
+					}
+				}
+			}
+		} catch {
+			return Task.FromResult(AuthenticateResult.Fail("invalid authorization header"));
+		}
+
+		return Task.FromResult(AuthenticateResult.Fail("invalid username or password"));
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/DummyClient.cs
+++ b/src/EventStore.AutoScavenge.Tests/DummyClient.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json;
+using EventStore.POC.IO.Core;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class DummyClient : IClient {
+	private long _count;
+	public bool BeNaughty { get; set; }
+
+	public Task WriteMetaDataMaxCountAsync(string stream, CancellationToken cancellationToken) {
+		return Task.CompletedTask;
+	}
+
+	public Task<long> WriteAsync(string stream, EventToWrite[] events, long expectedVersion, CancellationToken cancellationToken) {
+		if (BeNaughty)
+			throw new Exception("CrowdStrike !");
+
+		return Task.FromResult(_count++);
+	}
+
+	public IAsyncEnumerable<Event> SubscribeToAll(FromAll start, CancellationToken cancellationToken) {
+		return AsyncEnumerable.Empty<Event>();
+	}
+
+	public IAsyncEnumerable<Event> SubscribeToStream(string stream, CancellationToken cancellationToken) {
+		if (stream != "$mem-gossip")
+			return AsyncEnumerable.Empty<Event>();
+
+		var id = Guid.NewGuid();
+		var gossip = new GossipMessage {
+			NodeId = id,
+			Members = [ new ClusterMember {
+					InstanceId = id,
+					State = "Leader",
+					IsAlive = true,
+					InternalHttpEndPointIp = "foobar",
+					InternalHttpEndPointPort = 42,
+					WriterCheckpoint = 0,
+					IsReadOnlyReplica = false
+				}
+			]
+		};
+
+		return AsyncEnumerable.ToAsyncEnumerable([
+			new Event(Guid.NewGuid(), DateTime.Now, "$mem-gossip", 0, "$gossip", "application/json", 0, 0, false,
+				JsonSerializer.SerializeToUtf8Bytes(gossip), Array.Empty<byte>())
+		]);
+	}
+
+	public IAsyncEnumerable<Event> ReadStreamForwards(string stream, long maxCount, CancellationToken cancellationToken) {
+		return AsyncEnumerable.Empty<Event>();
+	}
+
+	public IAsyncEnumerable<Event> ReadStreamBackwards(string stream, long maxCount, CancellationToken cancellationToken) {
+		return AsyncEnumerable.Empty<Event>();
+	}
+
+	public IAsyncEnumerable<Event> ReadAllBackwardsAsync(Position position, long maxCount, CancellationToken cancellationToken) {
+		throw new NotImplementedException();
+	}
+
+	public Task DeleteStreamAsync(string stream, long expectedVersion, CancellationToken cancellationToken) {
+		throw new NotImplementedException();
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/DummyNodeHttpClientFactory.cs
+++ b/src/EventStore.AutoScavenge.Tests/DummyNodeHttpClientFactory.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class DummyNodeHttpClientFactory : INodeHttpClientFactory {
+	public HttpClient CreateHttpClient(string[] additionalCertificateNames) => new();
+}

--- a/src/EventStore.AutoScavenge.Tests/DummyOperationClient.cs
+++ b/src/EventStore.AutoScavenge.Tests/DummyOperationClient.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.POC.IO.Core;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class DummyOperationClient : IOperationsClient {
+	public void Resign() {
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/DummyStartup.cs
+++ b/src/EventStore.AutoScavenge.Tests/DummyStartup.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Reactive.Subjects;
+using EventStore.Core.Bus;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
+using EventStore.Plugins;
+using EventStore.Plugins.Licensing;
+using EventStore.POC.ConnectedSubsystemsPlugin;
+using EventStore.POC.IO.Core;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class DummyStartup {
+	private const string LicenseToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJlc2RiIiwiaXNzIjoiZXNkYiIsImV4cCI6MTgyNDQ1NjgyOCwianRpIjoiMTU3NDk2N2MtMmVkNC00OGZhLWIyNjItYTdhMGQzYTA1NTczIiwic3ViIjoiRVNEQiBUZXN0cyIsIklzVHJpYWwiOiJUcnVlIiwiSXNFeHBpcmVkIjoiRmFsc2UiLCJJc1ZhbGlkIjoiVHJ1ZSIsIklzRmxvYXRpbmciOiJUcnVlIiwiRGF5c1JlbWFpbmluZyI6IjEiLCJTdGFydERhdGUiOiIyNi8wNC8yMDI0IDAwOjAwOjAwICswMTowMCIsIkFVVE9fU0NBVkVOR0UiOiJ0cnVlIiwiaWF0IjoxNzI5ODQ4ODI4LCJuYmYiOjE3Mjk4NDg4Mjh9.jaQ58MxlqM2oORJw9bWJzvdTzwWxFeo-624SMN52Rm2j6HLvWsT2_jFTb_Xi-rXmP1C7KlJCQEMhksV_5QdsiRi37oao1fcxfywOBHQkPMqx2Hd1CMWq1_DAY0az12fRSrR9h3L_yIiez2coRNFKkc5mZSq2KHoZre0WWXbMUDL1RheG1KNTxL2qBelyYVMYRZ7lXfsUpgzahOTR36QTtWYETBbtzik8ZujINhYGUhqbGLtGO3Ad3kTqPQVB6MMDNgE6F-ZHLMrXPR08fJNYrkxcB8WoSbelzPduPN6tMJeyn1e6jYO3oOUBZZsD2tdX_Pai1qw4fiZlZlPycbYOBQ";
+	public ConnectedSubsystemsPlugin ConnectedPlugin { get; init; } = new();
+	public AutoScavengePlugin AutoScavengePlugin { get; init; } = new();
+	public FakeLicenseService LicenseService { get; init; } = new FakeLicenseService(LicenseToken);
+
+	public DummyStartup(IConfiguration configuration) {
+		Configuration = configuration;
+	}
+
+	public IConfiguration Configuration { get; }
+
+	public void ConfigureServices(IServiceCollection services) {
+		services.AddControllers();
+		services.AddAuthentication("dummy")
+			.AddScheme<AuthenticationSchemeOptions, DummyAuthHandler>("dummy", null);
+
+		services.AddSingleton<ILicenseService>(LicenseService);
+		services.AddSingleton<INodeHttpClientFactory, DummyNodeHttpClientFactory>();
+		services.AddSingleton<IClient, DummyClient>();
+		services.AddSingleton<IOperationsClient, DummyOperationClient>();
+		((IPlugableComponent)AutoScavengePlugin).ConfigureServices(services, Configuration);
+		services.AddSingleton(AutoScavengePlugin);
+	}
+
+	public void Configure(IApplicationBuilder app) {
+		app.UseRouting();
+		app.UseAuthentication();
+		app.UseAuthorization();
+
+		ConnectedPlugin.ConfigureApplication(app, Configuration);
+		((IPlugableComponent)AutoScavengePlugin).ConfigureApplication(app, Configuration);
+	}
+
+	class FakePublisher : IPublisher {
+		public void Publish(Message message) {
+			// No-op
+		}
+	}
+
+	public class FakeLicenseService : ILicenseService {
+		readonly BehaviorSubject<License> _licenseSubject;
+
+		public FakeLicenseService(string token) {
+			SelfLicense = new License(new(token));
+			CurrentLicense = SelfLicense; // they wouldn't normally be the same
+			_licenseSubject = new BehaviorSubject<License>(CurrentLicense);
+		}
+
+		public License SelfLicense { get; }
+
+		public License? CurrentLicense { get; }
+
+		public IObservable<License> Licenses => _licenseSubject;
+
+		public void RejectLicense(Exception ex) {
+		}
+
+		public void EmitLicense(License x) {
+			_licenseSubject.OnNext(x);
+		}
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/DummyWebApplicationFactory.cs
+++ b/src/EventStore.AutoScavenge.Tests/DummyWebApplicationFactory.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Core.Configuration.Sources;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class DummyWebApplicationFactory : WebApplicationFactory<DummyStartup>, IAsyncLifetime {
+	protected override void ConfigureWebHost(IWebHostBuilder builder) {
+		builder.UseContentRoot(Directory.GetCurrentDirectory());
+		builder.ConfigureAppConfiguration((_, config) => {
+			config.AddInMemoryCollection(new Dictionary<string, string?> {
+				{ $"{KurrentConfigurationKeys.Prefix}:AutoScavenge:Enabled", "true" },
+				{ $"{KurrentConfigurationKeys.Prefix}:ClusterSize", "1" },
+				{ $"{KurrentConfigurationKeys.Prefix}:Insecure", "true" },
+			});
+		});
+	}
+
+	protected override IHostBuilder CreateHostBuilder() {
+		return Host.CreateDefaultBuilder()
+			.ConfigureWebHostDefaults(builder => {
+				builder.UseStartup<DummyStartup>();
+			});
+	}
+
+	public async Task InitializeAsync() {
+		await Services.GetRequiredService<AutoScavengePlugin>().Start();
+	}
+
+	async Task IAsyncLifetime.DisposeAsync() {
+		await Services.GetRequiredService<AutoScavengePlugin>().Stop();
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/EventStore.AutoScavenge.Tests.csproj
+++ b/src/EventStore.AutoScavenge.Tests/EventStore.AutoScavenge.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Bogus" Version="35.5.1" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit" Version="2.5.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.AutoScavenge\EventStore.AutoScavenge.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/EventStore.AutoScavenge.Tests/FakeAutoScavengeClient.cs
+++ b/src/EventStore.AutoScavenge.Tests/FakeAutoScavengeClient.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Clients;
+using EventStore.AutoScavenge.Domain;
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class FakeAutoScavengeClient : IAutoScavengeClient {
+	public ICommand? Command { get; private set; }
+
+	public Task<Response<AutoScavengeStatusResponse>> GetStatus(CancellationToken token) {
+		Command = new Commands.GetStatus(_ => {});
+		return Task.FromResult(Response.Successful(new AutoScavengeStatusResponse(AutoScavengeStatusResponse.Status.NotConfigured, null, null)));
+	}
+
+	public Task<Response<Unit>> Pause(CancellationToken token) {
+		Command = new Commands.PauseProcess(_ => { });
+		return Task.FromResult(Response.Accepted());
+	}
+
+	public Task<Response<Unit>> Resume(CancellationToken token) {
+		Command = new Commands.ResumeProcess(_ => { });
+		return Task.FromResult(Response.Accepted());
+	}
+
+	public Task<Response<Unit>> Configure(CrontabSchedule schedule, CancellationToken token) {
+		Command = new Commands.Configure(schedule, _ => { });
+		return Task.FromResult(Response.Accepted());
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/FakeClient.cs
+++ b/src/EventStore.AutoScavenge.Tests/FakeClient.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Runtime.CompilerServices;
+using EventStore.POC.IO.Core;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class FakeClient : IClient {
+	private readonly Dictionary<string, List<Event>> _streams = new();
+
+	public async IAsyncEnumerable<Event> ReadStreamForwards(string stream, long maxCount, [EnumeratorCancellation] CancellationToken ct) {
+		if (!_streams.TryGetValue(stream, out var events))
+			yield break;
+
+		var count = 0L;
+		for (var i = 0; i < events.Count; i++) {
+			ct.ThrowIfCancellationRequested();
+			yield return events[i];
+			count++;
+
+			if (count >= maxCount)
+				break;
+		}
+
+		await Task.Delay(TimeSpan.Zero, ct);
+	}
+
+	public async IAsyncEnumerable<Event> ReadStreamBackwards(string stream, long maxCount, [EnumeratorCancellation] CancellationToken ct) {
+		if (!_streams.TryGetValue(stream, out var events))
+			yield break;
+
+		var count = 0L;
+		for (var i = events.Count - 1; i >= 0; i--) {
+			ct.ThrowIfCancellationRequested();
+			yield return events[i];
+			count++;
+
+			if (count >= maxCount)
+				break;
+		}
+
+		await Task.Delay(TimeSpan.Zero, ct);
+	}
+
+	public void AddEvent(string stream, IEvent @event, ReadOnlyMemory<byte> data) {
+		if (!_streams.TryGetValue(stream, out var events)) {
+			events = new List<Event>();
+			_streams[stream] = events;
+		}
+
+		events.Add(new Event(
+			eventId: Guid.Empty,
+			created: DateTime.Now,
+			stream: stream,
+			eventNumber: 0,
+			eventType: @event.Type,
+			contentType: string.Empty,
+			commitPosition: 0,
+			preparePosition: 0,
+			isRedacted: false,
+			data: data,
+			metadata: Array.Empty<byte>()));
+	}
+
+	public Task WriteMetaDataMaxCountAsync(string stream, CancellationToken cancellationToken) =>
+		throw new NotSupportedException();
+
+	public Task<long> WriteAsync(string stream, EventToWrite[] events, long expectedVersion, CancellationToken cancellationToken) =>
+		throw new NotSupportedException();
+
+	public IAsyncEnumerable<Event> SubscribeToAll(FromAll start, CancellationToken cancellationToken) =>
+		throw new NotSupportedException();
+
+	public IAsyncEnumerable<Event> ReadAllBackwardsAsync(Position position, long maxCount, CancellationToken cancellationToken) =>
+		throw new NotSupportedException();
+
+	public Task DeleteStreamAsync(string stream, long expectedVersion, CancellationToken cancellationToken) =>
+		throw new NotSupportedException();
+
+	public IAsyncEnumerable<Event> SubscribeToStream(string stream, CancellationToken cancellationToken) =>
+		throw new NotSupportedException();
+}

--- a/src/EventStore.AutoScavenge.Tests/FakeOperationsClient.cs
+++ b/src/EventStore.AutoScavenge.Tests/FakeOperationsClient.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.POC.IO.Core;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class FakeOperationsClient : IOperationsClient {
+	public bool ResignationIssued { get; private set; }
+	public void Resign() {
+		ResignationIssued = true;
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/FakeScavenger.cs
+++ b/src/EventStore.AutoScavenge.Tests/FakeScavenger.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Scavengers;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class FakeScavenger : INodeScavenger {
+	public Dictionary<Guid, ScavengingNode> Scavenges { get; } = new();
+
+	public bool Enabled { get; set; } = true;
+	public bool Pausable { get; set; } = true;
+
+	public Task<Guid?> TryStartScavengeAsync(string host, int port, CancellationToken token) {
+		if (!Enabled)
+			return Task.FromResult<Guid?>(null);
+
+		var scavengeId = Guid.NewGuid();
+
+		Scavenges.Add(scavengeId, new ScavengingNode {
+			ScavengeId = scavengeId,
+			Host = host,
+			Port = port,
+		});
+
+		return Task.FromResult((Guid?)scavengeId);
+	}
+
+	public Task<ScavengeStatus> TryGetScavengeAsync(string host, int port, Guid scavengeId, CancellationToken token) {
+		return Task.FromResult(Scavenges[scavengeId].Status);
+	}
+
+	public Task<bool> TryPauseScavengeAsync(string host, int port, Guid? scavengeId, CancellationToken token) {
+		if (!Pausable)
+			return Task.FromResult(false);
+
+		if (scavengeId is null) {
+			if (Scavenges.Count == 1) {
+				scavengeId = Scavenges.Single().Key;
+			} else {
+				return Task.FromResult(true);
+			}
+		}
+
+		Scavenges[scavengeId.Value].Status = ScavengeStatus.Stopped;
+		return Task.FromResult(true);
+	}
+
+	public void SetScavengeStatus(Guid scavengeId, ScavengeStatus status) {
+		Scavenges[scavengeId].Status = status;
+	}
+
+	public void RegisterScavengeFor(Guid scavengeId, ClusterMember member, ScavengeStatus status) {
+		Scavenges.Add(scavengeId, new ScavengingNode {
+			ScavengeId = scavengeId,
+			Host = member.InternalHttpEndPointIp,
+			Port = member.InternalHttpEndPointPort,
+			Status = status,
+		});
+	}
+
+	public class ScavengingNode {
+		public Guid ScavengeId { get; init; } = Guid.Empty;
+		public string Host { get; init; } = string.Empty;
+		public int Port { get; init; }
+		public ScavengeStatus Status { get; set; }
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/FakeSource.cs
+++ b/src/EventStore.AutoScavenge.Tests/FakeSource.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text;
+using System.Text.Json;
+using EventStore.AutoScavenge.Converters;
+using EventStore.AutoScavenge.Sources;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class FakeSource : ISource {
+	private readonly FakeClient _fakeClient;
+	private readonly ClientSource _clientSource;
+
+	public FakeSource() {
+		_fakeClient = new FakeClient();
+		_clientSource = new ClientSource(_fakeClient);
+	}
+
+	public Task<Events.ConfigurationUpdated?> ReadConfigurationEvent(CancellationToken token) => _clientSource.ReadConfigurationEvent(token);
+
+	public IAsyncEnumerable<IEvent> ReadAutoScavengeEvents(CancellationToken token) => _clientSource.ReadAutoScavengeEvents(token);
+
+	public void AddConfigurationEvent(Events.ConfigurationUpdated @event) {
+		var serializerOptions = new JsonSerializerOptions() {
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+			Converters = { new CrontableScheduleJsonConverter() }
+		};
+
+		var data = JsonSerializer.Serialize(@event, serializerOptions);
+		_fakeClient.AddEvent(StreamNames.AutoScavengeConfiguration, @event, Encoding.UTF8.GetBytes(data));
+	}
+
+	public void AddScavengeEvent(IEvent @event) {
+		var serializerOptions = new JsonSerializerOptions() {
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+			Converters = { new EventJsonConverter() }
+		};
+
+		var data = JsonSerializer.Serialize(@event, serializerOptions);
+		_fakeClient.AddEvent(StreamNames.AutoScavenges, @event, Encoding.UTF8.GetBytes(data));
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/LicenseTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/LicenseTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using EventStore.Plugins.Licensing;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class LicenseTests {
+	[Fact]
+	public void when_invalid_license_disable() {
+		var startup = new DummyStartup(new ConfigurationBuilder().Build());
+		var sut = startup.AutoScavengePlugin;
+
+		var builder = WebApplication.CreateBuilder();
+
+		startup.ConfigureServices(builder.Services);
+		startup.Configure(builder.Build());
+		Assert.True(sut.Enabled);
+
+		var tokenWithoutEntitlement = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJlc2RiIiwiaXNzIjoiZXNkYiIsImV4cCI6MTgyNDQ1NjgyOSwianRpIjoiOTVmZTY2YzAtMDRkMi00MjExLWI1ZGQtNTAyM2MyYTAxMGFiIiwic3ViIjoiRVNEQiBUZXN0cyIsIklzVHJpYWwiOiJUcnVlIiwiSXNFeHBpcmVkIjoiRmFsc2UiLCJJc1ZhbGlkIjoiVHJ1ZSIsIklzRmxvYXRpbmciOiJUcnVlIiwiRGF5c1JlbWFpbmluZyI6IjEiLCJTdGFydERhdGUiOiIyNi8wNC8yMDI0IDAwOjAwOjAwICswMTowMCIsIk5PTkUiOiJ0cnVlIiwiaWF0IjoxNzI5ODQ4ODI5LCJuYmYiOjE3Mjk4NDg4Mjl9.R24i-ZAow3BhRaST3n25Uc_nQ184k83YRZZ0oRcWbU9B9XNLRH0Iegj0HmkyzkT50I4gcIJOIfcO6mIPp4Y959CP7aTAlt7XEnXoGF0GwsfXatAxy4iXG8Gpya7INgMoWEeN0v8eDH8_OVmnieOxeba9ex5j1oAW_FtQDMzcFjAeErpW__8zmkCsn6GzvlhdLE4e3r2wjshvrTTcS_1fvSVjQZov5ce2sVBJPegjCLO_QGiIBK9QTnpHrhe6KCYje6fSTjgty0V1Qj22bftvrXreYzQijPrnC_ek1BwV-A1JvacZugMCPIy8WvE5jE3hVYRWGGUzQZ-CibPGsjudYA";
+		startup.LicenseService.EmitLicense(new License(new(tokenWithoutEntitlement)));
+		Assert.False(sut.Enabled);
+	}
+
+	[Fact]
+	public void when_valid_license_stay_enabled() {
+		var startup = new DummyStartup(new ConfigurationBuilder().Build());
+		var sut = startup.AutoScavengePlugin;
+
+		var builder = WebApplication.CreateBuilder();
+
+		startup.ConfigureServices(builder.Services);
+		startup.Configure(builder.Build());
+		Assert.True(sut.Enabled);
+
+		startup.LicenseService.EmitLicense(startup.LicenseService.CurrentLicense!);
+		Assert.True(sut.Enabled);
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/PluginTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/PluginTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using EventStore.AutoScavenge.Converters;
+using EventStore.AutoScavenge.Domain;
+using EventStore.POC.IO.Core.Serialization;
+using HttpMethod = System.Net.Http.HttpMethod;
+using HttpStatusCode = System.Net.HttpStatusCode;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class PluginTests : IClassFixture<DummyWebApplicationFactory>{
+	private static readonly JsonSerializerOptions JsonSerializerOptions = new() {
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters = {
+			new EnumConverterWithDefault<AutoScavengeStatus>(),
+			new EnumConverterWithDefault<AutoScavengeStatusResponse.Status>(),
+			new CrontableScheduleJsonConverter(),
+		},
+	};
+
+	private readonly HttpClient _client;
+
+	public PluginTests(DummyWebApplicationFactory factory) {
+		_client = factory.CreateClient();
+	}
+
+	[Fact]
+	public async Task ShouldDenyAccessToEnabledEndpoint() {
+		var resp = await _client.GetAsync("/auto-scavenge/enabled");
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task ShouldDenyAccessToStatusEndpoint() {
+		var resp = await _client.GetAsync("/auto-scavenge/status");
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task ShouldDenyAccessToConfigureEndpointAuthenticatedWrongRole() {
+		var msg = new HttpRequestMessage(HttpMethod.Post, "/auto-scavenge/configure");
+		msg.Headers.Authorization = new AuthenticationHeaderValue("dummy", Convert.ToBase64String("johndoe:1234"u8.ToArray()));
+		var resp = await _client.SendAsync(msg);
+
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task ShouldDenyAccessToPauseEndpointAuthenticatedWrongRole() {
+		var msg = new HttpRequestMessage(HttpMethod.Post, "/auto-scavenge/pause");
+		msg.Headers.Authorization = new AuthenticationHeaderValue("dummy", Convert.ToBase64String("johndoe:1234"u8.ToArray()));
+		var resp = await _client.SendAsync(msg);
+
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task ShouldDenyAccessToResumeEndpointAuthenticatedWrongRole() {
+		var msg = new HttpRequestMessage(HttpMethod.Post, "/auto-scavenge/resume");
+		msg.Headers.Authorization = new AuthenticationHeaderValue("dummy", Convert.ToBase64String("johndoe:1234"u8.ToArray()));
+		var resp = await _client.SendAsync(msg);
+
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task ShouldAccessEnabledEndpointAuthenticated() {
+		var msg = new HttpRequestMessage(HttpMethod.Get, "/auto-scavenge/enabled");
+		msg.Headers.Authorization = new AuthenticationHeaderValue("dummy", Convert.ToBase64String("ouro:changeit"u8.ToArray()));
+		var resp = await _client.SendAsync(msg);
+
+		resp.EnsureSuccessStatusCode();
+
+		var payload = await resp.Content.ReadFromJsonAsync<Dictionary<string, bool>>();
+		Assert.True(payload!["enabled"]!);
+	}
+
+	[Fact]
+	public async Task ShouldAccessStatusEndpoint() {
+		var attempt = 0;
+		HttpResponseMessage resp;
+
+		do {
+			var msg = new HttpRequestMessage(HttpMethod.Get, "/auto-scavenge/status");
+			msg.Headers.Authorization = new AuthenticationHeaderValue("dummy", Convert.ToBase64String("ouro:changeit"u8.ToArray()));
+			resp = await _client.SendAsync(msg);
+			attempt++;
+
+			var code = (int)resp.StatusCode;
+			if (code < 500)
+				break;
+			await Task.Delay(TimeSpan.FromSeconds(1));
+		} while (attempt < 30);
+
+		resp.EnsureSuccessStatusCode();
+		var payload = await resp.Content.ReadFromJsonAsync<AutoScavengeStatusResponse>(JsonSerializerOptions);
+
+		Assert.True(payload != null);
+
+		if (payload.Schedule != null) {
+			Assert.True(payload.State is AutoScavengeStatusResponse.Status.Waiting or AutoScavengeStatusResponse.Status.Paused);
+			Assert.NotNull(payload.TimeUntilNextCycle);
+		} else {
+			Assert.Equal(AutoScavengeStatusResponse.Status.NotConfigured, payload.State);
+			Assert.Null(payload.TimeUntilNextCycle);
+		}
+	}
+
+	[Fact]
+	public async Task ShouldAccessConfigureEndpoint() {
+		var attempt = 0;
+		HttpResponseMessage resp;
+
+		do {
+			var msg = new HttpRequestMessage(HttpMethod.Post, "/auto-scavenge/configure");
+			msg.Headers.Authorization = new AuthenticationHeaderValue("dummy", Convert.ToBase64String("ouro:changeit"u8.ToArray()));
+			msg.Content = JsonContent.Create(new JsonObject {
+				["schedule"] = "* * * * 1",
+			});
+			resp = await _client.SendAsync(msg);
+			attempt++;
+
+			var code = (int)resp.StatusCode;
+			if (code < 500)
+				break;
+			await Task.Delay(TimeSpan.FromSeconds(1));
+		} while (attempt < 30);
+
+		resp.EnsureSuccessStatusCode();
+	}
+
+	[Fact]
+	public async Task ShouldAccessPauseEndpoint() {
+		var attempt = 0;
+		HttpResponseMessage resp;
+
+		do {
+			var msg = new HttpRequestMessage(HttpMethod.Post, "/auto-scavenge/pause");
+			msg.Headers.Authorization = new AuthenticationHeaderValue("dummy", Convert.ToBase64String("ouro:changeit"u8.ToArray()));
+			resp = await _client.SendAsync(msg);
+			attempt++;
+
+			var code = (int)resp.StatusCode;
+			if (code < 500)
+				break;
+			await Task.Delay(TimeSpan.FromSeconds(1));
+		} while (attempt < 30);
+
+		resp.EnsureSuccessStatusCode();
+	}
+
+	[Fact]
+	public async Task ShouldAccessResumeEndpoint() {
+		var attempt = 0;
+		HttpResponseMessage resp;
+
+		do {
+			var msg = new HttpRequestMessage(HttpMethod.Post, "/auto-scavenge/resume");
+			msg.Headers.Authorization = new AuthenticationHeaderValue("dummy", Convert.ToBase64String("ouro:changeit"u8.ToArray()));
+			resp = await _client.SendAsync(msg);
+			attempt++;
+
+			var code = (int)resp.StatusCode;
+			if (code < 500)
+				break;
+			await Task.Delay(TimeSpan.FromSeconds(1));
+		} while (attempt < 30);
+
+		resp.EnsureSuccessStatusCode();
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/Schedule.cs
+++ b/src/EventStore.AutoScavenge.Tests/Schedule.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public static class Schedule {
+	public static CrontabSchedule EveryHour => CrontabSchedule.Parse("0 * * * *");
+	public static CrontabSchedule EveryDay => CrontabSchedule.Parse("0 0 * * *");
+	public static CrontabSchedule EveryWeek => CrontabSchedule.Parse("0 0 * * 0");
+}

--- a/src/EventStore.AutoScavenge.Tests/Simulator.cs
+++ b/src/EventStore.AutoScavenge.Tests/Simulator.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+using EventStore.AutoScavenge.Tests.TimeProviders;
+
+namespace EventStore.AutoScavenge.Tests;
+
+/// <summary>
+/// Utility object that helps auto scavenge state machine testing.
+/// </summary>
+public class Simulator {
+	private readonly FakeSource _source = new();
+	private readonly AutoScavengeProcessManager _machine;
+	private readonly Queue<ICommand> _queue = new();
+	private readonly List<ReactEvent> _reactsEvents = new();
+	private readonly List<ReactCommand> _reactsCommands = new();
+
+	/// <summary>
+	/// Holds all events and state updates that happened during the simulation.
+	/// </summary>
+	private readonly List<Snapshot> _snapshots = [];
+
+	/// <summary>
+	/// Holds all state transitions that happened during the simulation.
+	/// </summary>
+	private readonly List<ICommand> _transitions = [];
+
+	public DateTime Now => Time.Now;
+
+	public FakeScavenger Scavenger { get; } = new();
+
+	public FakeOperationsClient OperationsClient { get; } = new();
+
+	public FakeTimeProvider Time { get; } = new();
+
+
+	public Simulator(int clusterSize) {
+		_machine = new AutoScavengeProcessManager(clusterSize, Time, _source, OperationsClient, Scavenger);
+	}
+
+	/// <summary>
+	/// Feeds the simulator with a list of commands to be executed. The simulator handles commands in a FIFO order.
+	/// </summary>
+	/// <param name="inputs"></param>
+	public void EnqueueCommands(params ICommand[] inputs) {
+		foreach (var command in inputs)
+			_queue.Enqueue(command);
+	}
+
+	/// <summary>
+	/// Add events to the source of the simulator. Those events are not applied to the state machine but will be
+	/// available for the state machine to consume if it decides to load them.
+	/// </summary>
+	/// <param name="events"></param>
+	public void AddEventsToStorage(params IEvent[] events) {
+		foreach (var @event in events) {
+			if (@event is Events.ConfigurationUpdated update)
+				_source.AddConfigurationEvent(update);
+			else
+				_source.AddScavengeEvent(@event);
+		}
+	}
+
+	/// <summary>
+	/// Defines a list of actions to be executed if a specific event is emitted.
+	/// </summary>
+	/// <param name="reacts"></param>
+	public void Reacts(params ReactEvent[] reacts) {
+		foreach (var react in reacts)
+			_reactsEvents.Add(react);
+	}
+
+	/// <summary>
+	/// Defines a list of actions to be executed if the state machine moves do a specific command.
+	/// </summary>
+	/// <param name="reacts"></param>
+	public void Reacts(params ReactCommand[] reacts) {
+		foreach (var react in reacts)
+			_reactsCommands.Add(react);
+	}
+
+	/// <summary>
+	/// Runs the simulation until the command queue is empty or a <see cref="Suspend" /> command is found.
+	/// </summary>
+	/// <param name="token"></param>
+	public async Task Run(CancellationToken token) {
+		while (_queue.TryDequeue(out var command)) {
+			token.ThrowIfCancellationRequested();
+
+			if (command is SimulatorCommands.FastForward advance)
+				Time.FastForward(advance.Time);
+
+			if (command is SimulatorCommands.Suspend)
+				break;
+
+			while (command is not null)
+				command = await ProcessCommand(command);
+		}
+
+		async Task<ICommand?> ProcessCommand(ICommand command) {
+			var transition = await _machine.RunAsync(command, token);
+
+			// So far we only support reacting after a command is processed but we can add more as the need arises.
+			foreach (var react in _reactsCommands)
+				if (react.Type == command.GetType())
+					react.Fun(command);
+
+			if (transition.NextCommand != null) {
+				_queue.Enqueue(transition.NextCommand);
+				_transitions.Add(transition.NextCommand);
+			}
+
+			foreach (var @event in transition.Events) {
+				// When an event is emitted, we clone the both manager and configuration transient states before and after
+				// the event is applied. This allows us deeply state transition between snapshots.
+				var prevState = _machine.State.Clone();
+				_machine.Apply(@event);
+				_snapshots.Add(new Snapshot(
+					@event,
+					prevState,
+					_machine.State.Clone(),
+					Time.Now));
+
+				// We run event reacts after the event is applied to the state machine.
+				foreach (var react in _reactsEvents)
+					if (react.Type == @event.GetType())
+						react.Fun(@event);
+			}
+
+			command.OnSavedEvents();
+			return transition.NextCommand;
+		}
+	}
+
+	/// <summary>
+	/// Asserts that there are as many matches as we got snapshots. The order of each match should also have the same
+	/// type as the emitted event of that time.  A snapshot is taken every time an event is emitted
+	/// and applied to the state machine.
+	/// </summary>
+	/// <param name="matches"></param>
+	public void AssertSnapshots(List<Match> matches) {
+		Assert.Equal(matches.Count, _snapshots.Count);
+
+		for (var i = 0; i < matches.Count; i++) {
+			var (type, fun) = matches[i];
+			var snapshot = _snapshots[i];
+
+			Assert.IsType(type, snapshot.Event);
+
+			fun(snapshot.Event, snapshot);
+		}
+	}
+
+	public void ClearSnapshots() => _snapshots.Clear();
+}
+
+public record Match(Type Type, Action<IEvent, Snapshot> Fun);
+public record ReactEvent(Type Type, Action<IEvent> Fun);
+public record ReactCommand(Type Type, Action<ICommand> Fun);
+
+public static class Matches {
+	 public static Match MatchEvent<T>(Action<T, Snapshot> fun) =>
+		 new(typeof(T), (e, s) => fun((T)e, s));
+
+	 public static Match MatchEvent<T>() =>
+		 new(typeof(T), (_, _) => {});
+}
+
+public static class Reacts {
+	 public static ReactEvent OnEvent<T>(Action<T> fun) =>
+		 new(typeof(T), e => fun((T)e));
+
+	 public static ReactCommand After<T>(Action<T> fun) =>
+		 new(typeof(T), e => fun((T)e));
+}

--- a/src/EventStore.AutoScavenge.Tests/SimulatorCommands.cs
+++ b/src/EventStore.AutoScavenge.Tests/SimulatorCommands.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Tests;
+
+public class SimulatorCommands {
+	public record FastForward(TimeSpan Time) : Command<Unit>(_ => { });
+
+	public record Suspend() : Command<Unit>(_ => { });
+}

--- a/src/EventStore.AutoScavenge.Tests/Snapshot.cs
+++ b/src/EventStore.AutoScavenge.Tests/Snapshot.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+
+namespace EventStore.AutoScavenge.Tests;
+
+public record Snapshot(
+	IEvent Event,
+	AutoScavengeState PrevState,
+	AutoScavengeState NewState,
+	DateTime Time);
+

--- a/src/EventStore.AutoScavenge.Tests/StateMachine/CompleteProcessTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/StateMachine/CompleteProcessTests.cs
@@ -1,0 +1,464 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Linq;
+using EventStore.AutoScavenge.Domain;
+using EventStore.AutoScavenge.Scavengers;
+
+namespace EventStore.AutoScavenge.Tests.StateMachine;
+
+public class CompleteProcessTests {
+
+	/// This test verifies that with a pre-existing configuration, the state machine detects that an auto
+	/// scavenge process is due. In this scenario, everything goes well like remote node scavenges for
+	/// example. The test should end with the leader node resigning because it's the only node left that needs to be
+	/// scavenged at the end of the process. That test simulates a 3 node cluster.
+	[Fact]
+	public async Task ShouldCompleteAutoScavengeProcessToLeaderResignation() {
+		var tokenSource = new CancellationTokenSource();
+		var simulator = new Simulator(3);
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var activeNodes = clusterMembers.Values.Select(m => m.ToNodeId()).ToHashSet();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.FastForward(TimeSpan.FromHours(1)),
+		]);
+
+		// Sets an auto scavenge configuration event for when the state machine will reload its configuration.
+		simulator.AddEventsToStorage(new Events.ConfigurationUpdated {
+			Schedule = Schedule.EveryHour,
+			UpdatedAt = simulator.Now,
+		});
+
+		simulator.Reacts(
+			Reacts.OnEvent<Events.NodeScavengeStarted>(@event => {
+				simulator.Scavenger.SetScavengeStatus(@event.ScavengeId, ScavengeStatus.Success);
+				simulator.EnqueueCommands(Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()));
+			}));
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ClusterScavengeStarted>((@event, snapshot) => {
+				Assert.NotEqual(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.Members, snapshot.NewState.ClusterMembers);
+				Assert.Equal(@event.StartedAt, snapshot.Time);
+				Assert.Equal(AutoScavengeStatus.ContinuingClusterScavenge, snapshot.NewState.Status);
+
+				var needingScavenge = snapshot.NewState.NodesToScavenge.ToHashSet();
+				Assert.Equal(activeNodes, needingScavenge);
+				Assert.Equal(3, needingScavenge.Count);
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.NotEqual(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.DesignatedAt, snapshot.Time);
+
+				var needingScavenge = snapshot.PrevState.NodesToScavenge.ToHashSet();
+				var node = ClusterFixtures.GetFarthestNodeInReplication(
+					clusterMembers.Values.Where(m => needingScavenge.Contains(m.ToNodeId())));
+				Assert.Equal(snapshot.NewState.DesignatedNode, node.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.NotEqual(snapshot.PrevState.NodeScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.ScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.StartedAt, snapshot.Time);
+				Assert.Equal(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+
+				var scavengingNode = simulator.Scavenger.Scavenges[@event.ScavengeId];
+
+				Assert.Equal(scavengingNode.Host, @event.NodeId.Address);
+				Assert.Equal(scavengingNode.Port, @event.NodeId.Port);
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeCompleted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.PrevState.DesignatedNode);
+				Assert.Equal(@event.CompletedAt, snapshot.Time);
+				Assert.Null(snapshot.NewState.DesignatedNode);
+				Assert.Equal(2, snapshot.NewState.NodesToScavenge.Count());
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.NotEqual(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.DesignatedAt, snapshot.Time);
+
+				var needingScavenge = snapshot.PrevState.NodesToScavenge.ToHashSet();
+				var node = ClusterFixtures.GetFarthestNodeInReplication(
+					clusterMembers.Values.Where(m => needingScavenge.Contains(m.ToNodeId())));
+				Assert.Equal(snapshot.NewState.DesignatedNode, node.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.NotEqual(snapshot.PrevState.NodeScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.ScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.StartedAt, snapshot.Time);
+				Assert.Equal(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+
+				var scavengingNode = simulator.Scavenger.Scavenges[@event.ScavengeId];
+
+				Assert.Equal(scavengingNode.Host, @event.NodeId.Address);
+				Assert.Equal(scavengingNode.Port, @event.NodeId.Port);
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeCompleted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.PrevState.DesignatedNode);
+				Assert.Equal(@event.CompletedAt, snapshot.Time);
+				Assert.Null(snapshot.NewState.DesignatedNode);
+				Assert.Single(snapshot.NewState.NodesToScavenge);
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.NotEqual(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.DesignatedAt, snapshot.Time);
+
+				var needingScavenge = snapshot.PrevState.NodesToScavenge.ToHashSet();
+				Assert.Single(needingScavenge);
+				Assert.Equal(snapshot.NewState.DesignatedNode, leader.ToNodeId());
+			}),
+		]);
+
+		Assert.True(simulator.OperationsClient.ResignationIssued);
+	}
+
+	/// The test configures the simulator so the state machine detects there is only one node left that needs to be
+	/// scavenged. The test should end with that last node scavenged and the process marked as completed.
+	[Fact]
+	public async Task ShouldDetectThereIsOneNodeLeftThatNeedsScavengeThenCompleteTheProcess() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var clusterMembersByNodeId = clusterMembers.ToDictionary(
+			x => x.Value.ToNodeId(),
+			x => x.Value);
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+		var clusterScavengeId = Guid.NewGuid();
+		var followers = clusterMembersByNodeId.Keys.Except([leader.ToNodeId()]).ToList();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = clusterMembersByNodeId.Keys.ToList(),
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeDesignated {
+				NodeId = followers[0],
+				DesignatedAt = simulator.Now,
+			},
+
+			new Events.NodeScavengeStarted {
+				NodeId = followers[0],
+				ScavengeId = Guid.Parse("5cabeeee-0000-0000-0000-000000000001"),
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeScavengeCompleted {
+				NodeId = followers[0],
+				CompletedAt = simulator.Now,
+				Result = "Success"
+			},
+
+			new Events.NodeDesignated {
+				NodeId = followers[1],
+				DesignatedAt = simulator.Now,
+			},
+
+			new Events.NodeScavengeStarted {
+				NodeId = followers[1],
+				ScavengeId = Guid.Parse("5cabeeee-0000-0000-0000-000000000002"),
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeScavengeCompleted {
+				NodeId = followers[1],
+				CompletedAt = simulator.Now,
+				Result = "Success"
+			},
+
+			new Events.NodeDesignated {
+				NodeId = leader.ToNodeId(),
+				DesignatedAt = simulator.Now,
+			},
+		]);
+
+		leader.State = "Follower";
+		clusterMembersByNodeId[followers[0]].State = "Leader";
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(clusterMembersByNodeId[followers[0]].InstanceId, clusterMembers.Values.ToList())
+		]);
+
+		simulator.Reacts(
+			Reacts.OnEvent<Events.NodeScavengeStarted>(@event => {
+				simulator.Scavenger.SetScavengeStatus(@event.ScavengeId, ScavengeStatus.Success);
+				simulator.EnqueueCommands(Command.ReceiveGossip(clusterMembersByNodeId[followers[0]].InstanceId, clusterMembers.Values.ToList()));
+			}));
+
+		await simulator.Run(tokenSource.Token);
+
+		var previousLeader = leader;
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, _) => {
+				Assert.Equal(@event.NodeId, previousLeader.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeCompleted>((@event, _) => {
+				Assert.Equal(@event.NodeId, previousLeader.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.ClusterScavengeCompleted>((@event, _) => {
+				Assert.Equal(@event.ClusterScavengeId, clusterScavengeId);
+				Assert.Equal(@event.Members, clusterMembersByNodeId.Keys.ToList());
+			})
+		]);
+	}
+
+	/// The test verifies that a single node database is able to complete an auto scavenge process successfully.
+	[Fact]
+	public async Task ShouldCompleteAutoScavengeProcessOnASingleNodeSetUp() {
+		var simulator = new Simulator(1);
+		var tokenSource = new CancellationTokenSource();
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+
+		simulator.AddEventsToStorage(new Events.ConfigurationUpdated {
+			Schedule = Schedule.EveryHour,
+			UpdatedAt = simulator.Now,
+		});
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.FastForward(TimeSpan.FromHours(1))
+		]);
+
+		simulator.Reacts(
+			Reacts.OnEvent<Events.NodeScavengeStarted>(@event => {
+				simulator.Scavenger.SetScavengeStatus(@event.ScavengeId, ScavengeStatus.Success);
+				simulator.EnqueueCommands(Command.ReceiveGossip(singleNode.InstanceId, [singleNode]));
+			}));
+
+		await simulator.Run(tokenSource.Token).WaitAsync(TimeSpan.FromSeconds(2));
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ClusterScavengeStarted>((_, snapshot) => {
+				Assert.Equal(AutoScavengeStatus.ContinuingClusterScavenge, snapshot.NewState.Status);
+			}),
+			Matches.MatchEvent<Events.NodeDesignated>(),
+			Matches.MatchEvent<Events.NodeScavengeStarted>(),
+			Matches.MatchEvent<Events.NodeScavengeCompleted>(),
+			Matches.MatchEvent<Events.ClusterScavengeCompleted>(),
+		]);
+	}
+
+	[Fact]
+	public async Task ShouldCompleteAutoScavengeProcessToLeaderResignationWithRoR() {
+		var tokenSource = new CancellationTokenSource();
+		var simulator = new Simulator(3);
+		var clusterMembers = ClusterFixtures.Generate3NodesClusterWith2RoRs();
+		var activeNodes = clusterMembers.Values.Select(m => m.ToNodeId()).ToHashSet();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.FastForward(TimeSpan.FromHours(1)),
+		]);
+
+		// Sets an auto scavenge configuration event for when the state machine will reload its configuration.
+		simulator.AddEventsToStorage(new Events.ConfigurationUpdated {
+			Schedule = Schedule.EveryHour,
+			UpdatedAt = simulator.Now,
+		});
+
+		simulator.Reacts(
+			Reacts.OnEvent<Events.NodeScavengeStarted>(@event => {
+				simulator.Scavenger.SetScavengeStatus(@event.ScavengeId, ScavengeStatus.Success);
+				simulator.EnqueueCommands(Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()));
+			}));
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ClusterScavengeStarted>((@event, snapshot) => {
+				Assert.NotEqual(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.Members, snapshot.NewState.ClusterMembers);
+				Assert.Equal(@event.StartedAt, snapshot.Time);
+				Assert.Equal(AutoScavengeStatus.ContinuingClusterScavenge, snapshot.NewState.Status);
+
+				var needingScavenge = snapshot.NewState.NodesToScavenge.ToHashSet();
+				Assert.Equal(activeNodes, needingScavenge);
+				Assert.Equal(5, needingScavenge.Count);
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.NotEqual(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.DesignatedAt, snapshot.Time);
+
+				var needingScavenge = snapshot.PrevState.NodesToScavenge.ToHashSet();
+				var node = ClusterFixtures.GetFarthestNodeInReplication(
+					clusterMembers.Values.Where(m => needingScavenge.Contains(m.ToNodeId())));
+				Assert.Equal(snapshot.NewState.DesignatedNode, node.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.NotEqual(snapshot.PrevState.NodeScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.ScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.StartedAt, snapshot.Time);
+				Assert.Equal(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+
+				var scavengingNode = simulator.Scavenger.Scavenges[@event.ScavengeId];
+
+				Assert.Equal(scavengingNode.Host, @event.NodeId.Address);
+				Assert.Equal(scavengingNode.Port, @event.NodeId.Port);
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeCompleted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.PrevState.DesignatedNode);
+				Assert.Equal(@event.CompletedAt, snapshot.Time);
+				Assert.Null(snapshot.NewState.DesignatedNode);
+				Assert.Equal(4, snapshot.NewState.NodesToScavenge.Count());
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.NotEqual(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.DesignatedAt, snapshot.Time);
+
+				var needingScavenge = snapshot.PrevState.NodesToScavenge.ToHashSet();
+				var node = ClusterFixtures.GetFarthestNodeInReplication(
+					clusterMembers.Values.Where(m => needingScavenge.Contains(m.ToNodeId())));
+				Assert.Equal(snapshot.NewState.DesignatedNode, node.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.NotEqual(snapshot.PrevState.NodeScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.ScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.StartedAt, snapshot.Time);
+				Assert.Equal(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+
+				var scavengingNode = simulator.Scavenger.Scavenges[@event.ScavengeId];
+
+				Assert.Equal(scavengingNode.Host, @event.NodeId.Address);
+				Assert.Equal(scavengingNode.Port, @event.NodeId.Port);
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeCompleted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.PrevState.DesignatedNode);
+				Assert.Equal(@event.CompletedAt, snapshot.Time);
+				Assert.Null(snapshot.NewState.DesignatedNode);
+				Assert.Equal(3, snapshot.NewState.NodesToScavenge.Count());
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.NotEqual(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.DesignatedAt, snapshot.Time);
+
+				var needingScavenge = snapshot.PrevState.NodesToScavenge.ToHashSet();
+				var node = ClusterFixtures.GetFarthestNodeInReplication(
+					clusterMembers.Values.Where(m => needingScavenge.Contains(m.ToNodeId())));
+				Assert.Equal(snapshot.NewState.DesignatedNode, node.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.NotEqual(snapshot.PrevState.NodeScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.ScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.StartedAt, snapshot.Time);
+				Assert.Equal(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+
+				var scavengingNode = simulator.Scavenger.Scavenges[@event.ScavengeId];
+
+				Assert.Equal(scavengingNode.Host, @event.NodeId.Address);
+				Assert.Equal(scavengingNode.Port, @event.NodeId.Port);
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeCompleted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.PrevState.DesignatedNode);
+				Assert.Equal(@event.CompletedAt, snapshot.Time);
+				Assert.Null(snapshot.NewState.DesignatedNode);
+				Assert.Equal(2, snapshot.NewState.NodesToScavenge.Count());
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.NotEqual(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.DesignatedAt, snapshot.Time);
+
+				var needingScavenge = snapshot.PrevState.NodesToScavenge.ToHashSet();
+				var node = ClusterFixtures.GetFarthestNodeInReplication(
+					clusterMembers.Values.Where(m => needingScavenge.Contains(m.ToNodeId())));
+				Assert.Equal(snapshot.NewState.DesignatedNode, node.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.NotEqual(snapshot.PrevState.NodeScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.ScavengeId, snapshot.NewState.NodeScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.StartedAt, snapshot.Time);
+				Assert.Equal(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+
+				var scavengingNode = simulator.Scavenger.Scavenges[@event.ScavengeId];
+
+				Assert.Equal(scavengingNode.Host, @event.NodeId.Address);
+				Assert.Equal(scavengingNode.Port, @event.NodeId.Port);
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeCompleted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.PrevState.DesignatedNode);
+				Assert.Equal(@event.CompletedAt, snapshot.Time);
+				Assert.Null(snapshot.NewState.DesignatedNode);
+				Assert.Single(snapshot.NewState.NodesToScavenge);
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.NotEqual(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.DesignatedAt, snapshot.Time);
+
+				var needingScavenge = snapshot.PrevState.NodesToScavenge.ToHashSet();
+				Assert.Single(needingScavenge);
+				Assert.Equal(snapshot.NewState.DesignatedNode, leader.ToNodeId());
+			}),
+		]);
+
+		Assert.True(simulator.OperationsClient.ResignationIssued);
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/StateMachine/ConfigurationTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/StateMachine/ConfigurationTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Tests.StateMachine;
+
+public class ConfigurationTests {
+
+	/// We check that a user can set up the auto scavenge process when there is no pre-existing configuration. The
+	/// state machine must be updated accordingly and the configuration persisted.
+	[Fact]
+	public async Task ShouldBeConfiguredWithNoConfigurationHistory() {
+		var simulator = new Simulator(1);
+		var tokenSource = new CancellationTokenSource();
+		var schedule = Schedule.EveryDay;
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.Configure(schedule),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ConfigurationUpdated>((@event, snapshot) => {
+				Assert.False(snapshot.PrevState.Configuration.IsConfigured);
+				Assert.True(snapshot.NewState.Configuration.IsConfigured);
+				Assert.Equal(@event.Schedule, schedule);
+				Assert.Equal(@event.UpdatedAt, snapshot.Time);
+				Assert.Equal(@event.UpdatedAt, snapshot.NewState.Configuration.StartingPoint);
+				Assert.Equal(@event.Schedule, snapshot.NewState.Configuration.Schedule);
+			})
+		]);
+	}
+
+	/// We check that when a user updates the auto scavenge process with a pre-existing configuration, that the state
+	/// machine is updated accordingly and the configuration persisted.
+	[Fact]
+	public async Task ShouldOverrideExistingConfiguration() {
+		var simulator = new Simulator(1);
+		var tokenSource = new CancellationTokenSource();
+		var previousSchedule = Schedule.EveryDay;
+		var newSchedule = Schedule.EveryWeek;
+		var previousUpdateTime = simulator.Now;
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+
+		simulator.AddEventsToStorage(new Events.ConfigurationUpdated {
+			Schedule = previousSchedule,
+			UpdatedAt = previousUpdateTime,
+		});
+
+		var taskSource = new TaskCompletionSource<Response<Unit>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+		]);
+
+		await simulator.Run(tokenSource.Token).WaitAsync(TimeSpan.FromSeconds(2));
+
+		// At this point the simulator has been initialized with the previous configuration.
+		simulator.EnqueueCommands([
+			Command.FastForward(TimeSpan.FromHours(2)),
+			Command.Configure(newSchedule, taskSource.SetResult),
+		]);
+
+		await simulator.Run(tokenSource.Token).WaitAsync(TimeSpan.FromSeconds(2));
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ConfigurationUpdated>((@event, snapshot) => {
+				Assert.True(snapshot.PrevState.Configuration.IsConfigured);
+				Assert.Equal(snapshot.PrevState.Configuration.Schedule?.ToString(), previousSchedule.ToString());
+				Assert.Equal(snapshot.PrevState.Configuration.StartingPoint, previousUpdateTime);
+				Assert.True(snapshot.NewState.Configuration.IsConfigured);
+				Assert.Equal(@event.Schedule.ToString(), newSchedule.ToString());
+				Assert.Equal(@event.UpdatedAt, snapshot.Time);
+				Assert.Equal(@event.UpdatedAt, snapshot.NewState.Configuration.StartingPoint);
+				Assert.Equal(@event.Schedule.ToString(), snapshot.NewState.Configuration.Schedule?.ToString());
+			})
+		]);
+
+		var resp = await taskSource.Task.WaitAsync(TimeSpan.FromSeconds(2));
+		Assert.True(resp.IsSuccessful(out _));
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/StateMachine/ControlTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/StateMachine/ControlTests.cs
@@ -1,0 +1,391 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Scavengers;
+
+namespace EventStore.AutoScavenge.Tests.StateMachine;
+
+// Home of tests related to pause/resume commands of the auto scavenge process.
+public class ControlTests {
+	/// The test verifies that we are able to stop an auto scavenge process in normal condition. The test is a success
+	/// if the simulator ends up emitting an auto scavenge process paused event.
+	[Fact]
+	public async Task ShouldPauseTheAutoScavengeProcessWhenScavengingNode() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var clusterMembersByNodeId = clusterMembers.ToDictionary(
+			x => x.Value.ToNodeId(),
+			x => x.Value);
+		var activeNodes = clusterMembers.Values.Select(m => m.ToNodeId())
+			.ToHashSet();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+		var clusterScavengeId = Guid.NewGuid();
+		var followers = activeNodes.Except([leader.ToNodeId()]).ToList();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = activeNodes.ToList(),
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeDesignated {
+				NodeId = followers[0],
+				DesignatedAt = simulator.Now,
+			},
+
+			new Events.NodeScavengeStarted {
+				NodeId = followers[0],
+				ScavengeId = Guid.Parse("5cabeeee-0000-0000-0000-000000000001"),
+				StartedAt = simulator.Now,
+			},
+		]);
+
+		simulator.Scavenger.RegisterScavengeFor(Guid.Parse("5cabeeee-0000-0000-0000-000000000001"), clusterMembersByNodeId[followers[0]], ScavengeStatus.InProgress);
+
+		var pauseProcessTask = new TaskCompletionSource<Response<Unit>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.PauseProcess(resp => pauseProcessTask.SetResult(resp)),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.PauseRequested>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+			}),
+
+			Matches.MatchEvent<Events.Paused>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+			}),
+		]);
+
+		var response = await pauseProcessTask.Task;
+
+		Assert.True(response.IsAccepted(out _));
+	}
+
+	[Fact]
+	public async Task ShouldPauseTheAutoScavengeProcessWhenNotScavengingNode() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var activeNodes = clusterMembers.Values.Select(m => m.InstanceId)
+			.ToHashSet();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+		var clusterScavengeId = Guid.NewGuid();
+		var followers = activeNodes.Except([leader.InstanceId]).ToList();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+		]);
+
+		simulator.Scavenger.RegisterScavengeFor(Guid.Parse("5cabeeee-0000-0000-0000-000000000001"), clusterMembers[followers[0]], ScavengeStatus.InProgress);
+
+		var pauseProcessTask = new TaskCompletionSource<Response<Unit>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.PauseProcess(resp => pauseProcessTask.SetResult(resp)),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.Paused>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+			}),
+		]);
+
+		var response = await pauseProcessTask.Task;
+
+		Assert.True(response.IsSuccessful(out _));
+	}
+
+	[Fact]
+	public async Task ShouldPauseTheAutoScavengeProcessWhenPossiblyScavengingNode() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var activeNodes = clusterMembers.Values.Select(m => m.ToNodeId())
+			.ToHashSet();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+		var clusterScavengeId = Guid.NewGuid();
+		var followers = activeNodes.Except([leader.ToNodeId()]).ToList();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = activeNodes.ToList(),
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeDesignated {
+				NodeId = followers[0],
+				DesignatedAt = simulator.Now,
+			},
+		]);
+
+		simulator.Scavenger.Enabled = false;
+
+		var pauseProcessTask = new TaskCompletionSource<Response<Unit>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.PauseProcess(resp => pauseProcessTask.SetResult(resp)),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.PauseRequested>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+			}),
+
+			Matches.MatchEvent<Events.Paused>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+			}),
+		]);
+
+		var response = await pauseProcessTask.Task;
+
+		Assert.True(response.IsAccepted(out _));
+	}
+
+	/// The test verifies that we are able to resume a paused auto scavenge process in normal condition. The test is
+	/// a success if the simulator ends up emitting an auto scavenge process resumed event.
+	[Fact]
+	public async Task ShouldResumePausedAutoScavengeProcess() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var activeNodes = clusterMembers.Values.Select(m => m.ToNodeId())
+			.ToHashSet();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+		var clusterScavengeId = Guid.NewGuid();
+		var followers = activeNodes.Except([leader.ToNodeId()]).ToList();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = activeNodes.ToList(),
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeDesignated {
+				NodeId = followers[0],
+				DesignatedAt = simulator.Now,
+			},
+
+			new Events.Paused() {
+				PausedAt = simulator.Now,
+			},
+		]);
+
+		simulator.Reacts([
+			Reacts.OnEvent<Events.NodeScavengeStarted>(_ => simulator.EnqueueCommands(Command.Suspend)),
+		]);
+
+		var pauseProcessTask = new TaskCompletionSource<Response<Unit>>();
+
+		simulator.EnqueueCommands(
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.ResumeProcess(pauseProcessTask.SetResult)
+		);
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.Resumed>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>(),
+
+			// Testament that the auto scavenge process started a node scavenge on the designated node.
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.DesignatedNode, snapshot.NewState.DesignatedNode);
+				Assert.Equal(@event.NodeId, snapshot.NewState.DesignatedNode);
+				Assert.True(simulator.Scavenger.Scavenges.ContainsKey(@event.ScavengeId));
+			}),
+		]);
+
+		var response = await pauseProcessTask.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+		Assert.True(response.IsSuccessful(out _));
+	}
+
+	/// The test verifies that we are able to pause an auto scavenge process when the node being scavenged becomes
+	/// temporarily unavailable
+	[Fact]
+	public async Task ShouldPauseTheAutoScavengeProcessWhenNodeBeingScavengedIsTemporarilyUnavailable() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var clusterMembersByNodeId = clusterMembers.ToDictionary(
+			x => x.Value.ToNodeId(),
+			x => x.Value);
+		var activeNodes = clusterMembers.Values.Select(m => m.ToNodeId())
+			.ToHashSet();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+		var clusterScavengeId = Guid.NewGuid();
+		var followers = activeNodes.Except([leader.ToNodeId()]).ToList();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = activeNodes.ToList(),
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeDesignated {
+				NodeId = followers[0],
+				DesignatedAt = simulator.Now,
+			},
+
+			new Events.NodeScavengeStarted {
+				NodeId = followers[0],
+				ScavengeId = Guid.Parse("5cabeeee-0000-0000-0000-000000000001"),
+				StartedAt = simulator.Now,
+			}
+		]);
+
+		simulator.Scavenger.RegisterScavengeFor(Guid.Parse("5cabeeee-0000-0000-0000-000000000001"), clusterMembersByNodeId[followers[0]], ScavengeStatus.InProgress);
+		simulator.Scavenger.Pausable = false;
+
+		var pauseProcessTask = new TaskCompletionSource<Response<Unit>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.PauseProcess(resp => pauseProcessTask.SetResult(resp)),
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList())
+		]);
+
+		var gossipCount = 0;
+		simulator.Reacts(
+			Reacts.After<Commands.ReceiveGossip>(@event => {
+				if (++gossipCount == 3)
+					simulator.Scavenger.Pausable = true;
+			}));
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.PauseRequested>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+			}),
+			Matches.MatchEvent<Events.Paused>()
+		]);
+
+		var response = await pauseProcessTask.Task;
+
+		Assert.True(response.IsAccepted(out _));
+	}
+
+	/// The test verifies that we are able to pause an auto scavenge process when the node being scavenged is removed
+	/// from gossip, then replaced by a new node.
+	[Fact]
+	public async Task ShouldPauseTheAutoScavengeProcessWhenNodeBeingScavengedIsReplacedInGossip() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var clusterMembersByNodeId = clusterMembers.ToDictionary(
+			x => x.Value.ToNodeId(),
+			x => x.Value);
+		var activeNodes = clusterMembers.Values.Select(m => m.ToNodeId())
+			.ToHashSet();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+		var clusterScavengeId = Guid.NewGuid();
+		var followers = activeNodes.Except([leader.ToNodeId()]).ToList();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = activeNodes.ToList(),
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeDesignated {
+				NodeId = followers[0],
+				DesignatedAt = simulator.Now,
+			},
+
+			new Events.NodeScavengeStarted {
+				NodeId = followers[0],
+				ScavengeId = Guid.Parse("5cabeeee-0000-0000-0000-000000000001"),
+				StartedAt = simulator.Now,
+			}
+		]);
+
+		simulator.Scavenger.RegisterScavengeFor(Guid.Parse("5cabeeee-0000-0000-0000-000000000001"), clusterMembersByNodeId[followers[0]], ScavengeStatus.InProgress);
+		simulator.Scavenger.Pausable = false;
+
+		var pauseProcessTask = new TaskCompletionSource<Response<Unit>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.PauseProcess(resp => pauseProcessTask.SetResult(resp)),
+		]);
+
+		// remove the node being scavenged from the list of cluster members
+		var scavengingNode = clusterMembers.Values.First(x => x.ToNodeId() == followers[0]);
+		clusterMembers.Remove(scavengingNode.InstanceId);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+		]);
+
+		// replace the node that was being scavenged by a new node
+		var newNode = ClusterFixtures.ClusterMembers.Generate(1).First();
+		clusterMembers.Add(newNode.InstanceId, newNode);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.PauseRequested>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.ClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+			}),
+			Matches.MatchEvent<Events.ClusterMembersChanged>(),
+			Matches.MatchEvent<Events.Paused>()
+		]);
+
+		var response = await pauseProcessTask.Task;
+
+		Assert.True(response.IsAccepted(out _));
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/StateMachine/DetectionTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/StateMachine/DetectionTests.cs
@@ -1,0 +1,315 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+using EventStore.AutoScavenge.Scavengers;
+
+namespace EventStore.AutoScavenge.Tests.StateMachine;
+
+public class DetectionTests {
+	/// This test verifies that the state machine can detect that there has been enough time between the last auto
+	/// scavenge process to start a new one.
+	[Fact]
+	public async Task ShouldDetectAutoScavengeProcessIsDueFromPreviousRun() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+		var clusterScavengeId = Guid.NewGuid();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryDay,
+				UpdatedAt = simulator.Time.NowThenFastForward(TimeSpan.FromHours(1)),
+			},
+
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = clusterMembers.Values.Select(x => x.ToNodeId()).ToList(),
+				StartedAt = simulator.Time.NowThenFastForward(TimeSpan.FromHours(1)),
+			},
+
+			new Events.ClusterScavengeCompleted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = clusterMembers.Values.Select(x => x.ToNodeId()).ToList(),
+				CompletedAt = simulator.Time.Now
+			}
+		]);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.FastForward(TimeSpan.FromHours(22))
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ClusterScavengeStarted>(),
+			Matches.MatchEvent<Events.NodeDesignated>(),
+			Matches.MatchEvent<Events.NodeScavengeStarted>()
+		]);
+	}
+
+	/// Makes sure that the state machine does not start a new scavenge process if the node is not configured for
+	/// auto scavenge process.
+	[Fact]
+	public async Task ShouldNotStartScavengeProcessIfNodeIsNotConfigured() {
+		var simulator = new Simulator(1);
+		var tokenSource = new CancellationTokenSource();
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([]);
+	}
+
+	/// Makes sure that the state machine does not start a new scavenge process immediately after the node is configured
+	/// for auto scavenge process.
+	[Fact]
+	public async Task ShouldNotStartScavengeProcessImmediatelyAfterNodeIsConfigured() {
+		var simulator = new Simulator(1);
+		var tokenSource = new CancellationTokenSource();
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.FastForward(TimeSpan.FromHours(1)),
+			Command.Configure(Schedule.EveryHour)
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ConfigurationUpdated>()
+		]);
+	}
+
+	/// Makes sure that the state machine does not start a new scavenge process immediately after the node is re-configured
+	/// for auto scavenge process.
+	[Fact]
+	public async Task ShouldNotStartScavengeProcessImmediatelyAfterNodeIsReconfigured() {
+		var simulator = new Simulator(1);
+		var tokenSource = new CancellationTokenSource();
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryDay,
+				UpdatedAt = simulator.Time.Now
+			}
+		]);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.FastForward(TimeSpan.FromDays(1)),
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.FastForward(TimeSpan.FromHours(3)),
+			Command.Configure(Schedule.EveryHour),
+		]);
+
+		simulator.Reacts(
+			Reacts.OnEvent<Events.NodeScavengeStarted>(@event => {
+				simulator.Scavenger.SetScavengeStatus(@event.ScavengeId, ScavengeStatus.Success);
+			}));
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ClusterScavengeStarted>(),
+			Matches.MatchEvent<Events.NodeDesignated>(),
+			Matches.MatchEvent<Events.NodeScavengeStarted>(),
+			Matches.MatchEvent<Events.NodeScavengeCompleted>(),
+			Matches.MatchEvent<Events.ClusterScavengeCompleted>(),
+			Matches.MatchEvent<Events.ConfigurationUpdated>()
+		]);
+	}
+
+	/// When in a single node configuration, the test verifies that if we already started a node scavenge and the
+	/// node reboot, we should start a new one because node id changed after reboot.
+	[Fact]
+	public async Task ShouldDetectInSingleNodeThatNodeIdChangedAfterRestart() {
+		var simulator = new Simulator(1);
+		var tokenSource = new CancellationTokenSource();
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+		var previousClusterScavengeId = Guid.NewGuid();
+		var previousScavengeId = Guid.NewGuid();
+		var previousNodeId = ClusterFixtures.GenerateNodeId(1);
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = previousClusterScavengeId,
+				Members = [previousNodeId],
+				StartedAt = simulator.Now,
+			},
+
+			new Events.NodeDesignated {
+				NodeId = previousNodeId,
+				DesignatedAt = simulator.Now,
+			},
+
+			new Events.NodeScavengeStarted {
+				NodeId = previousNodeId,
+				ScavengeId = previousScavengeId,
+				StartedAt = simulator.Now,
+			}
+		]);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]), // Leads to detect the topology has changed.
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ClusterMembersChanged>((@event, snapshot) => {
+				Assert.Equal(snapshot.PrevState.DesignatedNode, previousNodeId);
+				Assert.Equal(previousClusterScavengeId, snapshot.PrevState.ClusterScavengeId);
+				Assert.Equal(previousClusterScavengeId, snapshot.NewState.ClusterScavengeId);
+				Assert.Equal([singleNode.ToNodeId()], @event.Added);
+				Assert.Equal([previousNodeId], @event.Removed);
+			}),
+
+			Matches.MatchEvent<Events.NodeDesignated>((@event, snapshot) => {
+				Assert.Equal(@event.NodeId, singleNode.ToNodeId());
+			}),
+
+			Matches.MatchEvent<Events.NodeScavengeStarted>((@event, snapshot) => {
+				Assert.Equal(@event.NodeId, singleNode.ToNodeId());
+				Assert.NotEqual(@event.ScavengeId, previousScavengeId);
+			})
+		]);
+	}
+
+	/// This test verifies that the state machine can detect that a cluster was offline during a certain period of time
+	/// and that a scavenge process must not be started if one or more cycles were missed while the cluster was offline.
+	[Fact]
+	public async Task ShouldSkipAutoScavengeIfCycleWasMissed() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryDay,
+				UpdatedAt = simulator.Time.NowThenFastForward(TimeSpan.FromDays(3)),
+			}
+		]);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.FastForward(TimeSpan.FromHours(1))
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([]);
+	}
+
+	/// This test verifies that the state machine can detect that a cluster was offline during a certain period of time
+	/// and that a scavenge process must be resumed if there was already an ongoing one even though one or more cycles
+	/// were missed while the cluster was offline.
+	[Fact]
+	public async Task ShouldResumeAutoScavengeEvenIfCycleWasMissed() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+
+		var clusterScavengeId = Guid.NewGuid();
+		var activeNodes = clusterMembers.Values.Select(m => m.ToNodeId())
+			.ToHashSet();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryDay,
+				UpdatedAt = simulator.Time.NowThenFastForward(TimeSpan.FromDays(3)),
+			},
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = activeNodes.ToList(),
+				StartedAt = simulator.Now,
+			}
+		]);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.FastForward(TimeSpan.FromHours(1))
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.NodeDesignated>(),
+			Matches.MatchEvent<Events.NodeScavengeStarted>()
+		]);
+	}
+
+	/// This test verifies that the state machine can detect that a cluster was offline during a certain period of time
+	/// and that a scavenge process must be started if the next cycle was not missed while the cluster was offline.
+	[Fact]
+	public async Task ShouldStartAutoScavengeIfCycleWasNotMissed() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryDay,
+				UpdatedAt = simulator.Time.NowThenFastForward(TimeSpan.FromHours(23)),
+			}
+		]);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.FastForward(TimeSpan.FromHours(1))
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([
+			Matches.MatchEvent<Events.ClusterScavengeStarted>(),
+			Matches.MatchEvent<Events.NodeDesignated>(),
+			Matches.MatchEvent<Events.NodeScavengeStarted>()
+		]);
+	}
+
+	/// This test verifies that the state machine can detect that a cluster was offline during a certain period of time
+	/// and that a scavenge process must not be started even if the next cycle was not missed as auto-scavenge was paused.
+	[Fact]
+	public async Task ShouldSkipAutoScavengeIfPausedAndCycleWasNotMissed() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryDay,
+				UpdatedAt = simulator.Time.Now,
+			},
+			new Events.Paused {
+				PausedAt = simulator.Time.NowThenFastForward(TimeSpan.FromHours(23))
+			}
+		]);
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.FastForward(TimeSpan.FromHours(1))
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([]);
+	}
+}

--- a/src/EventStore.AutoScavenge.Tests/StateMachine/StatusTests.cs
+++ b/src/EventStore.AutoScavenge.Tests/StateMachine/StatusTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+
+namespace EventStore.AutoScavenge.Tests.StateMachine;
+
+/// <summary>
+/// Home of the get-status command tests.
+/// </summary>
+public class StatusTests {
+	/// Verifies that the status is retrieved when the state machine is already loaded.
+	[Fact]
+	public async Task ShouldRetrieveStatusWhenLoaded() {
+		var simulator = new Simulator(3);
+		var tokenSource = new CancellationTokenSource();
+		var clusterMembers = ClusterFixtures.Generate3NodesCluster();
+		var leader = ClusterFixtures.GetLeader(clusterMembers.Values);
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+		]);
+
+		var statusTask = new TaskCompletionSource<Response<AutoScavengeStatusResponse>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(leader.InstanceId, clusterMembers.Values.ToList()),
+			Command.GetStatus(statusTask),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		var response = await statusTask.Task;
+
+		Assert.True(response.IsSuccessful(out var result));
+		Assert.Equal(AutoScavengeStatusResponse.Status.Waiting, result.State);
+		Assert.Equal(Schedule.EveryHour.ToString(), result.Schedule!.ToString());
+		Assert.Equal(TimeSpan.FromHours(1), result.TimeUntilNextCycle);
+	}
+
+	/// Verifies that the status is retrieved when the state machine is not loaded nor configured
+	[Fact]
+	public async Task ShouldRetrieveStatusWhenNotLoadedNorConfigured() {
+		var simulator = new Simulator(1);
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+		var tokenSource = new CancellationTokenSource();
+		var statusTask = new TaskCompletionSource<Response<AutoScavengeStatusResponse>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.GetStatus(statusTask),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([]);
+		var response = await statusTask.Task;
+
+		Assert.True(response.IsSuccessful(out var result));
+		Assert.Equal(AutoScavengeStatusResponse.Status.NotConfigured, result.State);
+		Assert.Null(result.Schedule);
+		Assert.Null(result.TimeUntilNextCycle);
+	}
+
+	/// Verifies that the status is retrieved when the state machine tried to load its configuration once but didn't
+	/// find anything.
+	[Fact]
+	public async Task ShouldRetrieveStatusWhenLoadedButNotConfigured() {
+		var simulator = new Simulator(1);
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+		var tokenSource = new CancellationTokenSource();
+		var statusTask = new TaskCompletionSource<Response<AutoScavengeStatusResponse>>();
+
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.GetStatus(statusTask),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([]);
+		var response = await statusTask.Task;
+
+		Assert.True(response.IsSuccessful(out var result));
+		Assert.Equal(AutoScavengeStatusResponse.Status.NotConfigured, result.State);
+		Assert.Null(result.Schedule);
+		Assert.Null(result.TimeUntilNextCycle);
+	}
+
+	[Fact]
+	public async Task when_paused_while_idle_next_cycle_is_schedule_from_now() {
+		var simulator = new Simulator(clusterSize: 1);
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+		var tokenSource = new CancellationTokenSource();
+		var statusTask = new TaskCompletionSource<Response<AutoScavengeStatusResponse>>();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+			new Events.Paused() {
+				PausedAt = simulator.Now,
+			},
+		]);
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.FastForward(TimeSpan.FromMinutes(65)),
+			Command.GetStatus(statusTask),
+		]);
+
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([]);
+		var response = await statusTask.Task;
+
+		Assert.True(response.IsSuccessful(out var result));
+		Assert.Equal(AutoScavengeStatusResponse.Status.Paused, result.State);
+		Assert.Equal(Schedule.EveryHour.ToString(), result.Schedule!.ToString());
+		Assert.Equal(TimeSpan.FromMinutes(55), result.TimeUntilNextCycle);
+	}
+
+	[Fact]
+	public async Task when_paused_while_scavenging_next_cycle_is_immediate() {
+		var simulator = new Simulator(clusterSize: 1);
+		var singleNode = ClusterFixtures.GenerateSingleNode();
+		var tokenSource = new CancellationTokenSource();
+		var statusTask = new TaskCompletionSource<Response<AutoScavengeStatusResponse>>();
+
+		simulator.AddEventsToStorage([
+			new Events.ConfigurationUpdated {
+				Schedule = Schedule.EveryHour,
+				UpdatedAt = simulator.Now,
+			},
+			new Events.ClusterScavengeStarted {
+				ClusterScavengeId = Guid.NewGuid(),
+				Members = [
+					singleNode.ToNodeId(),
+				],
+				StartedAt = simulator.Now,
+			},
+			new Events.Paused() {
+				PausedAt = simulator.Now,
+			},
+		]);
+		simulator.EnqueueCommands([
+			Command.ReceiveGossip(singleNode.InstanceId, [singleNode]),
+			Command.FastForward(TimeSpan.FromMinutes(65)),
+			Command.GetStatus(statusTask),
+		]);
+
+		simulator.Time.FastForward(TimeSpan.FromMinutes(65));
+		await simulator.Run(tokenSource.Token);
+
+		simulator.AssertSnapshots([]);
+		var response = await statusTask.Task;
+
+		Assert.True(response.IsSuccessful(out var result));
+		Assert.Equal(AutoScavengeStatusResponse.Status.Paused, result.State);
+		Assert.Equal(Schedule.EveryHour.ToString(), result.Schedule!.ToString());
+		Assert.Equal(TimeSpan.Zero, result.TimeUntilNextCycle);
+	}
+
+	// TODO - We also probably need to check the state transitions to ascertain we are moving the way we expect.
+}

--- a/src/EventStore.AutoScavenge.Tests/TimeProviders/FakeTimeProvider.cs
+++ b/src/EventStore.AutoScavenge.Tests/TimeProviders/FakeTimeProvider.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.TimeProviders;
+
+namespace EventStore.AutoScavenge.Tests.TimeProviders;
+
+public class FakeTimeProvider : ITimeProvider {
+	private DateTime _inner = DateTime.Now.Date;
+
+	public DateTime Now => _inner;
+
+	public void FastForward(TimeSpan timeSpan) {
+		_inner = _inner.Add(timeSpan);
+	}
+
+	public DateTime NowThenFastForward(TimeSpan timeSpan) {
+		var now = _inner;
+		_inner = _inner.Add(timeSpan);
+		return now;
+	}
+}

--- a/src/EventStore.AutoScavenge/AutoScavengePlugin.cs
+++ b/src/EventStore.AutoScavenge/AutoScavengePlugin.cs
@@ -1,0 +1,244 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json;
+using System.Threading.Channels;
+using EventStore.AutoScavenge.Clients;
+using EventStore.AutoScavenge.Converters;
+using EventStore.AutoScavenge.Domain;
+using EventStore.AutoScavenge.Scavengers;
+using EventStore.Core.Configuration.Sources;
+using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
+using EventStore.Plugins;
+using EventStore.Plugins.Diagnostics;
+using EventStore.Plugins.Subsystems;
+using EventStore.POC.IO.Core;
+using EventStore.POC.IO.Core.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NCrontab;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.AutoScavenge;
+
+public class AutoScavengePluginBase() : Plugin(requiredEntitlements: ["AUTO_SCAVENGE"]), ISubsystem {
+	public virtual Task Start() => Task.CompletedTask;
+
+	public virtual Task Stop() => Task.CompletedTask;
+}
+
+public class AutoScavengePlugin : AutoScavengePluginBase, IConnectedSubsystemsPlugin {
+	private static readonly ILogger Log = Serilog.Log.ForContext<AutoScavengePlugin>();
+	private readonly CancellationTokenSource _cts = new();
+	private AutoScavengeService? _autoScavengeService;
+
+	public string CommandLineName => "auto-scavenge";
+
+	public IReadOnlyList<ISubsystem> GetSubsystems() => [this];
+
+	private static readonly JsonSerializerOptions JsonSerializerOptions = new() {
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters = {
+			new EnumConverterWithDefault<AutoScavengeStatus>(),
+			new EnumConverterWithDefault<AutoScavengeStatusResponse.Status>(),
+			new CrontableScheduleJsonConverter(),
+		},
+	};
+
+	private readonly Channel<ICommand> _commands = Channel.CreateBounded<ICommand>(
+		new BoundedChannelOptions(capacity: 32) {
+			SingleReader = true,
+			SingleWriter = false,
+		});
+
+	private IAutoScavengeClient _dispatcher = IAutoScavengeClient.None;
+	private EventStoreOptions _options = new();
+
+	public override (bool Enabled, string EnableInstructions) IsEnabled(IConfiguration configuration) {
+		var enabledOption = configuration.GetValue<bool?>($"{KurrentConfigurationKeys.Prefix}:AutoScavenge:Enabled");
+		var devMode = configuration.GetValue($"{KurrentConfigurationKeys.Prefix}:Dev", defaultValue: false);
+		var memDb = configuration.GetValue($"{KurrentConfigurationKeys.Prefix}:MemDb", defaultValue: false);
+
+		// enabled by default
+		bool enabled = enabledOption ?? true;
+
+		if (!enabled)
+			return (false, $"To enable AutoScavenge: Do not set '{KurrentConfigurationKeys.Prefix}:AutoScavenge:Enabled' to 'false'");
+
+		// not compatible with dev mode or memdb
+		if (devMode || memDb) {
+			var msg = "AutoScavenge is not compatible with " + (devMode ? "dev mode" : "mem-db");
+
+			if (enabledOption.HasValue && enabledOption.Value) {
+				// user has explicitly enabled both
+				throw new Exception(msg);
+			}
+
+			// auto scavenge is not explicitly enabled, just disable it.
+			return (false, msg);
+		}
+
+		return (true, "");
+	}
+
+	public override void ConfigureServices(IServiceCollection services, IConfiguration configuration) {
+		_options = configuration.GetSection(KurrentConfigurationKeys.Prefix).Get<EventStoreOptions>() ?? _options;
+
+		services.AddSingleton(provider => {
+			var nodeHttpClientFactory = provider.GetRequiredService<INodeHttpClientFactory>();
+			return new HttpClientWrapper(_options, nodeHttpClientFactory);
+		});
+		services.AddSingleton<AutoScavengeClientDispatcher>(provider => {
+			var wrapper = provider.GetRequiredService<HttpClientWrapper>();
+			var internalClient = new InternalAutoScavengeClient(_commands.Writer);
+			var proxyClient = new ProxyAutoScavengeClient(wrapper);
+			var dispatcher = new AutoScavengeClientDispatcher(internalClient, proxyClient);
+			_dispatcher = dispatcher;
+			return dispatcher;
+		});
+		services.AddSingleton<AutoScavengeService>(provider => {
+			var client = provider.GetRequiredService<IClient>();
+			var wrapper = provider.GetRequiredService<HttpClientWrapper>();
+			var dispatcher = provider.GetRequiredService<AutoScavengeClientDispatcher>();
+			return new AutoScavengeService(
+				options: _options,
+				client: client,
+				operationsClient: provider.GetRequiredService<IOperationsClient>(),
+				commands: _commands,
+				scavenger: new HttpNodeScavenger(wrapper, client),
+				dispatcher,
+				cts: _cts);
+			});
+	}
+
+	protected override void OnLicenseException(Exception ex, Action<Exception> shutdown) {
+		var msg = "AutoScavenge is not licensed, stopping.";
+		Log.Information(msg);
+		Disable(msg);
+		PublishDiagnosticsData(
+			new Dictionary<string, object?>() { ["enabled"] = Enabled },
+			PluginDiagnosticsDataCollectionMode.Partial);
+		Stop();
+	}
+
+	public override void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration) {
+		_autoScavengeService = builder.ApplicationServices.GetRequiredService<AutoScavengeService>();
+
+		builder.UseEndpoints(endpoints => {
+			var anyUserGroup = endpoints.MapGroup("/auto-scavenge");
+			anyUserGroup.MapGet("/enabled", OnGetEnabled);
+			anyUserGroup.MapGet("/status", (Delegate)OnGetStatus);
+			anyUserGroup.RequireAuthorization();
+
+			var opsGroup = endpoints.MapGroup("/auto-scavenge");
+			opsGroup.MapPost("/resume", (Delegate)OnPostResume);
+			opsGroup.MapPost("/pause", (Delegate)OnPostPause);
+			opsGroup.MapPost("/configure", (Delegate)OnPostConfigure);
+			opsGroup.RequireAuthorization(policy => policy.RequireRole("$admins", "$ops"));
+		});
+	}
+
+	public override Task Start() {
+		return _autoScavengeService?.StartAsync() ?? Task.CompletedTask;
+	}
+
+	public override async Task Stop() {
+		await _cts.CancelAsync();
+	}
+
+	/// <summary>
+	/// Handles the POST request to configure the auto scavenge process. It disallows anonymous users from
+	/// configuring the auto scavenge process. The state machine could also deny the request if the node is no
+	/// longer the cluster's leader.
+	/// </summary>
+	private Task<IResult> OnPostConfigure(HttpContext context) =>
+		ExecuteCommand(context, Run.WithPayload<AutoScavengeConfigurationPayload, Unit>(
+			(conf) => _dispatcher.Configure(conf.Schedule, _cts.Token)));
+
+	/// <summary>
+	/// Handles the GET request to check if the auto scavenge plugin is enabled.
+	/// </summary>
+	private IResult OnGetEnabled() =>
+		Results.Json(new GetAutoScavengeEnabledResult(
+			Enabled: Enabled));
+
+	/// <summary>
+	/// Handles the POST request to resume the auto scavenge process.
+	/// </summary>
+	private Task<IResult> OnPostResume(HttpContext context) =>
+		ExecuteCommand(context, Run.WithoutPayload(() => _dispatcher.Resume(_cts.Token)));
+
+	/// <summary>
+	/// Handles the POST request to pause the auto scavenge process.
+	/// </summary>
+	private Task<IResult> OnPostPause(HttpContext context) =>
+		ExecuteCommand(context, Run.WithoutPayload(() => _dispatcher.Pause(_cts.Token)));
+
+	/// <summary>
+	/// Handles the GET request to get the status of the auto scavenge process. That status includes but not only
+	/// the current schedule, the state of the process and when next scavenge is expected.
+	/// </summary>
+	private Task<IResult> OnGetStatus(HttpContext context) =>
+		ExecuteCommand(context, Run.WithoutPayload(() => _dispatcher.GetStatus(_cts.Token)));
+
+	/// <summary>
+	/// Common implementation to execute an auto scavenge process state machine command.
+	/// </summary>
+	/// <param name="runner">A command to execute on the state machine</param>
+	/// <typeparam name="TParam">Type of the command's parameter</typeparam>
+	/// <typeparam name="TResp">Type of the command response</typeparam>
+	private async Task<IResult> ExecuteCommand<TParam, TResp>(
+		HttpContext context, RunCommand<TParam, TResp> runner) {
+
+		TParam? param = default;
+
+		if (!Enabled)
+			return Results.Problem("AutoScavenge is not enabled", statusCode: 503);
+
+		if (runner.ParsePayload) {
+			try {
+				param = await context.Request.ReadFromJsonAsync<TParam>(JsonSerializerOptions);
+				if (param is null)
+					return Results.BadRequest("Invalid payload");
+			} catch (JsonException ex) {
+				return Results.BadRequest(ex.Message);
+			}
+		}
+
+		Response<TResp> resp;
+
+		try {
+			resp = await runner.Run(param);
+		} catch (TaskCanceledException) {
+			return Results.Problem("AutoScavenge is no longer running", statusCode: 500);
+		}
+
+		return resp.Visit(
+			onSuccessful: static result => Results.Json(result, JsonSerializerOptions),
+			onAccepted: static () => Results.Accepted(),
+			onRejected: static rejectedReason => Results.BadRequest(rejectedReason),
+			onServerError: static serverError => Results.Problem(serverError, statusCode: 500));
+	}
+
+	private record RunCommand<TParam, TResp>(Func<TParam?, Task<Response<TResp>>> Run, bool ParsePayload);
+
+	private static class Run {
+		public static RunCommand<Unit, TResp> WithoutPayload<TResp>(Func<Task<Response<TResp>>> run) =>
+			new((_) => run(), false);
+
+		public static RunCommand<TParam, TResp> WithPayload<TParam, TResp>(Func<TParam, Task<Response<TResp>>> run) =>
+			new((p) => run(p!), true);
+	}
+
+	/// <summary>
+	/// JSON Payload for configuring the auto scavenge process.
+	/// </summary>
+	private class AutoScavengeConfigurationPayload {
+		public required CrontabSchedule Schedule { get; init; }
+	}
+
+	record struct GetAutoScavengeEnabledResult(bool Enabled);
+
+}

--- a/src/EventStore.AutoScavenge/AutoScavengeService.cs
+++ b/src/EventStore.AutoScavenge/AutoScavengeService.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json;
+using System.Threading.Channels;
+using EventStore.AutoScavenge.Clients;
+using EventStore.AutoScavenge.Converters;
+using EventStore.AutoScavenge.Domain;
+using EventStore.AutoScavenge.Scavengers;
+using EventStore.AutoScavenge.Sources;
+using EventStore.POC.IO.Core;
+using TimeProvider = EventStore.AutoScavenge.TimeProviders.TimeProvider;
+
+namespace EventStore.AutoScavenge;
+
+internal class AutoScavengeService : IDisposable {
+	private static readonly Serilog.ILogger Log = Serilog.Log.ForContext<AutoScavengeService>();
+
+	private static readonly JsonSerializerOptions JsonSerializerOptions = new() {
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters = { new EventJsonConverter(), new CrontableScheduleJsonConverter() }
+	};
+
+	private readonly CancellationTokenSource _cts;
+	private readonly EventStoreOptions _options;
+	private readonly IClient _client;
+	private readonly IOperationsClient _operationsClient;
+	private readonly Channel<ICommand> _commands;
+	private readonly INodeScavenger _scavenger;
+	private readonly IGossipAware _gossipHandler;
+
+	public AutoScavengeService(
+		EventStoreOptions options,
+		IClient client,
+		IOperationsClient operationsClient,
+		Channel<ICommand> commands,
+		INodeScavenger scavenger,
+		IGossipAware gossipHandler,
+		CancellationTokenSource cts) {
+
+		_options = options;
+		_client = client;
+		_operationsClient = operationsClient;
+		_commands = commands;
+		_scavenger = scavenger;
+		_gossipHandler = gossipHandler;
+		_cts = cts;
+	}
+
+	public Task StartAsync() {
+		// todo We might consider bulletproofing subscription tasks
+		var sub2 = Task.Run(() => SubscribeToGossip(_cts.Token), _cts.Token).WarnOnCompletion("AUTO SCAVENGE GOSSIP MONITOR STOPPED");
+		var process = Process(_cts.Token).WarnOnCompletion("AUTO SCAVENGE PROCESS MANAGER STOPPED");
+		return Task.CompletedTask;
+	}
+
+	public void Dispose() {
+		_cts.Cancel();
+	}
+
+	private async Task Process(CancellationToken token) {
+		var source = new ClientSource(_client);
+		var machine = new AutoScavengeProcessManager(_options.ClusterSize, new TimeProvider(), source, _operationsClient, _scavenger);
+
+		await foreach (var commandFromChannel in _commands.Reader.ReadAllAsync(token)) {
+			// if an additional command was yielded execute it now, do not queue it to the channel.
+			// this allows us to make the channel bounded without risk of deadlock.
+			var command = commandFromChannel;
+			while (command is not null) {
+				Log.Verbose("Autoscavenge processing command {Command}. Queue {Count}", command, _commands.Reader.Count);
+				command = await ProcessCommand(command);
+			}
+		}
+
+		async Task<ICommand?> ProcessCommand(ICommand command) {
+			try {
+				var transition = await machine.RunAsync(command, token);
+
+				foreach (var @event in transition.Events) {
+					if (@event is Events.ConfigurationUpdated)
+						await _client.WriteAsyncRetry(
+							StreamNames.AutoScavengeConfiguration,
+							[Serialize(@event)],
+							-2, // Any
+							token);
+					else
+						source.AutoScavengeStreamExpectedRevision = await _client.WriteAsyncRetry(
+							StreamNames.AutoScavenges,
+							[Serialize(@event)],
+							source.AutoScavengeStreamExpectedRevision,
+							token);
+
+					// We only update the machine's state if persisting the event was successful
+					machine.Apply(@event);
+				}
+
+				// events if any are successfully saved, we can now send the response
+				command.OnSavedEvents();
+
+				return transition.NextCommand;
+
+			} catch (ResponseException.NotLeader) {
+				Log.Information(
+					"Node is no longer a leader and stopped driving the automatic scavenge process");
+				command.OnServerError("Not leader");
+				return null;
+
+			} catch (Exception ex) {
+				Log.Error(ex, "Unexpected exception in auto-scavenge plugin");
+				await _cts.CancelAsync();
+				command.OnServerError(ex.Message);
+				return null;
+			}
+		}
+
+		if (_cts.Token.IsCancellationRequested) {
+			while (_commands.Reader.TryRead(out var command)) {
+				switch (command) {
+					case Commands.PauseProcess cmd:
+						cmd.Callback(Response.ServerError("auto-scavenge errored"));
+						break;
+					case Commands.ResumeProcess cmd:
+						cmd.Callback(Response.ServerError("auto-scavenge errored"));
+						break;
+					case Commands.GetStatus cmd:
+						cmd.Callback(Response.ServerError<AutoScavengeStatusResponse>("auto-scavenge errored"));
+						break;
+				}
+			}
+		}
+	}
+
+	private async Task SubscribeToGossip(CancellationToken cancellationToken) {
+		GossipMessage? lastGossip = null;
+		var singleNode = false;
+
+		await foreach(var @event in _client.SubscribeToStream("$mem-gossip", cancellationToken)) {
+			try {
+				var msg = JsonSerializer.Deserialize<GossipMessage>(@event.Data.Span)!;
+				_gossipHandler.ReceiveGossipMessage(msg);
+				await _commands.Writer.WriteAsync(new Commands.ReceiveGossip(msg), cancellationToken);
+
+				// If we are running in a single-node configuration, we will only receive one gossip message for
+				// the entirety of the node's lifetime.
+				if (msg.Members.Count != 1 || msg.Members[0].State != "Leader")
+					continue;
+
+				singleNode = true;
+				lastGossip = msg;
+				break;
+			} catch (JsonException ex) {
+				Log.Fatal(ex, "Failed to deserialize gossip message");
+				// TODO - Do we really want to break here? What about restarting the subscription?
+				break;
+			}
+		}
+
+		// If we are running in a single-node configuration, we simulate the reception of a gossip message to the
+		// auto scavenge state machine because gossip messages act as a metronome to the auto scavenge process.
+		// We don't update the proxy client because we won't ever need to proxy request in single-node mode.
+		if (singleNode) {
+			while (!cancellationToken.IsCancellationRequested) {
+				await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+				await _commands.Writer.WriteAsync(new Commands.ReceiveGossip(lastGossip!), cancellationToken);
+			}
+		}
+	}
+
+	private static EventToWrite Serialize(IEvent @event) {
+		return new EventToWrite(
+			Guid.NewGuid(),
+			@event.Type,
+			"application/json",
+			JsonSerializer.SerializeToUtf8Bytes(@event, JsonSerializerOptions),
+			Array.Empty<byte>());
+	}
+}

--- a/src/EventStore.AutoScavenge/Clients/AutoScavengeClientDispatcher.cs
+++ b/src/EventStore.AutoScavenge/Clients/AutoScavengeClientDispatcher.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Clients;
+
+// Manages the autoscavenge locally or remotely depending on whether we are leader
+public class AutoScavengeClientDispatcher(
+	InternalAutoScavengeClient internalClient,
+	ProxyAutoScavengeClient proxyClient) : IGossipAware, IAutoScavengeClient {
+
+	public Task<Response<AutoScavengeStatusResponse>> GetStatus(CancellationToken token) {
+		return Target.GetStatus(token);
+	}
+
+	public Task<Response<Unit>> Pause(CancellationToken token) {
+		return Target.Pause(token);
+	}
+
+	public Task<Response<Unit>> Resume(CancellationToken token) {
+		return Target.Resume(token);
+	}
+
+	public Task<Response<Unit>> Configure(CrontabSchedule schedule, CancellationToken token) {
+		return Target.Configure(schedule, token);
+	}
+
+	public void ReceiveGossipMessage(GossipMessage msg) {
+		proxyClient.ReceiveGossipMessage(msg);
+	}
+
+	private bool IsLeader() {
+		return proxyClient.TryGetCurrentLeader(out _, out var isSelf) && isSelf;
+	}
+
+	private IAutoScavengeClient Target => IsLeader() ? internalClient : proxyClient;
+}

--- a/src/EventStore.AutoScavenge/Clients/GossipAwareBase.cs
+++ b/src/EventStore.AutoScavenge/Clients/GossipAwareBase.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Clients;
+
+public abstract class GossipAwareBase : IGossipAware {
+	private readonly object _lock = new();
+	private NodeEndpoint? _leaderNode;
+	private bool _isLeader;
+
+	public void ReceiveGossipMessage(GossipMessage msg) {
+		lock (_lock) {
+			_leaderNode = null;
+			_isLeader = false;
+			foreach (var member in msg.Members) {
+				if (member.State == "Leader") {
+					_leaderNode = new NodeEndpoint {
+						Host = member.InternalHttpEndPointIp,
+						Port = member.InternalHttpEndPointPort,
+					};
+
+					_isLeader = member.InstanceId == msg.NodeId;
+					return;
+				}
+			}
+		}
+	}
+
+	public bool TryGetCurrentLeader(out NodeEndpoint leader, out bool isSelf) {
+		lock (_lock) {
+			isSelf = _isLeader;
+			leader = _leaderNode ?? default;
+			return _leaderNode is not null;
+		}
+	}
+}

--- a/src/EventStore.AutoScavenge/Clients/IAutoScavengeClient.cs
+++ b/src/EventStore.AutoScavenge/Clients/IAutoScavengeClient.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Clients;
+
+// Interface to manage the auto scavenge.
+public interface IAutoScavengeClient {
+	Task<Response<AutoScavengeStatusResponse>> GetStatus(CancellationToken token);
+	Task<Response<Unit>> Pause(CancellationToken token);
+	Task<Response<Unit>> Resume(CancellationToken token);
+	Task<Response<Unit>> Configure(CrontabSchedule schedule, CancellationToken token);
+
+	public static IAutoScavengeClient None => NoAutoScavengeClient.Instance;
+}
+
+file class NoAutoScavengeClient : IAutoScavengeClient {
+	public static NoAutoScavengeClient Instance { get; } = new NoAutoScavengeClient();
+
+	private const string Error = "No auto scavenge client";
+
+	readonly Task<Response<AutoScavengeStatusResponse>> _statusResponse =
+		Task.FromResult(Response.ServerError<AutoScavengeStatusResponse>(Error));
+
+	readonly Task<Response<Unit>> _unitResponse =
+		Task.FromResult(Response.ServerError(Error));
+
+	public Task<Response<Unit>> Configure(CrontabSchedule schedule, CancellationToken token) =>
+		_unitResponse;
+
+	public Task<Response<AutoScavengeStatusResponse>> GetStatus(CancellationToken token) =>
+		_statusResponse;
+
+	public Task<Response<Unit>> Pause(CancellationToken token) =>
+		_unitResponse;
+
+	public Task<Response<Unit>> Resume(CancellationToken token) =>
+		_unitResponse;
+}

--- a/src/EventStore.AutoScavenge/Clients/IGossipAware.cs
+++ b/src/EventStore.AutoScavenge/Clients/IGossipAware.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Clients;
+
+public interface IGossipAware {
+	public void ReceiveGossipMessage(GossipMessage msg);
+}

--- a/src/EventStore.AutoScavenge/Clients/InternalAutoScavengeClient.cs
+++ b/src/EventStore.AutoScavenge/Clients/InternalAutoScavengeClient.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Threading.Channels;
+using EventStore.AutoScavenge.Domain;
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Clients;
+
+// Manages the local auto scavenge by putting commands on the channel
+public class InternalAutoScavengeClient(ChannelWriter<ICommand> channel) : IAutoScavengeClient {
+	public Task<Response<AutoScavengeStatusResponse>> GetStatus(CancellationToken token) =>
+		Execute<AutoScavengeStatusResponse>(r => new Commands.GetStatus(r), token);
+
+	public Task<Response<Unit>> Pause(CancellationToken token) =>
+		Execute<Unit>(r => new Commands.PauseProcess(r), token);
+
+	public Task<Response<Unit>> Resume(CancellationToken token) =>
+		Execute<Unit>(r => new Commands.ResumeProcess(r), token);
+
+	public Task<Response<Unit>> Configure(CrontabSchedule schedule, CancellationToken token) =>
+		Execute<Unit>(r => new Commands.Configure(schedule, r), token);
+
+	private async Task<Response<TResp>> Execute<TResp>(Func<Action<Response<TResp>>, ICommand> make, CancellationToken token) {
+		var source = new TaskCompletionSource<Response<TResp>>();
+
+		await using var _ = token.Register(() => source.TrySetCanceled(token));
+		var command = make(source.SetResult);
+		if (!channel.TryWrite(command))
+			return Response.ServerError<TResp>("AutoScavenge queue is full");
+
+		return await source.Task;
+	}
+}

--- a/src/EventStore.AutoScavenge/Clients/ProxyAutoScavengeClient.cs
+++ b/src/EventStore.AutoScavenge/Clients/ProxyAutoScavengeClient.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using EventStore.AutoScavenge.Converters;
+using EventStore.AutoScavenge.Domain;
+using EventStore.POC.IO.Core.Serialization;
+using NCrontab;
+using Serilog;
+
+namespace EventStore.AutoScavenge.Clients;
+
+// Allows users to manage the autoscavenge from any node. Proxies the request on to the leader.
+public class ProxyAutoScavengeClient(HttpClientWrapper wrapper) : GossipAwareBase, IAutoScavengeClient {
+	private static readonly ILogger Log = Serilog.Log.ForContext<ProxyAutoScavengeClient>();
+
+	private static readonly JsonSerializerOptions JsonSerializerOptions = new() {
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters = {
+			new EnumConverterWithDefault<AutoScavengeStatus>(),
+			new EnumConverterWithDefault<AutoScavengeStatusResponse.Status>(),
+			new CrontableScheduleJsonConverter(),
+		},
+	};
+
+	public async Task<Response<AutoScavengeStatusResponse>> GetStatus(CancellationToken token) {
+		try {
+			var baseUrl = GetLeaderBaseUrl(nameof(GetStatus));
+			if (baseUrl is null)
+				return Response.ServerError<AutoScavengeStatusResponse>("No leader node was found in the cluster");
+
+			var resp = await wrapper.HttpClient.GetFromJsonAsync<AutoScavengeStatusResponse>(
+				$"{baseUrl}/auto-scavenge/status", JsonSerializerOptions, token);
+
+			return Response.Successful(resp!);
+		} catch (HttpRequestException ex) {
+			var code = (int)(ex.StatusCode ?? HttpStatusCode.ServiceUnavailable);
+			return code is >= 400 and < 500
+				? Response.Rejected<AutoScavengeStatusResponse>(ex.Message)
+				: Response.ServerError<AutoScavengeStatusResponse>(ex.Message);
+		} catch (JsonException ex) {
+			return Response.ServerError<AutoScavengeStatusResponse>($"error when proxying request: {ex.Message}");
+		} catch (Exception ex) {
+			return Response.ServerError<AutoScavengeStatusResponse>(ex.Message);
+		}
+	}
+
+	public async Task<Response<Unit>> Pause(CancellationToken token) {
+		try {
+			var baseUrl = GetLeaderBaseUrl(nameof(Pause));
+			if (baseUrl is null)
+				return Response.ServerError<Unit>("No leader node was found in the cluster");
+
+			var resp = await wrapper.HttpClient.PostAsync($"{baseUrl}/auto-scavenge/pause", null, token);
+			resp.EnsureSuccessStatusCode();
+
+			return Response.Accepted();
+		} catch (HttpRequestException ex) {
+			var code = (int)(ex.StatusCode ?? HttpStatusCode.ServiceUnavailable);
+			return code is >= 400 and < 500
+				? Response.Rejected<Unit>(ex.Message)
+				: Response.ServerError<Unit>(ex.Message);
+		} catch (Exception ex) {
+			return Response.ServerError(ex.Message);
+		}
+	}
+
+	public async Task<Response<Unit>> Resume(CancellationToken token) {
+		try {
+			var baseUrl = GetLeaderBaseUrl(nameof(Resume));
+			if (baseUrl is null)
+				return Response.ServerError<Unit>("No leader node was found in the cluster");
+
+			var resp = await wrapper.HttpClient.PostAsync($"{baseUrl}/auto-scavenge/resume", null, token);
+			resp.EnsureSuccessStatusCode();
+
+			return Response.Accepted();
+		} catch (HttpRequestException ex) {
+			var code = (int)(ex.StatusCode ?? HttpStatusCode.ServiceUnavailable);
+			return code is >= 400 and < 500
+				? Response.Rejected<Unit>(ex.Message)
+				: Response.ServerError<Unit>(ex.Message);
+		} catch (Exception ex) {
+			return Response.ServerError(ex.Message);
+		}
+	}
+
+	public async Task<Response<Unit>> Configure(CrontabSchedule schedule, CancellationToken token) {
+		try {
+			var baseUrl = GetLeaderBaseUrl(nameof(Configure));
+			if (baseUrl is null)
+				return Response.ServerError<Unit>("No leader node was found in the cluster");
+
+			var content = JsonContent.Create(new JsonObject {
+				["schedule"] = schedule.ToString(),
+			});
+
+			var resp = await wrapper.HttpClient.PostAsync($"{baseUrl}/auto-scavenge/configure", content, token);
+			resp.EnsureSuccessStatusCode();
+
+			return Response.Accepted();
+		} catch (HttpRequestException ex) {
+			var code = (int)(ex.StatusCode ?? HttpStatusCode.ServiceUnavailable);
+			return code is >= 400 and < 500
+				? Response.Rejected<Unit>(ex.Message)
+				: Response.ServerError<Unit>(ex.Message);
+		} catch (Exception ex) {
+			return Response.ServerError(ex.Message);
+		}
+	}
+
+	private string? GetLeaderBaseUrl(string request) {
+		if (!TryGetCurrentLeader(out var leaderNode, out var isSelf) || isSelf)
+			return null;
+
+		var leaderBase = $"{wrapper.Protocol}://{leaderNode.Host}:{leaderNode.Port}";
+		Log.Debug("Forwarding AutoScavenge request \"{Request}\" to leader at {LeaderBase}", request, leaderBase);
+		return leaderBase;
+	}
+}

--- a/src/EventStore.AutoScavenge/ClusterMember.cs
+++ b/src/EventStore.AutoScavenge/ClusterMember.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+
+namespace EventStore.AutoScavenge;
+
+public class ClusterMember {
+	public Guid InstanceId { get; set; } = default;
+	public string State { get; set; } = string.Empty;
+	public bool IsAlive { get; set; }
+	public string InternalHttpEndPointIp { get; set; } = string.Empty;
+	public int InternalHttpEndPointPort { get; set; }
+	public long WriterCheckpoint { get; set; }
+	public bool IsReadOnlyReplica { get; set; }
+}
+
+public static class ClusterMemberExtensions {
+	public static NodeId ToNodeId(this ClusterMember m) =>
+		new(m.InternalHttpEndPointIp, m.InternalHttpEndPointPort);
+}

--- a/src/EventStore.AutoScavenge/Commands.cs
+++ b/src/EventStore.AutoScavenge/Commands.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Domain;
+using NCrontab;
+
+namespace EventStore.AutoScavenge;
+
+public class Commands {
+	public record Assess() : Command<Unit>(_ => { }) {
+		public static Assess Instance { get; } = new();
+	}
+
+	public record Configure(CrontabSchedule Schedule, Action<Response<Unit>> Callback) : Command<Unit>(Callback);
+
+	public record GetStatus(Action<Response<AutoScavengeStatusResponse>> Callback) : Command<AutoScavengeStatusResponse>(Callback);
+
+	public record PauseProcess(Action<Response<Unit>> Callback) : Command<Unit>(Callback);
+
+	public record ResumeProcess(Action<Response<Unit>> Callback) : Command<Unit>(Callback);
+
+	public record ReceiveGossip(GossipMessage Msg) : Command<Unit>(_ => { });
+}

--- a/src/EventStore.AutoScavenge/Converters/CrontableScheduleJsonConverter.cs
+++ b/src/EventStore.AutoScavenge/Converters/CrontableScheduleJsonConverter.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Converters;
+
+public class CrontableScheduleJsonConverter : JsonConverter<CrontabSchedule> {
+	public override CrontabSchedule Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+		if (reader.TokenType != JsonTokenType.String)
+			throw new JsonException("CRON expression can only be a string");
+
+		try {
+			return CrontabSchedule.Parse(reader.GetString());
+		} catch (Exception ex) {
+			throw new JsonException("Invalid CRON expression", ex);
+		}
+	}
+
+	public override void Write(Utf8JsonWriter writer, CrontabSchedule value, JsonSerializerOptions options) {
+		JsonSerializer.Serialize(writer, value.ToString(), options);
+	}
+}

--- a/src/EventStore.AutoScavenge/Converters/EventJsonConverter.cs
+++ b/src/EventStore.AutoScavenge/Converters/EventJsonConverter.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EventStore.AutoScavenge.Converters;
+
+public class EventJsonConverter : JsonConverter<IEvent> {
+	public override IEvent? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+		throw new NotImplementedException();
+	}
+
+	public override void Write(Utf8JsonWriter writer, IEvent value, JsonSerializerOptions options) {
+		JsonSerializer.Serialize(writer, value, value.GetType(), options);
+	}
+}

--- a/src/EventStore.AutoScavenge/Domain/AutoScavengeConfiguration.cs
+++ b/src/EventStore.AutoScavenge/Domain/AutoScavengeConfiguration.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Domain;
+
+/// <summary>
+/// Auto scavenge configuration transient state.
+/// </summary>
+public class AutoScavengeConfiguration {
+
+	/// <summary>
+	/// Interval between two auto scavenge processes.
+	/// </summary>
+	public CrontabSchedule? Schedule { get; private set; }
+
+	/// <summary>
+	/// If configured at least once, when was the last time the auto scavenge process configuration was updated.
+	/// </summary>
+	public DateTime? StartingPoint { get; private set; }
+
+
+	/// <summary>
+	/// If the auto scavenge process is configured.
+	/// </summary>
+	public bool IsConfigured => StartingPoint != null;
+
+	/// <summary>
+	/// Deep instance copy, useful for testing purposes
+	/// </summary>
+	public AutoScavengeConfiguration Clone() {
+		return new AutoScavengeConfiguration {
+			Schedule = Schedule,
+			StartingPoint = StartingPoint,
+		};
+	}
+
+	/// <summary>
+	/// Resets internal state to default values.
+	/// </summary>
+	public void Clear() {
+		Schedule = null;
+		StartingPoint = null;
+	}
+
+	/// <summary>
+	/// Apply an event to the current state.
+	/// </summary>
+	/// <param name="event"></param>
+	public void Apply(IEvent @event) {
+		if (@event is not Events.ConfigurationUpdated msg)
+			return;
+
+		Handle(msg);
+	}
+
+	private void Handle(Events.ConfigurationUpdated msg) {
+		Schedule = msg.Schedule;
+		StartingPoint = msg.UpdatedAt;
+	}
+}

--- a/src/EventStore.AutoScavenge/Domain/AutoScavengeProcessManager.cs
+++ b/src/EventStore.AutoScavenge/Domain/AutoScavengeProcessManager.cs
@@ -1,0 +1,571 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.AutoScavenge.Scavengers;
+using EventStore.AutoScavenge.Sources;
+using EventStore.AutoScavenge.TimeProviders;
+using EventStore.POC.IO.Core;
+using NCrontab;
+using Serilog.Events;
+
+namespace EventStore.AutoScavenge.Domain;
+
+/// <summary>
+/// Responsible for managing the state transitions and operations related to the auto scavenge process in an Event Store
+/// cluster.
+/// </summary>
+/// <param name="timeProvider">
+/// Used when dealing with time-sensitive operations like when should the next auto scavenge process start.
+/// </param>
+/// <param name="source">
+/// Accesses the configuration and events related to the auto scavenge process.
+/// </param>
+public class AutoScavengeProcessManager {
+	private static readonly Serilog.ILogger Log = Serilog.Log.ForContext<AutoScavengeProcessManager>();
+
+	readonly ITimeProvider _timeProvider;
+	readonly ISource _source;
+	readonly IOperationsClient _operationClient;
+	readonly INodeScavenger _scavenger;
+	readonly int _clusterSize;
+
+	readonly Queue<IEvent> _uncommittedEvents = [];
+
+	NodeId _nodeId = new() { Address = "", Port = 0 };
+
+	NodeState _nodeState = NodeState.NotLeader;
+
+	List<ClusterMember> _gossip = [];
+	bool _isHealthyCluster;
+
+	// EventSourced state
+	public AutoScavengeState State { get; } = new();
+
+	public AutoScavengeProcessManager(
+		int clusterSize,
+		ITimeProvider timeProvider,
+		ISource source,
+		IOperationsClient operationsClient,
+		INodeScavenger scavenger) {
+
+		_timeProvider = timeProvider;
+		_source = source;
+		_operationClient = operationsClient;
+		_scavenger = scavenger;
+		_clusterSize = clusterSize;
+	}
+
+	/// <summary>
+	/// This is the entry point for the state machine. It operates one step at a time, requiring a command to progress.
+	/// </summary>
+	/// <remarks>
+	/// The state machine can generate another command, an event, or both. Here's the distinction:
+	/// - A command instructs the state machine to perform an action.
+	/// - An event notifies that a decision has been made.
+	///
+	/// It's expected that an event is persisted and should be retrievable using <see cref="ISource" />.
+	/// Only an event can modify the transient state of the state machine, which is done when <see cref="Apply"/> is called.
+	/// </remarks>
+	/// <returns>Events to persist and optionally a command to process afterward</returns>
+	public async ValueTask<Transition> RunAsync(ICommand command, CancellationToken token) {
+		switch (command) {
+			case Commands.ReceiveGossip gossip:
+				await ReceiveGossipAsync(gossip.Msg, token);
+				break;
+			case Commands.Configure configure:
+				configure.SetConditionalResponse(Configure(configure));
+				break;
+			case Commands.GetStatus status:
+				status.SetConditionalResponse(GetStatus());
+				break;
+			case Commands.PauseProcess pause:
+				pause.SetConditionalResponse(PauseProcess());
+				break;
+			case Commands.ResumeProcess resume:
+				resume.SetConditionalResponse(ResumeProcess());
+				break;
+			case Commands.Assess:
+				await AssessAsync(token);
+				break;
+			default:
+				return Transition.Noop;
+		}
+
+		// if we produced any events, commit them and reassess immediately
+		if (_uncommittedEvents.Count > 0) {
+			var events = _uncommittedEvents.ToArray();
+			_uncommittedEvents.Clear();
+			return new Transition(events, Commands.Assess.Instance);
+		}
+
+		if (command is Commands.Assess)
+			return Transition.Noop;
+
+		return new Transition([], Commands.Assess.Instance);
+	}
+
+	/// <summary>
+	/// Updates the transient state of the state machine.
+	/// </summary>
+	public void Apply(IEvent @event) {
+		State.Apply(@event);
+	}
+
+	/// <summary>
+	/// Resets the transient state of the state machine.
+	/// </summary>
+	private void Clear() {
+		State.Clear();
+		_uncommittedEvents.Clear();
+	}
+
+	// Cluster is healthy if all cluster nodes (not readonly replicas) are present
+	// todo: we may want to consider the statuses and the checkpoints
+	private bool IsHealthyCluster() {
+		var clusterMembers = 0;
+
+		foreach (var member in _gossip) {
+			if (member.InstanceId != Guid.Empty && !member.IsReadOnlyReplica)
+				clusterMembers++;
+		}
+
+		return clusterMembers == _clusterSize;
+	}
+
+	/// <summary>
+	/// Handles a gossip message from the cluster.
+	/// </summary>
+	/// <remarks>
+	/// This command serves as a central point in the state machine. It is triggered by frequent gossip messages,
+	/// which also act as a trigger mechanism to track the progress of operations such as the start of a new auto
+	/// scavenge process, completion or retry of a node scavenge. This command also detects changes in the cluster
+	/// topology.
+	///
+	/// It also tracks the node state this way. If it is no longer leader it resets all its transient state.
+	/// </remarks>
+	private async ValueTask ReceiveGossipAsync(GossipMessage msg, CancellationToken token) {
+		_gossip = msg.Members;
+		_isHealthyCluster = IsHealthyCluster();
+
+		var previousStatus = _nodeState;
+
+		foreach (var member in _gossip) {
+			if (member.InstanceId != msg.NodeId)
+				continue;
+
+			// member is this node
+			_nodeId = member.ToNodeId();
+
+			_nodeState = member.State == "Leader"
+				? NodeState.Leader
+				: NodeState.NotLeader;
+		}
+
+		if (_nodeState == NodeState.Leader) {
+			if (previousStatus != NodeState.Leader) {
+				// became the leader
+				await LoadConfigurationAsync(token);
+				await LoadStateAsync(token);
+			}
+		} else {
+			if (previousStatus == NodeState.Leader) {
+				// no longer the leader
+				Clear();
+			}
+			return;
+		}
+
+		// we are the leader
+		if (!_isHealthyCluster)
+			return;
+
+		if (!State.HasOngoingClusterScavenge(out _))
+			return;
+
+		// A cluster scavenge is in progress (even if paused), it may be affected by the new gossip.
+		var gossipNodeIds = _gossip.Select(x => x.ToNodeId()).ToList();
+		var newMembers = gossipNodeIds.Except(State.ClusterMembers).ToList();
+		var removedMembers = State.ClusterMembers.Except(gossipNodeIds).ToList();
+
+		if (newMembers.Count == 0 && removedMembers.Count == 0)
+			return;
+
+		_uncommittedEvents.Enqueue(new Events.ClusterMembersChanged {
+			Added = newMembers,
+			Removed = removedMembers,
+		});
+	}
+
+	/// <summary>
+	/// Handles auto scavenge configuration request.
+	/// </summary>
+	/// <remarks>
+	/// Because we always take the latest configuration, we don't need to reload passed configuration events. Updating
+	/// an auto scavenge process configuration must have no impact on an ongoing auto scavenge process.
+	/// </remarks>
+	private Response<Unit> Configure(Commands.Configure command) {
+		if (_nodeState != NodeState.Leader)
+			return Response.Rejected<Unit>("Node is not the leader");
+
+		_uncommittedEvents.Enqueue(new Events.ConfigurationUpdated {
+			Schedule = command.Schedule,
+			UpdatedAt = _timeProvider.Now,
+		});
+
+		return Response.Successful();
+	}
+
+	private async ValueTask LoadConfigurationAsync(CancellationToken token) {
+		Log.Information("Loading auto scavenge configuration...");
+
+		var @event = await _source.ReadConfigurationEvent(token);
+
+		if (@event != null)
+			Apply(@event);
+
+		Log.Information("Loaded auto scavenge configuration");
+	}
+
+	private async ValueTask LoadStateAsync(CancellationToken token) {
+		Log.Information("Loading auto scavenge state...");
+
+		await foreach (var @event in _source.ReadAutoScavengeEvents(token))
+			Apply(@event);
+
+		Apply(new Events.Initialized {
+			InitializedAt = _timeProvider.Now
+		});
+
+		Log.Information("Loaded auto scavenge state");
+	}
+
+	/// <summary>
+	///  Handles auto scavenge process assessment.
+	/// </summary>
+	/// <remarks>
+	/// During assessment, the state machine checks holistically the auto scavenge process current state:
+	/// <list type="bullet">
+	/// <item>
+	/// If enough time has passed since the last auto scavenge process, the state machine will start a new one.
+	/// </item>
+	/// <item>
+	/// If a node has been designated for scavenge, the state machine will issue a remote scavenge request to that
+	/// node.
+	/// </item>
+	/// <item>
+	/// If a node is scavenging, the state machine checks the status of that scavenge.
+	/// </item>
+	/// </list>
+	/// </remarks>
+	private async ValueTask AssessAsync(CancellationToken token) {
+		if (_nodeState != NodeState.Leader)
+			return;
+
+		// todo: consider reducing allocations here by passing a visitor object (nested struct? be careful not to box)
+		// this is called once every ~5s, so not often, and the allocations will usually be gen1
+		await State.Visit(
+			onNotConfigured: DoNothingAsync,
+			onPausedWhileIdle: DoNothingAsync,
+			onPausedWhileScavengingCluster: DoNothingAsync,
+			onPausing: TryToPause,
+			onContinuingClusterScavenge: PickANode,
+			onStartingNodeScavenge: StartNodeScavenge,
+			onMonitoringNodeScavenge: CheckOnTheNodeScavenge,
+			onWaiting: CheckTheSchedule);
+
+		static ValueTask DoNothingAsync() => ValueTask.CompletedTask;
+
+		async ValueTask TryToPause(NodeId? designatedNode, Guid? nodeScavengeId) {
+			if (designatedNode is null) {
+				_uncommittedEvents.Enqueue(new Events.Paused {
+					PausedAt = _timeProvider.Now,
+				});
+				return;
+			}
+
+			var success = await _scavenger.TryPauseScavengeAsync(
+				designatedNode.Value.Address,
+				designatedNode.Value.Port,
+				nodeScavengeId, token);
+
+			// If pausing the node scavenged failed, it will be retried on the next gossip message we got from
+			// the cluster.
+			if (!success)
+				return;
+
+			_uncommittedEvents.Enqueue(new Events.Paused {
+				PausedAt = _timeProvider.Now,
+			});
+		}
+
+		async ValueTask CheckOnTheNodeScavenge(NodeId designatedNode, Guid nodeScavengeId) {
+			ScavengeStatus status;
+
+			status = await _scavenger.TryGetScavengeAsync(
+				designatedNode.Address,
+				designatedNode.Port,
+				nodeScavengeId,
+				token);
+
+			if (status is ScavengeStatus.Unknown) {
+				Log.Information("Node scavenge on {NodeId} has Unknown status. Will retry.", designatedNode);
+				// retry will be triggered by next gossip
+				return;
+			}
+
+			if (status is ScavengeStatus.InProgress) {
+				Log.Verbose("Node Scavenge on {NodeId} is still in progress", designatedNode);
+				return;
+			}
+
+			if (status is ScavengeStatus.NotRunningUnknown) {
+				Log.Information("Node scavenge on {NodeId} is not running for an unknown reason. Restarting it.",
+					designatedNode);
+
+				_uncommittedEvents.Enqueue(new Events.NodeDesignated {
+					NodeId = designatedNode,
+					DesignatedAt = _timeProvider.Now,
+				});
+
+				return;
+			}
+
+			Log.Write(
+				status == ScavengeStatus.Success
+					? LogEventLevel.Information
+					: LogEventLevel.Warning,
+				"Node scavenge on {NodeId} has status: {Status}. Marking it as completed",
+				designatedNode, status);
+
+			_uncommittedEvents.Enqueue(new Events.NodeScavengeCompleted {
+				NodeId = designatedNode,
+				CompletedAt = _timeProvider.Now,
+				Result = status.ToString()
+			});
+		}
+
+		async ValueTask StartNodeScavenge(NodeId designatedNode) {
+			if (designatedNode == _nodeId && _clusterSize > 1) {
+				Log.Information(
+					"The leader {NodeId} is the last node to scavenge. We are resigning from leadership",
+					_nodeId);
+
+				_operationClient.Resign();
+				return;
+			}
+
+			var scavengeId = await _scavenger.TryStartScavengeAsync(designatedNode.Address, designatedNode.Port, token);
+
+			if (scavengeId == null)
+				// The idea is to let another gossip message come in and trigger the assessment again.
+				return;
+
+			_uncommittedEvents.Enqueue(new Events.NodeScavengeStarted {
+				NodeId = designatedNode,
+				ScavengeId = scavengeId.Value,
+				StartedAt = _timeProvider.Now,
+			});
+		}
+
+		ValueTask PickANode(Guid clusterScavengeId) {
+			DetermineBestCandidate(clusterScavengeId);
+			return ValueTask.CompletedTask;
+		}
+
+		ValueTask CheckTheSchedule(CrontabSchedule schedule, DateTime nextOccurence) {
+			// We are active but not currently scavenging the cluster. Maybe it's time to start!
+			if (_timeProvider.Now < nextOccurence)
+				return ValueTask.CompletedTask;
+
+			if (!_isHealthyCluster) {
+				Log.Information("Autoscavenge is due. Waiting for a healthy cluster");
+				return ValueTask.CompletedTask;
+			}
+
+			// We are due for a new auto scavenge process.
+			var activeMembers = _gossip.Select(x => x.ToNodeId());
+
+			_uncommittedEvents.Enqueue(new Events.ClusterScavengeStarted {
+				ClusterScavengeId = Guid.NewGuid(),
+				Members = activeMembers.ToList(),
+				StartedAt = _timeProvider.Now,
+			});
+
+			return ValueTask.CompletedTask;
+		}
+	}
+
+	/// <summary>
+	/// Determines the next best candidate for the auto scavenge process.
+	/// </summary>
+	/// <remarks>
+	/// This stage also handles the completion of the auto scavenge process when there are no more nodes to scavenge.
+	/// </remarks>
+	private void DetermineBestCandidate(Guid clusterScavengeId) {
+		if (!_isHealthyCluster) {
+			Log.Information("Waiting for a healthy cluster before picking a node to scavenge");
+			return;
+		}
+
+		var targets = State.NodesToScavenge.ToList();
+
+		// We detect if there is no longer any node to scavenge left.
+		if (targets.Count == 0) {
+			_uncommittedEvents.Enqueue(new Events.ClusterScavengeCompleted {
+				ClusterScavengeId = clusterScavengeId,
+				Members = State.ClusterMembers.ToList(),
+				CompletedAt = _timeProvider.Now,
+			});
+
+			Log.Information("Auto scavenge process {ClusterScavengeId} completed", clusterScavengeId);
+			return;
+		}
+
+		var candidate = targets[0];
+		var minWriterCheckpoint = long.MaxValue;
+
+		// We choose the node that is the farthest behind in its replication process.
+		foreach (var target in targets) {
+			var targetWriterCheckpoint = _gossip.Find(m => m.ToNodeId() == target)!.WriterCheckpoint;
+
+			if (targetWriterCheckpoint > minWriterCheckpoint)
+				continue;
+
+			if (target == _nodeId)
+				continue;
+
+			// In case a follower node is up-to-date, we will always choose it over the leader.
+			if (targetWriterCheckpoint == minWriterCheckpoint && candidate == _nodeId) {
+				candidate = target;
+				continue;
+			}
+
+			minWriterCheckpoint = targetWriterCheckpoint;
+			candidate = target;
+		}
+
+		Log.Information("Node {NodeId} is the next best candidate for scavenge", candidate);
+		_uncommittedEvents.Enqueue(new Events.NodeDesignated {
+			NodeId = candidate,
+			DesignatedAt = _timeProvider.Now,
+		});
+	}
+
+	/// <summary>
+	/// Pauses the auto scavenge process.
+	/// </summary>
+	private Response<Unit> PauseProcess() {
+		if (_nodeState != NodeState.Leader)
+			return Response.Rejected<Unit>("Node is not the leader");
+
+		switch (State.Status) {
+			case AutoScavengeStatus.PausedWhileIdle:
+			case AutoScavengeStatus.PausedWhileScavengingCluster:
+				return Response.Successful();
+
+			case AutoScavengeStatus.Pausing:
+				return Response.Accepted();
+
+			case AutoScavengeStatus.NotConfigured:
+			case AutoScavengeStatus.ContinuingClusterScavenge:
+			case AutoScavengeStatus.Waiting:
+				_uncommittedEvents.Enqueue(new Events.Paused {
+					PausedAt = _timeProvider.Now
+				});
+				return Response.Successful();
+
+			case AutoScavengeStatus.StartingNodeScavenge:
+			case AutoScavengeStatus.MonitoringNodeScavenge:
+				_uncommittedEvents.Enqueue(new Events.PauseRequested {
+					RequestedAt = _timeProvider.Now
+				});
+				return Response.Accepted();
+			default:
+				throw new InvalidOperationException();
+		}
+	}
+
+	/// <summary>
+	/// Resumes the auto scavenge process.
+	/// </summary>
+	private Response<Unit> ResumeProcess() {
+		if (_nodeState != NodeState.Leader)
+			return Response.Rejected<Unit>("Node is not the leader");
+
+		switch (State.Status) {
+			case AutoScavengeStatus.PausedWhileIdle:
+			case AutoScavengeStatus.PausedWhileScavengingCluster:
+				_uncommittedEvents.Enqueue(new Events.Resumed {
+					ResumedAt = _timeProvider.Now,
+				});
+				return Response.Successful();
+
+			case AutoScavengeStatus.Pausing:
+				return Response.Rejected("Auto scavenge process is currently pausing");
+
+			case AutoScavengeStatus.NotConfigured:
+			case AutoScavengeStatus.ContinuingClusterScavenge:
+			case AutoScavengeStatus.StartingNodeScavenge:
+			case AutoScavengeStatus.MonitoringNodeScavenge:
+			case AutoScavengeStatus.Waiting:
+				return Response.Successful();
+			default:
+				throw new InvalidOperationException();
+		}
+	}
+
+	/// <summary>
+	/// Produces the status breakdown of the auto scavenge process. If the auto scavenge process transient states
+	/// are loaded from the persistent storage, We produce the breakdown on the spot. If the state machine hasn't
+	/// loaded, we load it first then we produce the status breakdown.
+	/// </summary>
+	private Response<AutoScavengeStatusResponse> GetStatus() {
+		if (_nodeState != NodeState.Leader)
+			return Response.Rejected<AutoScavengeStatusResponse>("Node is not the leader");
+
+		State.HasSchedule(out var schedule, out var nextOccurence);
+
+		TimeSpan? nextCycle;
+
+		if (State.HasOngoingClusterScavenge(out _)) {
+			// cycle is happening right now
+			nextCycle = TimeSpan.Zero;
+		} else if (schedule is null) {
+			// not configured, there is no next cycle
+			nextCycle = null;
+		} else if (State.Status is AutoScavengeStatus.PausedWhileIdle) {
+			// we are paused while idle, show the time of the next cycle if we resumed now
+			nextCycle = schedule.GetNextOccurrence(_timeProvider.Now) - _timeProvider.Now;
+		} else {
+			// waiting
+			nextCycle = nextOccurence - _timeProvider.Now;
+		}
+
+		if (nextCycle < TimeSpan.Zero)
+			nextCycle = TimeSpan.Zero;
+
+		var state = State.Status switch {
+			AutoScavengeStatus.NotConfigured =>
+				AutoScavengeStatusResponse.Status.NotConfigured,
+
+			AutoScavengeStatus.Waiting =>
+				AutoScavengeStatusResponse.Status.Waiting,
+
+			AutoScavengeStatus.ContinuingClusterScavenge or
+			AutoScavengeStatus.MonitoringNodeScavenge or
+			AutoScavengeStatus.StartingNodeScavenge =>
+				AutoScavengeStatusResponse.Status.InProgress,
+
+			AutoScavengeStatus.Pausing =>
+				AutoScavengeStatusResponse.Status.Pausing,
+
+			AutoScavengeStatus.PausedWhileIdle or
+			AutoScavengeStatus.PausedWhileScavengingCluster =>
+				AutoScavengeStatusResponse.Status.Paused,
+
+			_ => throw new InvalidOperationException(),
+		};
+
+		return Response.Successful(new AutoScavengeStatusResponse(state, schedule, nextCycle));
+	}
+}

--- a/src/EventStore.AutoScavenge/Domain/AutoScavengeState.cs
+++ b/src/EventStore.AutoScavenge/Domain/AutoScavengeState.cs
@@ -1,0 +1,349 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Diagnostics.CodeAnalysis;
+using NCrontab;
+using Serilog;
+
+namespace EventStore.AutoScavenge.Domain;
+
+/// <summary>
+/// Auto scavenge process transient state.
+/// </summary>
+public class AutoScavengeState {
+	private static readonly ILogger Log = Serilog.Log.ForContext<AutoScavengeState>();
+
+	/// <summary>
+	/// Nodes that have been scavenged in the current process cycle.
+	/// </summary>
+	private HashSet<NodeId> _scavengedNodes = [];
+
+	/// <summary>
+	/// Id of the current cluster scavenge, if any.
+	/// </summary>
+	// todo: only used by this and tests, make private
+	public Guid ClusterScavengeId { get; private set; } = Guid.Empty;
+
+	/// <summary>
+	/// Id of the current node scavenge, if any.
+	/// </summary>
+	// todo: only used by this and tests, make private
+	public Guid NodeScavengeId { get; private set; } = Guid.Empty;
+
+	/// <summary>
+	/// Current node that is designated for scavenging.
+	/// </summary>
+	// NodeScavengeId == Guid.Empty => a scavenge may have been started on the DesignatedNode
+	// NodeScavengeId != Guid.Empty => a scavenge has been started on the DesignatedNode
+	// todo: only used by this and tests, make private
+	public NodeId? DesignatedNode { get; private set; } = null;
+
+	/// <summary>
+	/// Current list of cluster members.
+	/// </summary>
+	public HashSet<NodeId> ClusterMembers { get; private set; } = [];
+
+	/// <summary>
+	/// Last time a cluster scavenge was completed successfully or resume. Changing the anchor date when a cluster
+	/// scavenge was resumed is for consistency’s sake. For example if a schedule is set for once every week on Sundays,
+	/// if the process is paused for a whole week and resumed on the next Tuesday, the process will start on the next
+	/// Sunday, instead of starting right away.
+	/// </summary>
+	public DateTime? LastClusterAnchorDateTime { get; private set; }
+
+	/// <summary>
+	/// Nodes remaining to be scavenged in the current cluster scavenge.
+	/// </summary>
+	public IEnumerable<NodeId> NodesToScavenge => ClusterMembers.Except(_scavengedNodes);
+
+	public AutoScavengeConfiguration Configuration { get; init; } = new();
+
+	/// <summary>
+	/// Is there an ongoing auto scavenge process? By process, we mean if we have started a new cycle of node scavenges.
+	/// </summary>
+	public bool HasOngoingClusterScavenge(out Guid clusterScavengeId) {
+		clusterScavengeId = ClusterScavengeId;
+		return clusterScavengeId != Guid.Empty;
+	}
+
+	public bool HasSchedule(
+		[MaybeNullWhen(returnValue: false)] out CrontabSchedule schedule,
+		out DateTime nextOccurence) {
+
+		var since = LastClusterAnchorDateTime ?? Configuration.StartingPoint;
+
+		if (since is null || Configuration.Schedule is null) {
+			schedule = default;
+			nextOccurence = default;
+			return false;
+		}
+
+		schedule = Configuration.Schedule;
+		nextOccurence = schedule.GetNextOccurrence(since.Value);
+		return true;
+	}
+
+	public T Visit<T>(
+		Func<T> onNotConfigured,
+		Func<Guid, T> onContinuingClusterScavenge,
+		Func<NodeId, Guid, T> onMonitoringNodeScavenge,
+		Func<NodeId?, Guid?, T> onPausing,
+		Func<T> onPausedWhileIdle,
+		Func<T> onPausedWhileScavengingCluster,
+		Func<NodeId, T> onStartingNodeScavenge,
+		Func<CrontabSchedule, DateTime, T> onWaiting) {
+		switch (Status) {
+			case AutoScavengeStatus.NotConfigured:
+				return onNotConfigured();
+
+			case AutoScavengeStatus.ContinuingClusterScavenge:
+				return onContinuingClusterScavenge(ClusterScavengeId);
+
+			case AutoScavengeStatus.MonitoringNodeScavenge:
+				return onMonitoringNodeScavenge(DesignatedNode!.Value, NodeScavengeId);
+
+			case AutoScavengeStatus.Pausing:
+				return onPausing(DesignatedNode, NodeScavengeId == Guid.Empty ? null : NodeScavengeId);
+
+			case AutoScavengeStatus.PausedWhileIdle:
+				return onPausedWhileIdle();
+
+			case AutoScavengeStatus.PausedWhileScavengingCluster:
+				return onPausedWhileScavengingCluster();
+
+			case AutoScavengeStatus.StartingNodeScavenge:
+				return onStartingNodeScavenge(DesignatedNode!.Value);
+
+			case AutoScavengeStatus.Waiting:
+				if (!HasSchedule(out var schedule, out var nextOccurence))
+					throw new Exception("Invalid state");
+				return onWaiting(schedule, nextOccurence);
+
+			default: throw new Exception("Unexpected Status");
+		};
+	}
+
+	/// <summary>
+	/// Auto scavenge process status
+	/// </summary>
+	/// Checks that the invariants are maintained when changing status
+	AutoScavengeStatus _status = AutoScavengeStatus.NotConfigured;
+	public AutoScavengeStatus Status {
+		get {
+			return _status;
+		}
+		private set {
+			switch (value) {
+				// in these states we do not have an ongoing cluster scavenge
+				case AutoScavengeStatus.NotConfigured:
+				case AutoScavengeStatus.Waiting:
+				case AutoScavengeStatus.PausedWhileIdle:
+					if (HasOngoingClusterScavenge(out _))
+						throw new InvalidOperationException($"Cannot transition to {value}. There is an ongoing cluster scavenge.");
+					break;
+
+				// in these states we do have an ongoing cluster scavenge
+				case AutoScavengeStatus.ContinuingClusterScavenge:
+				case AutoScavengeStatus.PausedWhileScavengingCluster:
+				case AutoScavengeStatus.Pausing:
+					if (!HasOngoingClusterScavenge(out _))
+						throw new InvalidOperationException($"Cannot transition to {value}. There is no ongoing cluster scavenge.");
+					break;
+
+				// in these states it's possible that a node scavenge is running
+				case AutoScavengeStatus.StartingNodeScavenge:
+					if (!HasOngoingClusterScavenge(out _))
+						throw new InvalidOperationException($"Cannot transition to {value}. There is no ongoing cluster scavenge.");
+					if (DesignatedNode is null)
+						throw new InvalidOperationException($"Cannot transition to {value}. There is no designated node.");
+					break;
+
+				// in these states we have an ongoing node scavenge
+				case AutoScavengeStatus.MonitoringNodeScavenge:
+					if (!HasOngoingClusterScavenge(out _))
+						throw new InvalidOperationException($"Cannot transition to {value}. There is no ongoing cluster scavenge.");
+					if (DesignatedNode is null || NodeScavengeId == Guid.Empty)
+						throw new InvalidOperationException($"Cannot transition to {value}. There is no ongoing node scavenge.");
+					break;
+				default:
+					throw new InvalidOperationException($"Cannot transition to {value}. It is an unknown state.");
+			}
+			_status = value;
+		}
+	}
+
+	/// <summary>
+	/// Deep instance copy, useful for testing purposes
+	/// </summary>
+	public AutoScavengeState Clone() {
+		return new AutoScavengeState {
+			ClusterScavengeId = ClusterScavengeId,
+			ClusterMembers = ClusterMembers.ToHashSet(),
+			DesignatedNode = DesignatedNode,
+			LastClusterAnchorDateTime = LastClusterAnchorDateTime,
+			_scavengedNodes = _scavengedNodes.ToHashSet(),
+			NodeScavengeId = NodeScavengeId,
+			Configuration = Configuration.Clone(),
+			Status = Status,
+		};
+	}
+
+	/// <summary>
+	/// Resets internal state to default values.
+	/// </summary>
+	public void Clear() {
+		ClusterScavengeId = Guid.Empty;
+		DesignatedNode = null;
+		_scavengedNodes.Clear();
+		ClusterMembers.Clear();
+		Configuration.Clear();
+		LastClusterAnchorDateTime = null;
+		Status = AutoScavengeStatus.NotConfigured;
+	}
+
+	/// <summary>
+	/// Apply an event to the current state.
+	/// </summary>
+	/// <param name="event"></param>
+	public void Apply(IEvent @event) {
+		switch (@event) {
+			case Events.ClusterScavengeStarted msg:
+				Handle(msg);
+				break;
+			case Events.ClusterScavengeCompleted msg:
+				Handle(msg);
+				break;
+			case Events.NodeScavengeStarted msg:
+				Handle(msg);
+				break;
+			case Events.NodeScavengeCompleted msg:
+				Handle(msg);
+				break;
+			case Events.NodeDesignated msg:
+				Handle(msg);
+				break;
+			case Events.ClusterMembersChanged msg:
+				Handle(msg);
+				break;
+			case Events.Initialized msg:
+				Handle(msg);
+				break;
+			case Events.PauseRequested msg:
+				Handle(msg);
+				break;
+			case Events.Paused msg:
+				Handle(msg);
+				break;
+			case Events.Resumed msg:
+				Handle(msg);
+				break;
+			case Events.ConfigurationUpdated msg:
+				Handle(msg);
+				break;
+		}
+	}
+
+	private void Handle(Events.ClusterScavengeStarted msg) {
+		ClusterScavengeId = msg.ClusterScavengeId;
+		_scavengedNodes.Clear();
+		ClusterMembers = msg.Members.ToHashSet();
+		Status = AutoScavengeStatus.ContinuingClusterScavenge;
+	}
+
+	private void Handle(Events.ClusterScavengeCompleted msg) {
+		if (ClusterScavengeId != msg.ClusterScavengeId) {
+			Log.Warning("Ignoring uncorrelated {EventType} event", msg.Type);
+			return;
+		}
+
+		ClusterMembers = msg.Members.ToHashSet();
+		LastClusterAnchorDateTime = msg.CompletedAt;
+		ClusterScavengeId = Guid.Empty;
+		Status = AutoScavengeStatus.Waiting;
+	}
+
+	private void Handle(Events.NodeScavengeStarted msg) {
+		if (DesignatedNode != msg.NodeId) {
+			Log.Warning("Found out of order {EventType} event. Skipping it", msg.Type);
+			return;
+		}
+
+		NodeScavengeId = msg.ScavengeId;
+		Status = AutoScavengeStatus.MonitoringNodeScavenge;
+	}
+
+	private void Handle(Events.NodeScavengeCompleted msg) {
+		if (DesignatedNode != msg.NodeId) {
+			Log.Warning("Found out of order {EventType} event. Skipping it", msg.Type);
+			return;
+		}
+
+		DesignatedNode = null;
+		NodeScavengeId = Guid.Empty;
+		_scavengedNodes.Add(msg.NodeId);
+		Status = AutoScavengeStatus.ContinuingClusterScavenge;
+	}
+
+	private void Handle(Events.NodeDesignated msg) {
+		DesignatedNode = msg.NodeId;
+		Status = AutoScavengeStatus.StartingNodeScavenge;
+	}
+
+	private void Handle(Events.ClusterMembersChanged msg) {
+		foreach (var nodeId in msg.Added)
+			ClusterMembers.Add(nodeId);
+
+		foreach (var nodeId in msg.Removed) {
+			ClusterMembers.Remove(nodeId);
+			_scavengedNodes.Remove(nodeId);
+
+			if (DesignatedNode == nodeId) {
+				Log.Information("Node {NodeId} was designated to scavenge but has been removed from the cluster", nodeId);
+				DesignatedNode = null;
+				NodeScavengeId = Guid.Empty;
+
+				if (Status != AutoScavengeStatus.Pausing) {
+					Status = AutoScavengeStatus.ContinuingClusterScavenge;
+				} else {
+					// we are pausing but the designated node has left the cluster
+					// we remain in the pausing state, the manager will transition us to paused.
+				}
+			}
+		}
+	}
+
+	private void Handle(Events.Initialized msg) {
+		if (Configuration.IsConfigured)
+			LastClusterAnchorDateTime = msg.InitializedAt;
+	}
+
+	private void Handle(Events.PauseRequested msg) {
+		Status = AutoScavengeStatus.Pausing;
+	}
+
+	private void Handle(Events.Paused msg) {
+		DesignatedNode = null;
+
+		Status = ClusterScavengeId == Guid.Empty
+			? AutoScavengeStatus.PausedWhileIdle
+			: AutoScavengeStatus.PausedWhileScavengingCluster;
+	}
+
+	private void Handle(Events.Resumed msg) {
+		Status =
+			ClusterScavengeId != Guid.Empty ? AutoScavengeStatus.ContinuingClusterScavenge :
+			Configuration.IsConfigured ? AutoScavengeStatus.Waiting :
+			AutoScavengeStatus.NotConfigured;
+
+		if (Configuration.IsConfigured)
+			LastClusterAnchorDateTime = msg.ResumedAt;
+	}
+
+	private void Handle(Events.ConfigurationUpdated msg) {
+		Configuration.Apply(msg);
+		LastClusterAnchorDateTime = msg.UpdatedAt;
+
+		if (Status == AutoScavengeStatus.NotConfigured)
+			Status = AutoScavengeStatus.Waiting;
+	}
+}

--- a/src/EventStore.AutoScavenge/Domain/AutoScavengeStatus.cs
+++ b/src/EventStore.AutoScavenge/Domain/AutoScavengeStatus.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Domain;
+
+// Names are serialized on the status endpoint
+public enum AutoScavengeStatus {
+	// No schedule, do nothing
+	NotConfigured,
+
+	// Evaluating whether there are more nodes to scavenge this cycle.
+	ContinuingClusterScavenge,
+
+	// A node scavenge is under way and we are waiting for it.
+	MonitoringNodeScavenge,
+
+	// A node scavenge is under way and we are trying to stop it.
+	Pausing,
+
+	// Paused. No cluster scavenge is under way.
+	PausedWhileIdle,
+
+	// Paused. A cluster scavenge is ready to resume.
+	PausedWhileScavengingCluster,
+
+	// A node is designated, we are starting a nodescavenge on it.
+	StartingNodeScavenge,
+
+	// Waiting for the schedule to begin the next cycle.
+	Waiting,
+}

--- a/src/EventStore.AutoScavenge/Domain/AutoScavengeStatusResponse.cs
+++ b/src/EventStore.AutoScavenge/Domain/AutoScavengeStatusResponse.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using NCrontab;
+
+namespace EventStore.AutoScavenge.Domain;
+
+public record AutoScavengeStatusResponse(
+	AutoScavengeStatusResponse.Status State,
+	CrontabSchedule? Schedule,
+	TimeSpan? TimeUntilNextCycle) {
+
+	public enum Status {
+		NotConfigured,
+		Waiting,
+		InProgress,
+		Pausing,
+		Paused,
+	}
+}

--- a/src/EventStore.AutoScavenge/Domain/NodeId.cs
+++ b/src/EventStore.AutoScavenge/Domain/NodeId.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Domain;
+
+public readonly record struct NodeId(string Address, int Port);

--- a/src/EventStore.AutoScavenge/EventStore.AutoScavenge.csproj
+++ b/src/EventStore.AutoScavenge/EventStore.AutoScavenge.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<EnableDynamicLoading>true</EnableDynamicLoading>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.POC.ConnectedSubsystemHost\EventStore.POC.ConnectedSubsystemHost.csproj" />
+		<ProjectReference Include="..\EventStore.POC.ConnectedSubsystemsPlugin\EventStore.POC.ConnectedSubsystemsPlugin.csproj" />
+		<ProjectReference Include="..\EventStore.POC.IO.Core\EventStore.POC.IO.Core.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="NCrontab" Version="3.3.3" />
+	</ItemGroup>
+
+
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<ItemGroup>
+			<MySourceFiles Include="$(OutDir)\*.AutoScavenge.*" />
+			<MySourceFiles Include="$(OutDir)\NCrontab.dll" />
+		</ItemGroup>
+		<Copy SourceFiles="@(MySourceFiles)" DestinationFolder="..\..\EventStore\src\KurrentDB\$(OutDir)\plugins\$(ProjectName)" />
+	</Target>
+
+	<Target Name="PublishPlugin" AfterTargets="Publish">
+		<ItemGroup>
+			<PluginOutputFiles Include="$(PublishDir)\LICENSE.md" />
+			<PluginOutputFiles Include="$(PublishDir)\NOTICE.html" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.AutoScavenge.deps.json" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.AutoScavenge.dll" />
+			<PluginOutputFiles Include="$(PublishDir)\NCrontab.dll*" />
+		</ItemGroup>
+		<Copy SourceFiles="@(PluginOutputFiles)" DestinationFolder="$(PublishDir)/package" />
+	</Target>
+</Project>

--- a/src/EventStore.AutoScavenge/EventStoreOptions.cs
+++ b/src/EventStore.AutoScavenge/EventStoreOptions.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public class EventStoreOptions {
+	public bool Insecure { get; init; }
+	public bool DiscoverViaDns { get; init; }
+	public string? ClusterDns { get; init; }
+	public int ClusterSize { get; init; }
+}

--- a/src/EventStore.AutoScavenge/Events.cs
+++ b/src/EventStore.AutoScavenge/Events.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json.Serialization;
+using EventStore.AutoScavenge.Domain;
+using NCrontab;
+
+namespace EventStore.AutoScavenge;
+
+public class Events {
+	public class ConfigurationUpdated : IEvent {
+		public required CrontabSchedule Schedule { get; init; }
+		public required DateTime UpdatedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.ConfigurationUpdated;
+	}
+
+	public class ClusterMembersChanged : IEvent {
+		public required List<NodeId> Added { get; init; }
+		public required List<NodeId> Removed { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.ClusterMembersChanged;
+	}
+
+	public class ClusterScavengeStarted : IEvent {
+		public required Guid ClusterScavengeId { get; init; }
+		public required List<NodeId> Members { get; init; }
+		public required DateTime StartedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.ClusterScavengeStarted;
+	}
+
+	public class ClusterScavengeCompleted : IEvent {
+		public required Guid ClusterScavengeId { get; init; }
+		public required List<NodeId> Members { get; init; }
+		public required DateTime CompletedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.ClusterScavengeCompleted;
+	}
+
+	public class NodeDesignated : IEvent {
+		public required NodeId NodeId { get; init; }
+		public required DateTime DesignatedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.NodeDesignated;
+	}
+
+	public class NodeScavengeStarted : IEvent {
+		public required NodeId NodeId { get; init; }
+		public required Guid ScavengeId { get; init; }
+		public required DateTime StartedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.NodeScavengeStarted;
+	}
+
+	public class NodeScavengeCompleted : IEvent {
+		public required NodeId NodeId { get; init; }
+		public required DateTime CompletedAt { get; init; }
+		public required string Result { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.NodeScavengeCompleted;
+	}
+
+	public class Initialized : IEvent {
+		public required DateTime InitializedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.Initialized;
+	}
+
+	public class PauseRequested : IEvent {
+		public required DateTime RequestedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.PauseRequested;
+	}
+
+	public class Paused : IEvent {
+		public required DateTime PausedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.Paused;
+	}
+
+	public class Resumed : IEvent {
+		public required DateTime ResumedAt { get; init; }
+
+		[JsonIgnore]
+		public string Type => EventTypes.Resumed;
+	}
+}

--- a/src/EventStore.AutoScavenge/GossipMessage.cs
+++ b/src/EventStore.AutoScavenge/GossipMessage.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public class GossipMessage {
+	public Guid NodeId { get; init; } = default;
+	public List<ClusterMember> Members { get; init; } = new();
+}

--- a/src/EventStore.AutoScavenge/HttpClientWrapper.cs
+++ b/src/EventStore.AutoScavenge/HttpClientWrapper.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
+
+namespace EventStore.AutoScavenge;
+
+// An HttpClient with additional context
+public class HttpClientWrapper {
+	public HttpClient HttpClient { get; }
+	public string Protocol { get; }
+
+	public HttpClientWrapper(EventStoreOptions options, INodeHttpClientFactory nodeHttpClientFactory) {
+		var nodeHttpClient =
+			nodeHttpClientFactory.CreateHttpClient(options.DiscoverViaDns ? [options.ClusterDns] : null);
+
+		Protocol = options.Insecure ? "http" : "https";
+
+		HttpClient = nodeHttpClient;
+		HttpClient.DefaultRequestHeaders.Accept.Add(new("application/json"));
+		HttpClient.Timeout = TimeSpan.FromSeconds(1);
+	}
+}

--- a/src/EventStore.AutoScavenge/ICommand.cs
+++ b/src/EventStore.AutoScavenge/ICommand.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public interface ICommand {
+	public void OnSavedEvents();
+	public void OnServerError(string message);
+}
+
+public interface ICommand<T> : ICommand {
+	// conditional upon writing the events (if any).
+	public void SetConditionalResponse(Response<T> response);
+}
+
+public record Command<T> : ICommand<T> {
+	readonly Action<Response<T>> _callback;
+	Response<T> _conditionalResponse;
+
+	public Command(Action<Response<T>> callback) {
+		_callback = callback;
+	}
+
+	// This response will be sent if the associated events (if any) are persisted
+	public void SetConditionalResponse(Response<T> response) {
+		_conditionalResponse = response;
+	}
+
+	public void OnSavedEvents() {
+		_callback(_conditionalResponse);
+	}
+
+	public void OnServerError(string message) {
+		_callback(Response<T>.ServerError(message));
+	}
+}

--- a/src/EventStore.AutoScavenge/IEvent.cs
+++ b/src/EventStore.AutoScavenge/IEvent.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public interface IEvent {
+	string Type { get; }
+}

--- a/src/EventStore.AutoScavenge/NodeEndpoint.cs
+++ b/src/EventStore.AutoScavenge/NodeEndpoint.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public readonly record struct NodeEndpoint {
+	public string Host { get; init; }
+	public int Port { get; init; }
+}

--- a/src/EventStore.AutoScavenge/NodeState.cs
+++ b/src/EventStore.AutoScavenge/NodeState.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public enum NodeState {
+	NotLeader,
+	Leader,
+}

--- a/src/EventStore.AutoScavenge/README.md
+++ b/src/EventStore.AutoScavenge/README.md
@@ -1,0 +1,83 @@
+# AutoScavenge Plugin
+
+The Autoscavenge plugin automatically schedules _cluster scavenges_ which are composed of multiple _node scavenges_. Only one node scavenge
+can be executed at a time in the cluster. The Autoscavenge plugin allows to schedule said _cluster scavenges_. In order to use the plugin,
+it needs to be present in a subdirectory in the `./plugins` folder in your EventStoreDB installation directory.
+
+You then need to add the configuration to enable the plugin to a json file in the `{installation_directory}/config` directory. Note, the
+plugin doesn't support a server running in dev mode.
+For example, add the following configuration to `./config/auto-scavenge-plugin-config.json` file within the EventStoreDB installation directory:
+
+```json
+{
+  "EventStore": {
+    "AutoScavenge": {
+      "Enabled": true
+    }
+  }
+}
+```
+
+The name of the above json config file is not important. What is important is that the json config should be in the `{installation_directory}/config` directory.
+Once the plugin is installed and enabled the server should log a similar message to the one below:
+
+```
+[18304, 1,23:01:53.335,INF] "AutoScavenge" "24.10.0" plugin enabled.
+```
+
+## HTTP endpoints
+
+The Autoscavenge plugin exposes HTTP endpoints.
+
+* `GET /auto-scavenge/enabled`: Tells if the Autoscavenge plugin is enabled or not.
+* `GET /auto-scavenge/status`: Tells the current status of the cluster auto scavenge process. You can know for example if it's running or when the next process will run.
+* `POST /auto-scavenge/configure`: Configure the cluster auto scavenge process schedule. The expected json payload is the following:
+```json
+{
+  "schedule": "{ Valid standard CRON expression }"
+}
+```
+* `POST /auto-scavenge/pause`: Pauses the cluster auto scavenge process. No payload is needed.
+* `POST /auto-scavenge/resume`: Resumes the cluster auto scavenge process. No payload is needed.
+
+Unlike the `GET /auto-scavenge/enabled` endpoint, all the other endpoints require a user to be authenticated and to have either an ops or an admin role.
+
+## Troubleshooting
+
+### Plugin not loaded
+The plugin has to be located in a subdirectory of the server's plugins directory. To check this:
+
+1. Go to the installation directory of the server, the directory containing the EventStoreDB executable.
+2. In this directory there should be a directory called plugins, create it if this is not the case.
+3. The plugins directory should have a subdirectory for the plugin, for instance called `EventStore.AutoScavenge` but this could be any name. Create it if it doesn't exist.
+4. The binaries of the plugin should be located in the subdirectory which was checked in the previous step.
+
+You can verify which plugins have been found and loaded by looking for the following logs:
+
+```
+[11212, 1,18:44:30.420,INF] Plugins path: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins"
+[11212, 1,18:44:30.420,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins" to the plugin catalog.
+[11212, 1,18:44:30.422,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins\\EventStore.Licensing" to the plugin catalog.
+[11212, 1,18:44:30.432,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins\\EventStore.POC.ConnectedSubsystemsPlugin" to the plugin catalog.
+[11212, 1,18:44:30.433,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins\\EventStore.POC.ConnectorsPlugin" to the plugin catalog.
+[11212, 1,18:44:30.436,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins\\EventStore.TcpPlugin" to the plugin catalog.
+[11212, 1,18:44:30.479,INF] Loaded SubsystemsPlugin plugin: "licensing" "24.6.0.0".
+[11212, 1,18:44:30.483,INF] Loaded SubsystemsPlugin plugin: "connected" "0.0.5".
+[11212, 1,18:44:30.496,INF] Loaded ConnectedSubsystemsPlugin plugin: "connectors" "0.0.5".
+[11212, 1,18:44:30.496,INF] Loaded ConnectedSubsystemsPlugin plugin: "auto-scavenge" "24.10.0".
+```
+
+### Plugin not started
+The plugin has to be configured and the server must not run in dev mode to start in order to be able to be integrated into EventStoreDB server.
+If you see the following log it means the plugin was found but was not started:
+
+```
+[ 5104, 1,19:03:13.807,INF] "AutoScavenge" "24.10.0" plugin disabled. "Set 'EventStore:AutoScavenge:Enabled' to 'true' and don't run the server in dev mode to enable the auto-scavenge plugin"
+```
+
+Ensure the plugin is enabled by adding a json config file to the `{installation_directory}/config` directory as mentioned above.
+When the plugin starts correctly you should see the following log:
+
+```
+[11212, 1,18:44:34.070,INF] "AutoScavenge" "24.10.0" plugin enabled.
+```

--- a/src/EventStore.AutoScavenge/Response.cs
+++ b/src/EventStore.AutoScavenge/Response.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public static class Response {
+	public static Response<T> Successful<T>(T value) => Response<T>.Successful(value);
+	public static Response<T> Accepted<T>() => Response<T>.Accepted();
+	public static Response<T> Rejected<T>(string message) => Response<T>.Rejected(message);
+	public static Response<T> ServerError<T>(string message) => Response<T>.ServerError(message);
+
+	public static Response<Unit> Successful() => Response<Unit>.Successful(Unit.Instance);
+	public static Response<Unit> Accepted() => Response<Unit>.Accepted();
+	public static Response<Unit> Rejected(string message) => Response<Unit>.Rejected(message);
+	public static Response<Unit> ServerError(string message) => Response<Unit>.ServerError(message);
+}
+
+public readonly struct Response<T> {
+	public enum State {
+		ServerError,
+		Rejected,
+
+		// Command has been accepted by the server but processing of it has not complete,
+		// it may yet succeed or fail.
+		Accepted,
+		Successful,
+	};
+
+	private readonly State _state;
+	private readonly T? _value;
+	private readonly string? _message = "default response";
+
+	private Response(State state, T? value = default, string? message = null) {
+		_state = state;
+		_value = value;
+		_message = message;
+	}
+
+	public static Response<T> Successful(T value) => new(State.Successful, value);
+	public static Response<T> Accepted() => new(State.Accepted);
+	public static Response<T> Rejected(string message) => new(State.Rejected, message: message);
+	public static Response<T> ServerError(string message) => new(State.ServerError, message: message);
+
+	public U Visit<U>(
+		Func<T, U> onSuccessful,
+		Func<U> onAccepted,
+		Func<string, U> onRejected,
+		Func<string, U> onServerError) =>
+
+		_state switch {
+			State.Successful => onSuccessful(_value!),
+			State.Accepted => onAccepted(),
+			State.Rejected => onRejected(_message!),
+			State.ServerError => onServerError(_message!),
+			_ => onServerError("Unexpected state"),
+		};
+
+	public readonly bool IsSuccessful(out T value) {
+		value = _value!;
+		return _state == State.Successful;
+	}
+
+	public readonly bool IsAccepted(out string message) {
+		message = _message!;
+		return _state == State.Accepted;
+	}
+
+	public readonly bool IsRejected(out string message) {
+		message = _message!;
+		return _state == State.Rejected;
+	}
+
+	public readonly bool IsServerError(out string message) {
+		message = _message!;
+		return _state == State.ServerError;
+	}
+}

--- a/src/EventStore.AutoScavenge/Scavengers/HttpNodeScavenger.cs
+++ b/src/EventStore.AutoScavenge/Scavengers/HttpNodeScavenger.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using EventStore.POC.IO.Core;
+using EventStore.POC.IO.Core.Serialization;
+using Serilog;
+
+namespace EventStore.AutoScavenge.Scavengers;
+
+/// Performs remote node scavenge operations.
+public class HttpNodeScavenger : INodeScavenger {
+	private static readonly ILogger Log = Serilog.Log.ForContext<HttpNodeScavenger>();
+
+	private readonly HttpClientWrapper _wrapper;
+	private readonly IClient _client;
+
+	public HttpNodeScavenger(HttpClientWrapper wrapper, IClient client) {
+		_wrapper = wrapper;
+		_client = client;
+	}
+
+	private static readonly JsonSerializerOptions JsonSerializerOptions = new() {
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters = {
+			new EnumConverterWithDefault<ScavengeResult>(),
+			new EnumConverterWithDefault<LastScavengeStatus>(),
+		},
+	};
+
+	public async Task<Guid?> TryStartScavengeAsync(string host, int port, CancellationToken token) {
+		Log.Information("Starting node scavenge on node {Host}:{Port}...", host, port);
+
+		try {
+			var resp = await _wrapper.HttpClient.PostAsync($"{_wrapper.Protocol}://{host}:{port}/admin/scavenge", null, token);
+			resp.EnsureSuccessStatusCode();
+			var record = await resp.Content.ReadFromJsonAsync<ScavengeRecord>(JsonSerializerOptions, token);
+			var scavengeId = record?.ScavengeId;
+			Log.Information("Started node scavenge on node {Host}:{Port}. ScavengeId: {ScavengeId}", host, port, scavengeId);
+			return scavengeId;
+
+		} catch (Exception ex) {
+			Log.Information(ex, "Failed to start scavenge on node {Host}:{Port}", host, port);
+			return null;
+		}
+	}
+
+	public async Task<ScavengeStatus> TryGetScavengeAsync(string host, int port, Guid scavengeId, CancellationToken token) {
+		Log.Verbose("Getting node scavenge status from node {Host}:{Port}...", host, port);
+
+		try {
+			var httpResponse = await _wrapper.HttpClient.GetAsync($"{_wrapper.Protocol}://{host}:{port}/admin/scavenge/last",
+				token);
+
+			httpResponse.EnsureSuccessStatusCode();
+			var response = (await httpResponse.Content.ReadFromJsonAsync<LastScavengeStatusResponse>(JsonSerializerOptions, token))!;
+
+			if (response.ScavengeResult == LastScavengeStatus.Unknown) {
+				// the node was restarted. we don't know if our scavenge completed successfully, so we try to read its
+				// stream from the scavenge log.
+				var streamResult = await GetScavengeStatusFromStream(scavengeId, token);
+				Log.Verbose("Got node scavenge status for {Host}:{Port} from stream: {Result}", host, port, streamResult);
+				return streamResult;
+			}
+
+			if (response.ScavengeId != scavengeId) {
+				// the scavenge ids do not match. this means that a new scavenge was launched, presumably by the user,
+				// definitely after the one we started. we just log a warning and continue normally, pretending that
+				// this scavenge is the one we started.
+				Log.Warning("The last scavenge ID: {lastScavengeId} does not match with the expected scavenge ID: {expectedScavengeId}.",
+					response.ScavengeId, scavengeId);
+			}
+
+			var result = response.ScavengeResult switch {
+				LastScavengeStatus.InProgress => ScavengeStatus.InProgress,
+				LastScavengeStatus.Success => ScavengeStatus.Success,
+				LastScavengeStatus.Errored => ScavengeStatus.Errored,
+				LastScavengeStatus.Stopped => ScavengeStatus.Stopped,
+				_ => ScavengeStatus.Unknown,
+			};
+
+			Log.Verbose("Got node scavenge status from node {Host}:{Port}: {Result}", host, port, result);
+			return result;
+
+		} catch (Exception ex) {
+			Log.Information(ex, "Failed to get scavenge status on node {Host}:{Port}", host, port);
+			return ScavengeStatus.Unknown;
+		}
+	}
+
+	public async Task<bool> TryPauseScavengeAsync(string host, int port, Guid? scavengeId, CancellationToken token) {
+		Log.Information("Stopping node scavenge {ScavengeId} on node {Host}:{Port}...", scavengeId, host, port);
+
+		try {
+			var scavengeIdString = scavengeId?.ToString() ?? "current";
+			var resp = await _wrapper.HttpClient.DeleteAsync($"{_wrapper.Protocol}://{host}:{port}/admin/scavenge/{scavengeIdString}", token);
+			resp.EnsureSuccessStatusCode();
+			Log.Information("Stopped node scavenge on node {Host}:{Port}", host, port);
+			return true;
+
+		} catch (HttpRequestException ex) {
+			if (ex.StatusCode == HttpStatusCode.NotFound) {
+				// Valid case of the scavenge successfully paused because by not being found, it means the scavenge has
+				// completed. Whether the scavenge completed with an error or a success is not important in that case.
+				Log.Information("Node scavenge {ScavengeId} on node {Host}:{Port} was already stopped", scavengeId, host, port);
+				return true;
+			} else {
+				Log.Information(ex, "Failed to stop scavenge on node {Host}:{Port} > {Status}", host, port, ex.StatusCode);
+				return false;
+			}
+
+		} catch (Exception ex) {
+			Log.Information(ex, "Failed to stop scavenge on node {Host}:{Port}", host, port);
+			return false;
+		}
+	}
+
+	// this is only called if the node reported that it is not currently scavenging and has not scavenged since startup
+	private async Task<ScavengeStatus> GetScavengeStatusFromStream(Guid scavengeId, CancellationToken token) {
+		// it's possible that the `$scavengeCompleted` event is not the last event in the stream as in some cases the
+		// events may be out of order. so, we read more than one event to increase the chance of finding it if it is there.
+		var events = _client
+			.ReadStreamBackwards($"$scavenges-{scavengeId}", maxCount: 20, token)
+			.HandleStreamNotFound();
+
+		await foreach (var @event in events) {
+			if (@event.EventType != "$scavengeCompleted")
+				continue;
+
+			var completed =
+				JsonSerializer.Deserialize<ScavengeRecordCompleted>(@event.Data.Span, JsonSerializerOptions)!;
+
+			if (completed.ScavengeId != scavengeId) {
+				// ignore, malformed entry
+				continue;
+			}
+
+			switch (completed.Result) {
+				case ScavengeResult.Unknown:
+					return ScavengeStatus.NotRunningUnknown;
+				case ScavengeResult.Success:
+					return ScavengeStatus.Success;
+				case ScavengeResult.Stopped:
+					return ScavengeStatus.Stopped;
+				case ScavengeResult.Errored:
+					return ScavengeStatus.Errored;
+				case ScavengeResult.Interrupted:
+					return ScavengeStatus.NotRunningUnknown;
+			}
+		}
+
+		// at this point, we cannot know the status of the scavenge for sure:
+		// entries may be missing from the scavenge log even if a scavenge had completed, for example:
+		// i)   a cluster loses its leader after a scavenge has started on a node. the scavenge continues but
+		//      events can no longer be written to the scavenge log.
+		// ii)  a network partition separates a node from the cluster after a scavenge started on that node. the node
+		//      won't be able to forward scavenge log events to the leader.
+
+		return ScavengeStatus.NotRunningUnknown;
+	}
+
+	// Names match the status in the $scavengeCompleted event from the server (apart from Unknown)
+	private enum ScavengeResult {
+		Unknown,
+		Success,
+		Stopped,
+		Errored,
+		Interrupted,
+	}
+
+	private class ScavengeRecord {
+		public Guid? ScavengeId { get; init; }
+	}
+
+	private class ScavengeRecordCompleted {
+		public required Guid ScavengeId { get; init; }
+		public required ScavengeResult Result { get; init; }
+	}
+
+	// Names match the result from the server
+	private enum LastScavengeStatus {
+		Unknown,
+		InProgress,
+		Success,
+		Stopped,
+		Errored,
+	}
+
+	private class LastScavengeStatusResponse {
+		public Guid? ScavengeId { get; init; }
+		public required LastScavengeStatus ScavengeResult { get; init; }
+	}
+}

--- a/src/EventStore.AutoScavenge/Scavengers/INodeScavenger.cs
+++ b/src/EventStore.AutoScavenge/Scavengers/INodeScavenger.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Scavengers;
+
+public interface INodeScavenger {
+	/// <returns>Returns a scavenge id if it was successful, null otherwise</returns>
+	Task<Guid?> TryStartScavengeAsync(string host, int port, CancellationToken token);
+
+	Task<ScavengeStatus> TryGetScavengeAsync(string host, int port, Guid scavengeId, CancellationToken token);
+
+	Task<bool> TryPauseScavengeAsync(string host, int port, Guid? scavengeId, CancellationToken token);
+}

--- a/src/EventStore.AutoScavenge/Scavengers/ScavengeStatus.cs
+++ b/src/EventStore.AutoScavenge/Scavengers/ScavengeStatus.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Scavengers;
+
+public enum ScavengeStatus {
+	Unknown, // couldn't get the status
+	InProgress,
+	Success, // completed successfuly
+	Stopped, // intentionally stopped
+	Errored, // completed with an error
+	NotRunningUnknown, // not running but don't know if it completed/stopped/errored/interrupted
+}

--- a/src/EventStore.AutoScavenge/Sources/ClientSource.cs
+++ b/src/EventStore.AutoScavenge/Sources/ClientSource.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using EventStore.AutoScavenge.Converters;
+using EventStore.POC.IO.Core;
+
+namespace EventStore.AutoScavenge.Sources;
+
+public class ClientSource : ISource {
+	// todo - We should probably use the same serialization options across the board.
+	private static readonly JsonSerializerOptions JsonSerializerOptions = new() {
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters = { new CrontableScheduleJsonConverter() }
+	};
+
+	private readonly IClient _client;
+
+	public ClientSource(IClient client) {
+		_client = client;
+	}
+
+	public long AutoScavengeStreamExpectedRevision { get; set; } = -1;
+
+	public async Task<Events.ConfigurationUpdated?> ReadConfigurationEvent(CancellationToken token) {
+		var events = _client
+			.ReadStreamBackwards(
+				StreamNames.AutoScavengeConfiguration,
+				maxCount: 1,
+				token)
+			.HandleStreamNotFound();
+
+		await foreach (var @event in events) {
+			if (@event.EventType != EventTypes.ConfigurationUpdated)
+				throw new Exception($"Expected to find event of type {EventTypes.ConfigurationUpdated} but found {@event.EventType}");
+
+			var configurationUpdated =
+				JsonSerializer.Deserialize<Events.ConfigurationUpdated>(
+					@event.Data.Span,
+					JsonSerializerOptions);
+
+			return configurationUpdated!;
+		}
+
+		return null;
+	}
+
+	public async IAsyncEnumerable<IEvent> ReadAutoScavengeEvents([EnumeratorCancellation] CancellationToken token) {
+		AutoScavengeStreamExpectedRevision = -1;
+
+		var events = _client
+			.ReadStreamBackwards(
+				StreamNames.AutoScavenges,
+				maxCount: long.MaxValue,
+				token)
+			.HandleStreamNotFound();
+
+		// in practice, there should not be too many events until we reach a `ClusterScavengeCompleted` event or the
+		// beginning of the stream, so we can keep the events in memory.
+		var requiredEvents = new List<IEvent>();
+		var isLatestEvent = true;
+
+		await foreach (var @event in events) {
+			if (isLatestEvent) {
+				AutoScavengeStreamExpectedRevision = (long)@event.EventNumber;
+				isLatestEvent = false;
+			}
+
+			// after completing a cluster scavenge, auto-scavenge is always in an idle state, so we can always rehydrate
+			// the auto-scavenge state machine from the next event onwards.
+			if (@event.EventType is EventTypes.ClusterScavengeCompleted)
+				break;
+
+			IEvent? deserialized = @event.EventType switch {
+				EventTypes.ClusterMembersChanged => JsonSerializer.Deserialize<Events.ClusterMembersChanged>(@event.Data.Span, JsonSerializerOptions),
+				EventTypes.ClusterScavengeStarted => JsonSerializer.Deserialize<Events.ClusterScavengeStarted>(@event.Data.Span, JsonSerializerOptions),
+				EventTypes.ClusterScavengeCompleted => JsonSerializer.Deserialize<Events.ClusterScavengeCompleted>(@event.Data.Span, JsonSerializerOptions),
+				EventTypes.NodeDesignated => JsonSerializer.Deserialize<Events.NodeDesignated>(@event.Data.Span, JsonSerializerOptions),
+				EventTypes.NodeScavengeStarted => JsonSerializer.Deserialize<Events.NodeScavengeStarted>(@event.Data.Span, JsonSerializerOptions),
+				EventTypes.NodeScavengeCompleted => JsonSerializer.Deserialize<Events.NodeScavengeCompleted>(@event.Data.Span, JsonSerializerOptions),
+				EventTypes.PauseRequested => JsonSerializer.Deserialize<Events.PauseRequested>(@event.Data.Span, JsonSerializerOptions),
+				EventTypes.Paused => JsonSerializer.Deserialize<Events.Paused>(@event.Data.Span, JsonSerializerOptions),
+				EventTypes.Resumed => JsonSerializer.Deserialize<Events.Resumed>(@event.Data.Span, JsonSerializerOptions),
+				_ => null,
+			};
+
+			if (deserialized is not null)
+				requiredEvents.Add(deserialized);
+		}
+
+		for (var i = requiredEvents.Count - 1; i >=0 ; i--)
+			yield return requiredEvents[i];
+	}
+}

--- a/src/EventStore.AutoScavenge/Sources/ISource.cs
+++ b/src/EventStore.AutoScavenge/Sources/ISource.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.Sources;
+
+/// <summary>
+/// Event provider abstraction use to source events to the auto scavenge state machine.
+/// </summary>
+public interface ISource {
+	/// <summary>
+	/// Reads the last auto scavenge configuration event.
+	/// </summary>
+	/// <param name="token"></param>
+	/// <returns></returns>
+	Task<Events.ConfigurationUpdated?> ReadConfigurationEvent(CancellationToken token);
+
+	/// <summary>
+	/// Reads the events necessary to initialize the auto scavenge state machine.
+	/// </summary>
+	/// <param name="token"></param>
+	/// <returns>Ascending ordered collection of events related to the auto scavenge process</returns>
+	IAsyncEnumerable<IEvent> ReadAutoScavengeEvents(CancellationToken token);
+}

--- a/src/EventStore.AutoScavenge/SystemNames.cs
+++ b/src/EventStore.AutoScavenge/SystemNames.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public static class StreamNames {
+	public const string AutoScavenges = "$auto-scavenges";
+	public const string AutoScavengeConfiguration = "$auto-scavenge-configuration";
+}
+
+public static class EventTypes {
+	public const string ConfigurationUpdated = "$configuration-updated";
+	public const string ClusterMembersChanged = "$cluster-members-changed";
+
+	public const string ClusterScavengeStarted = "$cluster-scavenge-started";
+	public const string ClusterScavengeCompleted = "$cluster-scavenge-completed";
+
+	public const string NodeDesignated = "$node-designated";
+
+	public const string NodeScavengeStarted = "$node-scavenge-started";
+	public const string NodeScavengeCompleted = "$node-scavenge-completed";
+
+	public const string Initialized = "$initialized";
+	public const string PauseRequested = "$pause-requested";
+	public const string Paused = "$paused";
+	public const string ResumeRequested = "$resume-requested";
+	public const string Resumed = "$resumed";
+}

--- a/src/EventStore.AutoScavenge/TaskExtensions.cs
+++ b/src/EventStore.AutoScavenge/TaskExtensions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Serilog;
+
+namespace EventStore.AutoScavenge;
+
+public static class TaskExtensions {
+	public static Task WarnOnCompletion(this Task task, string warning) {
+		return task.ContinueWith(t => {
+			if (t.Exception is null)
+				return;
+			Log.Warning(t.Exception, warning);
+		});
+	}
+}

--- a/src/EventStore.AutoScavenge/TimeProviders/ITimeProvider.cs
+++ b/src/EventStore.AutoScavenge/TimeProviders/ITimeProvider.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.TimeProviders;
+
+/// <summary>
+/// Time abstraction providing the current date.
+/// </summary>
+public interface ITimeProvider {
+	DateTime Now { get; }
+}

--- a/src/EventStore.AutoScavenge/TimeProviders/TimeProvider.cs
+++ b/src/EventStore.AutoScavenge/TimeProviders/TimeProvider.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge.TimeProviders;
+
+public class TimeProvider : ITimeProvider {
+	public DateTime Now => DateTime.Now;
+}

--- a/src/EventStore.AutoScavenge/Transition.cs
+++ b/src/EventStore.AutoScavenge/Transition.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public record struct Transition(IEvent[] Events, ICommand? NextCommand) {
+	public static readonly Transition Noop = new([], null);
+}

--- a/src/EventStore.AutoScavenge/Unit.cs
+++ b/src/EventStore.AutoScavenge/Unit.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.AutoScavenge;
+
+public readonly record struct Unit {
+	public static Unit Instance { get; } = new();
+}

--- a/src/EventStore.AutoScavenge/auto-scavenge-plugin-example.json
+++ b/src/EventStore.AutoScavenge/auto-scavenge-plugin-example.json
@@ -1,0 +1,7 @@
+{
+  "EventStore": {
+    "AutoScavenge": {
+      "Enabled": true
+    }
+  }
+}

--- a/src/EventStore.AutoScavenge/auto-scavenge-plugin-example.yaml
+++ b/src/EventStore.AutoScavenge/auto-scavenge-plugin-example.yaml
@@ -1,0 +1,2 @@
+AutoScavenge:
+  Enabled: true

--- a/src/EventStore.AutoScavenge/sample-requests.http
+++ b/src/EventStore.AutoScavenge/sample-requests.http
@@ -1,0 +1,46 @@
+### enabled
+GET https://127.0.0.1:2113/auto-scavenge/enabled
+Authorization: Basic admin:changeit
+
+### status
+GET https://127.0.0.1:2113/auto-scavenge/status
+Authorization: Basic admin:changeit
+
+### pause
+POST https://127.0.0.1:2113/auto-scavenge/pause
+Authorization: Basic ops:changeit
+
+###
+POST https://127.0.0.1:2113/auto-scavenge/resume
+Authorization: Basic ops:changeit
+
+
+### configure to scavenge every 5 mins
+POST https://127.0.0.1:2113/auto-scavenge/configure
+Content-Type: application/json
+Authorization: Basic admin:changeit
+
+{
+    "schedule": "* * * * *"
+}
+
+
+
+#
+# manual scavenge controls
+#
+
+### Start a scavenge
+POST https://127.0.0.1:2113/admin/scavenge
+Authorization: Basic admin:changeit
+Accept: application/json
+
+### Get current scavenge
+GET https://127.0.0.1:2113/admin/scavenge/current
+Authorization: Basic admin:changeit
+Accept: application/json
+
+### Stop current scavenge
+DELETE https://127.0.0.1:2113/admin/scavenge/current
+Authorization: Basic admin:changeit
+Accept: application/json

--- a/src/EventStore.Diagnostics.LogsEndpointPlugin.Tests/EventStore.Diagnostics.LogsEndpointPlugin.Tests.csproj
+++ b/src/EventStore.Diagnostics.LogsEndpointPlugin.Tests/EventStore.Diagnostics.LogsEndpointPlugin.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+			<TargetFramework>net8.0</TargetFramework>
+			<ImplicitUsings>enable</ImplicitUsings>
+			<Nullable>enable</Nullable>
+			<IsPackable>false</IsPackable>
+			<IsPublishable>false</IsPublishable>
+			<IsTestProject>true</IsTestProject>
+			<Platforms>x64</Platforms>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+					<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+					<PrivateAssets>all</PrivateAssets>
+			</PackageReference>
+			<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+			<PackageReference Include="xunit" Version="2.4.2"/>
+			<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+					<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+					<PrivateAssets>all</PrivateAssets>
+			</PackageReference>
+			<PackageReference Include="coverlet.collector" Version="6.0.0">
+					<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+					<PrivateAssets>all</PrivateAssets>
+			</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.Diagnostics.LogsEndpointPlugin\EventStore.Diagnostics.LogsEndpointPlugin.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Diagnostics.LogsEndpointPlugin.Tests/JsonDirectoryFormatterTests.cs
+++ b/src/EventStore.Diagnostics.LogsEndpointPlugin.Tests/JsonDirectoryFormatterTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.FileProviders;
+using Xunit;
+
+namespace EventStore.Diagnostics.LogsEndpointPlugin.Tests;
+
+public class JsonDirectoryFormatterTests {
+	[Fact]
+	public async Task formats_content_correctly() {
+		var dirContent = new List<IFileInfo>() {
+			TestFile.Named("file-1.json"),
+			TestFile.Named("file-2.json")
+		};
+
+		var json = await GenerateResponse(dirContent);
+
+		Assert.NotNull(json);
+		Assert.Equal(JsonValueKind.Array, json.GetValueKind());
+		Assert.Equal(dirContent.Count, json.AsArray().Count);
+	}
+
+	[Fact]
+	public async Task skips_directories() {
+		List<IFileInfo> files = [
+			TestFile.Named("file-1.json"),
+			TestFile.Named("file-2.json")
+		];
+		List<IFileInfo> directories = [
+			TestDirectory.Named("uploads")
+		];
+
+		var dirContent = new List<IFileInfo>(files).Concat(directories);
+
+		var json = await GenerateResponse(dirContent);
+
+		Assert.NotNull(json);
+		Assert.Equal(JsonValueKind.Array, json.GetValueKind());
+		Assert.Equal(files.Count, json.AsArray().Count);
+	}
+
+	[Fact]
+	public async Task only_returns_json_files() {
+		List<IFileInfo> jsonFiles = [
+			TestFile.Named("file-1.json"),
+			TestFile.Named("file-2.json")
+		];
+		List<IFileInfo> otherFiles = [
+			TestFile.Named("upload.exe"),
+			TestFile.Named("upload.jpg"),
+		];
+
+		var dirContent = new List<IFileInfo>(jsonFiles).Concat(otherFiles);
+
+		var json = await GenerateResponse(dirContent);
+
+		Assert.NotNull(json);
+		Assert.Equal(JsonValueKind.Array, json.GetValueKind());
+		Assert.Equal(jsonFiles.Count, json.AsArray().Count);
+	}
+
+	[Fact]
+	public async Task responds_with_most_recent_modification_first() {
+		var now = DateTimeOffset.Now;
+		List<IFileInfo> dirContent = [
+			TestFile.Named("monday.json").ModifiedAt(now.AddDays(-4)),
+			TestFile.Named("tuesday.json").ModifiedAt(now.AddDays(-3)),
+			TestFile.Named("wednesday.json").ModifiedAt(now.AddDays(-2)),
+			TestFile.Named("thursday.json").ModifiedAt(now.AddDays(-1)),
+			TestFile.Named("friday.json").ModifiedAt(now),
+		];
+
+		var json = await GenerateResponse(dirContent);
+
+		Assert.NotNull(json);
+		Assert.Equal(JsonValueKind.Array, json.GetValueKind());
+
+		var filenames = json.AsArray().Select(f => f?["name"]?.GetValue<string>());
+
+		Assert.Equal([
+			"friday.json",
+			"thursday.json",
+			"wednesday.json",
+			"tuesday.json",
+			"monday.json"
+		], filenames);
+	}
+
+	[Fact]
+	public async Task returns_a_maximum_of_1000_items() {
+		var dirContent = Enumerable
+			.Range(1, 2113)
+			.Select(i => TestFile
+				.Named($"log-file-{i}.json")
+				.ModifiedAt(DateTimeOffset.Now.AddDays(i)));
+
+		var json = await GenerateResponse(dirContent);
+
+		Assert.NotNull(json);
+		Assert.Equal(JsonValueKind.Array, json.GetValueKind());
+		Assert.Equal(1000, json.AsArray().Count);
+
+		Assert.Equal(
+			"log-file-2113.json",
+			json.AsArray().First()!["name"]!.GetValue<string>());
+	}
+
+	[Fact]
+    public async Task returns_a_date_as_local_time_with_time_zone_information() {
+	    var now = DateTimeOffset.Now;
+	    List<IFileInfo> dirContent = [
+		    TestFile.Named("file-1.json").ModifiedAt(now),
+	    ];
+
+    	var json = await GenerateResponse(dirContent);
+
+    	Assert.NotNull(json);
+    	Assert.Equal(JsonValueKind.Array, json.GetValueKind());
+    	Assert.Equal(dirContent.Count, json.AsArray().Count);
+
+    	Assert.Equal(
+    		now.ToString("o"),
+    		json.AsArray().First()!["lastModified"]!.GetValue<string>());
+    }
+
+	[Fact]
+	public async Task returns_an_empty_array_when_there_is_nothing_to_return() {
+		var json = await GenerateResponse(Array.Empty<IFileInfo>());
+
+		Assert.NotNull(json);
+		Assert.Equal(JsonValueKind.Array, json.GetValueKind());
+		Assert.Empty(json.AsArray());
+	}
+
+	private static async Task<JsonNode?> GenerateResponse(IEnumerable<IFileInfo> dirContent) {
+		var formatter = new JsonDirectoryFormatter();
+		var ctx = new DefaultHttpContext();
+		var stream = new MemoryStream();
+
+		ctx.Features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(stream));
+
+		await formatter.GenerateContentAsync(ctx, dirContent);
+
+		stream.Position = 0;
+
+		return await JsonNode.ParseAsync(stream);
+	}
+
+	private static class TestDirectory {
+		public static TestFile Named(string name) {
+			return new TestFile(
+				Name: name,
+				Exists: true,
+				IsDirectory: true,
+				Length: 303,
+				LastModified: DateTimeOffset.Now,
+				PhysicalPath: null);
+		}
+	}
+
+	private record TestFile(bool Exists, bool IsDirectory, DateTimeOffset LastModified, long Length, string Name,
+		string? PhysicalPath) : IFileInfo {
+
+		public Stream CreateReadStream() {
+			throw new NotImplementedException();
+		}
+
+		public static TestFile Named(string name) {
+			return new TestFile(
+				Name: name,
+				Exists: true,
+				IsDirectory: false,
+				Length: 303,
+				LastModified: DateTimeOffset.Now,
+				PhysicalPath: null);
+		}
+
+		public TestFile ModifiedAt(DateTimeOffset offset) {
+			return this with {
+				LastModified = offset
+			};
+		}
+	}
+}

--- a/src/EventStore.Diagnostics.LogsEndpointPlugin.Tests/LogsEndpointPluginTests.cs
+++ b/src/EventStore.Diagnostics.LogsEndpointPlugin.Tests/LogsEndpointPluginTests.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json.Nodes;
+using EventStore.Plugins.Authentication;
+using EventStore.Plugins;
+using EventStore.Plugins.Diagnostics;
+using EventStore.Plugins.Tests;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using EventStore.Plugins.Licensing;
+
+namespace EventStore.Diagnostics.LogsEndpointPlugin.Tests;
+
+public class LogsEndpointPluginTests :
+	IClassFixture<LicensedFixture>,
+	IClassFixture<UnlicensedFixture> {
+
+	private readonly LicensedFixture _fixture;
+	private readonly UnlicensedFixture _unlicensedFixture;
+	private const string Endpoint = "/admin/logs";
+
+	public LogsEndpointPluginTests(LicensedFixture fixture, UnlicensedFixture unlicensedFixture) {
+		_fixture = fixture;
+		_unlicensedFixture = unlicensedFixture;
+	}
+
+	[Fact]
+	public async Task does_not_throw_when_configuration_is_missing() {
+		var ex = await Record.ExceptionAsync(async () => {
+
+			var sut = new LogsEndpointPlugin();
+
+			var builder = WebApplication.CreateBuilder();
+
+			builder.Services.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService());
+			sut.ConfigureServices(builder.Services, builder.Configuration);
+
+			await using var app = builder.Build();
+
+			sut.ConfigureApplication(app, builder.Configuration);
+		});
+
+		Assert.Null(ex);
+	}
+
+	[Fact]
+	public async Task requires_authentication() {
+		var result = await _fixture.UnauthenticatedClient.GetAsync(Endpoint);
+
+		Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+	}
+
+	[Fact]
+	public async Task is_available_at_endpoint() {
+		var result = await _fixture.AuthenticatedClient.GetAsync(Endpoint);
+
+		Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task respects_license(bool licensePresent) {
+		// given
+		LogsEndpointPluginFixture f = licensePresent ? _fixture : _unlicensedFixture;
+
+		// when
+		var result = await f.AuthenticatedClient.GetAsync(Endpoint);
+
+		// then
+		if (licensePresent) {
+			Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+		} else {
+			Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+		}
+	}
+
+	[Fact]
+	public void can_collect_telemetry() {
+		// given
+		var sut = new LogsEndpointPlugin();
+		using var collector = PluginDiagnosticsDataCollector.Start(sut.DiagnosticsName);
+
+		var config = new ConfigurationBuilder().Build();
+		var builder = WebApplication.CreateBuilder();
+		builder.Services.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService());
+
+		// when
+		((IPlugableComponent)sut).ConfigureServices(builder.Services, config);
+		var app = builder.Build();
+		((IPlugableComponent)sut).ConfigureApplication(app, config);
+
+		// then
+		collector.CollectedEvents(sut.DiagnosticsName).Should().ContainSingle().Which
+			.Data["enabled"].Should().Be(true);
+	}
+}
+
+public class LicensedFixture : LogsEndpointPluginFixture {
+	public LicensedFixture() : base(licensed: true) {
+	}
+}
+
+public class UnlicensedFixture : LogsEndpointPluginFixture {
+	public UnlicensedFixture() : base(licensed: false) {
+	}
+}
+
+public class LogsEndpointPluginFixture : IAsyncLifetime {
+	private WebApplication? _app;
+	private HttpClient? _authenticatedClient;
+	private HttpClient? _unauthenticatedClient;
+	private readonly bool _licensed;
+
+	public HttpClient AuthenticatedClient => _authenticatedClient!;
+	public HttpClient UnauthenticatedClient => _unauthenticatedClient!;
+
+	public LogsEndpointPluginFixture(bool licensed) {
+		_licensed = licensed;
+	}
+
+	public async Task InitializeAsync() {
+		var ip = "1.2.3.4";
+		var port = "99";
+		var fullPath = Path.Combine(Directory.GetCurrentDirectory(), $"{ip}-{port}-cluster-node");
+		Directory.CreateDirectory(fullPath);
+
+		var builder = WebApplication.CreateBuilder();
+		builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+		builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>() {
+			{$"{KurrentConfigurationConstants.Prefix}:Log", "./"},
+			{$"{KurrentConfigurationConstants.Prefix}:NodeIp", ip},
+			{$"{KurrentConfigurationConstants.Prefix}:NodePort", port}
+		}!);
+
+		var sut = new LogsEndpointPlugin();
+		builder.Services.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService(_licensed, "LOGS_ENDPOINT"));
+		sut.ConfigureServices(builder.Services, builder.Configuration);
+
+		_app = builder.Build();
+
+		_app.UseMiddleware<FakeBasicAuthMiddleware>();
+
+		sut.ConfigureApplication(_app, builder.Configuration);
+
+		await _app.StartAsync();
+
+		_authenticatedClient = new HttpClient() {
+			BaseAddress = new Uri(_app.Urls.First())
+		};
+		_authenticatedClient.BaseAddress = new Uri(_app!.Urls.First());
+		_authenticatedClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
+			Convert.ToBase64String(
+				Encoding.ASCII.GetBytes($"{FakeBasicAuthMiddleware.Username}:{FakeBasicAuthMiddleware.Password}")));
+
+		_unauthenticatedClient = new HttpClient() {
+			BaseAddress = new Uri(_app.Urls.First())
+		};
+		_unauthenticatedClient.BaseAddress = new Uri(_app!.Urls.First());
+	}
+
+	public async Task DisposeAsync() {
+		if (_app != null) {
+			await _app.DisposeAsync();
+		}
+	}
+
+	public class FakeBasicAuthMiddleware {
+		public const string Username = "fake";
+		public const string Password = "fake";
+
+		private readonly RequestDelegate _next;
+
+		public FakeBasicAuthMiddleware(RequestDelegate next) {
+			_next = next;
+		}
+
+		public async Task Invoke(HttpContext context) {
+			try {
+				var authHeader = AuthenticationHeaderValue.Parse(context.Request.Headers.Authorization!);
+				var credentialBytes = Convert.FromBase64String(authHeader.Parameter ?? "");
+				var credentials = Encoding.UTF8.GetString(credentialBytes).Split(':', 2);
+				var username = credentials[0];
+				var password = credentials[1];
+
+				if (username == Username && password == Password) {
+					context.User = new ClaimsPrincipal(new ClaimsIdentity(new [] {
+						new Claim(ClaimTypes.Name,"test-user"),
+						new Claim(ClaimTypes.Role,"$ops"),
+					}, "fake"));
+				}
+			}
+			catch {
+				// noop
+			}
+
+			await _next(context);
+		}
+	}
+}

--- a/src/EventStore.Diagnostics.LogsEndpointPlugin/EventStore.Diagnostics.LogsEndpointPlugin.csproj
+++ b/src/EventStore.Diagnostics.LogsEndpointPlugin/EventStore.Diagnostics.LogsEndpointPlugin.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Platforms>x64</Platforms>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+	</PropertyGroup>
+	<PropertyGroup>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+		<DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+</Project>

--- a/src/EventStore.Diagnostics.LogsEndpointPlugin/JsonDirectoryFormatter.cs
+++ b/src/EventStore.Diagnostics.LogsEndpointPlugin/JsonDirectoryFormatter.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+
+namespace EventStore.Diagnostics.LogsEndpointPlugin;
+
+public class JsonDirectoryFormatter : IDirectoryFormatter {
+	// Implementation based on: https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/StaticFiles/src/HtmlDirectoryFormatter.cs
+	private const string JsonUtf8 = "application/json; charset=utf-8";
+	private const string JsonExt = ".json";
+	private const int MaxResultCount = 1000;
+
+	public async Task GenerateContentAsync(HttpContext ctx, IEnumerable<IFileInfo> contents) {
+		ArgumentNullException.ThrowIfNull(ctx);
+		ArgumentNullException.ThrowIfNull(contents);
+
+		ctx.Response.ContentType = JsonUtf8;
+
+		if (HttpMethods.IsHead(ctx.Request.Method)) {
+			return;
+		}
+
+		var filesToList = contents
+			.Where(c => !c.IsDirectory && c.Name.EndsWith(JsonExt))
+			.ToList();
+
+		await using var response = ctx.Response.BodyWriter.AsStream();
+		await using var writer = new Utf8JsonWriter(response);
+
+		writer.WriteStartArray();
+
+		foreach (var fileInfo in filesToList.OrderByDescending(f => f.LastModified).Take(MaxResultCount)) {
+			writer.WriteStartObject();
+			writer.WriteString("name", fileInfo.Name);
+
+			if (fileInfo.PhysicalPath != null) {
+				var createdAt = File.GetCreationTime(fileInfo.PhysicalPath);
+				writer.WriteString("createdAt", createdAt.ToString("O"));
+			}
+
+			writer.WriteString("lastModified", fileInfo.LastModified.LocalDateTime.ToString("O"));
+			writer.WriteNumber("size", fileInfo.Length);
+			writer.WriteEndObject();
+		}
+
+		writer.WriteEndArray();
+
+		await writer.FlushAsync();
+	}
+}

--- a/src/EventStore.Diagnostics.LogsEndpointPlugin/LogsEndpointPlugin.cs
+++ b/src/EventStore.Diagnostics.LogsEndpointPlugin/LogsEndpointPlugin.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using EventStore.Plugins.Diagnostics;
+using EventStore.Plugins.Licensing;
+using EventStore.Plugins.Subsystems;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.Diagnostics.LogsEndpointPlugin;
+
+// TODO: use SubsystemPlugin now that it is more flexible about licence requirements and what to do when they fail
+public class LogsEndpointPlugin : ISubsystemsPlugin, ISubsystem {
+	public string Name => "LogsEndpoint";
+	public string Version => typeof(LogsEndpointPlugin).Assembly.GetName().Version!.ToString();
+	public string CommandLineName => "logs-endpoint";
+	public string DiagnosticsName => Name;
+	public KeyValuePair<string, object>[] DiagnosticsTags { get; } = [];
+	public bool Enabled { get; private set; } = true;
+	public string LicensePublicKey => LicenseConstants.LicensePublicKey;
+
+	private static readonly ILogger _logger = Log.ForContext<LogsEndpointPlugin>();
+	private const string EndpointPath = "/admin/logs";
+	private KurrentDBOptions _options;
+
+	public LogsEndpointPlugin () {
+		_logger.Information("LogsEndpointPlugin is loaded");
+	}
+
+	// ISubsystemsPlugin
+	public IReadOnlyList<ISubsystem> GetSubsystems() => new[] { this };
+
+	// ISubsystem
+	public void ConfigureServices(IServiceCollection services, IConfiguration configuration) {
+		_options = configuration.GetSection("KurrentDB").Get<KurrentDBOptions>();
+	}
+
+	void DisableEndpoint(Exception ex) {
+		_logger.Information("LogsEndpoint: Failed to get license, endpoint will not be available.");
+		Enabled = false;
+	}
+
+	public void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration) {
+		var diagnosticListener = new DiagnosticListener(DiagnosticsName);
+		var value = new PluginDiagnosticsData {
+			Source = DiagnosticsName,
+			Data = new() { ["enabled"] = Enabled },
+			CollectionMode = PluginDiagnosticsDataCollectionMode.Partial
+		};
+		diagnosticListener.Write(nameof(PluginDiagnosticsData), value);
+
+		var licenseService = builder.ApplicationServices.GetService<ILicenseService>();
+		var logger = builder.ApplicationServices.GetRequiredService<ILoggerFactory>().CreateLogger(GetType());
+
+		_ = LicenseMonitor.MonitorAsync(
+			featureName: Name,
+			requiredEntitlements: ["LOGS_ENDPOINT"],
+			licenseService: licenseService,
+			onLicenseException: DisableEndpoint,
+			logger: logger,
+			licensePublicKey: LicensePublicKey);
+
+		if (_options == null) {
+			_logger.Error("LogsEndpoint: Failed to get configuration, endpoint will not be available!");
+			return;
+		}
+
+		if (_options.Log == null) {
+			_logger.Error("LogsEndpoint: Failed to get the configured directory for log files, endpoint will not be available!");
+			return;
+		}
+
+		if (_options.NodeIp == null) {
+			_logger.Error("LogsEndpoint: Failed to get the configured node IP, endpoint will not be available!");
+			return;
+		}
+
+		if (_options.NodePort == null) {
+			_logger.Error("LogsEndpoint: Failed to get the configured node port, endpoint will not be available!");
+			return;
+		}
+
+		var logsDir = Path.Combine(_options.Log, $"{_options.NodeIp}-{_options.NodePort}-cluster-node");
+		logsDir = Path.GetFullPath(logsDir);
+		if (!Directory.Exists(logsDir)) {
+			_logger.Error("LogsEndpoint: Failed to find the log files directory at {logsDir}, endpoint will not be available", logsDir);
+			return;
+		}
+
+		ConfigureEndpoint(builder, logsDir);
+	}
+
+	private void ConfigureEndpoint(IApplicationBuilder builder, string logsDir) {
+		_logger.Information("LogsEndpoint: Serving logs from {dir} at endpoint {endpoint}", logsDir, EndpointPath);
+
+		builder.Map(EndpointPath, b => b
+			.Use(async (context, next) => {
+				if (!Enabled) {
+					context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+				} else if (context.User.IsInRole("$ops") || context.User.IsInRole("$admins")) {
+					await next(context);
+				} else {
+					context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+				}
+			})
+			.UseFileServer(new FileServerOptions {
+				EnableDirectoryBrowsing = true,
+				FileProvider = new PhysicalFileProvider(logsDir),
+				DirectoryBrowserOptions = {
+					Formatter = new JsonDirectoryFormatter(),
+					RedirectToAppendTrailingSlash = false,
+				},
+				StaticFileOptions = {
+					ContentTypeProvider = JsonOnlyContentTypeProvider(),
+				}
+			}));
+
+		static FileExtensionContentTypeProvider JsonOnlyContentTypeProvider() {
+			var c = new FileExtensionContentTypeProvider();
+			c.Mappings.Clear();
+			c.Mappings.Add(".json", "application/json");
+			return c;
+		}
+	}
+
+	public Task Start() => Task.CompletedTask;
+
+	public Task Stop() => Task.CompletedTask;
+
+	class KurrentDBOptions {
+		public string Log { get; set; }
+		public string NodeIp { get; set; }
+		public string NodePort { get; set; }
+	}
+}

--- a/src/EventStore.Diagnostics.LogsEndpointPlugin/README.md
+++ b/src/EventStore.Diagnostics.LogsEndpointPlugin/README.md
@@ -1,0 +1,95 @@
+# Logs Endpoint Plugin
+This plugin allows access to the EventStoreDB log files by using an HTTP endpoint.
+
+To enable the endpoint you will need to download the plugin and add it to the plugins folder in your EventStoreDB installation directory. EventStoreDB should use it the next time it starts up.
+
+After succesfull installation the server should log a similar message like below:
+```
+[19676, 1,13:46:13.151,INF] LogsEndpoint: Serving logs from "<FULL-PATH-TO-LOGS>" at endpoint "/admin/logs"
+```
+
+The endpoint can be found at `/admin/logs` of the server, the full url can be constructed as:
+```
+http(s)://< node ip or hostname >:<node port>/admin/logs
+```
+For example like this:
+```
+https://localhost:2113/admin/logs
+```
+
+## Access Restrictions
+
+Usage of the endpoint is restricted to authenticated users who are either in the `$admins` or `$ops` groups.
+
+## Usage
+
+The functionality of the endpoint can be tested with a utility such as `curl` and optionally `jq` to improve displaying the endpoint output.
+
+### List the Log Files
+
+To display the current log files run:
+```bash
+curl https://<USER>:<PASSWORD>@hostname-or-ip:2113/admin/logs | jq
+```
+For example like this:
+```bash
+
+curl https://user:password@localhost:2113/admin/logs | jq
+```
+
+This should show something similar to:
+```json
+[
+  {
+    "name": "log-stats20240205.json",
+    "lastModified": "2024-02-05T13:14:14.2789475+00:00",
+    "size": 1058614
+  },
+  {
+    "name": "log20240205.json",
+    "lastModified": "2024-02-05T13:14:37.0781601+00:00",
+    "size": 158542
+  }
+]
+```
+
+The response is ordered as most recent change first and limited to a maximum of 1000 items and contains the following information:
+
+| Name | Description |
+|---|---|
+| name | File name of the log file |
+| createdAt | Timestamp of when the log file was created in [round-trip format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-round-trip-o-o-format-specifier) (local time with time zone information) |
+| lastModified | Timestamp of the last modification in [round-trip format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-round-trip-o-o-format-specifier) (local time with time zone information) |
+| size | Size of the log file in bytes |
+
+### Downloading a Log File
+
+Downloading a log file can be done by appending the name to the url:
+```bash
+curl https://<USER>:<PASSWORD>@hostname-or-ip:2113/admin/logs/<name> --output <name>
+```
+For example like this:
+```bash
+curl https://user:password@localhost:2113/admin/logs/log20240205.json --output log20240205.json
+```
+
+## Troubleshooting
+
+## Plugin not loaded
+The plugin has to be located in a subdirectory of the server's `plugin` directoy.
+To check this:
+1. Go to the installation directory of the server, the directory containing the EventStoreDb executable.
+1. In this directory there should be a directoy called `plugins`, create it if this is not the case.
+1. The `plugins` directory should have a subdirectoy for the plugin, for instance called `EventStore.Diagnostics.LogsEndpointPlugin` but this could be any name. Create it if it doesn't exist.
+1. The binaries of the plugin should be located in the subdirectory which was checked in the previous step.
+
+## Requests to endpoint return 404 not found
+This could be caused by the endpoint not being loaded, check the server startup logs if this is the case.
+
+## Requests to endpoint return 401 unauthorized
+Make sure the used credentials are correct and the user is in either the `$ops` or `$admins` group.
+
+## Failed to find the log files directory
+It is possible the plugin is using a wrong directory for the logs when using a custom `NodeIp` and/or `NodePort`.
+The directory for the logs is constructed with the IP and port of the server.
+Make sure these are set with the latest `NodeIp` and `NodePort` settings and not the deprecated equivalents `HttpIp` or `HttpPort`.

--- a/src/EventStore.POC.ConnectedSubsystemsPlugin/ConnectedSubsystemsPlugin.cs
+++ b/src/EventStore.POC.ConnectedSubsystemsPlugin/ConnectedSubsystemsPlugin.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using System.IO;
+using EventStore.Common.Utils;
+using EventStore.PluginHosting;
+using EventStore.Plugins;
+using EventStore.Plugins.Subsystems;
+using EventStore.POC.IO.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
+namespace EventStore.POC.ConnectedSubsystemsPlugin;
+
+public class ConnectedSubsystemsPlugin : SubsystemsPlugin {
+	private static readonly ILogger Log = Serilog.Log.ForContext<ConnectedSubsystemsPlugin>();
+
+	public ConnectedSubsystemsPlugin() : base(version: "0.0.5", name: "ConnectedSubsystems") {
+	}
+
+	public override IReadOnlyList<ISubsystem> GetSubsystems() {
+		var conntectedSubsystemsDir = new DirectoryInfo(Locations.PluginsDirectory);
+		var pluginLoader = new PluginLoader(conntectedSubsystemsDir, typeof(IClient).Assembly);
+
+		var plugins = pluginLoader.Load<IConnectedSubsystemsPlugin>();
+		var subsystems = new List<ISubsystem> { this };
+		foreach (var plugin in plugins) {
+			Log.Information("Loaded ConnectedSubsystemsPlugin plugin: {plugin} {version}.",
+				plugin.CommandLineName,
+				plugin.Version);
+			subsystems.AddRange(plugin.GetSubsystems());
+		}
+
+		return subsystems;
+	}
+
+	public override void ConfigureServices(IServiceCollection services, IConfiguration configuration) {
+		services.AddSingleton<IClient, InternalClient>();
+		services.AddSingleton<IOperationsClient, InternalOperationsClient>();
+	}
+}

--- a/src/EventStore.POC.ConnectedSubsystemsPlugin/EventStore.POC.ConnectedSubsystemsPlugin.csproj
+++ b/src/EventStore.POC.ConnectedSubsystemsPlugin/EventStore.POC.ConnectedSubsystemsPlugin.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\EventStore\src\EventStore.Core\EventStore.Core.csproj" />
+		<ProjectReference Include="..\..\EventStore\src\EventStore.PluginHosting\EventStore.PluginHosting.csproj" />
+		<ProjectReference Include="..\EventStore.POC.IO.Core\EventStore.POC.IO.Core.csproj" />
+	</ItemGroup>
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+			<ItemGroup>
+				<MySourceFiles Include="$(OutDir)\*.ConnectedSubsystemsPlugin.*" />
+				<MySourceFiles Include="$(OutDir)\*.IO.Core.*" />
+		</ItemGroup>
+		<Copy SourceFiles="@(MySourceFiles)" DestinationFolder="..\..\EventStore\src\KurrentDB\$(OutDir)\plugins\$(ProjectName)" />
+	</Target>
+	<Target Name="PublishPlugin" AfterTargets="Publish">
+		<ItemGroup>
+			<PluginOutputFiles Include="$(PublishDir)\LICENSE.md" />
+			<PluginOutputFiles Include="$(PublishDir)\NOTICE.html" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.POC.ConnectedSubsystemsPlugin.deps.json" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.POC.ConnectedSubsystemsPlugin.dll" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.POC.IO.Core.dll" />
+		</ItemGroup>
+		<Copy SourceFiles="@(PluginOutputFiles)" DestinationFolder="$(PublishDir)/package" />
+	</Target>
+</Project>

--- a/src/EventStore.POC.ConnectedSubsystemsPlugin/InternalClient.cs
+++ b/src/EventStore.POC.ConnectedSubsystemsPlugin/InternalClient.cs
@@ -1,0 +1,395 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Services.Transport.Common;
+using EventStore.Core.Services.Transport.Enumerators;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.POC.IO.Core;
+using Serilog;
+using CommonPosition = EventStore.Core.Services.Transport.Common.Position;
+
+namespace EventStore.POC.ConnectedSubsystemsPlugin;
+
+// this provides a client interface
+public class InternalClient : IClient {
+	private static readonly ILogger Log = Serilog.Log.ForContext<InternalClient>();
+
+	private const int MaxLiveEventBufferCount = 32;
+
+	private readonly IPublisher _publisher;
+	private readonly bool _requiresLeader;
+
+	private static readonly BoundedChannelOptions _boundedChannelOptions =
+		new(MaxLiveEventBufferCount) {
+			FullMode = BoundedChannelFullMode.Wait,
+			SingleReader = true,
+			SingleWriter = true
+		};
+
+	public InternalClient(IPublisher publisher, bool requiresLeader = false) {
+		_publisher = publisher;
+		_requiresLeader = requiresLeader;
+	}
+
+	public async Task WriteMetaDataMaxCountAsync(string stream, CancellationToken cancellationToken) {
+		var metadata = new StreamMetadata(maxCount: 3);
+		var data = metadata.ToJsonBytes();
+		var eventToWrite = new EventToWrite(Guid.NewGuid(), SystemEventTypes.StreamMetadata, "application/json", data,
+			null);
+
+		await WriteAsync(SystemStreams.MetastreamOf(stream), new[] { eventToWrite }, -2, cancellationToken);
+	}
+
+	public async Task<long> WriteAsync(string stream, EventToWrite[] events, long expectedVersion, CancellationToken cancellationToken) {
+
+		var appendResponseSource = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var envelope = new CallbackEnvelope(HandleWriteEventsCompleted);
+
+		//qq consider all the args
+		var correlationId = Guid.NewGuid(); //qq
+		_publisher.Publish(new ClientMessage.WriteEvents(
+			correlationId,
+			correlationId,
+			envelope,
+			requireLeader: _requiresLeader,
+			stream,
+			expectedVersion,
+			events.Select(evt =>
+				new Core.Data.Event(
+					evt.EventId, evt.EventType, isJson: evt.ContentType == "application/json",
+					evt.Data.ToArray(),
+					evt.Metadata.ToArray())).ToArray(),
+			SystemAccounts.System,
+			cancellationToken: cancellationToken));
+
+		return await appendResponseSource.Task.ConfigureAwait(false);
+
+		void HandleWriteEventsCompleted(Message message) {
+			if (message is ClientMessage.NotHandled notHandled) {
+				Exception ex = notHandled.Reason switch {
+					ClientMessage.NotHandled.Types.NotHandledReason.NotReady => new ResponseException.ServerNotReady(),
+					ClientMessage.NotHandled.Types.NotHandledReason.TooBusy => new ResponseException.ServerBusy(),
+					ClientMessage.NotHandled.Types.NotHandledReason.NotLeader or
+					ClientMessage.NotHandled.Types.NotHandledReason.IsReadOnly => new ResponseException.NotLeader(),
+					_ => new ResponseException.UnexpectedError($"NotHandled {notHandled.Reason}"),
+				};
+				appendResponseSource.TrySetException(ex);
+				return;
+			}
+
+			if (message is not ClientMessage.WriteEventsCompleted completed) {
+				appendResponseSource.TrySetException(new ResponseException.UnexpectedError($"Unexpected message {message}"));
+				return;
+			}
+
+			//qqqqqqqq
+			switch (completed.Result) {
+				case OperationResult.Success:
+					appendResponseSource.TrySetResult(completed.LastEventNumber);
+					return;
+				case OperationResult.PrepareTimeout:
+				case OperationResult.CommitTimeout:
+				case OperationResult.ForwardTimeout:
+					appendResponseSource.TrySetException(new ResponseException.Timeout(completed.Message));
+					return;
+				case OperationResult.WrongExpectedVersion:
+					//qq irl this is much more complicated see Streams.Append.cs
+					appendResponseSource.TrySetException(new ResponseException.WrongExpectedVersion(completed.Message));
+					return;
+				case OperationResult.StreamDeleted:
+					appendResponseSource.TrySetException(new ResponseException.StreamDeleted(completed.Message));
+					return;
+				case OperationResult.InvalidTransaction:
+					appendResponseSource.TrySetException(new ResponseException.UnexpectedError(completed.Message));
+					return;
+				case OperationResult.AccessDenied:
+					appendResponseSource.TrySetException(new ResponseException.AccessDenied(completed.Message));
+					return;
+				default:
+					appendResponseSource.TrySetException(new ResponseException.UnexpectedError(completed.Message));
+					return;
+			}
+		}
+	}
+
+	private static CommonPosition Convert(FromAll start) {
+		if (start == FromAll.Start)
+			return CommonPosition.Start;
+		else if (start == FromAll.End)
+			return CommonPosition.End;
+		else
+			return Convert(start.Position!.Value);
+	}
+
+	private static CommonPosition Convert(IO.Core.Position position) =>
+		new(position.CommitPosition, position.PreparePosition);
+
+	public IAsyncEnumerable<IO.Core.Event> SubscribeToAll(FromAll start, CancellationToken token) =>
+		//qq consider all these options
+		Create(
+			"SUBSCRIPTION TO $all",
+			() => new Enumerator.AllSubscription(
+				bus: _publisher,
+				expiryStrategy: new DefaultExpiryStrategy(),
+				checkpoint: Convert(start),
+				resolveLinks: false,
+				user: SystemAccounts.System,
+				requiresLeader: _requiresLeader,
+				cancellationToken: token));
+
+	public IAsyncEnumerable<IO.Core.Event> SubscribeToStream(string stream, CancellationToken token) =>
+		Create(
+			$"SUBSCRIPTION TO {stream}",
+			() => new Enumerator.StreamSubscription<string>(
+				streamName: stream,
+				bus: _publisher,
+				expiryStrategy: new DefaultExpiryStrategy(),
+				checkpoint: null,
+				resolveLinks: false,
+				user: SystemAccounts.System,
+				requiresLeader: _requiresLeader,
+				cancellationToken: token));
+
+	public IAsyncEnumerable<IO.Core.Event> ReadStreamBackwards(string stream, long maxCount, CancellationToken token) =>
+		Create(
+			$"Reading stream {stream} backwards for max {maxCount} events",
+			() => new Enumerator.ReadStreamBackwards(
+				bus: _publisher,
+				streamName: stream,
+				startRevision: StreamRevision.End,
+				maxCount: (ulong)maxCount,
+				resolveLinks: false,
+				user: SystemAccounts.System,
+				requiresLeader: _requiresLeader,
+				deadline: DateTime.UtcNow.AddSeconds(10),
+				cancellationToken: token,
+				compatibility: 1));
+
+	public IAsyncEnumerable<IO.Core.Event> ReadAllBackwardsAsync(IO.Core.Position position, long maxCount, CancellationToken token) =>
+		Create($"Reading from $all Backwards", () =>
+			new Enumerator.ReadAllBackwards(
+				bus: _publisher,
+				position: Convert(position),
+				maxCount: (ulong)maxCount,
+				resolveLinks: false,
+				user: SystemAccounts.System,
+				requiresLeader: _requiresLeader,
+				deadline: DateTime.UtcNow.AddSeconds(10),
+				cancellationToken: token
+			));
+
+	public IAsyncEnumerable<IO.Core.Event> ReadStreamForwards(string stream, long maxCount, CancellationToken token) =>
+		Create(
+			$"Reading stream {stream} forwards for max {maxCount} events",
+			() => new Enumerator.ReadStreamForwards(
+				bus: _publisher,
+				streamName: stream,
+				startRevision: StreamRevision.Start,
+				maxCount: (ulong)maxCount,
+				resolveLinks: false,
+				user: SystemAccounts.System,
+				requiresLeader: _requiresLeader,
+				deadline: DateTime.UtcNow.AddSeconds(10),
+				cancellationToken: token,
+				compatibility: 1));
+
+	public async Task DeleteStreamAsync(string stream, long expectedVersion, CancellationToken cancellationToken) {
+		var appendResponseSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var envelope = new CallbackEnvelope(HandleDeleteStreamCompleted);
+
+		var correlationId = Guid.NewGuid();
+		_publisher.Publish(new ClientMessage.DeleteStream(
+			correlationId,
+			correlationId,
+			envelope,
+			requireLeader: _requiresLeader,
+			stream,
+			expectedVersion,
+			hardDelete: false,
+			SystemAccounts.System,
+			cancellationToken: cancellationToken));
+
+		await appendResponseSource.Task.ConfigureAwait(false);
+
+		void HandleDeleteStreamCompleted(Message message) {
+			if (message is ClientMessage.NotHandled notHandled) {
+				Exception ex = notHandled.Reason switch {
+					ClientMessage.NotHandled.Types.NotHandledReason.NotReady => new ResponseException.ServerNotReady(),
+					ClientMessage.NotHandled.Types.NotHandledReason.TooBusy => new ResponseException.ServerBusy(),
+					ClientMessage.NotHandled.Types.NotHandledReason.NotLeader or
+					ClientMessage.NotHandled.Types.NotHandledReason.IsReadOnly => new ResponseException.NotLeader(),
+					_ => new ResponseException.UnexpectedError($"NotHandled {notHandled.Reason}"),
+				};
+				appendResponseSource.TrySetException(ex);
+				return;
+			}
+
+			if (message is not ClientMessage.DeleteStreamCompleted completed) {
+				appendResponseSource.TrySetException(new ResponseException.UnexpectedError($"Unexpected message {message}"));
+				return;
+			}
+
+			switch (completed.Result) {
+				case OperationResult.Success:
+					appendResponseSource.TrySetResult();
+					return;
+				case OperationResult.PrepareTimeout:
+				case OperationResult.CommitTimeout:
+				case OperationResult.ForwardTimeout:
+					appendResponseSource.TrySetException(new ResponseException.Timeout(completed.Message));
+					return;
+				case OperationResult.WrongExpectedVersion:
+					appendResponseSource.TrySetException(new ResponseException.WrongExpectedVersion(completed.Message));
+					return;
+				case OperationResult.StreamDeleted:
+					appendResponseSource.TrySetException(new ResponseException.StreamDeleted(completed.Message));
+					return;
+				case OperationResult.InvalidTransaction:
+					appendResponseSource.TrySetException(new ResponseException.UnexpectedError(completed.Message));
+					return;
+				case OperationResult.AccessDenied:
+					appendResponseSource.TrySetException(new ResponseException.AccessDenied(completed.Message));
+					return;
+				default:
+					appendResponseSource.TrySetException(new ResponseException.UnexpectedError(completed.Message));
+					return;
+			}
+		}
+	}
+
+	private static IO.Core.Event ConvertEvent(ref ResolvedEvent evt) {
+		var e = evt.OriginalEvent;
+		return new IO.Core.Event(
+			eventId: e.EventId,
+			created: e.TimeStamp,
+			stream: e.EventStreamId,
+			eventNumber: (ulong)e.EventNumber,
+			eventType: e.EventType,
+			contentType: e.IsJson ? "application/json" : "application/octet-stream",
+			commitPosition: (ulong)evt.OriginalPosition!.Value.CommitPosition,
+			preparePosition: (ulong)evt.OriginalPosition!.Value.PreparePosition,
+			isRedacted: e.Flags.HasAllOf(PrepareFlags.IsRedacted),
+			data: e.Data,
+			metadata: e.Metadata);
+	}
+
+	private static IAsyncEnumerable<IO.Core.Event> Create(
+		string message,
+		Func<IAsyncEnumerator<ReadResponse>> enumeratorFactory) {
+
+		return new LoggingEnumerable<ReadResponse>(enumeratorFactory, message)
+			.MapExceptions()
+			.Select(x => {
+				if (x is ReadResponse.StreamNotFound y)
+					throw new ResponseException.StreamNotFound(y.StreamName);
+				return x;
+			})
+			.OfType<ReadResponse.EventReceived>()
+			.Select(x => ConvertEvent(ref x.Event));
+	}
+
+	class LoggingEnumerable<T> : IAsyncEnumerable<T> {
+		private readonly Func<IAsyncEnumerator<T>> _enumeratorFactory;
+		private readonly string _message;
+
+		public LoggingEnumerable(Func<IAsyncEnumerator<T>> enumeratorFactory, string message) {
+			_enumeratorFactory = enumeratorFactory;
+			_message = message;
+		}
+
+		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) {
+			return new LoggingEnumerator<T>(_enumeratorFactory(), _message);
+		}
+	}
+
+	sealed class LoggingEnumerator<T> : IAsyncEnumerator<T> {
+		private readonly string _message;
+		private readonly IAsyncEnumerator<T> _wrapped;
+
+		public LoggingEnumerator(IAsyncEnumerator<T> wrapped, string message) {
+			_wrapped = wrapped;
+			_message = message;
+			Log.Information("Internal Client: Started {message}", _message);
+		}
+
+		public T Current => _wrapped.Current;
+
+		public ValueTask DisposeAsync() {
+			Log.Information("Internal Client: Ended {message}", _message);
+			return _wrapped.DisposeAsync();
+		}
+
+		public ValueTask<bool> MoveNextAsync() {
+			return _wrapped.MoveNextAsync();
+		}
+	}
+}
+
+public static class IAsyncEnumerableExtenions {
+	public static bool TryMap(this Exception ex, out Exception mapped) {
+		mapped = ex.Map();
+		return mapped != ex;
+	}
+
+	private static Exception Map(this Exception ex) => ex switch {
+		ReadResponseException.AccessDenied =>
+			new ResponseException.AccessDenied(ex),
+
+		ReadResponseException.NotHandled.ServerNotReady =>
+			new ResponseException.ServerNotReady(ex),
+
+		ReadResponseException.NotHandled.ServerBusy =>
+			new ResponseException.ServerBusy(ex),
+
+		ReadResponseException.NotHandled.LeaderInfo or
+		ReadResponseException.NotHandled.NoLeaderInfo =>
+			new ResponseException.NotLeader(ex),
+
+		ReadResponseException.StreamDeleted =>
+			new ResponseException.StreamDeleted(ex),
+
+		ReadResponseException.Timeout =>
+			new ResponseException.Timeout(ex),
+
+		OperationCanceledException =>
+			ex,
+
+		ReadResponseException.InvalidPosition or
+		ReadResponseException.UnknownError or
+		ReadResponseException.UnknownMessage or
+		_ =>
+			new ResponseException.UnexpectedError(ex),
+	};
+
+	public static async IAsyncEnumerable<T> MapExceptions<T>(
+		this IAsyncEnumerable<T> self) {
+
+		await Task.Yield();
+
+		await using var enumerator = self.GetAsyncEnumerator();
+		while (true) {
+			try {
+				if (!await enumerator.MoveNextAsync())
+					break;
+
+			} catch (Exception ex) when (ex.TryMap(out var mapped)) {
+				throw mapped;
+			}
+
+			yield return enumerator.Current;
+		}
+	}
+}

--- a/src/EventStore.POC.ConnectedSubsystemsPlugin/InternalOperationsClient.cs
+++ b/src/EventStore.POC.ConnectedSubsystemsPlugin/InternalOperationsClient.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.POC.IO.Core;
+
+namespace EventStore.POC.ConnectedSubsystemsPlugin;
+
+public class InternalOperationsClient : IOperationsClient {
+	readonly IPublisher _publisher;
+
+	public InternalOperationsClient(IPublisher publisher) {
+		_publisher = publisher;
+	}
+
+	public void Resign() {
+		_publisher.Publish(new ClientMessage.ResignNode());
+	}
+}

--- a/src/EventStore.POC.ConnectedSubsystemsPlugin/README.md
+++ b/src/EventStore.POC.ConnectedSubsystemsPlugin/README.md
@@ -1,0 +1,4 @@
+ConnectedSubsystemsPlugin
+
+This is a RawPlugin that hosts ConnectedSubsystem plugins
+it is allow to know about messages and other stuff in eventstore.core

--- a/src/EventStore.POC.IO.Core/Event.cs
+++ b/src/EventStore.POC.IO.Core/Event.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+
+namespace EventStore.POC.IO.Core;
+
+//qq move, rename? and does this want to be events or records
+//qq we probably want to reuse these, and we may want part of the pipline to transform them
+// but they should be immutable so that parallel parts of the pipeline don't trip each other up.
+public class Event {
+	public Guid EventId { get; init; }
+	public DateTime Created { get; init; }
+	public string Stream { get; init; }
+	public ulong EventNumber { get; init; }
+	public string EventType { get; init; }
+	public string ContentType { get; init; }
+	//qq do these want to be long or ulong
+	public ulong CommitPosition { get; init; }
+	public ulong PreparePosition { get; init; }
+	public bool IsRedacted { get; init; }
+	public ReadOnlyMemory<byte> Data { get; init; }
+	public ReadOnlyMemory<byte> Metadata { get; init; }
+
+	public Event(
+		Guid eventId,
+		DateTime created,
+		string stream,
+		ulong eventNumber,
+		string eventType,
+		string contentType,
+		ulong commitPosition,
+		ulong preparePosition,
+		bool isRedacted,
+		ReadOnlyMemory<byte> data,
+		ReadOnlyMemory<byte> metadata) {
+
+		EventId = eventId;
+		Created = created;
+		Stream = stream;
+		EventNumber = eventNumber;
+		EventType = eventType;
+		ContentType = contentType;
+		CommitPosition = commitPosition;
+		PreparePosition = preparePosition;
+		IsRedacted = isRedacted;
+		Data = data;
+		Metadata = metadata;
+	}
+}

--- a/src/EventStore.POC.IO.Core/EventStore.POC.IO.Core.csproj
+++ b/src/EventStore.POC.IO.Core/EventStore.POC.IO.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="EventStore.Plugins" Version="25.2.5" />
+	</ItemGroup>
+</Project>

--- a/src/EventStore.POC.IO.Core/EventToWrite.cs
+++ b/src/EventStore.POC.IO.Core/EventToWrite.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+
+namespace EventStore.POC.IO.Core;
+
+public class EventToWrite {
+	public Guid EventId { get; init; }
+	public string EventType { get; init; }
+	public string ContentType { get; init; }
+	public ReadOnlyMemory<byte> Data { get; init; }
+	public ReadOnlyMemory<byte> Metadata { get; init; }
+
+	public EventToWrite(
+		Guid eventId,
+		string eventType,
+		string contentType,
+		ReadOnlyMemory<byte> data,
+		ReadOnlyMemory<byte> metadata) {
+
+		EventId = eventId;
+		EventType = eventType;
+		ContentType = contentType;
+		Data = data;
+		Metadata = metadata;
+	}
+}

--- a/src/EventStore.POC.IO.Core/IAsyncEnumerableExtentions.cs
+++ b/src/EventStore.POC.IO.Core/IAsyncEnumerableExtentions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace EventStore.POC.IO.Core;
+
+public static class IAsyncEnumerableExtentions {
+	public static async Task ToChannelAsync<T>(
+		this IAsyncEnumerable<T> self,
+		ChannelWriter<T> writer,
+		CancellationToken ct) {
+
+		await foreach (var x in self.WithCancellation(ct)) {
+			await writer.WriteAsync(x, ct);
+		}
+	}
+
+	public static async IAsyncEnumerable<T> HandleStreamNotFound<T>(
+		this IAsyncEnumerable<T> self) {
+
+		await Task.Yield();
+
+		await using var enumerator = self.GetAsyncEnumerator();
+		while (true) {
+			try {
+				if (!await enumerator.MoveNextAsync())
+					break;
+			} catch (ResponseException.StreamNotFound) {
+				break;
+			}
+
+			yield return enumerator.Current;
+		}
+	}
+}

--- a/src/EventStore.POC.IO.Core/IClient.cs
+++ b/src/EventStore.POC.IO.Core/IClient.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.POC.IO.Core;
+
+public readonly record struct Position(ulong CommitPosition, ulong PreparePosition) {
+	public static readonly Position Start = new(0, 0);
+
+	public static readonly Position End = new(ulong.MaxValue, ulong.MaxValue);
+
+	public static bool operator <(Position a, Position b) {
+		if (a.CommitPosition != b.CommitPosition) {
+			return a.CommitPosition < b.CommitPosition;
+		}
+
+		return a.PreparePosition < b.PreparePosition;
+	}
+
+	public static bool operator >(Position p1, Position p2) => p2 < p1;
+}
+
+// This exists to prevent people constructing a position when subscribing to all and expecting
+// to receive the event at that position in their subscription. The subscribe call is expecting
+// a checkpoint of the last received event and the `After` method makes that intuitive
+public readonly record struct FromAll(Position? Position) {
+	public static readonly FromAll Start = new(null);
+
+	public static readonly FromAll End = new(IO.Core.Position.End);
+
+	public static FromAll After(Position position) => new(position);
+}
+
+public static class ExpectedVersion {
+	public const long Any = -2;
+	public const long NoStream = -1;
+}
+
+public interface IClient {
+	//qq consider what api we actually want here
+	// and clearly define the semantics such that we get the same behaviour from internal and external
+	// wrt exception handling etc.
+
+	Task WriteMetaDataMaxCountAsync(string stream, CancellationToken cancellationToken);
+	Task<long> WriteAsync(string stream, EventToWrite[] events, long expectedVersion, CancellationToken cancellationToken);
+	IAsyncEnumerable<Event> SubscribeToAll(FromAll start, CancellationToken cancellationToken);
+	IAsyncEnumerable<Event> SubscribeToStream(string stream, CancellationToken cancellationToken);
+	IAsyncEnumerable<Event> ReadStreamForwards(string stream, long maxCount, CancellationToken cancellationToken);
+	IAsyncEnumerable<Event> ReadStreamBackwards(string stream, long maxCount, CancellationToken cancellationToken);
+	IAsyncEnumerable<Event> ReadAllBackwardsAsync(Position position, long maxCount, CancellationToken cancellationToken);
+	Task DeleteStreamAsync(string stream, long expectedVersion, CancellationToken cancellationToken);
+
+	async Task<long> WriteAsyncRetry(string stream, EventToWrite[] events, long expectedVersion,
+		CancellationToken cancellationToken, int maxRetries = 50) {
+
+		ResponseException? lastException = null;
+		for (var i = 0; i < maxRetries; i++) {
+			try {
+				return await WriteAsync(stream, events, expectedVersion, cancellationToken);
+			} catch (ResponseException e) {
+				switch (e) {
+					case ResponseException.ServerBusy:
+					case ResponseException.ServerNotReady:
+					case ResponseException.Timeout:
+						break;
+					default:
+						throw;
+				}
+
+				lastException = e;
+				await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+			}
+		}
+
+		throw lastException!;
+	}
+
+	class None : IClient {
+		public IAsyncEnumerable<Event> SubscribeToAll(FromAll start, CancellationToken cancellationToken) {
+			throw new System.NotImplementedException();
+		}
+
+		public IAsyncEnumerable<Event> SubscribeToStream(string stream, CancellationToken cancellationToken) {
+			throw new System.NotImplementedException();
+		}
+
+		public IAsyncEnumerable<Event> ReadStreamForwards(string stream, long maxCount, CancellationToken cancellationToken) {
+			throw new System.NotImplementedException();
+		}
+
+		public IAsyncEnumerable<Event> ReadStreamBackwards(string stream, long maxCount, CancellationToken cancellationToken) {
+			throw new System.NotImplementedException();
+		}
+
+		public IAsyncEnumerable<Event> ReadAllBackwardsAsync(Position position, long maxCount, CancellationToken cancellationToken) {
+			throw new System.NotImplementedException();
+		}
+
+		public Task DeleteStreamAsync(string stream, long expectedVersion, CancellationToken cancellationToken) {
+			throw new System.NotImplementedException();
+		}
+
+		public Task WriteMetaDataMaxCountAsync(string stream, CancellationToken cancellationToken) {
+			throw new System.NotImplementedException();
+		}
+
+		public Task<long> WriteAsync(string stream, EventToWrite[] events, long expectedVersion, CancellationToken cancellationToken) {
+			throw new System.NotImplementedException();
+		}
+	}
+}

--- a/src/EventStore.POC.IO.Core/IConnectedSubsystemsPlugin.cs
+++ b/src/EventStore.POC.IO.Core/IConnectedSubsystemsPlugin.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using EventStore.Plugins.Subsystems;
+
+namespace EventStore.POC.IO.Core;
+
+// Necessary for now because of how PluginLoader works.
+// Later it may be possible to remove this interface entirely.
+public interface IConnectedSubsystemsPlugin {
+	string Name { get; }
+	string Version { get; }
+	string CommandLineName { get; }
+	IReadOnlyList<ISubsystem> GetSubsystems();
+}

--- a/src/EventStore.POC.IO.Core/IOperationsClient.cs
+++ b/src/EventStore.POC.IO.Core/IOperationsClient.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.POC.IO.Core;
+
+/// <summary>
+/// A client abstraction used for administrative operations.
+/// </summary>
+public interface IOperationsClient {
+	/// <summary>
+	/// Demotes the current node to a follower if it is a leader. Don't expect the node to be demoted immediately. The
+	/// call start demotion process.
+	/// </summary>
+	void Resign();
+}

--- a/src/EventStore.POC.IO.Core/ISink.cs
+++ b/src/EventStore.POC.IO.Core/ISink.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.POC.IO.Core;
+
+public interface ISink {
+
+	public Uri Config { get; }
+
+	public Task Write(Event e, CancellationToken ct);
+}

--- a/src/EventStore.POC.IO.Core/ResponseException.cs
+++ b/src/EventStore.POC.IO.Core/ResponseException.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+
+namespace EventStore.POC.IO.Core;
+
+public abstract class ResponseException : Exception {
+	protected ResponseException() : base() { }
+	protected ResponseException(string? message) : base(message) { }
+	protected ResponseException(string? message, Exception inner) : base(message, inner) { }
+
+	/// Request was not authorized
+	public class AccessDenied : ResponseException {
+		public AccessDenied(string message) : base(message) { }
+		public AccessDenied(Exception inner) : base(null, inner) { }
+	}
+
+	public class NotAuthenticated : ResponseException {
+		public NotAuthenticated(Exception inner) : base(null, inner) { }
+	}
+
+	public class NotLeader : ResponseException {
+		public NotLeader() { }
+		public NotLeader(Exception inner) : base(null, inner) { }
+	}
+
+	public class SubscriptionDropped : ResponseException {
+		public SubscriptionDropped() { }
+		public SubscriptionDropped(string stream, string reason) :
+			base($"Subscription to {stream} was dropped {reason}.") { }
+	}
+	
+	public class ServerBusy : ResponseException {
+		public ServerBusy() { }
+		public ServerBusy(Exception inner) : base(null, inner) { }
+	}
+
+	public class ServerNotReady : ResponseException {
+		public ServerNotReady() { }
+		public ServerNotReady(Exception inner) : base(null, inner) { }
+	}
+
+	public class StreamDeleted : ResponseException {
+		public StreamDeleted(string message) : base(message) { }
+		public StreamDeleted(Exception inner) : base(null, inner) { }
+	}
+
+	public class StreamNotFound : ResponseException {
+		public StreamNotFound(string message) : base(message) {
+		}
+	}
+
+	public class Timeout : ResponseException {
+		public Timeout(string message) : base(message) { }
+		public Timeout(Exception inner) : base(null, inner) { }
+	}
+
+	public class UnexpectedError : ResponseException {
+		public UnexpectedError(string message) : base(message) { }
+		public UnexpectedError(Exception inner) : base(null, inner) { }
+	}
+
+	public class WrongExpectedVersion : ResponseException {
+		public WrongExpectedVersion(string message) : base(message) { }
+		public WrongExpectedVersion(Exception inner) : base(null, inner) { }
+	}
+}

--- a/src/EventStore.POC.IO.Core/Serialization/EnumConverterWithDefault.cs
+++ b/src/EventStore.POC.IO.Core/Serialization/EnumConverterWithDefault.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EventStore.POC.IO.Core.Serialization;
+
+public class EnumConverterWithDefault<T> : JsonConverter<T> where T : struct, Enum {
+	public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+		var s = reader.GetString();
+		if (!Enum.TryParse<T>(s, true, out var result) || !Enum.IsDefined(result))
+			return default;
+		return result;
+	}
+
+	public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) {
+		writer.WriteStringValue(value.ToString());
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest.Tests/EncryptionAtRestPluginTests.cs
+++ b/src/EventStore.Security.EncryptionAtRest.Tests/EncryptionAtRestPluginTests.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Security.Cryptography;
+using EventStore.Plugins;
+using EventStore.Plugins.Diagnostics;
+using EventStore.Plugins.Licensing;
+using EventStore.Plugins.Tests;
+using EventStore.Plugins.Transforms;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.Security.EncryptionAtRest.Tests;
+
+public class EncryptionAtTestPluginTests {
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void can_collect_telemetry(bool enabled) {
+		using var sut = new EncryptionAtRestPlugin();
+		using var collector = PluginDiagnosticsDataCollector.Start(sut.DiagnosticsName);
+
+		IConfigurationBuilder configBuilder = new ConfigurationBuilder();
+
+		if (enabled)
+			configBuilder = configBuilder.AddInMemoryCollection(new Dictionary<string, string?> {
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:Enabled", "true"},
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:MasterKey:File:KeyPath", "./keys"},
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:Encryption:AesGcm:Enabled", "true"},
+			});
+
+		var config = configBuilder.Build();
+
+		var builder = WebApplication.CreateBuilder();
+		builder.Services
+			.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService())
+			.AddSingleton<IReadOnlyList<IDbTransform>>([]);
+
+		// when
+		((IPlugableComponent)sut).ConfigureServices(
+			builder.Services,
+			config);
+
+		var app = builder.Build();
+		((IPlugableComponent)sut).ConfigureApplication(app, config);
+
+		// then
+		collector.CollectedEvents(sut.DiagnosticsName).Should().ContainSingle().Which
+			.Data["enabled"].Should().Be(enabled);
+	}
+
+	[Theory]
+	[InlineData(true, true, "ENCRYPTION_AT_REST", false)]
+	[InlineData(true, false, "ENCRYPTION_AT_REST", true)]
+	[InlineData(false, true, "ENCRYPTION_AT_REST", false)]
+	[InlineData(false, false, "ENCRYPTION_AT_REST", false)]
+	[InlineData(true, true, "NONE", true)]
+	[InlineData(true, false, "NONE", true)]
+	[InlineData(false, true, "NONE", false)]
+	[InlineData(false, false, "NONE", false)]
+	public void respects_license(bool enabled, bool licensePresent, string entitlement, bool expectedException) {
+		// given
+		using var sut = new EncryptionAtRestPlugin();
+
+		IConfigurationBuilder configBuilder = new ConfigurationBuilder();
+
+		if (enabled)
+			configBuilder = configBuilder.AddInMemoryCollection(new Dictionary<string, string?> {
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:Enabled", "true"},
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:MasterKey:File:KeyPath", "./keys"},
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:Encryption:AesGcm:Enabled", "true"},
+			});
+
+		var config = configBuilder.Build();
+
+		var builder = WebApplication.CreateBuilder();
+		builder.Services.AddSingleton<IReadOnlyList<IDbTransform>>([]);
+
+		var licenseService = new Fixtures.FakeLicenseService(licensePresent, entitlement);
+		builder.Services.AddSingleton<ILicenseService>(licenseService);
+
+		((IPlugableComponent)sut).ConfigureServices(
+			builder.Services,
+			config);
+
+		var app = builder.Build();
+
+		// when
+		((IPlugableComponent)sut).ConfigureApplication(app, config);
+
+		// then
+		if (expectedException) {
+			Assert.NotNull(licenseService.RejectionException);
+		} else {
+			Assert.Null(licenseService.RejectionException);
+		}
+	}
+
+	[Fact]
+	public async Task works() {
+		// given
+		using var sut = new EncryptionAtRestPlugin();
+
+		IConfigurationBuilder configBuilder = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?> {
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:Enabled", "true"},
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:MasterKey:File:KeyPath", "./keys"},
+				{$"{KurrentConfigurationConstants.Prefix}:EncryptionAtRest:Encryption:AesGcm:Enabled", "true"},
+			});
+
+		var config = configBuilder.Build();
+
+		// when
+		var builder = WebApplication.CreateBuilder();
+		builder.Services.AddSingleton<ILicenseService>(new Fixtures.FakeLicenseService());
+		builder.Services.AddSingleton<IReadOnlyList<IDbTransform>>([]);
+
+		((IPlugableComponent)sut).ConfigureServices(
+			builder.Services,
+			config);
+
+		var app = builder.Build();
+		((IPlugableComponent)sut).ConfigureApplication(app, config);
+
+		// then
+		var transforms = app.Services.GetService<IReadOnlyList<IDbTransform>>();
+
+		Assert.NotNull(transforms);
+		Assert.Single(transforms);
+		Assert.Equal(TransformType.Encryption_AesGcm, transforms[0].Type);
+
+		var chunk = Path.GetTempFileName();
+		try {
+			await VerifyTransformWorks(transforms[0], chunk);
+		} finally {
+			File.Delete(chunk);
+		}
+	}
+
+	private static async Task VerifyTransformWorks(IDbTransform dbTransform, string chunk) {
+		const int dataSize = 1_000_000;
+		const int chunkHeaderSize = 128; // this value is hardcoded in the transform and cannot be changed in the test
+		const int footerSize = 128;
+		const int alignmentSize = 4096;
+
+		var writeHeader = new byte[chunkHeaderSize];
+		var writeData = new byte[dataSize];
+		var writeFooter = new byte[footerSize];
+
+		RandomNumberGenerator.Fill(writeHeader);
+		RandomNumberGenerator.Fill(writeData);
+		RandomNumberGenerator.Fill(writeFooter);
+
+		await WriteFirstPart(writeHeader, writeData[..(dataSize/3)]);
+		await WriteMiddlePart(dataSize / 3, writeData[(dataSize/3)..(dataSize*2/3)]);
+		var writeHash = await WriteLastPart(dataSize * 2 / 3, writeData[(dataSize*2/3)..], writeFooter);
+
+		await VerifyReads();
+		await VerifyRandomReads(numRandomReads: 1000);
+
+		return;
+
+		async Task WriteFirstPart(ReadOnlyMemory<byte> header, ReadOnlyMemory<byte> data) {
+			var transformHeader = new byte[dbTransform.ChunkFactory.TransformHeaderLength];
+			dbTransform.ChunkFactory.CreateTransformHeader(transformHeader);
+
+			var transform = dbTransform.ChunkFactory.CreateTransform(transformHeader);
+
+			using var fileStream = File.Open(chunk, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+			await fileStream.WriteAsync(header);
+			await fileStream.WriteAsync(transformHeader);
+
+			using var checksum = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+			checksum.AppendData(header.Span);
+			checksum.AppendData(transformHeader);
+
+			using var writeStream = transform.Write.TransformData(new ChunkDataWriteStream(fileStream, checksum));
+			await WriteData(writeStream, data);
+		}
+
+		async Task WriteMiddlePart(long writeResumePosition, ReadOnlyMemory<byte> data) {
+			using var fileStream = File.Open(chunk, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+			var (transform, _) = await CreateTransform(fileStream);
+
+			using var checksum = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+			fileStream.Position = 0;
+			using var writeStream = transform.Write.TransformData(new ChunkDataWriteStream(fileStream, checksum));
+			writeStream.Position = chunkHeaderSize + writeResumePosition;
+			await WriteData(writeStream, data);
+		}
+
+		async Task<byte[]> WriteLastPart(long writeResumePosition, ReadOnlyMemory<byte> data, ReadOnlyMemory<byte> footer) {
+			using var fileStream = File.Open(chunk, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+			var (transform, _) = await CreateTransform(fileStream);
+
+			using var checksum = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+			fileStream.Position = 0;
+			using var writeStream = transform.Write.TransformData(new ChunkDataWriteStream(fileStream, checksum));
+			writeStream.Position = chunkHeaderSize + writeResumePosition;
+			await WriteData(writeStream, data);
+
+			await transform.Write.CompleteData(footerSize, alignmentSize);
+			await transform.Write.WriteFooter(footer);
+			checksum.AppendData(footer.Span);
+
+			return checksum.GetCurrentHash();
+		}
+
+		async Task WriteData(Stream stream, ReadOnlyMemory<byte> data) {
+			while (data.Length > 0) {
+				var len = Random.Shared.Next(data.Length + 1);
+				await stream.WriteAsync(data[..len]);
+				await stream.FlushAsync();
+				data = data[len..];
+			}
+			await stream.FlushAsync();
+		}
+
+		async Task VerifyReads() {
+			using var fileStream = File.Open(chunk, FileMode.Open, FileAccess.Read, FileShare.None);
+			var fileData = new byte[fileStream.Length];
+			await fileStream.ReadExactlyAsync(fileData);
+			var stream = new MemoryStream(fileData);
+			var (transform, header) = await CreateTransform(stream);
+
+			var data = new byte[dataSize];
+			using (var readStream = transform.Read.TransformData(new ChunkDataReadStream(stream))) {
+				readStream.Position = chunkHeaderSize;
+				await readStream.ReadExactlyAsync(data);
+			}
+
+			var footer = new byte[footerSize];
+			fileData[^footer.Length..].AsSpan().CopyTo(footer);
+
+			using var checksum = MD5.Create();
+			checksum.ComputeHash(fileData);
+
+			Assert.True(new FileInfo(chunk).Length % alignmentSize == 0, "file size is not aligned");
+			Assert.True(header.SequenceEqual(writeHeader), "header does not match");
+			Assert.True(data.SequenceEqual(writeData), "data does not match");
+			Assert.True(footer.SequenceEqual(writeFooter), "footer does not match");
+			Assert.True(checksum.Hash!.SequenceEqual(writeHash), "checksum does not match");
+		}
+
+		async Task VerifyRandomReads(int numRandomReads) {
+			using var fileStream = File.Open(chunk, FileMode.Open, FileAccess.Read, FileShare.None);
+			var fileData = new byte[fileStream.Length];
+			await fileStream.ReadExactlyAsync(fileData);
+			var stream = new MemoryStream(fileData);
+			var (transform, _) = await CreateTransform(stream);
+
+			using (var readStream = transform.Read.TransformData(new ChunkDataReadStream(stream))) {
+				for (var i = 0; i < numRandomReads; i++) {
+					var startPos = Random.Shared.Next(dataSize);
+					var endPos = Math.Min(dataSize, startPos + Random.Shared.Next(10000));
+
+					var len = endPos - startPos;
+					var buffer = new byte[len];
+
+					readStream.Position = chunkHeaderSize + startPos;
+
+					// split the reads to cover more scenarios
+					var mem = buffer.AsMemory();
+					while (mem.Length > 0) {
+						var slice = mem[..Random.Shared.Next(1, mem.Length + 1)];
+						mem = mem[slice.Length..];
+						await readStream.ReadExactlyAsync(slice);
+					}
+
+					Assert.True(buffer.SequenceEqual(writeData[startPos..endPos]), "random data read does not match");
+				}
+			}
+		}
+
+		async Task<(IChunkTransform transform, byte[] chunkHeader)> CreateTransform(Stream stream) {
+			var chunkHeader = new byte[chunkHeaderSize];
+			await stream.ReadExactlyAsync(chunkHeader);
+			var transformHeader = new byte[dbTransform.ChunkFactory.TransformHeaderLength];
+			await dbTransform.ChunkFactory.ReadTransformHeader(stream, transformHeader);
+			return (dbTransform.ChunkFactory.CreateTransform(transformHeader), chunkHeader);
+		}
+	}
+
+}

--- a/src/EventStore.Security.EncryptionAtRest.Tests/EventStore.Security.EncryptionAtRest.Tests.csproj
+++ b/src/EventStore.Security.EncryptionAtRest.Tests/EventStore.Security.EncryptionAtRest.Tests.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<Platforms>AnyCPU;x64</Platforms>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit" Version="2.5.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.Security.EncryptionAtRest\EventStore.Security.EncryptionAtRest.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Update="keys\1.esdb.master.key">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Security.EncryptionAtRest.Tests/SieveBlockCacheTests.cs
+++ b/src/EventStore.Security.EncryptionAtRest.Tests/SieveBlockCacheTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Security.EncryptionAtRest.Transforms.DataStructures;
+
+namespace EventStore.Security.EncryptionAtRest.Tests;
+
+public class SieveBlockCacheTests {
+	private const int DataSize = 10;
+
+	[Fact]
+	public void works() {
+		// example from: https://cachemon.github.io/SIEVE-website/blog/assets/sieve/sieve_diagram_animation.gif
+		var sut = new SieveBlockCache(7, DataSize);
+		var data = new byte[DataSize];
+
+		// set up
+		Put('A');
+		Put('B');
+		Put('C');
+		Put('D');
+		Put('E');
+		Put('F');
+		Put('G');
+		Get('A');
+		Get('B');
+		Get('G');
+
+		// tests
+		Put('H');
+		CantGet('C');
+
+		Put('A');
+		Put('D');
+		Put('I');
+		CantGet('E');
+
+		Put('B');
+		Put('J');
+		CantGet('F');
+
+		// final checks
+		CanGet('A');
+		CanGet('B');
+		CanGet('D');
+		CanGet('G');
+		CanGet('H');
+		CanGet('I');
+		CanGet('J');
+
+		return;
+
+		bool Get(char c) {
+			return sut.TryGet(c, data);
+		}
+
+		void Put(char c) {
+			if (!Get(c))
+				sut.Put(c, GenData(c));
+		}
+
+		void CanGet(char c) {
+			Assert.True(Get(c));
+			Assert.True(data.All(x => x == c));
+		}
+
+		void CantGet(char c) {
+			Assert.False(Get(c));
+		}
+
+		static ReadOnlySpan<byte> GenData(char c) {
+			var data = new byte[DataSize];
+			for (var i = 0; i < DataSize; i++)
+				data[i] = (byte) c;
+			return data;
+		}
+	}
+
+	[Fact]
+	public void works_with_cache_size_one() {
+		var sut = new SieveBlockCache(1, 0);
+		var data = Array.Empty<byte>();
+
+		sut.Put('A', data);
+		Assert.True(sut.TryGet('A', data));
+
+		sut.Put('B', data);
+		Assert.True(sut.TryGet('B', data));
+
+		sut.Put('C', data);
+		Assert.True(sut.TryGet('C', data));
+
+		sut.Put('D', data);
+		Assert.True(sut.TryGet('D', data));
+
+		Assert.False(sut.TryGet('A', data));
+		Assert.False(sut.TryGet('B', data));
+		Assert.False(sut.TryGet('C', data));
+	}
+
+	[Fact]
+	public void throws_with_cache_size_zero() =>
+		Assert.Throws<ArgumentOutOfRangeException>(() => new SieveBlockCache(0, 1));
+
+	[Fact]
+	public void throws_with_negative_block_data_size() =>
+		Assert.Throws<ArgumentOutOfRangeException>(() => new SieveBlockCache(1, -1));
+}

--- a/src/EventStore.Security.EncryptionAtRest.Tests/keys/1.esdb.master.key
+++ b/src/EventStore.Security.EncryptionAtRest.Tests/keys/1.esdb.master.key
@@ -1,0 +1,3 @@
+-----BEGIN ESDB MASTER KEY-----
+HkqzPwpAc/NTCNsZawmGI4BG+nWP6sjxxRPiYV74ssE=
+-----END ESDB MASTER KEY-----

--- a/src/EventStore.Security.EncryptionAtRest/EncryptionAtRestOptions.cs
+++ b/src/EventStore.Security.EncryptionAtRest/EncryptionAtRestOptions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+#nullable enable
+
+namespace EventStore.Security.EncryptionAtRest;
+
+public class EncryptionAtRestOptions {
+	public bool Enabled { get; init; }
+
+	public MasterKeyOptions MasterKey { get; init; } = new();
+
+	public EncryptionOptions Encryption { get; init; } = new();
+
+	public class EncryptionOptions {
+		public AesGcmOptions AesGcm { get; init; } = new();
+	}
+
+	public class MasterKeyOptions {
+		public FileConfiguratorOptions? File { get; init; }
+	}
+
+	public class FileConfiguratorOptions {
+		public string KeyPath { get; init; } = "";
+	}
+
+	public class AesGcmOptions {
+		public bool Enabled { get; init; }
+		public int KeySize { get; init; } = 256;
+	}
+}
+

--- a/src/EventStore.Security.EncryptionAtRest/EncryptionAtRestPlugin.cs
+++ b/src/EventStore.Security.EncryptionAtRest/EncryptionAtRestPlugin.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Plugins;
+using EventStore.Plugins.Transforms;
+using EventStore.Security.EncryptionAtRest.EncryptionConfigurators;
+using EventStore.Security.EncryptionAtRest.MasterKeySourceConfigurators;
+using EventStore.Security.EncryptionAtRest.MasterKeySources;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.Security.EncryptionAtRest;
+
+public class EncryptionAtRestPlugin() : SubsystemsPlugin(requiredEntitlements: ["ENCRYPTION_AT_REST"]) {
+	const string ConfigRoot = "KurrentDB:EncryptionAtRest";
+
+	private static readonly ILogger _logger = Log.ForContext<EncryptionAtRestPlugin>();
+
+	public override (bool Enabled, string EnableInstructions) IsEnabled(IConfiguration configuration) {
+		var enabled = configuration.GetValue($"{ConfigRoot}:Enabled", defaultValue: false);
+		return (enabled, $"Set '{ConfigRoot}:Enabled' to 'true' to enable the encryption at rest plugin");
+	}
+
+	public override void ConfigureServices(IServiceCollection services, IConfiguration config) {
+		var options = config.GetSection(ConfigRoot).Get<EncryptionAtRestOptions>() ?? new();
+
+		if (!TryConfigureMasterKeySource(
+			    options: options.MasterKey,
+			    out var masterKeySource))
+			return;
+
+		var masterKeys = LoadMasterKeys(masterKeySource);
+
+		if (!TryConfigureEncryptionAlgorithms(
+			    options: options.Encryption,
+			    masterKeys: masterKeys,
+			    out var encryptionTransforms))
+			return;
+
+		services.Decorate<IReadOnlyList<IDbTransform>>((dbTransforms, _) =>
+			Decorate(dbTransforms, encryptionTransforms));
+	}
+
+	private static IReadOnlyList<IDbTransform> Decorate(IReadOnlyList<IDbTransform> dbTransforms, List<IDbTransform> encryptionTransforms) {
+		var newDbTransforms = dbTransforms.Concat(encryptionTransforms).ToList();
+		return newDbTransforms;
+	}
+
+	private static bool TryConfigureMasterKeySource(
+		EncryptionAtRestOptions.MasterKeyOptions options,
+		out IMasterKeySource masterKeySource) {
+
+		if (options.File is { } fileConfiguratorOptions) {
+			var configurator = new FileConfigurator();
+			_logger.Information("Encryption-At-Rest: Loaded master key source: {masterKeySource}", configurator.Name);
+			configurator.Configure(fileConfiguratorOptions, out masterKeySource);
+			return true;
+		}
+
+		masterKeySource = null;
+		LogErrorAndThrow($"Encryption-At-Rest: No supported master key source was specified");
+		return false;
+	}
+
+	private static IReadOnlyList<MasterKey> LoadMasterKeys(IMasterKeySource masterKeySource) {
+		var masterKeys = masterKeySource.LoadMasterKeys();
+		if (masterKeys.Count == 0)
+			LogErrorAndThrow("No master key loaded");
+
+		if (masterKeys.DistinctBy(x => x.Id).Count() != masterKeys.Count)
+			LogErrorAndThrow("All master keys should have a unique numeric ID");
+
+		_logger.Information($"Encryption-At-Rest: Active master key ID: {masterKeys[^1].Id}");
+		return masterKeys;
+	}
+
+	private static bool TryConfigureEncryptionAlgorithms(
+		EncryptionAtRestOptions.EncryptionOptions options,
+		IReadOnlyList<MasterKey> masterKeys,
+		out List<IDbTransform> encryptionTransforms) {
+
+		encryptionTransforms = [];
+
+		if (options.AesGcm.Enabled) {
+			var configurator = new AesGcmConfigurator();
+			_logger.Information("Encryption-At-Rest: Loaded encryption algorithm: {encryptionAlgorithm}", configurator.Name);
+			configurator.Configure(options.AesGcm, masterKeys, out var encryptionTransform);
+			encryptionTransforms.Add(encryptionTransform);
+		}
+
+		if (encryptionTransforms.Count == 0) {
+			LogErrorAndThrow($"Encryption-At-Rest: No supported encryption algorithm was specified");
+		}
+
+		return true;
+	}
+
+	private static void LogErrorAndThrow(string error) {
+		_logger.Error(error);
+		throw new Exception(error);
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/EncryptionConfigurators/AesGcmConfigurator.cs
+++ b/src/EventStore.Security.EncryptionAtRest/EncryptionConfigurators/AesGcmConfigurator.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using EventStore.Plugins.Transforms;
+using EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+using Serilog;
+
+namespace EventStore.Security.EncryptionAtRest.EncryptionConfigurators;
+
+public class AesGcmConfigurator : IEncryptionConfigurator<EncryptionAtRestOptions.AesGcmOptions> {
+	private static readonly ILogger _logger = Log.ForContext<AesGcmConfigurator>();
+	public string Name => "AesGcm";
+
+	public void Configure(EncryptionAtRestOptions.AesGcmOptions options, IReadOnlyList<MasterKey> masterKeys, out IDbTransform encryptionTransform) {
+		_logger.Information($"Encryption-At-Rest: ({Name}) Using key size: {options.KeySize} bits");
+
+		try {
+			encryptionTransform = new AesGcmDbTransform(masterKeys, options.KeySize);
+		} catch (Exception exc) {
+			_logger.Error(exc, $"Encryption-At-Rest: ({Name}) Error while creating encryption transform.");
+			throw;
+		}
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/EncryptionConfigurators/IEncryptionConfigurator.cs
+++ b/src/EventStore.Security.EncryptionAtRest/EncryptionConfigurators/IEncryptionConfigurator.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using EventStore.Plugins.Transforms;
+
+namespace EventStore.Security.EncryptionAtRest.EncryptionConfigurators;
+
+public interface IEncryptionConfigurator<TOptions> {
+	public string Name { get; }
+	public void Configure(
+		TOptions options,
+		IReadOnlyList<MasterKey> masterKeys,
+		out IDbTransform encryptionTransform);
+}

--- a/src/EventStore.Security.EncryptionAtRest/EventStore.Security.EncryptionAtRest.csproj
+++ b/src/EventStore.Security.EncryptionAtRest/EventStore.Security.EncryptionAtRest.csproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Platforms>x64</Platforms>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+	</PropertyGroup>
+	<PropertyGroup>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+	  <DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Scrutor" Version="4.2.2" />
+	</ItemGroup>
+	<ItemGroup>
+	  <None Update="encryption-at-rest-plugin-example.yaml">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	  <None Update="encryption-at-rest-plugin-example.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+</Project>

--- a/src/EventStore.Security.EncryptionAtRest/MasterKey.cs
+++ b/src/EventStore.Security.EncryptionAtRest/MasterKey.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+
+namespace EventStore.Security.EncryptionAtRest;
+
+public readonly record struct MasterKey {
+	public ushort Id { get; }
+	public ReadOnlyMemory<byte> Key { get; }
+
+	public MasterKey(int id, ReadOnlyMemory<byte> key) {
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(id);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(id, ushort.MaxValue);
+
+		Id = (ushort) id;
+		Key = key;
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/MasterKeySourceConfigurators/FileConfigurator.cs
+++ b/src/EventStore.Security.EncryptionAtRest/MasterKeySourceConfigurators/FileConfigurator.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using EventStore.Security.EncryptionAtRest.MasterKeySources;
+using EventStore.Security.EncryptionAtRest.MasterKeySources.File;
+using Serilog;
+
+namespace EventStore.Security.EncryptionAtRest.MasterKeySourceConfigurators;
+
+public class FileConfigurator : IMasterKeySourceConfigurator<EncryptionAtRestOptions.FileConfiguratorOptions> {
+	private static readonly ILogger _logger = Log.ForContext<FileConfigurator>();
+	public string Name => "File";
+
+	public void Configure(EncryptionAtRestOptions.FileConfiguratorOptions options, out IMasterKeySource masterKeySource) {
+		if (string.IsNullOrWhiteSpace(options.KeyPath))
+			LogErrorAndThrow($"Encryption-At-Rest: ({Name}) '{nameof(options.KeyPath)}' not specified.");
+
+		try {
+			masterKeySource = new FileSource(options.KeyPath);
+		} catch (Exception exc) {
+			_logger.Error(exc, $"Encryption-At-Rest: ({Name}) Error while configuring master key source.");
+			throw;
+		}
+	}
+
+	private static void LogErrorAndThrow(string error) {
+		_logger.Error(error);
+		throw new Exception(error);
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/MasterKeySourceConfigurators/IMasterKeySourceConfigurator.cs
+++ b/src/EventStore.Security.EncryptionAtRest/MasterKeySourceConfigurators/IMasterKeySourceConfigurator.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Security.EncryptionAtRest.MasterKeySources;
+
+namespace EventStore.Security.EncryptionAtRest.MasterKeySourceConfigurators;
+
+public interface IMasterKeySourceConfigurator<TOptions> {
+	public string Name { get; }
+	public void Configure(TOptions options, out IMasterKeySource masterKeySource);
+}

--- a/src/EventStore.Security.EncryptionAtRest/MasterKeySources/File/FileSource.cs
+++ b/src/EventStore.Security.EncryptionAtRest/MasterKeySources/File/FileSource.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Serilog;
+
+namespace EventStore.Security.EncryptionAtRest.MasterKeySources.File;
+
+public class FileSource(string path) : IMasterKeySource {
+	private static readonly ILogger _logger = Log.ForContext<FileSource>();
+
+	public string Name => "File";
+	private readonly string _path = VerifyPath(path);
+	private const string KeyFileExtension = ".esdb.master.key";
+
+	public IReadOnlyList<MasterKey> LoadMasterKeys() {
+		var masterKeyFiles = Directory
+			.EnumerateFiles(_path, $"*{KeyFileExtension}")
+			.Where(HasValidKeyId)
+			.ToArray();
+
+		var masterKeys = new List<MasterKey>(masterKeyFiles.Length);
+		masterKeys.AddRange(
+			masterKeyFiles
+				.Select(ReadMasterKey)
+				.OrderBy(x => x.Id));
+
+		return masterKeys;
+	}
+
+	private static bool HasValidKeyId(string keyFilePath) => GetKeyId(keyFilePath) > 0;
+
+	private static int GetKeyId(string keyFilePath) {
+		var keyFileName = Path.GetFileName(keyFilePath);
+		var dotIndex = keyFileName.IndexOf('.');
+		if (dotIndex < 0)
+			return -1;
+
+		if (!int.TryParse(keyFileName[..dotIndex], out var keyId))
+			return -1;
+
+		return keyId;
+	}
+
+	private MasterKey ReadMasterKey(string file) {
+		var lines = System.IO.File.ReadAllLines(file);
+		if (lines[0]  != "-----BEGIN ESDB MASTER KEY-----" ||
+		    lines[^1] != "-----END ESDB MASTER KEY-----")
+			throw new Exception($"Invalid master key file: {Path.GetFileName(file)}");
+
+		var keyId = GetKeyId(file);
+		var key = Convert.FromBase64String(string.Join(string.Empty, lines[1..^1]));
+
+		_logger.Information($"Encryption-At-Rest: ({Name}) Loaded master key: {keyId} ({key.Length * 8} bits)");
+		return new MasterKey(keyId, key);
+	}
+
+	private static string VerifyPath(string path) {
+		try {
+			path = Path.GetFullPath(path);
+		} catch {
+			throw new Exception($"The specified path '{path}' is invalid.");
+		}
+
+		if (!Path.Exists(path))
+			throw new Exception($"The specified path '{path}' does not exist.");
+
+		var dirInfo = new DirectoryInfo(path);
+		if (!dirInfo.Exists)
+			throw new Exception($"The specified path '{path}' is not a directory.");
+
+		return path;
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/MasterKeySources/IMasterKeySource.cs
+++ b/src/EventStore.Security.EncryptionAtRest/MasterKeySources/IMasterKeySource.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+
+namespace EventStore.Security.EncryptionAtRest.MasterKeySources;
+
+public interface IMasterKeySource {
+	public string Name { get; }
+
+	// the interface supports loading multiple master keys to cater for scenarios where a master key is compromised:
+	// a new master key with a new, higher, ID can be generated to encrypt new data. however, old data must still be
+	// decrypted using the old master key(s). the master key with the highest ID is always the active one.
+	// master key sources are responsible for sorting the resulting list of master keys by increasing ID.
+	public IReadOnlyList<MasterKey> LoadMasterKeys();
+}

--- a/src/EventStore.Security.EncryptionAtRest/README.md
+++ b/src/EventStore.Security.EncryptionAtRest/README.md
@@ -1,0 +1,90 @@
+# Encryption-At-Rest Plugin
+The Encryption-At-Rest plugin allows users to encrypt their EventStoreDB database. Currently, only chunk files are encrypted - the indexes are not. The primary objective is to protect against an attacker who obtains access to the physical disk. In contrast to volume level encryption, file level encryption provides some degree of protection for attacks against the live system or remote exploits as the plaintext data is not directly readable. Protecting against memory-dump based attacks is out of the scope of this plugin.
+
+## Encryption Algorithm
+Data is encrypted using a symmetric-key encryption algorithm.
+
+
+The plugin is designed to support different encryption algorithms. Currently, the following encryption algorithms are implemented:
+- `AesGcm` - Advanced Encryption Standard (AES) Galois Counter Mode (GCM)
+  - The default key size is 256 bits, but 128-bit and 192-bit keys are also supported.
+
+## Master Key
+The `master` key is the topmost key in the key hierarchy.
+
+The size of the master key is not defined but it needs to be long enough (e.g at least 128 bits) to provide reasonable security.
+
+Using a key-derivation function (HKDF in our case), the master key is used to derive multiple `data` keys. Each `data` key is used to encrypt a single chunk file. If the `master` key is compromised, the whole database can be decrypted. However, if a `data` key is compromised, only one chunk file can be decrypted.
+
+Usually, only one `master` key should be necessary. However, to cater for scenarios where a `master` key is compromised, the plugin supports loading multiple `master` keys. The latest `master` key is actively used to encrypt/decrypt new chunks, while old `master` keys are used only to decrypt old chunks - thus the new data is secure.
+
+## Master Key Source
+The function of a master key source is to load master keys.
+
+Master keys are loaded from the source only once at process startup. They are then kept in memory throughout the lifetime of the process.
+
+The plugin is designed to support different master key sources. Currently, the following master key sources are implemented:
+- `File` - loads master keys from a directory
+  - The master key can be generated using [es-genkey-cli](https://github.com/EventStore/es-genkey-cli)
+  - For proper security, the master key files must be located on a drive other than where the database files are.
+  - This master key source is not recommended to be used in production as it provides minimal protection.
+
+You can contact Event Store if you want us to support a particular master key source.
+
+## Configuration
+- By default, the encryption plugin is bundled with EventStoreDB and located inside the `plugins` directory.
+
+- A JSON configuration file (e.g. `encryption-config.json`)  needs to be added in the `./config` directory located within the EventStoreDB installation directory:
+
+```
+{
+  "EventStore": {
+    "EncryptionAtRest": {
+      "Enabled": true,
+      "MasterKey": {
+        "File": {
+          "KeyPath": "/path/to/keys/"
+        }
+      },
+      "Encryption": {
+        "AesGcm": {
+          "Enabled": true,
+          "KeySize": 256 # optional. supported key sizes: 128, 192, 256 (default)
+        }
+      }
+    }
+  }
+}
+```
+
+- The `Transform` configuration parameter must be specified in the server's configuration file:
+
+```
+Transform: aes-gcm
+```
+
+- When using the `File` master key source, a master key must be generated using [es-genkey-cli](https://github.com/EventStore/es-genkey-cli) and placed in the configured `KeyPath` directory. The master key having the highest ID will be chosen as the active one.
+
+Once the plugin is installed and enabled the server should log messages similar to the following:
+
+```
+...
+[141828, 1,11:42:45.325,INF] Encryption-At-Rest: Loaded master key source: "File"
+[141828, 1,11:42:45.340,INF] Encryption-At-Rest: (File) Loaded master key: 2 (256 bits)
+[141828, 1,11:42:45.340,INF] Encryption-At-Rest: (File) Loaded master key: 1 (256 bits)
+[141828, 1,11:42:45.345,INF] Encryption-At-Rest: Active master key ID: 2
+[141828, 1,11:42:45.345,INF] Encryption-At-Rest: Loaded encryption algorithm: "AesGcm"
+[141828, 1,11:42:45.347,INF] Encryption-At-Rest: (AesGcm) Using key size: 256 bits
+[141828, 1,11:42:45.401,INF] Loaded the following transforms: Identity, Encryption_AesGcm
+[141828, 1,11:42:45.402,INF] Active transform set to: Encryption_AesGcm
+...
+```
+
+New and scavenged chunks will be encrypted.
+
+## Compatibility
+When encryption is enabled, it's no longer possible to revert back to an unencrypted database if:
+- at least one new chunk file has been created or
+- at least one chunk has been scavenged
+
+The encrypted chunks would first need to be decrypted before a user can revert to the `identity` transform. Special tooling or endpoints are not currently available to do this.

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmBlockInfo.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmBlockInfo.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+public static class AesGcmBlockInfo {
+	public const int BlockSize = 512;
+	public const int HeaderSize = 2;
+	public const int DataSize = BlockSize - HeaderSize - TagSize;
+	public const int TagSize = 14; // so that `DataSize` is aligned to the AES block size: 16 bytes
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkReadStream.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkReadStream.cs
@@ -1,0 +1,287 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Plugins.Transforms;
+using EventStore.Security.EncryptionAtRest.Transforms.DataStructures;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+using AesGcm = System.Security.Cryptography.AesGcm;
+using BlockInfo = AesGcmBlockInfo;
+
+public sealed class AesGcmChunkReadStream : ChunkDataReadStream {
+	private const int ChunkHeaderSize = 128;
+
+	private readonly AesGcmReadBlock _block;
+	private readonly SieveBlockCache _blockCache;
+
+	private int _curBlockNumber;
+
+	private int BlockSize { get; }
+	private int DataSize { get; }
+	private int TransformHeaderSize { get; }
+
+	// plaintext of the last read block
+	private readonly Memory<byte> _lastBlock;
+
+	// size of the plaintext of the last read block
+	private int _lastBlockDataSize;
+
+	// position that the stream has reached within the last plaintext block
+	private int _lastBlockPos;
+
+	// pending position that the stream needs to be set to
+	private long? _positionToApply;
+
+	// keeps track of the base stream's position for performance reasons: when we read from the cache, we don't move
+	// the base stream's position but we update this value instead.
+	private long _basePosition;
+
+	public AesGcmChunkReadStream(
+		ChunkDataReadStream stream,
+		ReadOnlySpan<byte> key,
+		int transformHeaderSize) :
+		base(stream.ChunkFileStream) {
+		ArgumentNullException.ThrowIfNull(stream);
+		ArgumentOutOfRangeException.ThrowIfNegative(transformHeaderSize);
+
+		var aesGcm = new AesGcm(key, BlockInfo.TagSize);
+		_block = new AesGcmReadBlock(aesGcm, ReadFileStream);
+		_blockCache = new SieveBlockCache(cacheSize: 15, blockDataSize: BlockInfo.DataSize);
+		_curBlockNumber = 0;
+
+		BlockSize = BlockInfo.BlockSize;
+		DataSize = BlockInfo.DataSize;
+		TransformHeaderSize = transformHeaderSize;
+
+		_lastBlock = new byte[BlockInfo.DataSize];
+		_lastBlockDataSize = DataSize;
+		_lastBlockPos = 0;
+
+		_basePosition = base.Position;
+	}
+
+	public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) {
+		await ApplyPosition(ct);
+
+		var count = buffer.Length;
+
+		// if the last block we've read was incomplete and the read is requesting for more data than it contains,
+		// then read the last block again. note that this code path is executed only when reading from the same stream
+		// that we're writing to, e.g when using --mem-db on the server.
+		if (_lastBlockDataSize < DataSize &&
+		    _lastBlockDataSize - _lastBlockPos < count) {
+			await ReadLastBlockAgain(ct);
+		}
+
+		// first, read data from the last plaintext block, if available, into the output buffer
+		if (_lastBlockPos > 0) {
+			var numCopied = Copy(_lastBlock.Span[_lastBlockPos.._lastBlockDataSize], buffer.Span);
+
+			buffer = buffer[numCopied..];
+			_lastBlockPos += numCopied;
+
+			// if all data from the last plaintext block has been read, clear it
+			if (_lastBlockPos == DataSize)
+				ClearLastBlock();
+		}
+
+		// now, decrypt as many full blocks as possible directly into the output buffer
+		while (buffer.Length >= DataSize) {
+			await ReadBlock(buffer[..DataSize], ct);
+			buffer = buffer[DataSize..];
+		}
+
+		// finally, decrypt one last block and copy the required amount of data to the output buffer
+		if (buffer.Length > 0) {
+			await ReadLastBlock(ct);
+			_lastBlockPos = Copy(_lastBlock.Span[.._lastBlockDataSize], buffer.Span);
+		}
+
+		return count;
+	}
+
+	public override long Seek(long offset, SeekOrigin origin) {
+		if (origin != SeekOrigin.Begin)
+			throw new NotSupportedException();
+		SetPosition(offset);
+		return offset;
+	}
+
+	public override long Position {
+		get => GetPosition();
+		set => SetPosition(value);
+	}
+
+	protected override void Dispose(bool disposing) {
+		try {
+			if (!disposing)
+				return;
+
+			_block.Dispose();
+		} finally {
+			base.Dispose(disposing);
+		}
+	}
+
+	public async Task PeekBlock(int blockNumber, Memory<byte> plaintext, CancellationToken ct) {
+		var originalPos = _basePosition;
+		var originalBlockNumber = _curBlockNumber;
+
+		_curBlockNumber = blockNumber;
+		await ReadBlock(plaintext, ct);
+
+		_curBlockNumber = originalBlockNumber;
+		_basePosition = originalPos;
+
+		// immediately apply the pending seek as the base stream is used externally
+		base.Position = _basePosition;
+	}
+
+	private static int Copy(ReadOnlySpan<byte> input, Span<byte> output) {
+		var numToCopy = Math.Min(input.Length, output.Length);
+		input[..numToCopy].CopyTo(output);
+		return numToCopy;
+	}
+
+	private void ClearLastBlock() {
+		_lastBlockPos = 0;
+	}
+
+	private async ValueTask<int> ReadBlock(Memory<byte> plaintext, CancellationToken ct) {
+		var blockNumber = _curBlockNumber++;
+
+		// first, try to obtain the block data from the cache
+		if (_blockCache.TryGet(blockNumber, plaintext.Span)) {
+			_basePosition += BlockSize;
+			return BlockInfo.DataSize; // we cache only complete blocks
+		}
+
+		// otherwise read the block from the base stream
+		var dataSize = await _block.Read(blockNumber, plaintext, ct);
+
+		if (dataSize == BlockInfo.DataSize) // cache only complete blocks
+			_blockCache.Put(blockNumber, plaintext.Span);
+
+		return dataSize;
+	}
+
+	private async ValueTask ReadLastBlock(CancellationToken ct) {
+		int retries = 20;
+		do {
+			try {
+				_lastBlockDataSize = await ReadBlock(_lastBlock, ct);
+				break;
+			} catch (AuthenticationTagMismatchException) {
+				// the block was either:
+				// i)  updated while we were reading it (this can usually happen when using --mem-db)
+				// ii) really corrupted
+				if (retries-- == 0)
+					throw;
+
+				// retry
+				_basePosition -= BlockSize;
+				_curBlockNumber--;
+			}
+		} while (true);
+	}
+
+	private ValueTask ReadLastBlockAgain(CancellationToken ct) {
+		_basePosition -= BlockSize;
+		_curBlockNumber--;
+		return ReadLastBlock(ct);
+	}
+
+	private async ValueTask ReadFileStream(Memory<byte> output, CancellationToken ct) {
+		ApplyBasePosition();
+
+		var slice = output;
+		while (slice.Length > 0) {
+			var read = await base.ReadAsync(slice, ct);
+			if (read == 0)
+				throw new EndOfStreamException();
+
+			slice = slice[read..];
+		}
+
+		_basePosition += output.Length;
+	}
+
+	private long GetPosition() {
+		if (_positionToApply is { } positionToApply)
+			return positionToApply;
+
+		var position = UntransformPosition(_basePosition);
+		if (_lastBlockPos > 0) {
+			position -= DataSize; // we need to subtract DataSize as we had read one additional block
+			position += _lastBlockPos;
+		}
+		return position;
+	}
+
+	private void SetPosition(long position) {
+		_positionToApply = position;
+	}
+
+	private async ValueTask ApplyPosition(CancellationToken ct) {
+		if (_positionToApply is null)
+			return;
+
+		var (blockNumber, blockStartPosition, remainder) = TransformPosition(_positionToApply.Value);
+		_positionToApply = null;
+
+		// optimization to avoid a block read when we're already at the block we want to go to
+		if (remainder > 0 &&
+		    _lastBlockPos > 0 &&
+		    _curBlockNumber == blockNumber + 1) {
+			_lastBlockPos = remainder;
+
+			// this line is required because we're using DotNext.IO.StreamSource.AsSharedStream() on the server and
+			// not setting the base stream's position will cause it to have a value of zero.
+			_basePosition = blockStartPosition + BlockSize;
+			return;
+		}
+
+		ClearLastBlock();
+		_curBlockNumber = blockNumber;
+		_basePosition = blockStartPosition;
+
+		if (remainder > 0) {
+			await ReadLastBlock(ct);
+			_lastBlockPos = remainder;
+		}
+	}
+
+	private void ApplyBasePosition() {
+		base.Position = _basePosition;
+	}
+
+	private (int blockNumber, long blockStartPosition, int remainder) TransformPosition(long position) {
+		position -= ChunkHeaderSize;
+		var (blockNumber, remainder) = long.DivRem(position, DataSize);
+		Debug.Assert(blockNumber <= int.MaxValue);
+		Debug.Assert(remainder <= int.MaxValue);
+
+		position = blockNumber * BlockSize;
+		position += ChunkHeaderSize + TransformHeaderSize;
+		return ((int)blockNumber, position, (int)remainder);
+	}
+
+	private long UntransformPosition(long blockStartPosition) {
+		var position = blockStartPosition;
+
+		position -= ChunkHeaderSize + TransformHeaderSize;
+		var blockNumber = (int)(position / BlockSize);
+		Debug.Assert(position % BlockSize == 0);
+		position = blockNumber * DataSize;
+		position += ChunkHeaderSize;
+
+		return position;
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkReadTransform.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkReadTransform.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using EventStore.Plugins.Transforms;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+public sealed class AesGcmChunkReadTransform(ReadOnlyMemory<byte> key, int transformHeaderSize) : IChunkReadTransform {
+	public ChunkDataReadStream TransformData(ChunkDataReadStream dataStream) {
+		ArgumentNullException.ThrowIfNull(dataStream);
+		return new AesGcmChunkReadStream(dataStream, key.Span, transformHeaderSize);
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkTransform.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkTransform.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using EventStore.Plugins.Transforms;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+public sealed class AesGcmChunkTransform : IChunkTransform {
+	public IChunkReadTransform Read { get; }
+	public IChunkWriteTransform Write { get; }
+
+	public AesGcmChunkTransform(ReadOnlyMemory<byte> key, int transformHeaderSize) {
+		ArgumentNullException.ThrowIfNull(key);
+		ArgumentOutOfRangeException.ThrowIfNegative(transformHeaderSize);
+
+		Read = new AesGcmChunkReadTransform(key, transformHeaderSize);
+		Write = new AesGcmChunkWriteTransform(key, transformHeaderSize, Read);
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkTransformFactory.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkTransformFactory.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Plugins.Transforms;
+using EventStore.Security.EncryptionAtRest.Transforms.Common;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+using BlockInfo = AesGcmBlockInfo;
+
+public sealed class AesGcmChunkTransformFactory(IReadOnlyList<MasterKey> masterKeys, int keySize) : IChunkTransformFactory {
+	private const int ChunkHeaderSize = 128;
+	private const int TransformHeaderSize = EncryptionHeader.Size + AesGcmHeader.Size;
+
+	static AesGcmChunkTransformFactory() {
+		ArgumentOutOfRangeException.ThrowIfLessThan(TransformHeaderSize, EncryptionHeader.Size + AesGcmHeader.Size);
+	}
+
+	public TransformType Type => TransformType.Encryption_AesGcm;
+	public int TransformHeaderLength => TransformHeaderSize;
+
+	public int TransformDataPosition(int dataPosition) {
+		var numBlocks = dataPosition / BlockInfo.DataSize;
+		if (dataPosition % BlockInfo.DataSize != 0)
+			numBlocks++;
+
+		return TransformHeaderSize + numBlocks * BlockInfo.BlockSize;
+	}
+
+	public void CreateTransformHeader(Span<byte> transformHeader) {
+		var header = transformHeader;
+
+		var encryptionHeader = header[..EncryptionHeader.Size];
+		EncryptionHeader.Write(encryptionHeader, EncryptionHeader.CurrentVersion, masterKeys[^1]);
+		header = header[EncryptionHeader.Size..];
+
+		var aesGcmHeader = header[..AesGcmHeader.Size];
+		AesGcmHeader.Write(aesGcmHeader, AesGcmHeader.CurrentVersion, keySize * 8);
+	}
+
+	public ValueTask ReadTransformHeader(Stream stream, Memory<byte> transformHeader, CancellationToken token = new CancellationToken()) {
+		return stream.ReadExactlyAsync(transformHeader, token);
+	}
+
+	public IChunkTransform CreateTransform(ReadOnlySpan<byte> transformHeader) {
+		var header = transformHeader;
+
+		var encryptionHeader = header[..EncryptionHeader.Size];
+		EncryptionHeader.Read(encryptionHeader, out _, out var masterKeyId, out var salt);
+		var masterKey = masterKeys.FirstOrDefault(x => x.Id == masterKeyId);
+		if (masterKey == default)
+			throw new Exception($"Failed to load master key with ID: {masterKeyId}");
+		header = header[EncryptionHeader.Size..];
+
+		var aesGcmHeader = header[..AesGcmHeader.Size];
+		AesGcmHeader.Read(aesGcmHeader, out _, out var aesKeySizeInBits);
+		var dataKey = DeriveDataKey(
+			dataKeySize: aesKeySizeInBits / 8,
+			masterKey: masterKey.Key.Span,
+			salt: salt);
+
+		return new AesGcmChunkTransform(dataKey, TransformHeaderSize);
+	}
+
+	private static ReadOnlyMemory<byte> DeriveDataKey(int dataKeySize, ReadOnlySpan<byte> masterKey, ReadOnlySpan<byte> salt) {
+		var dataKey = new byte[dataKeySize].AsMemory();
+
+		// see: https://soatok.blog/2021/11/17/understanding-hkdf/ about why passing the salt to the info parameter
+		// is important to have "KDF security" guarantees.
+		HKDF.DeriveKey(HashAlgorithmName.SHA256, masterKey, dataKey.Span, "AesGcm-Chunk"u8, salt);
+		return dataKey;
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkWriteStream.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkWriteStream.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Plugins.Transforms;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+using AesGcm = System.Security.Cryptography.AesGcm;
+using BlockInfo = AesGcmBlockInfo;
+
+public sealed class AesGcmChunkWriteStream : ChunkDataWriteStream {
+	private const int ChunkHeaderSize = 128;
+
+	private readonly AesGcmWriteBlock _block;
+	private int _curBlockNumber;
+
+	private int BlockSize { get; }
+	private int DataSize { get; }
+	private int TransformHeaderSize { get; }
+
+	// plaintext of the last, incomplete, block
+	private readonly Memory<byte> _lastBlock;
+
+	// position that the stream has reached within the last plaintext block
+	private int _lastBlockPos;
+
+	// pending position that the stream needs to be set to
+	private long? _positionToApply;
+
+	private readonly IChunkReadTransform _readTransform;
+
+	public AesGcmChunkWriteStream(
+		ChunkDataWriteStream stream,
+		ReadOnlySpan<byte> key,
+		int transformHeaderSize,
+		IChunkReadTransform readTransform) :
+		base(stream.ChunkFileStream, stream.ChecksumAlgorithm) {
+		ArgumentNullException.ThrowIfNull(stream);
+		ArgumentOutOfRangeException.ThrowIfNegative(transformHeaderSize);
+		ArgumentNullException.ThrowIfNull(readTransform);
+
+		var aesGcm = new AesGcm(key, BlockInfo.TagSize);
+		_block = new AesGcmWriteBlock(aesGcm, WriteToFileStream);
+		_curBlockNumber = 0;
+		_positionToApply = null;
+
+		BlockSize = BlockInfo.BlockSize;
+		DataSize = BlockInfo.DataSize;
+		TransformHeaderSize = transformHeaderSize;
+
+		_lastBlock = new byte[BlockInfo.DataSize];
+		_lastBlockPos = 0;
+
+		_readTransform = readTransform;
+	}
+
+	public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ct = default) {
+		await ApplyInitialPosition(ct);
+
+		// first, continue filling up the last plaintext block with data if it's not empty
+		if (_lastBlockPos > 0) {
+			var lastBlock = _lastBlock[_lastBlockPos..];
+			var numCopied = Copy(buffer.Span, lastBlock.Span);
+
+			buffer = buffer[numCopied..];
+			_lastBlockPos += numCopied;
+
+			// if the last block becomes full, write it to disk
+			if (_lastBlockPos == DataSize) {
+				await WriteCompleteBlock(_lastBlock, ct);
+				ClearLastBlock();
+			}
+		}
+
+		// now, write as many full blocks as possible directly to disk
+		while (buffer.Length >= DataSize) {
+			await WriteCompleteBlock(buffer[..DataSize], ct);
+			buffer = buffer[DataSize..];
+		}
+
+		// finally, copy any remaining data to the last plaintext block
+		if (buffer.Length > 0) {
+			_lastBlockPos = Copy(buffer.Span, _lastBlock.Span);
+		}
+	}
+
+	public override async Task FlushAsync(CancellationToken ct) {
+		await ApplyInitialPosition(ct);
+
+		// write the last block to disk before flushing for proper recovery on startup but don't commit the changes
+		await WriteLastBlock(commit: false, ct);
+		await base.FlushAsync(ct);
+	}
+
+	public override long Position {
+		get => GetPosition();
+		set => SetPosition(value);
+	}
+
+	public override long Length => throw new NotSupportedException();
+
+	protected override void Dispose(bool disposing) {
+		try {
+			if (!disposing)
+				return;
+
+			_block.Dispose();
+		} finally {
+			base.Dispose(disposing);
+		}
+	}
+
+	private static int Copy(ReadOnlySpan<byte> input, Span<byte> output) {
+		var numToCopy = Math.Min(input.Length, output.Length);
+		input[..numToCopy].CopyTo(output);
+		return numToCopy;
+	}
+
+	private void ClearLastBlock() {
+		_lastBlockPos = 0;
+	}
+
+	public async ValueTask WriteLastBlock(bool commit, CancellationToken ct) {
+		if (_lastBlockPos == 0) {
+			// the last block is empty, we don't need to write anything
+			return;
+		}
+
+		if (commit) {
+			PadLastBlock(); // if committing, pad the last block with zeroes as there'll be no additional data
+			await WriteCompleteBlock(_lastBlock, ct);
+			ClearLastBlock();
+		} else {
+			await WriteIncompleteBlock(_lastBlock[.._lastBlockPos], ct);
+		}
+	}
+
+	private void PadLastBlock() {
+		_lastBlock[_lastBlockPos..].Span.Clear();
+		_lastBlockPos = DataSize;
+	}
+
+	private async ValueTask WriteCompleteBlock(ReadOnlyMemory<byte> data, CancellationToken ct) {
+		await _block.Write(_curBlockNumber++, data, updateChecksum: true, ct);
+	}
+
+	private async ValueTask WriteIncompleteBlock(ReadOnlyMemory<byte> data, CancellationToken ct) {
+		// write the block without:
+		// 1) updating the checksum
+		// 2) changing the stream position
+		// 3) incrementing the block number
+
+		var fileStreamPos = ChunkFileStream.Position;
+		await _block.Write(_curBlockNumber, data, updateChecksum: false, ct);
+		ChunkFileStream.Position = fileStreamPos;
+	}
+
+	private async ValueTask WriteToFileStream(ReadOnlyMemory<byte> data, bool updateChecksum, CancellationToken ct) {
+		await ChunkFileStream.WriteAsync(data, ct);
+		if (updateChecksum)
+			ChecksumAlgorithm.AppendData(data.Span);
+	}
+
+	private long GetPosition() {
+		return _positionToApply ?? UntransformPosition(base.Position) + _lastBlockPos;
+	}
+
+	private void SetPosition(long position) {
+		_positionToApply = position;
+	}
+
+	private async ValueTask ApplyInitialPosition(CancellationToken ct) {
+		if (_positionToApply is null)
+			return;
+
+		Debug.Assert(_curBlockNumber == 0);
+		Debug.Assert(_lastBlockPos == 0);
+
+		(_curBlockNumber, base.Position, _lastBlockPos) = TransformPosition(_positionToApply.Value);
+		_positionToApply = null;
+
+		// force the base stream's position to be set to compute the hash at the current position
+		await base.WriteAsync(ReadOnlyMemory<byte>.Empty, ct);
+
+		if (_lastBlockPos == 0)
+			return;
+
+		// create a temporary stream to decrypt the last block from the file stream without closing it
+		var fileStream = new NonClosingStreamWrapper(ChunkFileStream);
+		await using var stream = (AesGcmChunkReadStream) _readTransform.TransformData(new ChunkDataReadStream(fileStream));
+
+		// note: truncation is done at block boundaries, so the block that's decrypted below may contain more data than
+		// what we need. but this doesn't matter as we have already set _lastBlockPos to the correct position in the
+		// plaintext block and we won't use this excessive data.
+		await stream.PeekBlock(_curBlockNumber, _lastBlock, ct);
+	}
+
+	private (int blockNumber, long blockStartPosition, int remainder) TransformPosition(long position) {
+		position -= ChunkHeaderSize;
+		var (blockNumber, remainder) = long.DivRem(position, DataSize);
+		Debug.Assert(blockNumber <= int.MaxValue);
+		Debug.Assert(remainder <= int.MaxValue);
+
+		position = blockNumber * BlockSize;
+		position += ChunkHeaderSize + TransformHeaderSize;
+		return ((int)blockNumber, position, (int)remainder);
+	}
+
+	private long UntransformPosition(long blockStartPosition) {
+		var position = blockStartPosition;
+
+		position -= ChunkHeaderSize + TransformHeaderSize;
+		var blockNumber = (int)(position / BlockSize);
+		Debug.Assert(position % BlockSize == 0);
+		position = blockNumber * DataSize;
+		position += ChunkHeaderSize;
+
+		return position;
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkWriteTransform.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmChunkWriteTransform.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Plugins.Transforms;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+public sealed class AesGcmChunkWriteTransform(ReadOnlyMemory<byte> key, int transformHeaderSize, IChunkReadTransform readTransform) : IChunkWriteTransform {
+	private AesGcmChunkWriteStream _transformedStream;
+
+	public ChunkDataWriteStream TransformData(ChunkDataWriteStream dataStream) {
+		ArgumentNullException.ThrowIfNull(dataStream);
+
+		_transformedStream = new AesGcmChunkWriteStream(dataStream, key.Span, transformHeaderSize, readTransform);
+		return _transformedStream;
+	}
+
+	public async ValueTask CompleteData(int footerSize, int alignmentSize, CancellationToken ct) {
+		await _transformedStream.WriteLastBlock(commit: true, ct);
+
+		var chunkHeaderAndDataSize = (int)_transformedStream.ChunkFileStream.Position;
+		var alignedSize = GetAlignedSize(chunkHeaderAndDataSize + footerSize, alignmentSize);
+		var paddingSize = alignedSize - chunkHeaderAndDataSize - footerSize;
+		if (paddingSize > 0) {
+			var padding = new byte[paddingSize];
+			await _transformedStream.ChunkFileStream.WriteAsync(padding, ct);
+			_transformedStream.ChecksumAlgorithm.AppendData(padding);
+		}
+	}
+
+	public async ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken ct) {
+		await _transformedStream.ChunkFileStream.WriteAsync(footer, ct);
+		await _transformedStream.ChunkFileStream.FlushAsync(ct);
+		return (int)_transformedStream.ChunkFileStream.Position;
+	}
+
+	private static int GetAlignedSize(int size, int alignmentSize) {
+		if (size % alignmentSize == 0) return size;
+		return (size / alignmentSize + 1) * alignmentSize;
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmDbTransform.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmDbTransform.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Plugins.Transforms;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+public sealed class AesGcmDbTransform : IDbTransform {
+	public string Name => "aes-gcm";
+	public TransformType Type => TransformType.Encryption_AesGcm;
+	public IChunkTransformFactory ChunkFactory { get; }
+
+	private readonly int[] _keySizesInBits = { 128, 192, 256 };
+
+	public AesGcmDbTransform(IReadOnlyList<MasterKey> masterKeys, int keySizeInBits) {
+		ArgumentOutOfRangeException.ThrowIfZero(masterKeys.Count);
+
+		if (!_keySizesInBits.Contains(keySizeInBits))
+			throw new ArgumentOutOfRangeException(nameof(keySizeInBits), $"Key size not supported: {keySizeInBits}");
+
+		ChunkFactory = new AesGcmChunkTransformFactory(masterKeys, keySizeInBits / 8);
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmHeader.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmHeader.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+public static class AesGcmHeader {
+	private const int VersionSize = 1; // byte
+	private const int AesKeySize = 1;
+
+	public const byte CurrentVersion = 1;
+	public const int Size = 32;
+
+	private enum KeySize {
+		None = 0,
+		Aes128 = 1,
+		Aes192 = 2,
+		Aes256 = 3
+	}
+
+	public static void Write(Span<byte> header, byte version, int aesKeySizeInBits) {
+		header[0] = version;
+		header = header[VersionSize..];
+
+		var keySize = aesKeySizeInBits switch {
+			128 => KeySize.Aes128,
+			192 => KeySize.Aes192,
+			256 => KeySize.Aes256,
+			_ => throw new ArgumentOutOfRangeException(nameof(aesKeySizeInBits), $"Key size not supported: {aesKeySizeInBits}")
+		};
+
+		header[..AesKeySize][0] = (byte)keySize;
+	}
+
+	public static void Read(ReadOnlySpan<byte> header, out byte version, out int aesKeySizeInBits) {
+		version = header[0];
+		header = header[VersionSize..];
+
+		var keySize = (KeySize) header[..AesKeySize][0];
+		aesKeySizeInBits = keySize switch {
+			KeySize.Aes128 => 128,
+			KeySize.Aes192 => 192,
+			KeySize.Aes256 => 256,
+			_ => throw new ArgumentOutOfRangeException(nameof(keySize), $"Unexpected key size value: {keySize}")
+		};
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmReadBlock.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmReadBlock.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+using AesGcm = System.Security.Cryptography.AesGcm;
+using BlockInfo = AesGcmBlockInfo;
+
+public sealed class AesGcmReadBlock : IDisposable {
+	private readonly AesGcm _aesGcm;
+
+	private readonly byte[] _block;
+	private readonly ReadOnlyMemory<byte> _header;
+	private readonly ReadOnlyMemory<byte> _data;
+	private readonly ReadOnlyMemory<byte> _tag;
+
+	private const int NonceSize = 12;
+	private readonly Memory<byte> _nonce = new byte[NonceSize];
+
+	private readonly Func<Memory<byte>, CancellationToken, ValueTask> _readBlock;
+
+	public AesGcmReadBlock(AesGcm aesGcm, Func<Memory<byte>, CancellationToken, ValueTask> readBlock) {
+		ArgumentNullException.ThrowIfNull(aesGcm);
+		ArgumentNullException.ThrowIfNull(readBlock);
+
+		_aesGcm = aesGcm;
+		_readBlock = readBlock;
+
+		_block = new byte[BlockInfo.BlockSize];
+
+		var block = _block.AsMemory();
+
+		_header = block[..BlockInfo.HeaderSize];
+		block = block[BlockInfo.HeaderSize..];
+
+		_data = block[..BlockInfo.DataSize];
+		block = block[BlockInfo.DataSize..];
+
+		_tag = block[..BlockInfo.TagSize];
+		block = block[BlockInfo.TagSize..];
+
+		Debug.Assert(block.Length == 0);
+	}
+
+	public async ValueTask<int> Read(int blockNumber, Memory<byte> plaintext, CancellationToken ct) {
+		await _readBlock(_block, ct);
+		var dataSize = BinaryPrimitives.ReadUInt16LittleEndian(_header.Span);
+		CalcNonce(blockNumber, dataSize);
+		Decrypt(dataSize, plaintext.Span);
+		return dataSize;
+	}
+
+	private void Decrypt(int dataSize, Span<byte> plaintext) {
+		_aesGcm.Decrypt(_nonce.Span, _data.Span[..dataSize], _tag.Span, plaintext[..dataSize]);
+	}
+
+	private void CalcNonce(int blockNumber, int dataSize) {
+		var uniquePosition = (long) blockNumber * BlockInfo.DataSize + dataSize;
+		BinaryPrimitives.WriteInt64LittleEndian(_nonce.Span, uniquePosition);
+	}
+
+	public void Dispose() {
+		_aesGcm.Dispose();
+	}
+
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmWriteBlock.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/AesGcmWriteBlock.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+using AesGcm = System.Security.Cryptography.AesGcm;
+using BlockInfo = AesGcmBlockInfo;
+
+public sealed class AesGcmWriteBlock : IDisposable {
+	private readonly AesGcm _aesGcm;
+
+	private readonly byte[] _block;
+	private readonly Memory<byte> _header;
+	private readonly Memory<byte> _data;
+	private readonly Memory<byte> _tag;
+
+	private const int NonceSize = 12;
+	private readonly Memory<byte> _nonce = new byte[NonceSize];
+
+	private readonly Func<ReadOnlyMemory<byte>, bool, CancellationToken, ValueTask> _writeBlock;
+
+	public AesGcmWriteBlock(AesGcm aesGcm, Func<ReadOnlyMemory<byte>, bool, CancellationToken, ValueTask> writeBlock) {
+		ArgumentNullException.ThrowIfNull(aesGcm);
+		ArgumentNullException.ThrowIfNull(writeBlock);
+
+		_aesGcm = aesGcm;
+		_writeBlock = writeBlock;
+
+		_block = new byte[BlockInfo.BlockSize];
+
+		var block = _block.AsMemory();
+
+		_header = block[..BlockInfo.HeaderSize];
+		block = block[BlockInfo.HeaderSize..];
+
+		_data = block[..BlockInfo.DataSize];
+		block = block[BlockInfo.DataSize..];
+
+		_tag = block[..BlockInfo.TagSize];
+		block = block[BlockInfo.TagSize..];
+
+		Debug.Assert(block.Length == 0);
+	}
+
+	public async ValueTask Write(int blockNumber, ReadOnlyMemory<byte> plaintext, bool updateChecksum, CancellationToken ct) {
+		var dataSize = plaintext.Length;
+		BinaryPrimitives.WriteUInt16LittleEndian(_header.Span, (ushort) dataSize);
+		CalcNonce(blockNumber, dataSize);
+		Encrypt(plaintext.Span, dataSize);
+		await _writeBlock(_block, updateChecksum, ct);
+	}
+
+	private void Encrypt(ReadOnlySpan<byte> plaintext, int dataSize) {
+		// note: for performance reasons, we do not clear the unused portion of _data with zeroes.
+		// so, some ciphertext from the previous block may be present after the ciphertext of the current block.
+		// security-wise, it doesn't matter as we have already written the previous ciphertext block to disk,
+		// so we're not leaking any new information.
+
+		_aesGcm.Encrypt(_nonce.Span, plaintext, _data.Span[..dataSize], _tag.Span);
+	}
+
+	private void CalcNonce(int blockNumber, int dataSize) {
+		var uniquePosition = (long) blockNumber * BlockInfo.DataSize + dataSize;
+		BinaryPrimitives.WriteInt64LittleEndian(_nonce.Span, uniquePosition);
+	}
+
+	public void Dispose() {
+		_aesGcm.Dispose();
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/NonClosingStreamWrapper.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/AesGcm/NonClosingStreamWrapper.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.IO;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.AesGcm;
+
+
+public sealed class NonClosingStreamWrapper(Stream innerStream) : Stream {
+	public override void Flush() => innerStream.Flush();
+	public override int Read(byte[] buffer, int offset, int count) => innerStream.Read(buffer, offset, count);
+	public override long Seek(long offset, SeekOrigin origin) => innerStream.Seek(offset, origin);
+	public override void SetLength(long value) => innerStream.SetLength(value);
+	public override void Write(byte[] buffer, int offset, int count) => innerStream.Write(buffer, offset, count);
+
+	public override bool CanRead => innerStream.CanRead;
+	public override bool CanSeek => innerStream.CanSeek;
+	public override bool CanWrite => innerStream.CanWrite;
+	public override long Length => innerStream.Length;
+	public override long Position { get => innerStream.Position; set => innerStream.Position = value; }
+
+	protected override void Dispose(bool disposing) {
+		// we don't dispose the inner stream
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/Common/EncryptionHeader.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/Common/EncryptionHeader.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.Common;
+
+public static class EncryptionHeader {
+	private const int VersionSize = 1; // byte
+	private const int MasterKeyIdSize = 2; // ushort
+	private const int SaltSize = 16; // 128 random bits, to have an extremely low probability of reusing the same salt
+
+	public const byte CurrentVersion = 1;
+	public const int Size = 32;
+
+	public static void Write(Span<byte> header, byte version, MasterKey masterKey) {
+		header[0] = version;
+		header = header[VersionSize..];
+
+		var masterKeyIdSpan = header[..MasterKeyIdSize];
+		BinaryPrimitives.WriteUInt16LittleEndian(masterKeyIdSpan, masterKey.Id);
+		header = header[MasterKeyIdSize..];
+
+		var saltSpan = header[..SaltSize];
+		RandomNumberGenerator.Fill(saltSpan);
+	}
+
+	public static void Read(ReadOnlySpan<byte> header, out byte version, out ushort masterKeyId, out ReadOnlySpan<byte> salt) {
+		version = header[0];
+		header = header[VersionSize..];
+
+		masterKeyId = BinaryPrimitives.ReadUInt16LittleEndian(header[..MasterKeyIdSize]);
+		header = header[MasterKeyIdSize..];
+
+		salt = header[..SaltSize];
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/Transforms/DataStructures/SieveBlockCache.cs
+++ b/src/EventStore.Security.EncryptionAtRest/Transforms/DataStructures/SieveBlockCache.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+
+namespace EventStore.Security.EncryptionAtRest.Transforms.DataStructures;
+
+// implements the SIEVE cache eviction algorithm: https://cachemon.github.io/SIEVE-website/
+
+public class SieveBlockCache {
+	private readonly int _cacheSize;
+	private readonly int _blockDataSize;
+
+	private readonly Dictionary<int, CacheItem> _cacheDict = new();
+	private int _count;
+	private CacheItem _first, _last, _hand;
+
+	public SieveBlockCache(int cacheSize, int blockDataSize) {
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cacheSize);
+		ArgumentOutOfRangeException.ThrowIfNegative(blockDataSize);
+
+		_cacheSize = cacheSize;
+		_blockDataSize = blockDataSize;
+	}
+
+	public void Put(int blockNumber, ReadOnlySpan<byte> blockData) {
+		CacheItem item;
+		if (_count >= _cacheSize) {
+			var o = _hand ?? _last;
+
+			while (o!.Visited) {
+				o.Visited = false;
+				o = o.Previous ?? _last;
+			}
+
+			_hand = o.Previous;
+			Remove(o);
+			item = o;
+		} else {
+			item = new CacheItem {
+				BlockNumber = -1,
+				BlockData = new byte[_blockDataSize],
+				Visited = false
+			};
+		}
+
+		item.BlockNumber = blockNumber;
+		blockData.CopyTo(item.BlockData.Span);
+		item.Visited = false;
+
+		Add(item);
+	}
+
+
+	private void Add(CacheItem item) {
+		_cacheDict.Add(item.BlockNumber, item);
+
+		if (_first is not null)
+			_first.Previous = item;
+
+		item.Previous = null;
+		item.Next = _first;
+		_first = item;
+		_last ??= item;
+
+		_count++;
+	}
+
+	private void Remove(CacheItem item) {
+		_cacheDict.Remove(item.BlockNumber);
+
+		if (_first == _last) {
+			_first = null;
+			_last = null;
+		} else if (item == _first) {
+			_first = item.Next;
+			_first.Previous = null;
+		} else if (item == _last) {
+			_last = item.Previous;
+			_last.Next = null;
+		} else {
+			item.Previous.Next = item.Next;
+			item.Next.Previous = item.Previous;
+		}
+
+		_count--;
+	}
+
+	public bool TryGet(int blockNumber, Span<byte> blockData) {
+		if (!_cacheDict.TryGetValue(blockNumber, out var item))
+			return false;
+
+		item.BlockData.Span.CopyTo(blockData);
+		item.Visited = true;
+		return true;
+	}
+
+	private class CacheItem {
+		public int BlockNumber { get; set; }
+		public Memory<byte> BlockData { get; init; }
+		public bool Visited { get; set; }
+
+		public CacheItem Next { get; set; }
+		public CacheItem Previous { get; set; }
+	}
+}

--- a/src/EventStore.Security.EncryptionAtRest/encryption-at-rest-plugin-example.json
+++ b/src/EventStore.Security.EncryptionAtRest/encryption-at-rest-plugin-example.json
@@ -1,0 +1,17 @@
+{
+  "KurrentDB": {
+    "EncryptionAtRest": {
+      "Enabled": true,
+      "MasterKey": {
+        "File": {
+          "KeyPath": "./keys"
+        }
+      },
+      "Encryption": {
+        "AesGcm": {
+          "Enabled": true
+        }
+      }
+    }
+  }
+}

--- a/src/EventStore.Security.EncryptionAtRest/encryption-at-rest-plugin-example.yaml
+++ b/src/EventStore.Security.EncryptionAtRest/encryption-at-rest-plugin-example.yaml
@@ -1,0 +1,8 @@
+EncryptionAtRest:
+  Enabled: true
+  MasterKey:
+    File:
+      KeyPath: ./keys
+  Encryption:
+    AesGcm:
+      Enabled: true

--- a/src/EventStore.TcpPlugin.Tests/EventStore.TcpPlugin.Tests.csproj
+++ b/src/EventStore.TcpPlugin.Tests/EventStore.TcpPlugin.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="EventStore.Client" Version="22.0.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\..\EventStore\src\EventStore.Core.Tests\EventStore.Core.Tests.csproj" />
+	  <ProjectReference Include="..\EventStore.TcpPlugin\EventStore.TcpPlugin.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/EventStore.TcpPlugin.Tests/EventStoreOptionsTests.cs
+++ b/src/EventStore.TcpPlugin.Tests/EventStoreOptionsTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using EventStore.Core.Configuration;
+using EventStore.Core.Configuration.Sources;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace EventStore.TcpPlugin.Tests;
+
+public class EventStoreOptionsTests {
+	static EventStoreOptionsTests() {
+		TypeDescriptor.AddAttributes(typeof(IPAddress), new TypeConverterAttribute(typeof(IPAddressConverter)));
+	}
+
+	private EventStoreOptions CreateSut(params (string Key, string? Value)[] options) {
+		var sut = new ConfigurationBuilder()
+			.AddInMemoryCollection(options.Select(
+				pair => new KeyValuePair<string, string?>(pair.Key, pair.Value)))
+			.Build()
+			.GetSection(KurrentConfigurationKeys.Prefix)
+			.Get<EventStoreOptions>() ?? new();
+
+		return sut;
+	}
+
+	[Fact]
+	public void when_empty_configuration() {
+		var sut = CreateSut();
+		Assert.False(sut.Insecure);
+		Assert.False(sut.TcpPlugin.EnableExternalTcp);
+	}
+
+	[Fact]
+	public void can_be_enabled() {
+		var sut = CreateSut(
+			($"{KurrentConfigurationKeys.Prefix}:TcpPlugin:EnableExternalTcp", "true"));
+		Assert.True(sut.TcpPlugin.EnableExternalTcp);
+	}
+
+	[Fact]
+	public void can_be_insecure() {
+		var sut = CreateSut(
+			($"{KurrentConfigurationKeys.Prefix}:Insecure", "true"));
+		Assert.True(sut.Insecure);
+	}
+
+	[Fact]
+	public void can_set_ip() {
+		var sut = CreateSut(
+			($"{KurrentConfigurationKeys.Prefix}:NodeIp", "1.2.3.4"));
+		Assert.Equal(IPAddress.Parse("1.2.3.4"), sut.NodeIp);
+	}
+}

--- a/src/EventStore.TcpPlugin.Tests/FakeLicenseService.cs
+++ b/src/EventStore.TcpPlugin.Tests/FakeLicenseService.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Reactive.Subjects;
+using EventStore.Plugins.Licensing;
+
+namespace EventStore.TcpPlugin.Tests;
+
+class FakeLicenseService : ILicenseService {
+	public FakeLicenseService(string token) {
+		SelfLicense = new License(new(token));
+		CurrentLicense = SelfLicense; // they wouldn't normally be the same
+		Licenses = new BehaviorSubject<License>(CurrentLicense);
+	}
+
+	public License SelfLicense { get; }
+
+	public License? CurrentLicense { get; }
+
+	public IObservable<License> Licenses { get; }
+
+	public void RejectLicense(Exception ex) {
+	}
+}

--- a/src/EventStore.TcpPlugin.Tests/TcpApiPluginTests.cs
+++ b/src/EventStore.TcpPlugin.Tests/TcpApiPluginTests.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using DotNext.Collections.Generic;
+using DotNext.Net.Http;
+using EventStore.ClientAPI;
+using EventStore.Core;
+using EventStore.Core.Authentication;
+using EventStore.Core.Authentication.DelegatedAuthentication;
+using EventStore.Core.Authentication.PassthroughAuthentication;
+using EventStore.Core.Authorization;
+using EventStore.Core.Bus;
+using EventStore.Core.Certificates;
+using EventStore.Core.Configuration.Sources;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Metrics;
+using EventStore.Core.Services;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Services.Transport.Http;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Plugins;
+using EventStore.Plugins.Authentication;
+using EventStore.Plugins.Licensing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Xunit;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.TcpPlugin.Tests;
+
+public class TcpApiPluginTests {
+	private const string LicenseToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJlc2RiIiwiaXNzIjoiZXNkYiIsImV4cCI6MTgyNDQ1NjgyOSwianRpIjoiOTVmZTY2YzAtMDRkMi00MjExLWI1ZGQtNTAyM2MyYTAxMGFiIiwic3ViIjoiRVNEQiBUZXN0cyIsIklzVHJpYWwiOiJUcnVlIiwiSXNFeHBpcmVkIjoiRmFsc2UiLCJJc1ZhbGlkIjoiVHJ1ZSIsIklzRmxvYXRpbmciOiJUcnVlIiwiRGF5c1JlbWFpbmluZyI6IjEiLCJTdGFydERhdGUiOiIyNi8wNC8yMDI0IDAwOjAwOjAwICswMTowMCIsIk5PTkUiOiJ0cnVlIiwiaWF0IjoxNzI5ODQ4ODI5LCJuYmYiOjE3Mjk4NDg4Mjl9.R24i-ZAow3BhRaST3n25Uc_nQ184k83YRZZ0oRcWbU9B9XNLRH0Iegj0HmkyzkT50I4gcIJOIfcO6mIPp4Y959CP7aTAlt7XEnXoGF0GwsfXatAxy4iXG8Gpya7INgMoWEeN0v8eDH8_OVmnieOxeba9ex5j1oAW_FtQDMzcFjAeErpW__8zmkCsn6GzvlhdLE4e3r2wjshvrTTcS_1fvSVjQZov5ce2sVBJPegjCLO_QGiIBK9QTnpHrhe6KCYje6fSTjgty0V1Qj22bftvrXreYzQijPrnC_ek1BwV-A1JvacZugMCPIy8WvE5jE3hVYRWGGUzQZ-CibPGsjudYA";
+	private static readonly ILogger _logger = Log.ForContext<TcpApiPluginTests>();
+	private readonly TcpApiPlugin _sut;
+	private readonly StandardComponents _components;
+	private readonly int _port;
+	private readonly WebApplicationBuilder _builder;
+	private readonly WebApplication _app;
+	private readonly List<Message> _buffer;
+	private readonly TcpMessageCollector _collector;
+
+	public TcpApiPluginTests() {
+		_collector = new TcpMessageCollector();
+		_buffer = new List<Message>();
+		_builder = WebApplication.CreateBuilder();
+		_sut = new TcpApiPlugin();
+		_port = PortsHelper.GetAvailablePort(IPAddress.Loopback);
+		var httpPort = PortsHelper.GetAvailablePort(IPAddress.Loopback);
+
+		_builder.Configuration.AddInMemoryCollection(new KeyValuePair<string, string?>[] {
+			new($"{KurrentConfigurationKeys.Prefix}:Insecure", "true"),
+			new($"{KurrentConfigurationKeys.Prefix}:TcpPlugin:NodeTcpPort", _port.ToString()),
+			new($"{KurrentConfigurationKeys.Prefix}:TcpPlugin:EnableExternalTcp", "true"),
+		});
+		var workerThreadsCount = 2;
+		var workerBuses = Enumerable.Range(0, workerThreadsCount).Select(queueNum =>
+			new InMemoryBus($"Worker #{queueNum + 1} Bus",
+				watchSlowMsg: true,
+				slowMsgThreshold: TimeSpan.FromMilliseconds(200))).ToArray();
+
+
+		_components = CreateStandardComponents(workerThreadsCount, workerBuses);
+		var httpPipe = new HttpMessagePipe();
+		var httpSendService = new HttpSendService(httpPipe, true, delegate { return (true, ""); });
+		var httpService = new KestrelHttpService(ServiceAccessibility.Public, _components.MainQueue, new TrieUriRouter(),
+			(MultiQueuedHandler)_components.NetworkSendService, false, "localhost",
+			_port,
+			true,
+			new HttpEndPoint(IPAddress.Loopback, httpPort, false));
+
+		var components = new AuthenticationProviderFactoryComponents {
+			MainBus = _components.MainBus,
+			MainQueue = _components.MainQueue,
+			WorkerBuses = workerBuses,
+			WorkersQueue = _components.NetworkSendService,
+			HttpSendService = httpSendService,
+			HttpService = httpService,
+		};
+
+		var authorizationProviderFactory =
+			new AuthorizationProviderFactory(_ => new PassthroughAuthorizationProviderFactory());
+		var authenticationProviderFactory =
+			new AuthenticationProviderFactory(_ => new PassthroughAuthenticationProviderFactory());
+
+		var authenticationProvider =  new DelegatedAuthenticationProvider(
+			authenticationProviderFactory.GetFactory(components).Build(false));
+
+		var authorizationProvider = authorizationProviderFactory.GetFactory(
+			new AuthorizationProviderFactoryComponents {
+				MainQueue = _components.MainQueue,
+				MainBus = _components.MainBus
+			}).Build();
+		var authGateway = new AuthorizationGateway(authorizationProvider);
+		var licenseService = new FakeLicenseService(LicenseToken);
+
+		_components.MainBus.Subscribe(_collector);
+
+		_builder.Services.AddSingleton(_components);
+		_builder.Services.AddSingleton<IAuthenticationProvider>(authenticationProvider);
+		_builder.Services.AddSingleton(authorizationProvider);
+		_builder.Services.AddSingleton(authGateway);
+		_builder.Services.AddSingleton<CertificateProvider>(_ => null!);
+		_builder.Services.AddSingleton<ILicenseService>(licenseService);
+
+		((IPlugableComponent)_sut).ConfigureServices(_builder.Services, _builder.Configuration);
+		_app = _builder.Build();
+		((IPlugableComponent)_sut).ConfigureApplication(_app, _builder.Configuration);
+		_app.StartAsync();
+		_components.MainQueue.Publish(new SystemMessage.SystemInit());
+	}
+
+	private static StandardComponents CreateStandardComponents(int workerThreadsCount, InMemoryBus[] workerBuses) {
+		var queueStatsManager = new QueueStatsManager();
+		var queueTrackers = new QueueTrackers();
+		var workersHandler = new MultiQueuedHandler(
+			workerThreadsCount,
+			queueNum => new QueuedHandlerThreadPool(workerBuses[queueNum],
+				$"Worker #{queueNum + 1}",
+				queueStatsManager,
+				queueTrackers,
+				groupName: "Workers",
+				watchSlowMsg: true,
+				slowMsgThreshold: TimeSpan.FromMilliseconds(200)));
+
+		var dbConfig = TFChunkHelper.CreateDbConfig(Path.GetTempPath(), 0);
+		var mainBus = new InMemoryBus("mainBus");
+		var mainQueue = new QueuedHandlerThreadPool(
+			mainBus, "MainQueue", queueStatsManager, queueTrackers);
+		mainQueue.Start();
+		var threadBasedScheduler = new ThreadBasedScheduler(queueStatsManager, queueTrackers);
+		var timerService = new TimerService(threadBasedScheduler);
+
+		return new StandardComponents(dbConfig, mainQueue, mainBus,
+			timerService, timeProvider: null, httpForwarder: null, httpServices: [],
+			networkSendService: workersHandler, queueStatsManager: queueStatsManager,
+			trackers: queueTrackers,
+			metricsConfiguration: new());
+	}
+
+	[Fact]
+	public async Task can_receive_tcp_connection() {
+		var connection = EventStoreConnection.Create(
+			$"ConnectTo=tcp://admin:changeit@localhost:{_port}; UseSslConnection=false"
+		);
+
+		await connection.ConnectAsync();
+		_ = Task.Run(() => connection.ReadEventAsync("foobar", 42, true));
+
+		var msg = await _collector.Message.WaitAsync(TimeSpan.FromSeconds(30));
+		Assert.Equal("foobar", msg.EventStreamId);
+		Assert.Equal(42, msg.EventNumber);
+		Assert.True(msg.ResolveLinkTos);
+
+		_components.MainQueue.Publish(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), true, true));
+	}
+}

--- a/src/EventStore.TcpPlugin.Tests/TcpMessageCollector.cs
+++ b/src/EventStore.TcpPlugin.Tests/TcpMessageCollector.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+
+namespace EventStore.TcpPlugin.Tests;
+
+public class TcpMessageCollector : IHandle<ClientMessage.ReadEvent> {
+	private TaskCompletionSource<ClientMessage.ReadEvent> _source = new();
+
+	public Task<ClientMessage.ReadEvent> Message => _source.Task;
+	public void Handle(ClientMessage.ReadEvent message) {
+		_source.TrySetResult(message);
+	}
+}

--- a/src/EventStore.TcpPlugin/EventStore.TcpPlugin.csproj
+++ b/src/EventStore.TcpPlugin/EventStore.TcpPlugin.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\EventStore\src\EventStore.Core\EventStore.Core.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Update="tcp-plugin-example.yaml">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	  <None Update="tcp-plugin-example.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<ItemGroup>
+			<MySourceFiles Include="$(OutDir)\*.TcpPlugin.*" />
+		</ItemGroup>
+		<Copy SourceFiles="@(MySourceFiles)" DestinationFolder="..\..\EventStore\src\KurrentDB\$(OutDir)\plugins\$(ProjectName)" />
+	</Target>
+
+	<Target Name="PublishPlugin" AfterTargets="Publish">
+		<ItemGroup>
+			<PluginOutputFiles Include="$(PublishDir)\LICENSE.md" />
+			<PluginOutputFiles Include="$(PublishDir)\NOTICE.html" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.TcpPlugin.deps.json" />
+			<PluginOutputFiles Include="$(PublishDir)\EventStore.TcpPlugin.dll" />
+		</ItemGroup>
+		<Copy SourceFiles="@(PluginOutputFiles)" DestinationFolder="$(PublishDir)/package" />
+	</Target>
+</Project>

--- a/src/EventStore.TcpPlugin/EventStoreOptions.cs
+++ b/src/EventStore.TcpPlugin/EventStoreOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+
+namespace EventStore.TcpPlugin;
+
+public class EventStoreOptions {
+	public int ConnectionPendingSendBytesThreshold { get; init; } = 10 * 1_024 * 1_024;
+	public int ConnectionQueueSizeThreshold { get; init; } = 50_000;
+	public int WriteTimeoutMs { get; init; } = 2_000;
+	public bool Insecure { get; init; }
+	public IPAddress NodeIp { get; init; } = IPAddress.Loopback;
+	public TcpPluginOptions TcpPlugin { get; init; } = new();
+
+	public class TcpPluginOptions {
+		public bool EnableExternalTcp { get; init; }
+		public int NodeTcpPort { get; init; } = 1113;
+		public int NodeHeartbeatInterval { get; init; } = 2_000;
+		public int NodeHeartbeatTimeout { get; init; } = 1_000;
+	}
+}

--- a/src/EventStore.TcpPlugin/PublicTcpApiService.cs
+++ b/src/EventStore.TcpPlugin/PublicTcpApiService.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Core;
+using EventStore.Core.Certificates;
+using EventStore.Core.Messages;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Transport.Tcp;
+using EventStore.Plugins.Authentication;
+using Microsoft.Extensions.Hosting;
+
+namespace EventStore.TcpPlugin;
+
+public class PublicTcpApiService : IHostedService {
+	public PublicTcpApiService(
+		StandardComponents components,
+		EventStoreOptions options,
+		AuthorizationGateway authGateway,
+		IAuthenticationProvider authProvider,
+		CertificateProvider? certificateProvider) {
+
+		var endpoint = new IPEndPoint(options.NodeIp, options.TcpPlugin.NodeTcpPort);
+		if (options.Insecure) {
+			var extTcpService = new TcpService(
+				components.MainQueue, endpoint, components.NetworkSendService,
+				TcpServiceType.External, TcpSecurityType.Normal,
+				new ClientTcpDispatcher(options.WriteTimeoutMs),
+				TimeSpan.FromMilliseconds(options.TcpPlugin.NodeHeartbeatInterval),
+				TimeSpan.FromMilliseconds(options.TcpPlugin.NodeHeartbeatTimeout),
+				authProvider,
+				authGateway,
+				null,
+				null,
+				null,
+				options.ConnectionPendingSendBytesThreshold,
+				options.ConnectionQueueSizeThreshold);
+
+			components.MainBus.Subscribe<SystemMessage.SystemInit>(extTcpService);
+			components.MainBus.Subscribe<SystemMessage.SystemStart>(extTcpService);
+			components.MainBus.Subscribe<SystemMessage.BecomeShuttingDown>(extTcpService);
+		} else {
+			var extTcpSecureService = new TcpService(
+				components.MainQueue, endpoint, components.NetworkSendService,
+				TcpServiceType.External, TcpSecurityType.Secure,
+				new ClientTcpDispatcher(options.WriteTimeoutMs),
+				TimeSpan.FromMilliseconds(options.TcpPlugin.NodeHeartbeatInterval),
+				TimeSpan.FromMilliseconds(options.TcpPlugin.NodeHeartbeatTimeout),
+				authProvider,
+				authGateway,
+				() => certificateProvider?.Certificate,
+				() => {
+					var intermediates = certificateProvider?.IntermediateCerts;
+					return intermediates == null
+						? null
+						: new X509Certificate2Collection(intermediates);
+				},
+				delegate { return (true, null); },
+				options.ConnectionPendingSendBytesThreshold,
+				options.ConnectionQueueSizeThreshold);
+
+			components.MainBus.Subscribe<SystemMessage.SystemInit>(extTcpSecureService);
+			components.MainBus.Subscribe<SystemMessage.SystemStart>(extTcpSecureService);
+			components.MainBus.Subscribe<SystemMessage.BecomeShuttingDown>(extTcpSecureService);
+		}
+	}
+
+	public Task StartAsync(CancellationToken cancellationToken) {
+		return Task.CompletedTask;
+	}
+
+	public Task StopAsync(CancellationToken cancellationToken) {
+		return Task.CompletedTask;
+	}
+}

--- a/src/EventStore.TcpPlugin/README.md
+++ b/src/EventStore.TcpPlugin/README.md
@@ -1,0 +1,89 @@
+# TCP API Plugin
+The external TCP API had been removed since v24.2, which meant that any external clients using the TCP API will no longer work with EventStoreDB versions 24.2.0 and onwards.
+The TCP API Plugin allows users to integrate the external TCP API into EventStoreDB, thus allowing the users to use their existing TCP Client functionality with future versions of EventStoreDB.
+To enable the TCP API Plugin, you will need to download the plugin and add it to the ./plugins folder in your EventStoreDB installation directory.
+
+You then need to add the configuration to enable the plugin to a json file in the {installation_directory}/config directory.
+For example, add the following configuration to ./config/tcp-plugin-config.json file within the EventStoreDB installation directory:
+
+```
+{
+	"EventStore": {
+		"TcpPlugin": {
+			"EnableExternalTcp": true
+		}
+	}
+}
+```
+
+The name of the above json config file is not important. What is important is that the json config file should be in the {installation_directory}/config directory.
+Once the plugin is installed and enabled the server should log a similar message to the one below:
+
+```
+[11212, 1,18:44:34.070,INF] "TcpApi" "24.6.0.0" plugin enabled.
+```
+
+You should then be able to connect and perform operations in a similar manner as with the legacy TCP client on EventStoreDB v23.10 and before.
+
+## Other parameters
+
+The following options can be set using the json config as mentioned above :
+1. NodeHeartbeatTimeout. Default value : 1000
+2. NodeHeartbeatInterval. Default value : 2000
+3. NodeTcpPort. Default value : 1113
+
+The default values for the above can be overridden by the following example json config :
+
+```
+{
+	"EventStore": {
+		"TcpPlugin": {
+			"EnableExternalTcp": true,
+			"NodeTcpPort": 1113,
+			"NodeTcpPortAdvertiseAs": 1113,
+			"NodeHeartbeatInterval": 2000,
+			"NodeHeartbeatTimeout": 1000
+		}
+	}
+}
+```
+
+## Troubleshooting
+
+### Plugin not loaded
+The plugin has to be located in a subdirectory of the server's plugins directory. To check this:
+
+1. Go to the installation directory of the server, the directory containing the EventStoreDb executable.
+2. In this directory there should be a directory called plugins, create it if this is not the case.
+3. The plugins directory should have a subdirectory for the plugin, for instance called EventStore.TcpPlugin but this could be any name. Create it if it doesn't exist.
+4. The binaries of the plugin should be located in the subdirectory which was checked in the previous step.
+
+You can verify which plugins have been found and loaded by looking for the following logs:
+
+```
+[11212, 1,18:44:30.420,INF] Plugins path: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins"
+[11212, 1,18:44:30.420,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins" to the plugin catalog.
+[11212, 1,18:44:30.422,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins\\EventStore.Licensing" to the plugin catalog.
+[11212, 1,18:44:30.432,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins\\EventStore.POC.ConnectedSubsystemsPlugin" to the plugin catalog.
+[11212, 1,18:44:30.433,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins\\EventStore.POC.ConnectorsPlugin" to the plugin catalog.
+[11212, 1,18:44:30.436,INF] Adding: "C:\\EventStore.CoupledPlugins\\EventStore\\src\\EventStore.ClusterNode\\bin\\Debug\\net8.0\\plugins\\EventStore.TcpPlugin" to the plugin catalog.
+[11212, 1,18:44:30.479,INF] Loaded SubsystemsPlugin plugin: "licensing" "24.6.0.0".
+[11212, 1,18:44:30.483,INF] Loaded SubsystemsPlugin plugin: "connected" "0.0.5".
+[11212, 1,18:44:30.496,INF] Loaded ConnectedSubsystemsPlugin plugin: "connectors" "0.0.5".
+[11212, 1,18:44:30.504,INF] Loaded SubsystemsPlugin plugin: "tcp-api" "24.6.0.0".
+```
+
+### Plugin not started
+The plugin has to be configured to start in order to be able to be integrated into EventStoreDB server.
+If you see the following log it means the plugin was found but was not started:
+
+```
+[ 5104, 1,19:03:13.807,INF] "TcpApi" "24.6.0.0" plugin disabled. "Set 'EventStore:TcpPlugin:EnableExternalTcp' to 'true' to enable"
+```
+
+Ensure the plugin is enabled by adding a json config file to the {installation_directory}/config directory as mentioned above.
+When the plugin starts correctly you should see the following log:
+
+```
+[11212, 1,18:44:34.070,INF] "TcpApi" "24.6.0.0" plugin enabled.
+```

--- a/src/EventStore.TcpPlugin/TcpApiPlugin.cs
+++ b/src/EventStore.TcpPlugin/TcpApiPlugin.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Core.Configuration.Sources;
+using EventStore.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.TcpPlugin;
+
+public class TcpApiPlugin : SubsystemsPlugin {
+	public TcpApiPlugin() : base(requiredEntitlements: ["TCP_CLIENT_PLUGIN"]) {
+	}
+
+	public override (bool Enabled, string EnableInstructions) IsEnabled(IConfiguration configuration) {
+		var enabled = configuration.GetValue($"{KurrentConfigurationKeys.Prefix}:TcpPlugin:EnableExternalTcp", defaultValue: false);
+		return (enabled, $"Set '{KurrentConfigurationKeys.Prefix}:TcpPlugin:EnableExternalTcp' to 'true' to enable");
+	}
+
+	public override void ConfigureServices(IServiceCollection services, IConfiguration configuration) {
+		var options = configuration.GetSection(KurrentConfigurationKeys.Prefix).Get<EventStoreOptions>() ?? new();
+		services.AddSingleton(options);
+		services.AddHostedService<PublicTcpApiService>();
+	}
+}

--- a/src/EventStore.TcpPlugin/tcp-plugin-example.json
+++ b/src/EventStore.TcpPlugin/tcp-plugin-example.json
@@ -1,0 +1,11 @@
+{
+  "EventStore": {
+    "TcpPlugin": {
+      "EnableExternalTcp": true,
+      "NodeTcpPort": 1113,
+      "NodeTcpPortAdvertiseAs": 1113,
+      "NodeHeartbeatInterval": 2000,
+      "NodeHeartbeatTimeout": 1000
+    }
+  }
+}

--- a/src/EventStore.TcpPlugin/tcp-plugin-example.yaml
+++ b/src/EventStore.TcpPlugin/tcp-plugin-example.yaml
@@ -1,0 +1,6 @@
+TcpPlugin:
+  EnableExternalTcp: true
+  NodeTcpPort: 1113
+  NodeTcpPortAdvertiseAs: 1113
+  NodeHeartbeatInterval: 2000
+  NodeHeartbeatTimeout: 1000


### PR DESCRIPTION
New license (ESLv2 / KLv1) means the source code for the commercial plugins can live in the main repository, saving us a bunch of procedures/administration.

This PR simply copies the relevant files. A subsequent PR will follow with adjustments necessary to integrate them into the server

Sources:
```
CoupledPlugins: 9b4115d - Merge pull request #102 from EventStore/timothycoleman/update
Commercial HA:  8c7cc10 - Merge pull request #279 from EventStore/hayley-jean/fix-oauth-callback
```