### PR TITLE
[DEV-1010] Add POST method support to list connectors

### DIFF
--- a/src/Connectors/KurrentDB.Connectors.Contracts/protos/managementplane/queries.proto
+++ b/src/Connectors/KurrentDB.Connectors.Contracts/protos/managementplane/queries.proto
@@ -15,7 +15,7 @@ service ConnectorsQueryService {
     option (google.api.http) = {
       get: "/connectors"
       additional_bindings {
-        post: "/connectors"
+        post: "/connectors/list"
         body: "*"
       }
     };


### PR DESCRIPTION
Support querying connectors using `POST /connectors` while still supporting `GET /connectors` with query params.