### PR TITLE
[DB-1740] Fix multi-stream-append that completes a chunk (#5362)

### DIFF
--- a/src/KurrentDB.Core.Testing/Helpers/MiniNode.cs
+++ b/src/KurrentDB.Core.Testing/Helpers/MiniNode.cs
@@ -65,6 +65,7 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 	public readonly string DbPath;
 	public HttpClient HttpClient;
 	public HttpMessageHandler HttpMessageHandler;
+	public readonly ClusterVNodeOptions Options;
 
 	private readonly WebApplication _webHost;
 	private readonly TaskCompletionSource<bool> _started;
@@ -260,6 +261,7 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 		Node.Startup.Configure(_webHost);
 		_started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		_adminUserCreated = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		Options = options;
 	}
 
 	public async Task StartTestServer() {

--- a/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using KurrentDB.Core.Data;
 using KurrentDB.Core.Messages;
 using KurrentDB.Core.Messaging;
+using KurrentDB.Core.Services.Transport.Common;
 using KurrentDB.Core.Services.UserManagement;
 using Xunit;
 using Assert = Xunit.Assert;
@@ -16,7 +17,13 @@ namespace KurrentDB.Core.XUnit.Tests.TransactionLog.MultiStreamWrites;
 
 public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixture)
 	: IClassFixture<MiniNodeFixture<MultiStreamWritesTests>> {
-	private static Event NewEvent => new(Guid.NewGuid(), "type", false, "data", "metadata");
+	private static Event NewEvent => CreateEvent();
+	private static Event CreateEvent(int dataSize = 4) => new(
+		eventId: Guid.NewGuid(),
+		eventType: "type",
+		isJson: false,
+		data: new string('#', dataSize),
+		metadata: "metadata");
 
 	[Fact]
 	public async Task succeeds() {
@@ -157,6 +164,43 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 		Assert.Equal(OperationResult.Success, completed.Result);
 		Assert.Equal([2, 1], completed.FirstEventNumbers.ToArray());
 		Assert.Equal([3, 2], completed.LastEventNumbers.ToArray());
+	}
+
+	[Fact]
+	public async Task succeeds_when_reaching_chunk_boundary() {
+		const string test = nameof(succeeds_when_reaching_chunk_boundary);
+
+		var streamA = $"{test}-a";
+		var streamB = $"{test}-b";
+		var streamC = $"{test}-c";
+
+		var client = new SystemClient(fixture.MiniNode.Node.MainQueue);
+		var chunkSize = fixture.MiniNode.Options.Database.ChunkSize;
+
+		// Use up 2/3 of the remaining space in the chunk so that the next write does not fit
+		var writer = fixture.MiniNode.Node.Db.Config.WriterCheckpoint.Read();
+		var spaceLeftInChunk = chunkSize - (int)writer % chunkSize;
+		if (spaceLeftInChunk > 10_000) {
+			await client.Writing.WriteEvents(streamA, [CreateEvent(spaceLeftInChunk * 2 / 3)]);
+		}
+
+		// A write that does not fit in chunk and so creates a new one
+		var thirdOfAChunk = chunkSize / 3;
+		var completed = await WriteEvents(
+			eventStreamIds: [streamB, streamC],
+			expectedVersions: [ExpectedVersion.NoStream, ExpectedVersion.NoStream],
+			events: [CreateEvent(thirdOfAChunk), CreateEvent(thirdOfAChunk)],
+			eventStreamIndexes: [0, 1]);
+
+		Assert.Equal(OperationResult.Success, completed.Result);
+		Assert.Equal((writer / chunkSize) + 1, completed.CommitPosition / chunkSize); // important: wrote to the next chunk
+		Assert.Equal([0, 0], completed.FirstEventNumbers.ToArray());
+		Assert.Equal([0, 0], completed.LastEventNumbers.ToArray());
+
+		var lastA = await client.Reading.ReadStreamBackwards(streamB, StreamRevision.End, maxCount: 1).SingleAsync();
+		var lastB = await client.Reading.ReadStreamBackwards(streamC, StreamRevision.End, maxCount: 1).SingleAsync();
+		Assert.Equal(0, lastA.OriginalEventNumber);
+		Assert.Equal(0, lastB.OriginalEventNumber);
 	}
 
 	[Fact]

--- a/src/KurrentDB.Core/Services/Storage/StorageWriterService.cs
+++ b/src/KurrentDB.Core/Services/Storage/StorageWriterService.cs
@@ -815,14 +815,9 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			}
 
 			long logPos = Writer.Position;
-			long transactionPos = default;
+			long transactionPos = logPos;
 
 			for (int i = 0; i < prepares.Count; i++) {
-				// the prepares may be from different streams due to the stream & event type records
-				// we thus adjust the transaction position to the correct value on each stream id change
-				if (i is 0 || !StreamIdComparer.Equals(prepares[i].EventStreamId, prepares[i - 1].EventStreamId))
-					transactionPos = logPos;
-
 				prepares[i] = prepares[i].CopyForRetry(logPos, transactionPos);
 				logPos += prepares[i].GetSizeWithLengthPrefixAndSuffix();
 			}


### PR DESCRIPTION
cherry pick of #5362

When a transaction reaches a chunk boundary we open a new chunk and write the transaction there instead. The records in the transaction are updated to reflect the new position of the transaction (log positions and transaction positions), but this code assumed that all the user's prepares belonged to the same stream. This assumption is not true for MSA appends and the code needed updating.

For the user this meant that when reaching a chunk boundary with an MSA, the lastEventNumbers for some of the streams could be calculated incorrectly.