### PR TITLE
Complete the move to new KurrentDB.slnx

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -50,11 +50,11 @@ jobs:
           return;
         }
         Remove-Item $env:APPDATA\NuGet\NuGet.Config
-    -  
+    -
       name: Compile
       shell: bash
       run: |
-        dotnet build --configuration ${{ matrix.configuration }} -p:Platform=${{ inputs.arch }} src/KurrentDB.sln
+        dotnet build --configuration ${{ matrix.configuration }} -p:Platform=${{ inputs.arch }} KurrentDB.slnx
     -  
       name: Verify Build
       shell: bash
@@ -69,7 +69,7 @@ jobs:
         load: true
         target: runtime
         tags: ${{ env.DB_IMAGE }}
-    -  
+    -
       name: Run Tests
       shell: bash
       run: >
@@ -84,7 +84,7 @@ jobs:
         --logger:trx
         --logger:"console;verbosity=normal"
         --results-directory $(pwd)/test-results
-        src/KurrentDB.sln
+        KurrentDB.slnx
         -- --report-trx --results-directory $(pwd)/test-results
     -  
       name: Publish Test Results (All)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,10 @@ KurrentDB 25.1 introduces several major features and improvements:
 ### Build
 - `./build.sh [version] [configuration]` - Build KurrentDB (Linux/MacOS)
 - `./build.ps1 [version] [configuration]` - Build KurrentDB (Windows)
-- `dotnet build -c Release /p:Platform=x64 --framework=net8.0 src/KurrentDB.sln` - Direct dotnet build
+- `dotnet build -c Release /p:Platform=x64 --framework=net8.0 KurrentDB.slnx` - Direct dotnet build
 
 ### Test
-- `dotnet test src/KurrentDB.sln` - Run all tests
+- `dotnet test KurrentDB.slnx` - Run all tests
 - `dotnet test src/ProjectName.Tests/` - Run tests for a specific project
 - Tests use xunit, NUnit, and TUnit frameworks depending on the project
 
@@ -603,7 +603,7 @@ await foreach (var response in enumerator) {
 **Running Tests**:
 ```bash
 # All tests
-dotnet test src/KurrentDB.sln
+dotnet test KurrentDB.slnx
 
 # Specific project
 dotnet test src/KurrentDB.Api.V2.Tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY ./proto ./
 WORKDIR /build/src
 COPY ./src/Connectors/*/*.csproj ./Connectors/
 COPY ./src/SchemaRegistry/*/*.csproj ./SchemaRegistry/
-COPY ./src/KurrentDB.sln ./src/*/*.csproj ./src/Directory.Build.* ./src/Directory.Packages.props ./
+COPY ./src/*/*.csproj ./src/Directory.Build.* ./src/Directory.Packages.props ./
+COPY ./KurrentDB.slnx /build/
 RUN for file in $(ls Connectors/*.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.*}/; done && \
     for file in $(ls SchemaRegistry/*.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.*}/; done && \
     for file in $(ls *.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.*}/; done && \
@@ -49,7 +50,7 @@ CMD dotnet test \
     --logger:"GitHubActions;report-warnings=false" \
     --logger:"console;verbosity=normal" \
     --results-directory "/build/test-results" \
-    /build/src/KurrentDB.sln \
+    /build/KurrentDB.slnx \
     -- --report-trx --results-directory "/build/test-results"
 
 # "publish" image

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ dotnet ./src/KurrentDB/bin/Release/net8.0/KurrentDB.dll --dev --db ./tmp/data --
 You can launch the tests as follows:
 
 ```
-dotnet test src/KurrentDB.sln
+dotnet test KurrentDB.slnx
 ```
 
 ### Build KurrentDB Docker image

--- a/build.ps1
+++ b/build.ps1
@@ -42,7 +42,7 @@ Function Start-Build{
     $baseDirectory = $PSScriptRoot
     $srcDirectory = Join-Path $baseDirectory "src"
     $binDirectory = Join-Path $baseDirectory "bin"
-    $kurrentDbSolution = Join-Path $srcDirectory "KurrentDB.sln"
+    $kurrentDbSolution = Join-Path $baseDirectory "KurrentDB.slnx"
 
     Write-Info "Build Configuration"
     Write-Info "-------------------"

--- a/build.sh
+++ b/build.sh
@@ -121,7 +121,7 @@ function patchVersionInfo {
 function buildKurrentDB {
     patchVersionInfo
     rm -rf bin/
-    dotnet build -c $CONFIGURATION /p:Platform=x64 /p:Version=$VERSIONSTRING --framework=$NET_FRAMEWORK src/KurrentDB.sln || err
+    dotnet build -c $CONFIGURATION /p:Platform=x64 /p:Version=$VERSIONSTRING --framework=$NET_FRAMEWORK KurrentDB.slnx || err
     revertVersionInfo
 }
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -3,7 +3,7 @@ version: "1.0"
 linter: jetbrains/qodana-dotnet:2024.3
 
 dotnet:
-  solution: src/KurrentDB.sln
+  solution: KurrentDB.slnx
 
 exclude:
   - name: RedundantTypeArgumentsOfMethod

--- a/tools/license-notices/generate-notice.ps1
+++ b/tools/license-notices/generate-notice.ps1
@@ -6,7 +6,7 @@ $commonArgs = @(
   "--exclude-projects-matching ignored-projects.json"
   "--include-transitive"
   "--ignored-packages ignored-packages.json"
-  "--input ../../src/KurrentDB.sln"
+  "--input ../../KurrentDB.slnx"
   "--licenseurl-to-license-mappings license-url-mappings.json"
   "--override-package-information overridden-packages.json"
 )


### PR DESCRIPTION
This pull request updates the project to use the new `KurrentDB.slnx` solution file instead of the old `src/KurrentDB.sln` across all build, test, documentation, and tooling scripts. This change ensures consistency and prepares the codebase for future improvements tied to the new solution structure.