### PR TITLE
[DB-1746] Add release notes for KurrentDB v25.1.1

### DIFF
--- a/docs/server/release-schedule/release-notes.md
+++ b/docs/server/release-schedule/release-notes.md
@@ -10,7 +10,7 @@ This page contains the release notes for KurrentDB v25.1.
 
 19 November 2025
 
-### Fixed multi-stream-append that completes a chunk (PR [#5363](https://github.com/kurrent-io/KurrentDB/pull/5363))
+### Fixed multi-stream-append that completes a chunk (PR [#5362](https://github.com/kurrent-io/KurrentDB/pull/5362))
 
 A multi-stream-append that causes a new chunk to be created could result in incorrect last event numbers being calculated for the associated streams.
 


### PR DESCRIPTION
### **User description**
Added release notes for version 25.1.1, including a fix for multi-stream-append.


___

### **Auto-created Ticket**

[#5370](https://github.com/kurrent-io/KurrentDB/issues/5370)

### **PR Type**
Documentation


___

### **Description**
- Added release notes for KurrentDB v25.1.1

- Documented fix for multi-stream-append chunk completion bug

- Updated release date for v25.1.0 to October 15, 2025


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Notes Document"] -->|"Add v25.1.1 section"| B["v25.1.1 Release Entry"]
  B -->|"Document bug fix"| C["Multi-stream-append Fix"]
  A -->|"Update date"| D["v25.1.0 Date Correction"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-notes.md</strong><dd><code>Add v25.1.1 release notes with bug fix documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/server/release-schedule/release-notes.md

<ul><li>Added new section for KurrentDB v25.1.1 released on November 19, 2025<br> <li> Documented fix for multi-stream-append bug that caused incorrect last <br>event numbers when creating new chunks<br> <li> Corrected v25.1.0 release date from placeholder to October 15, 2025<br> <li> Added reference to PR #5363 for the multi-stream-append fix</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5369/files#diff-3545a49c037b6615117d40d20cfa2c843fca710f4ede15a50256b283e1fde106">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

