### PR TITLE
Remove fetch-depth:0 from builds

### DIFF
--- a/.github/workflows/build-container-reusable.yml
+++ b/.github/workflows/build-container-reusable.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Install net8.0
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Set up Docker Buildx
       if: inputs.os != 'windows-2019'
       uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
We no longer need the full history since we stopped using minVer for calculating the version