### PR TITLE
[DB-1673] Deprecate MemDb

### DIFF
--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -339,6 +339,7 @@ public partial record ClusterVNodeOptions {
 		public string Transform { get; init; } = "identity";
 
 		[Description("Keep everything in memory, no directories or files are created.")]
+		[Deprecated("MemDb is deprecated and will be removed in a future version. Please contact Kurrent if your use case requires it.")]
 		public bool MemDb { get; init; } = false;
 
 		[Description("Creates a Bloom filter file for each new index file to speed up index reads.")]


### PR DESCRIPTION
- MemDb adds extra complexity to core code paths, especially in TFChunk. Removing it will speed up future development.
- To our knowledge there is no production use case for MemDb.
- We are deprecating it in this version so give users time to notice and respond if it is important to anyone.
- Users wishing to run in memory can still use `ramfs` or `tmpfs` etc to do so
- This also resolves in-mem compatibility issues with metadata databases (SQLite, DuckDB)