### PR TITLE
[DB-1607] Make InMemoryBus.DefaultSlowMessageThreshold configurable

### DIFF
--- a/src/KurrentDB.Core/Bus/InMemoryBus.cs
+++ b/src/KurrentDB.Core/Bus/InMemoryBus.cs
@@ -23,7 +23,6 @@ public partial class InMemoryBus : ISubscriber, IAsyncHandle<Message> {
 	public static InMemoryBus CreateTest(bool watchSlowMsg = true) =>
 		new("Test", watchSlowMsg);
 
-	public static readonly TimeSpan DefaultSlowMessageThreshold = TimeSpan.FromMilliseconds(48);
 	private static readonly ILogger Log = Serilog.Log.ForContext<InMemoryBus>();
 
 	private readonly FrozenDictionary<Type, MessageTypeHandler> _handlers;
@@ -34,7 +33,7 @@ public partial class InMemoryBus : ISubscriber, IAsyncHandle<Message> {
 		Name = name;
 
 		if (watchSlowMsg)
-			_slowMsgThresholdMs = slowMsgThreshold.GetValueOrDefault(DefaultSlowMessageThreshold).TotalMilliseconds;
+			_slowMsgThresholdMs = slowMsgThreshold.GetValueOrDefault(TimeSpan.FromMilliseconds(ClusterVNodeOptions.InMemoryBusOptions.DefaultSlowMessageThreshold)).TotalMilliseconds;
 	}
 
 	public string Name { get; }

--- a/src/KurrentDB.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/KurrentDB.Core/Bus/QueuedHandlerThreadPool.cs
@@ -71,7 +71,7 @@ public class QueuedHandlerThreadPool : IQueuedHandler, IMonitoredQueue, IThreadP
 		_lifetimeToken = _lifetimeSource.Token;
 
 		_watchSlowMsg = watchSlowMsg;
-		_slowMsgThreshold = slowMsgThreshold ?? InMemoryBus.DefaultSlowMessageThreshold;
+		_slowMsgThreshold = slowMsgThreshold ?? TimeSpan.FromMilliseconds(ClusterVNodeOptions.InMemoryBusOptions.DefaultSlowMessageThreshold);
 		_threadStopWaitTimeout = threadStopWaitTimeout ?? DefaultStopWaitTimeout;
 
 		_queueMonitor = QueueMonitor.Default;

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -334,7 +334,7 @@ public class ClusterVNode<TStreamId> :
 
 		var trackers = new Trackers();
 		var metricsConfiguration = MetricsConfiguration.Get(configuration);
-		MetricsBootstrapper.Bootstrap(metricsConfiguration, dbConfig, trackers);
+		MetricsBootstrapper.Bootstrap(metricsConfiguration, dbConfig, trackers, options.InMemoryBus.SlowMessageThresholdMs);
 
 		var namingStrategy = new VersionedPatternFileNamingStrategy(dbConfig.Path, "chunk-");
 		IChunkFileSystem fileSystem = new ChunkLocalFileSystem(namingStrategy);

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -47,6 +47,7 @@ public partial record ClusterVNodeOptions {
 	[OptionGroup] public GrpcOptions Grpc { get; init; } = new();
 	[OptionGroup] public InterfaceOptions Interface { get; init; } = new();
 	[OptionGroup] public ProjectionOptions Projection { get; init; } = new();
+	[OptionGroup] public InMemoryBusOptions InMemoryBus { get; set; } = new();
 	public UnknownOptions Unknown { get; init; } = new([]);
 
 	public byte IndexBitnessVersion { get; init; } = PTableVersions.IndexV4;
@@ -85,6 +86,7 @@ public partial record ClusterVNodeOptions {
 			Grpc = configuration.BindOptions<GrpcOptions>(),
 			Interface = configuration.BindOptions<InterfaceOptions>(),
 			Projection = configuration.BindOptions<ProjectionOptions>(),
+			InMemoryBus = configuration.BindOptions<InMemoryBusOptions>(),
 
 			Unknown = UnknownOptions.FromConfiguration(configuration),
 			ConfigurationRoot = configurationRoot,
@@ -589,6 +591,14 @@ public partial record ClusterVNodeOptions {
 
 		[Description("The maximum size, in bytes, of a projection's state and result. A projection will fault if its state size exceeds this value. May not exceed 16mb.")]
 		public int MaxProjectionStateSize { get; set; } = Opts.MaxProjectionStateSizeDefault;
+	}
+
+	[Description("InMemoryBus Options")]
+	public record InMemoryBusOptions {
+		public const int DefaultSlowMessageThreshold = 48;
+		[Description("The time limit in milliseconds beyond which a SLOW MSG would be logged"),
+		 Unit("ms")]
+		public int SlowMessageThresholdMs { get; set; } = DefaultSlowMessageThreshold;
 	}
 
 	public record UnknownOptions(IReadOnlyList<(string, string)> Options) {

--- a/src/KurrentDB.Core/KurrentDB.Core.csproj
+++ b/src/KurrentDB.Core/KurrentDB.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<LangVersion>preview</LangVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/KurrentDB.Core/Metrics/GCSuspensionMetric.cs
+++ b/src/KurrentDB.Core/Metrics/GCSuspensionMetric.cs
@@ -19,7 +19,11 @@ public class GcSuspensionMetric(DurationMaxTracker? tracker) : EventListener {
 	private static readonly ILogger Log = Serilog.Log.ForContext<GcSuspensionMetric>();
 
 	// Match DefaultSlowMessageThreshold so slow messages can be attributed to GC.
-	private static readonly TimeSpan LongSuspensionThreshold = InMemoryBus.DefaultSlowMessageThreshold;
+	private static TimeSpan LongSuspensionThreshold;
+	public static void ConfigureLongSuspensionThreshold(int ? _slowMessageThresholdMs) {
+		LongSuspensionThreshold = TimeSpan.FromMilliseconds(_slowMessageThresholdMs.GetValueOrDefault(ClusterVNodeOptions.InMemoryBusOptions
+			.DefaultSlowMessageThreshold));
+	}
 	private static readonly TimeSpan VeryLongSuspensionThreshold = TimeSpan.FromMilliseconds(600);
 	private static readonly TimeSpan LongSuspensionLogPeriod = TimeSpan.FromMilliseconds(10_000);
 
@@ -183,7 +187,7 @@ public class GcSuspensionMetric(DurationMaxTracker? tracker) : EventListener {
 						_periodLongSuspensionCount = 0;
 						_periodLongSuspensionsElapsedTotal = TimeSpan.Zero;
 					} else {
-						// have logged recently 
+						// have logged recently
 						_periodLongSuspensionCount++;
 						_periodLongSuspensionsElapsedTotal += elapsed;
 					}

--- a/src/KurrentDB.Core/MetricsBootstrapper.cs
+++ b/src/KurrentDB.Core/MetricsBootstrapper.cs
@@ -67,7 +67,7 @@ public static class MetricsBootstrapper {
 	public static void Bootstrap(
 		Conf conf,
 		TFChunkDbConfig dbConfig,
-		Trackers trackers) {
+		Trackers trackers, int _slowMessageThresholdMs) {
 
 		OptionsFormatter.LogConfig("Metrics", conf);
 
@@ -307,7 +307,7 @@ public static class MetricsBootstrapper {
 				? $"{serviceName}-gc-total-allocated"
 				: $"{serviceName}-gc-allocated" },
 			{ Conf.ProcessTracker.GcPauseDuration, $"{serviceName}-gc-pause-duration-max" },
-		});
+		}, _slowMessageThresholdMs);
 
 		processMetrics.CreateMemoryMetric($"{serviceName}-proc-mem", new() {
 			{ Conf.ProcessTracker.MemWorkingSet, "working-set" },

--- a/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
@@ -102,9 +102,9 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		_forwardingTimeout = TimeSpan.FromMilliseconds(options.Database.PrepareTimeoutMs +
 													   options.Database.CommitTimeoutMs + 300);
 
-		_outputBus = new InMemoryBus("MainBus");
+		_outputBus = new InMemoryBus("MainBus", true, TimeSpan.FromMilliseconds(options.InMemoryBus.SlowMessageThresholdMs));
 		_fsm = CreateFSM();
-		_mainQueue = new QueuedHandlerThreadPool(_fsm, "MainQueue", statsManager, trackers.QueueTrackers);
+		_mainQueue = new QueuedHandlerThreadPool(_fsm, "MainQueue", statsManager, trackers.QueueTrackers, true, TimeSpan.FromMilliseconds(options.InMemoryBus.SlowMessageThresholdMs));
 		_publishEnvelope = _mainQueue;
 	}
 

--- a/src/KurrentDB.Projections.Core/KurrentDB.Projections.Core.csproj
+++ b/src/KurrentDB.Projections.Core/KurrentDB.Projections.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<LangVersion>preview</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="Prelude\1Prelude.js" />

--- a/src/KurrentDB.Projections.Core/ProjectionCoreWorkersNode.cs
+++ b/src/KurrentDB.Projections.Core/ProjectionCoreWorkersNode.cs
@@ -23,20 +23,22 @@ namespace KurrentDB.Projections.Core;
 public static class ProjectionCoreWorkersNode {
 	public static Dictionary<Guid, CoreWorker> CreateCoreWorkers(
 		StandardComponents standardComponents,
-		ProjectionsStandardComponents projectionsStandardComponents) {
+		ProjectionsStandardComponents projectionsStandardComponents , TimeSpan _slowMessageThresholdMs) {
 		var coreWorkers = new Dictionary<Guid, CoreWorker>();
 		while (coreWorkers.Count < projectionsStandardComponents.ProjectionWorkerThreadCount) {
-			var coreInputBus = new InMemoryBus("bus");
+			var coreInputBus = new InMemoryBus("bus" , true , _slowMessageThresholdMs);
 			var coreInputQueue = new QueuedHandlerThreadPool(coreInputBus,
 				"Projection Core #" + coreWorkers.Count,
 				standardComponents.QueueStatsManager,
-				standardComponents.QueueTrackers,
+				standardComponents.QueueTrackers, true,
+				_slowMessageThresholdMs,
 				groupName: "Projection Core");
-			var coreOutputBus = new InMemoryBus("output bus");
+			var coreOutputBus = new InMemoryBus("output bus" , true , _slowMessageThresholdMs);
 			var coreOutputQueue = new QueuedHandlerThreadPool(coreOutputBus,
 				"Projection Core #" + coreWorkers.Count + " output",
 				standardComponents.QueueStatsManager,
-				standardComponents.QueueTrackers,
+				standardComponents.QueueTrackers, true,
+				_slowMessageThresholdMs,
 				groupName: "Projection Core");
 			var workerId = Guid.NewGuid();
 			var projectionNode = new ProjectionWorkerNode(

--- a/src/KurrentDB/ClusterVNodeHostedService.cs
+++ b/src/KurrentDB/ClusterVNodeHostedService.cs
@@ -95,7 +95,7 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable {
 					options.Projection.FaultOutOfOrderProjections,
 					options.Projection.ProjectionCompilationTimeout,
 					options.Projection.ProjectionExecutionTimeout,
-					options.Projection.MaxProjectionStateSize)))
+					options.Projection.MaxProjectionStateSize) , options.InMemoryBus.SlowMessageThresholdMs))
 			: options;
 
 		if (!_options.Database.MemDb) {


### PR DESCRIPTION
The default value was configured at 48 ms. Any message taking longer than this to be processed was logged as a SLOW BUS/QUEUE MSG in the KurrentDB logs. This PR makes this parameter configurable. If it is not set/configured, it will stick to the previous default of 48 ms.