### PR TITLE
[master] Add extra logging when UnwrapEnvelopeMessage is slow (#5198)

### DIFF
--- a/src/KurrentDB.Projections.Core/Messaging/PublishToWrapEnvelop.cs
+++ b/src/KurrentDB.Projections.Core/Messaging/PublishToWrapEnvelop.cs
@@ -6,16 +6,20 @@ using KurrentDB.Core.Messaging;
 
 namespace KurrentDB.Projections.Core.Messaging;
 
+// When this envelope is replied to it puts that message in the original envelope, however
+// it arranges for this to be done elsewhere by sending a message on the provided publisher.
 class PublishToWrapEnvelop : IEnvelope {
 	private readonly IPublisher _publisher;
-	private readonly IEnvelope _nestedEnevelop;
+	private readonly IEnvelope _nestedEnvelope;
+	private readonly string _extraInformation;
 
-	public PublishToWrapEnvelop(IPublisher publisher, IEnvelope nestedEnevelop) {
+	public PublishToWrapEnvelop(IPublisher publisher, IEnvelope nestedEnvelope, string extraInformation) {
 		_publisher = publisher;
-		_nestedEnevelop = nestedEnevelop;
+		_nestedEnvelope = nestedEnvelope;
+		_extraInformation = extraInformation;
 	}
 
 	public void ReplyWith<T>(T message) where T : Message {
-		_publisher.Publish(new UnwrapEnvelopeMessage(() => _nestedEnevelop.ReplyWith(message)));
+		_publisher.Publish(new UnwrapEnvelopeMessage(() => _nestedEnvelope.ReplyWith(message), _extraInformation));
 	}
 }

--- a/src/KurrentDB.Projections.Core/Messaging/UnwrapEnvelopeMessage.cs
+++ b/src/KurrentDB.Projections.Core/Messaging/UnwrapEnvelopeMessage.cs
@@ -10,12 +10,18 @@ namespace KurrentDB.Projections.Core.Messaging;
 [DerivedMessage(ProjectionMessage.Misc)]
 public partial class UnwrapEnvelopeMessage : Message {
 	private readonly Action _action;
+	private readonly string _extraInformation;
 
-	public UnwrapEnvelopeMessage(Action action) {
+	public UnwrapEnvelopeMessage(Action action, string extraInformation) {
 		_action = action;
+		_extraInformation = extraInformation;
 	}
 
 	public Action Action {
 		get { return _action; }
 	}
+
+	public override string ToString() =>
+		$"{base.ToString()}, " +
+		$"Extra Information: {_extraInformation}";
 }

--- a/src/KurrentDB.Projections.Core/Services/Processing/MultiStream/MultiStreamEventReader.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/MultiStream/MultiStreamEventReader.cs
@@ -88,7 +88,7 @@ public class MultiStreamEventReader : EventReader,
 			_publisher.Publish(
 				TimerMessage.Schedule.Create(
 					TimeSpan.FromMilliseconds(250), _publisher,
-					new UnwrapEnvelopeMessage(ProcessBuffers2)));
+					new UnwrapEnvelopeMessage(ProcessBuffers2, nameof(ProcessBuffers2))));
 		foreach (var stream in _streams)
 			RequestEvents(stream, delay: _eofs[stream]);
 	}

--- a/src/KurrentDB.Projections.Core/Services/Processing/Phases/EventSubscriptionBasedProjectionProcessingPhase.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/Phases/EventSubscriptionBasedProjectionProcessingPhase.cs
@@ -152,7 +152,7 @@ public abstract partial class EventSubscriptionBasedProjectionProcessingPhase : 
 			TimerMessage.Schedule.Create(
 				_updateInterval,
 				_inutQueueEnvelope,
-				new UnwrapEnvelopeMessage(MarkTicketReceivedAndUpdateStatistics)));
+				new UnwrapEnvelopeMessage(MarkTicketReceivedAndUpdateStatistics, nameof(MarkTicketReceivedAndUpdateStatistics))));
 	}
 
 	private void MarkTicketReceivedAndUpdateStatistics() {

--- a/src/KurrentDB.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -29,21 +29,21 @@ public class RequestResponseQueueForwarder : IHandle<ClientMessage.ReadEvent>,
 	public void Handle(ClientMessage.ReadEvent msg) {
 		_externalRequestQueue.Publish(
 			new ClientMessage.ReadEvent(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope, nameof(ClientMessage.ReadEvent)),
 				msg.EventStreamId, msg.EventNumber, msg.ResolveLinkTos, msg.RequireLeader, msg.User));
 	}
 
 	public void Handle(ClientMessage.WriteEvents msg) {
 		_externalRequestQueue.Publish(
 			new ClientMessage.WriteEvents(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope), true,
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope, nameof(ClientMessage.WriteEvents)), true,
 				msg.EventStreamIds, msg.ExpectedVersions, msg.Events, msg.EventStreamIndexes, msg.User));
 	}
 
 	public void Handle(ClientMessage.DeleteStream msg) {
 		_externalRequestQueue.Publish(
 			new ClientMessage.DeleteStream(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope), true,
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope, nameof(ClientMessage.DeleteStream)), true,
 				msg.EventStreamId, msg.ExpectedVersion, msg.HardDelete, msg.User));
 	}
 
@@ -54,7 +54,7 @@ public class RequestResponseQueueForwarder : IHandle<ClientMessage.ReadEvent>,
 	public void Handle(ClientMessage.ReadStreamEventsBackward msg) {
 		_externalRequestQueue.Publish(
 			new ClientMessage.ReadStreamEventsBackward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope, nameof(ClientMessage.ReadStreamEventsBackward)),
 				msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationStreamVersion, msg.User,
 				expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
@@ -63,7 +63,7 @@ public class RequestResponseQueueForwarder : IHandle<ClientMessage.ReadEvent>,
 	public void Handle(ClientMessage.ReadStreamEventsForward msg) {
 		_externalRequestQueue.Publish(
 			new ClientMessage.ReadStreamEventsForward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope, nameof(ClientMessage.ReadStreamEventsForward)),
 				msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationStreamVersion, msg.User, replyOnExpired: false,
 				expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
@@ -72,7 +72,7 @@ public class RequestResponseQueueForwarder : IHandle<ClientMessage.ReadEvent>,
 	public void Handle(ClientMessage.ReadAllEventsForward msg) {
 		_externalRequestQueue.Publish(
 			new ClientMessage.ReadAllEventsForward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope, nameof(ClientMessage.ReadAllEventsForward)),
 				msg.CommitPosition, msg.PreparePosition, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationTfLastCommitPosition, msg.User, replyOnExpired: false));
 	}


### PR DESCRIPTION
Cherry pick of #5198

This message just executes an Action and it is used by a few places in Projections. When it triggers a SLOW QUEUE MESSAGE log, it's not clear what it was actually doing. This extra logging points to the action being performed.

e.g.
```
[41392,47,08:04:39.252,DBG] QueuedHandlerThreadPool        SLOW QUEUE MSG [Projection Core #1]: UnwrapEnvelopeMessage - 1ms. Q: 8/32. EventStore.Projections.Core.Messaging.UnwrapEnvelopeMessage, Extra Information: ReadAllEventsForward.
```