### PR TITLE
[DEV-857] Serialize duration values as ISO 8601 strings

### DIFF
--- a/src/KurrentDB.Core.Tests/Services/Transport/Grpc/PropertiesTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/Transport/Grpc/PropertiesTests.cs
@@ -209,7 +209,7 @@ public class PropertiesTests : GrpcSpecification<LogFormat.V2, string> {
 			  "my-string":           "hello-world",
 			  "my-boolean":          true,
 			  "my-timestamp":        "2025-07-14T05:05:05Z",
-			  "my-duration":         "00:02:01",
+			  "my-duration":         "PT2M1S",
 			  "$schema.data-format": "{{dataFormat}}",
 			  "$schema.name":        "test-type"
 			}

--- a/src/KurrentDB.Core.XUnit.Tests/Util/PropertiesExtendedTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Util/PropertiesExtendedTests.cs
@@ -47,7 +47,7 @@ public class PropertiesExtendedTests {
 			  "my-boolean":   true,
 			  "my-string":    "hello-world",
 			  "my-timestamp": "2025-07-14T05:05:05Z",
-			  "my-duration":  "00:02:01"
+			  "my-duration":  "PT2M1S"
 			}
 			""";
 

--- a/src/KurrentDB.Core/Services/Transport/Grpc/V2/Utils/PropertiesExtended.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/V2/Utils/PropertiesExtended.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Xml;
 using static System.Text.Json.JsonSerializer;
 using static KurrentDB.Protobuf.DynamicValue.KindOneofCase;
 
@@ -36,7 +37,7 @@ public sealed partial class Properties {
 				case FloatValue:     Serialize(writer, value.FloatValue, options); break;
 				case DoubleValue:    Serialize(writer, value.DoubleValue, options); break;
 				case TimestampValue: Serialize(writer, value.TimestampValue.ToDateTime(), options); break;
-				case DurationValue:  Serialize(writer, value.DurationValue.ToTimeSpan(), options); break;
+				case DurationValue:  Serialize(writer, XmlConvert.ToString(value.DurationValue.ToTimeSpan()), options); break;
 				case BytesValue:     Serialize(writer, value.BytesValue.Memory, options); break;
 
 				case NullValue or None: writer.WriteNullValue(); break;


### PR DESCRIPTION
By default, .NET serializes `TimeSpan` values to JSON using the "c" format (e.g., "1.02:03:00"). This format is not widely supported outside of .NET and makes it harder for other languages to consume duration values reliably. 

This pull request updates the serialization of `TimeSpan` to use ISO 8601 duration strings (e.g., "P1DT2H3M"), which are a standardized and widely recognized format. Corresponding tests have been updated to reflect the new representation.
