### PR TITLE
[DB-1686] Add 'patched' label to release exclusions

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,7 @@ changelog:
     labels:
       - ignore-for-release
       - documentation
+      - patched
   categories:
     - title: Added
       labels:


### PR DESCRIPTION
Intention being to use 'patched' label for changes (usually bug fixes) that have been previously released in a patch to an earlier version. Such patches needn't be included in the release notes for the next version.