### PR TITLE
[KDB-936] Add support for running as a windows service.

### DIFF
--- a/docs/server/quick-start/installation.md
+++ b/docs/server/quick-start/installation.md
@@ -179,11 +179,6 @@ We recommend that when using Linux you set the 'open file limit' to a high numbe
 
 ## Windows
 
-::: warning
-EventStoreDB doesn't install as a Windows service. You need to ensure that the server executable
-starts automatically.
-:::
-
 ### NuGet
 
 EventStoreDB has NuGet packages available on Cloudsmith, which replaces the previous Chocolatey packages.
@@ -215,6 +210,34 @@ You can uninstall EventStoreDB through Chocolatey with:
 ```powershell
 choco uninstall eventstoredb-ee
 ```
+
+#### Running as a service
+
+EventStoreDB 24.10.6+ can be run as a windows service. The following commands are for example. Consult the [sc.exe documentation](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-config) for details. 
+
+Create the service:
+
+```powershell
+sc.exe create "EventStoreDB" `
+  start= delayed-auto        `
+  binpath= "C:\ProgramData\chocolatey\lib\eventstoredb-ee\eventstoredb-24.10.6-ee-windows.x64\EventStore.ClusterNode.exe --config=c:\path\to\eventstore-config.yaml"
+```
+
+Configure the restart policy:
+
+```powershell
+sc.exe failure "EventStoreDB" `
+  reset= 0                    `
+  actions= restart/5000/restart/5000/restart/5000
+```
+
+Start the service:
+
+```powershell
+sc.exe start "EventStoreDB"
+```
+
+Logs will still be written to the usual log file location. By default on windows this is the `logs` directory within the directory that contains `EventStore.ClusterNode.exe`.
 
 ## Docker
 

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -8,6 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="SharpDotYaml.Extensions.Configuration" Version="0.3.0" />
 		<PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.ClusterNode.Web\EventStore.ClusterNode.Web.csproj" />


### PR DESCRIPTION
Added: Support for running as a Windows Service.

This is equivalent to #5152 on more recent versions

Unlike 25.0+ here on 24.10 we are calling RunConsoleAsync which specifies a console lifetime. We implement this patch with the minimal change to minimise risk.