### PR TITLE
[DB-1656] Avoid adding windows event logging when running as a windows service

### DIFF
--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -217,6 +217,8 @@ try {
 
 			var builder = WebApplication.CreateBuilder(applicationOptions);
 			builder.Configuration.AddConfiguration(configuration);
+			// AddWindowsService adds EventLog logging, which we remove afterwards.
+			builder.Services.AddWindowsService();
 			builder.Logging.ClearProviders().AddSerilog();
 			builder.Services.Configure<KestrelServerOptions>(configuration.GetSection("Kestrel"));
 			builder.Services.Configure<HostOptions>(x => {
@@ -257,7 +259,6 @@ try {
 			builder.Services.AddScoped<IdentityRedirectManager>();
 			builder.Services.AddSingleton(monitoringService);
 			builder.Services.AddSingleton(metricsObserver);
-			builder.Services.AddWindowsService();
 			Log.Information("Environment Name: {0}", builder.Environment.EnvironmentName);
 			Log.Information("ContentRoot Path: {0}", builder.Environment.ContentRootPath);
 


### PR DESCRIPTION
When running as a windows service we log to the windows event log, but on shutdown some part of this mechanism in the framework gets shutdown before we are done logging, resulting in scary errors in the regular log about not being able to log.

This also cuts down on the amount of logs being produced.