### PR TITLE
[KDB-927] Add kurrentdb_projection_state_size_bound metric

### DIFF
--- a/docs/server/diagnostics/metrics.md
+++ b/docs/server/diagnostics/metrics.md
@@ -395,14 +395,17 @@ kurrentdb_gc_pause_duration_max_seconds{range="16-20 seconds"} 0.0485873 1688147
 
 Projection metrics track the statistics for projections.
 
-| Time series                                                                                      | Type                     | Description                                                      |
-|:-------------------------------------------------------------------------------------------------|:-------------------------|:-----------------------------------------------------------------|
-| `kurrentdb_projection_events_processed_after_restart_total`<br/>`{projection=<PROJECTION_NAME>}` | [Counter](#common-types) | Projection event processed count after restart                   |
-| `kurrentdb_projection_progress{projection=<PROJECTION_NAME>}`                                    | [Gauge](#common-types)   | Projection progress 0 - 1, where 1 = projection progress at 100% |
-| `kurrentdb_projection_running{projection=<PROJECTION_NAME>}`                                     | [Gauge](#common-types)   | If 1, projection is in 'Running' state                           |
-| `kurrentdb_projection_status{projection=<PROJECTION_NAME>,status=<PROJECTION_STATUS>}`           | [Gauge](#common-types)   | If 1, projection is in specified state                           |
-| `kurrentdb_projection_execution_duration_max_seconds{name=<PROJECTION_NAME>,range=<RANGE>}`      | [RecentMax](#recentmax)  | Recent maximum time in seconds for custom projection to execute an event |
-| `kurrentdb_projection_execution_duration_seconds_bucket{projection=<PROJECTION_NAME>,jsFunction=<JS_FUNCTION>,le=<DURATION>}` | [Histogram](#common-types) | Number of events executed by JS_FUNCTION of custom projection PROJECTION_NAME that took less than or equal to DURATION seconds.
+| Time series                                                                                                                                               | Type                       | Description                                                      |
+|:----------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------|:-----------------------------------------------------------------|
+| `kurrentdb_projection_`<br/>`events_processed_after_restart_total{`<br/>`projection=<PROJECTION_NAME>}`                                                   | [Counter](#common-types)   | Projection event processed count after restart                   |
+| `kurrentdb_projection_`<br/>`progress{`<br/>`projection=<PROJECTION_NAME>}`                                                                               | [Gauge](#common-types)     | Projection progress 0 - 1, where 1 = projection progress at 100% |
+| `kurrentdb_projection_`<br/>`running{`<br/>`projection=<PROJECTION_NAME>}`                                                                                | [Gauge](#common-types)     | If 1, projection is in 'Running' state                           |
+| `kurrentdb_projection_`<br/>`status{`<br/>`projection=<PROJECTION_NAME>,`<br/>`status=<PROJECTION_STATUS>}`                                               | [Gauge](#common-types)     | If 1, projection is in specified state                           |
+| `kurrentdb_projection_`<br/>`state_size{`<br/>`projection=<PROJECTION_NAME>,`<br/>`partition=<PARTITION>}`                                                | [Gauge](#common-types)     | State sizes of projections/partitions that are more than 50% of the size limit |
+| `kurrentdb_projection_`<br/>`state_size_bound{`<br/>`bound=<"THRESHOLD"\|"LIMIT">}`                                                                       | [Gauge](#common-types)     | `THRESHOLD` is the size at which a large state will appear in the metrics, which is half of the limit. `LIMIT` is the `MaxProjectionStateSize` option |
+| `kurrentdb_projection_`<br/>`state_serialization_duration_max_seconds{`<br/>`name=<PROJECTION_NAME>,`<br/>`range=<RANGE>}`                                | [RecentMax](#recentmax)    | Recent maximum time in seconds for custom projection to serialize its state |
+| `kurrentdb_projection_`<br/>`execution_duration_max_seconds{`<br/>`name=<PROJECTION_NAME>,`<br/>`range=<RANGE>}`                                          | [RecentMax](#recentmax)    | Recent maximum time in seconds for custom projection to execute an event |
+| `kurrentdb_projection_`<br/>`execution_duration_seconds_bucket{`<br/>`projection=<PROJECTION_NAME>,`<br/>`jsFunction=<JS_FUNCTION>,`<br/>`le=<DURATION>}` | [Histogram](#common-types) | Number of events executed by JS_FUNCTION of custom projection PROJECTION_NAME that took less than or equal to DURATION seconds. |
 
 `Status` can have one of the following statuses:
 

--- a/docs/server/quick-start/whatsnew.md
+++ b/docs/server/quick-start/whatsnew.md
@@ -8,8 +8,29 @@ order: 2
 
 These are the new features in KurrentDB 25.1:
 
+* [Additional Projection Metrics](#additional-projection-metrics)
 * [ServerGC](#server-garbage-collection)
 * [StreamInfoCacheCapacity default](#streaminfocachecapacity-default)
+
+### Additional Projection Metrics
+
+Several new metrics have been added to track important properties of projections.
+
+- `kurrentdb_projection_state_size` contains the state size of projections and their state partitions that are over 50% of the state size limit (`MaxProjectionStateSize`).
+  This helps to show if any projections are in danger of reaching the limit.
+
+- `kurrentdb_projection_state_size_bound` contains the projection state size `LIMIT` (driven by `MaxProjectionStateSize`) and the `THRESHOLD` for displaying a projection or partition in `kurrentdb_projection_state_size` (50% of the limit).
+  This makes it easy to graph what the limit is and how close projections are to it.
+
+- `kurrentdb_projection_state_serialization_duration_max_seconds` contains the recent maximum time that each custom projection has taken to serialize its state.
+
+- `kurrentdb_projection_execution_duration_max_seconds` contains the recent maximum time that each custom projection has taken to execute an event.
+
+- `kurrentdb_projection_execution_duration_seconds_bucket` creates a histogram for each (Projection x Function) pair showing, for example, the distribution of how long each custom projection takes to process each event type.
+  This creates a lot of timeseries and is off by default. It can be enabled by setting `ProjectionExecutionByFunction` to true in `metricsconfig.json`.
+  Typically this would only be enabled in development environments.
+
+See [the documentation](../diagnostics/metrics.md#projections) for more information.
 
 ### Server Garbage Collection
 

--- a/src/KurrentDB.Projections.Core.XUnit.Tests/Metrics/ProjectionTrackerTests.cs
+++ b/src/KurrentDB.Projections.Core.XUnit.Tests/Metrics/ProjectionTrackerTests.cs
@@ -75,6 +75,18 @@ public class ProjectionTrackerTests {
 		}
 	}
 
+	[Fact]
+	public void ObserveStateSizeBounds() {
+		_sut.OnNewStats([Stat("TestProjection", ProjectionMode.Continuous, ManagedProjectionState.Running, stateSizes: null)]);
+
+		var measurements = _sut.ObserveStateSizeBound();
+
+		var ms = measurements.ToArray();
+		Assert.Equal(2, ms.Length);
+		AssertMeasurement(500, new KeyValuePair<string, object>("bound", "THRESHOLD"))(ms[0]);
+		AssertMeasurement(900, new KeyValuePair<string, object>("bound", "LIMIT"))(ms[1]);
+	}
+
 	static Action<Measurement<T>> AssertMeasurement<T>(T expectedValue, params KeyValuePair<string, object>[] tags)
 		where T : struct =>
 
@@ -138,5 +150,7 @@ public class ProjectionTrackerTests {
 			Progress = 75,
 			EventsProcessedAfterRestart = 50,
 			StateSizes = stateSizes,
+			StateSizeThreshold = 500,
+			StateSizeLimit = 900,
 		};
 }

--- a/src/KurrentDB.Projections.Core/Metrics/ProjectionTracker.cs
+++ b/src/KurrentDB.Projections.Core/Metrics/ProjectionTracker.cs
@@ -105,4 +105,14 @@ public class ProjectionTracker : IProjectionTracker {
 			}
 		}
 	}
+
+	public IReadOnlyList<Measurement<int>> ObserveStateSizeBound() {
+		if (_currentStats is not [var x, ..])
+			return [];
+
+		return [
+			new(x.StateSizeThreshold, new KeyValuePair<string, object>("bound", "THRESHOLD")),
+			new(x.StateSizeLimit, new KeyValuePair<string, object>("bound", "LIMIT")),
+		];
+	}
 }

--- a/src/KurrentDB.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/KurrentDB.Projections.Core/ProjectionsSubsystem.cs
@@ -212,6 +212,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 			projectionMeter.CreateObservableUpDownCounter($"{serviceName}-projection-running", tracker.ObserveRunning);
 			projectionMeter.CreateObservableUpDownCounter($"{serviceName}-projection-status", tracker.ObserveStatus);
 			projectionMeter.CreateObservableUpDownCounter($"{serviceName}-projection-state-size", tracker.ObserveStateSize);
+			projectionMeter.CreateObservableUpDownCounter($"{serviceName}-projection-state-size-bound", tracker.ObserveStateSizeBound);
 
 			serializationTrackerFactory = name =>
 				new ProjectionStateSerializationTracker(

--- a/src/KurrentDB.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -82,7 +82,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		_requestedCheckpointState = new PartitionState("", null, _zeroTag);
 		_currentProjectionState = new PartitionState("", null, _zeroTag);
 		_maxProjectionStateSize = maxProjectionStateSize;
-		_maxProjectionStateSizeThreshold = (int)(0.80 * _maxProjectionStateSize);
+		_maxProjectionStateSizeThreshold = (int)(0.50 * _maxProjectionStateSize);
 	}
 
 	protected abstract ProjectionCheckpoint CreateProjectionCheckpoint(CheckpointTag checkpointPosition);
@@ -186,9 +186,12 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		info.CheckpointStatus = _inCheckpoint ? "Requested" : "";
 
 		foreach (var (partition, stateSize) in _stateSizeByPartition) {
-			info.StateSizes ??= new();
+			info.StateSizes ??= [];
 			info.StateSizes[partition] = stateSize;
 		}
+
+		info.StateSizeThreshold = _maxProjectionStateSizeThreshold;
+		info.StateSizeLimit = _maxProjectionStateSize;
 	}
 
 	public void StateUpdated(

--- a/src/KurrentDB.Projections.Core/Services/ProjectionStatistics.cs
+++ b/src/KurrentDB.Projections.Core/Services/ProjectionStatistics.cs
@@ -57,6 +57,10 @@ public class ProjectionStatistics {
 
 	public Dictionary<string, int> StateSizes { get; set; }
 
+	public int StateSizeThreshold { get; set; }
+
+	public int StateSizeLimit { get; set; }
+
 	public ProjectionStatistics Clone() {
 		return (ProjectionStatistics)MemberwiseClone();
 	}


### PR DESCRIPTION
The kurrentdb_projection_state_size_bound metric shows the THRESHOLD and LIMIT associated with kurrentdb_projection_state_size Threshold is the point at which a projection/partition will appear in the metrics (50% of limit) Limit is MaxProjectionStateSize database option.

This allows easy graphing showing how close projections are to the limit.

Also bump the threshold down to 50% from 80% to give more advance warning.

Also add documentation for
- kurrentdb_projection_state_size
- kurrentdb_projection_state_size_bound
- kurrentdb_projection_state_serialization_duration_max_seconds