### PR TITLE
[DB-689] Remove DisableFirstLevelHttpAuthorization option and doc

### DIFF
--- a/docs/server/configuration/configuration.md
+++ b/docs/server/configuration/configuration.md
@@ -178,7 +178,6 @@ DEFAULT OPTIONS:
          AUTHENTICATION TYPE:                                internal (<DEFAULT>)
          AUTHORIZATION CONFIG:                                (<DEFAULT>)
          AUTHORIZATION TYPE:                                 internal (<DEFAULT>)
-         DISABLE FIRST LEVEL HTTP AUTHORIZATION:             False (<DEFAULT>)
 
     CERTIFICATE OPTIONS:
          CERTIFICATE RESERVED NODE COMMON NAME:               (<DEFAULT>)

--- a/docs/server/security/user-authentication.md
+++ b/docs/server/security/user-authentication.md
@@ -75,12 +75,6 @@ Use the following option to enable this feature:
 | YAML                 | `EnableTrustedAuth`              |
 | Environment variable | `KURRENTDB_ENABLE_TRUSTED_AUTH`  |
 
-### Disable HTTP authentication
-
-It is possible to disable authentication on all protected HTTP endpoints by setting
-the `DisableFirstLevelHttpAuthorization` setting to `true`. The setting is set to `false` by default. When
-`true`, the setting will force KurrentDB to use the supplied credentials only to check [stream access](./user-authorization.md#stream-access).
-
 ## User X.509 Certificates 
 
 <Badge type="info" vertical="middle" text="License Required"/>

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -216,10 +216,6 @@ public partial record ClusterVNodeOptions {
 
 		[Description("Path to the configuration file for Authentication configuration (if applicable).")]
 		public string? AuthenticationConfig { get; init; }
-
-		[Description("Disables first level authorization checks on all HTTP endpoints. " +
-					 "This option can be enabled for backwards compatibility with EventStore 5.0.1 or earlier.")]
-		public bool DisableFirstLevelHttpAuthorization { get; init; } = false;
 	}
 
 	[Description("Certificate Options (from file)")]


### PR DESCRIPTION
Remove DisableFirstLevelHttpAuthorization option and doc.

This option has had no effect since EventStore v20.6.0 https://github.com/EventStore/EventStore/pull/2334 

Breaking change because it will need to be removed from the configuration file if it is specified.