### PR TITLE
[DB-1748] Fix http request purge race condition

### DIFF
--- a/src/KurrentDB.Core/Services/GrpcSendService.cs
+++ b/src/KurrentDB.Core/Services/GrpcSendService.cs
@@ -9,6 +9,7 @@ using Serilog;
 
 namespace KurrentDB.Core.Services;
 
+// Called by worker bus concurrently. Thread Safe.
 public class GrpcSendService :
 	IHandle<GrpcMessage.SendOverGrpc> {
 

--- a/src/KurrentDB.Core/Services/HttpSendService.cs
+++ b/src/KurrentDB.Core/Services/HttpSendService.cs
@@ -20,6 +20,7 @@ using ILogger = Serilog.ILogger;
 
 namespace KurrentDB.Core.Services;
 
+// Called by worker bus concurrently. Thread Safe.
 public class HttpSendService : IHttpForwarder,
 	IHandle<SystemMessage.StateChangeMessage>,
 	IHandle<HttpMessage.HttpSend> {

--- a/src/KurrentDB.Core/Services/TcpSendService.cs
+++ b/src/KurrentDB.Core/Services/TcpSendService.cs
@@ -6,6 +6,7 @@ using KurrentDB.Core.Messages;
 
 namespace KurrentDB.Core.Services;
 
+// Called by worker bus concurrently. Thread Safe.
 public class TcpSendService : IHandle<TcpMessage.TcpSend> {
 	public void Handle(TcpMessage.TcpSend message) {
 		// todo: histogram metric?


### PR DESCRIPTION
### **User description**
Edit: I thought briefly that this affected 25.1 but it doesn't, only master.

### **User description**
In 25.1 and earlier there was one AuthenticatedHttpRequestProcessor per worker bus, with each bus handling one message at a time so it didn't have to be thread safe.

Now there is only one worker bus which handles messages concurrently so AuthenticatedHttpRequestProcessor needs to be thread safe.

___

### **Auto-created Ticket**

[#5368](https://github.com/kurrent-io/KurrentDB/issues/5368)

### **PR Type**
Bug fix


___

### **Description**
- Make AuthenticatedHttpRequestProcessor thread-safe for concurrent worker bus access

- Add synchronization to PairingHeap operations using Monitor and lock

- Document thread-safety requirements across send service classes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WB["Worker Bus<br/>Concurrent Messages"]
  AHRP["AuthenticatedHttpRequestProcessor"]
  PH["PairingHeap<br/>Pending Requests"]
  SYNC["Thread Synchronization<br/>Monitor/Lock"]
  
  WB -- "Handle Messages" --> AHRP
  AHRP -- "Access" --> PH
  SYNC -- "Protects" --> PH
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthenticatedHttpRequestProcessor.cs</strong><dd><code>Add thread synchronization to HTTP request processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/Transport/Http/AuthenticatedHttpRequestProcessor.cs

<ul><li>Added <code>System.Threading</code> import for synchronization primitives<br> <li> Added thread-safety documentation comment to class<br> <li> Wrapped <code>PurgeTimedOutRequests()</code> with <code>Monitor.TryEnter()</code> to prevent <br>blocking<br> <li> Protected <code>_pending.Add()</code> operation with <code>lock</code> statement in <code>Handle()</code> <br>method<br> <li> Added <code>finally</code> block to ensure <code>Monitor.Exit()</code> is called</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5367/files#diff-253542176d700ac0222d87ad40a5a953154e5de987b50574364a80c99ea7a651">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GrpcSendService.cs</strong><dd><code>Document thread-safety for GRPC send service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/GrpcSendService.cs

<ul><li>Added documentation comment indicating concurrent access and <br>thread-safety</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5367/files#diff-374932bdf016de776d858ec11d4db900acb5c562194e3d07b3f368dcb32c5616">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HttpSendService.cs</strong><dd><code>Document thread-safety for HTTP send service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/HttpSendService.cs

<ul><li>Added documentation comment indicating concurrent access and <br>thread-safety</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5367/files#diff-0d03d528d789d4e4fafc9d659b5c9fdad6c608246ecfc005b779863b4eb09e52">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TcpSendService.cs</strong><dd><code>Document thread-safety for TCP send service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/TcpSendService.cs

<ul><li>Added documentation comment indicating concurrent access and <br>thread-safety</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5367/files#diff-4daaf52d6e06b89a99bd4a9f4d0e6d25edfecd48d115f09e5721fad4c686e50e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **Auto-created Ticket**

[#5368](https://github.com/kurrent-io/KurrentDB/issues/5368)

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Add thread synchronization to AuthenticatedHttpRequestProcessor for concurrent access
  - Use Monitor.TryEnter() in PurgeTimedOutRequests() to prevent blocking
  - Protect _pending.Add() operation with lock statement

- Document thread-safety requirements across send service classes
  - Add thread-safety comments to GrpcSendService, HttpSendService, TcpSendService


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WB["Worker Bus<br/>Concurrent Messages"]
  AHRP["AuthenticatedHttpRequestProcessor"]
  PH["PairingHeap<br/>Pending Requests"]
  SYNC["Thread Synchronization<br/>Monitor/Lock"]
  
  WB -- "Handle Messages" --> AHRP
  AHRP -- "Access" --> PH
  SYNC -- "Protects" --> PH
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthenticatedHttpRequestProcessor.cs</strong><dd><code>Add thread synchronization to HTTP request processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/Transport/Http/AuthenticatedHttpRequestProcessor.cs

<ul><li>Added <code>System.Threading</code> import for synchronization primitives<br> <li> Added thread-safety documentation comment to class<br> <li> Wrapped <code>PurgeTimedOutRequests()</code> with <code>Monitor.TryEnter()</code> to prevent <br>blocking<br> <li> Protected <code>_pending.Add()</code> operation with <code>lock</code> statement in <code>Handle()</code> <br>method<br> <li> Added <code>finally</code> block to ensure <code>Monitor.Exit()</code> is called</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5367/files#diff-253542176d700ac0222d87ad40a5a953154e5de987b50574364a80c99ea7a651">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GrpcSendService.cs</strong><dd><code>Document thread-safety for GRPC send service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/GrpcSendService.cs

<ul><li>Added documentation comment indicating concurrent access and <br>thread-safety</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5367/files#diff-374932bdf016de776d858ec11d4db900acb5c562194e3d07b3f368dcb32c5616">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HttpSendService.cs</strong><dd><code>Document thread-safety for HTTP send service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/HttpSendService.cs

<ul><li>Added documentation comment indicating concurrent access and <br>thread-safety</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5367/files#diff-0d03d528d789d4e4fafc9d659b5c9fdad6c608246ecfc005b779863b4eb09e52">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TcpSendService.cs</strong><dd><code>Document thread-safety for TCP send service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/TcpSendService.cs

<ul><li>Added documentation comment indicating concurrent access and <br>thread-safety</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5367/files#diff-4daaf52d6e06b89a99bd4a9f4d0e6d25edfecd48d115f09e5721fad4c686e50e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

