### PR TITLE
Fix connectors command service logging issue

### DIFF
--- a/src/Connectors/KurrentDB.Connectors.Contracts/KurrentDB.Connectors.Contracts.csproj
+++ b/src/Connectors/KurrentDB.Connectors.Contracts/KurrentDB.Connectors.Contracts.csproj
@@ -23,6 +23,6 @@
 
 		<Protobuf ProtoRoot="protos" Include="protos/controlplane/**/*.proto" Link="protos\controlplane\%(RecursiveDir)/%(FileName)%(Extension)" GrpcServices="None" />
 
-		<Protobuf ProtoRoot="protos" Include="protos/managementplane/**/*.proto" Link="protos\managementplane\%(RecursiveDir)/%(FileName)%(Extension)" GrpcServices="Server" />
+		<Protobuf ProtoRoot="protos" Include="protos/managementplane/**/*.proto" Link="protos\managementplane\%(RecursiveDir)/%(FileName)%(Extension)" GrpcServices="Both" />
 	</ItemGroup>
 </Project>

--- a/src/Connectors/KurrentDB.Connectors/Planes/Management/ConnectorsCommandService.cs
+++ b/src/Connectors/KurrentDB.Connectors/Planes/Management/ConnectorsCommandService.cs
@@ -48,7 +48,7 @@ public class ConnectorsCommandService(
             _ => {
                 logger.LogDebug(
                     "{TraceIdentifier} {CommandType} executed [connector_id, {ConnectorId}]",
-                    http.TraceIdentifier, command.GetType().Name, http.Request.RouteValues.First().Value
+                    http.TraceIdentifier, command.GetType().Name, http.Request.RouteValues.FirstOrDefault().Value
                 );
 
                 return new Empty();


### PR DESCRIPTION
### **User description**
Cherry picked from https://github.com/kurrent-io/KurrentDB/pull/5324


___

### **Auto-created Ticket**

[#5372](https://github.com/kurrent-io/KurrentDB/issues/5372)

### **PR Type**
Bug fix


___

### **Description**
- Replace `First()` with `FirstOrDefault()` to prevent IndexOutOfRangeException

- Change gRPC services configuration from Server to Both for management plane


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ConnectorsCommandService"] -->|"Replace First() with FirstOrDefault()"| B["Safe RouteValues Access"]
  C["Contracts Project"] -->|"Update GrpcServices config"| D["Both Server and Client Support"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConnectorsCommandService.cs</strong><dd><code>Fix route values access in logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Connectors/KurrentDB.Connectors/Planes/Management/ConnectorsCommandService.cs

<ul><li>Replace <code>First()</code> with <code>FirstOrDefault()</code> when accessing RouteValues to <br>prevent IndexOutOfRangeException<br> <li> Improves robustness of logging when route values may be empty</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5371/files#diff-b83e89efa06fea5c877a68e636dab673b6ed86fb2592499c20ce227c48dfd0da">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KurrentDB.Connectors.Contracts.csproj</strong><dd><code>Update gRPC services configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Connectors/KurrentDB.Connectors.Contracts/KurrentDB.Connectors.Contracts.csproj

<ul><li>Change management plane protobuf GrpcServices attribute from Server to <br>Both<br> <li> Enables both server and client gRPC service generation for management <br>plane</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5371/files#diff-756b0e3c4442ff628908bcc9044e81231a25089090369c2a0a2736ed7a408b0c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

