### PR TITLE
[DB-1753] Update stream existence filter correctly with multi stream append (#5376)

### DIFF
--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -133,6 +133,7 @@ public abstract class ClusterVNode {
 	abstract public IAuthenticationProvider AuthenticationProvider { get; }
 	abstract public IHttpService HttpService { get; }
 	abstract public VNodeInfo NodeInfo { get; }
+	abstract public IReadIndex ReadIndex { get; }
 	abstract public CertificateDelegates.ClientCertificateValidator InternalClientCertificateValidator { get; }
 	abstract public Func<X509Certificate2> CertificateSelector { get; }
 	abstract public Func<X509Certificate2Collection> IntermediateCertificatesSelector { get; }
@@ -179,6 +180,7 @@ public class ClusterVNode<TStreamId> :
 
 	public override VNodeInfo NodeInfo { get; }
 
+	public override IReadIndex<TStreamId> ReadIndex => _readIndex;
 
 	private readonly IPublisher _mainQueue;
 	private readonly ISubscriber _mainBus;

--- a/src/KurrentDB.Core/Services/Storage/ReaderIndex/IndexBackend.cs
+++ b/src/KurrentDB.Core/Services/Storage/ReaderIndex/IndexBackend.cs
@@ -45,6 +45,9 @@ public class IndexBackend<TStreamId> : IIndexBackend<TStreamId> {
 
 	public ITransactionFileReader TFReader { get; }
 
+	public ILRUCache<TStreamId, EventNumberCached> StreamLastEventNumberCache => _streamLastEventNumberCache;
+	public ILRUCache<TStreamId, MetadataCached> StreamMetadataCache => _streamMetadataCache;
+
 	public EventNumberCached TryGetStreamLastEventNumber(TStreamId streamId) {
 		_streamLastEventNumberCache.TryGet(streamId, out var cacheInfo);
 		return cacheInfo;


### PR DESCRIPTION
### **User description**
cherry picked from  #5376

The LogV2StreamNameIndex had an assumption (no longer true) that all prepares in a transaction are for the same stream and was only adding one of them to the stream existence filter. This incorrect behaviour was masked because all streams were being added correctly to the LRU caches


___

### **Auto-created Ticket**

[#5379](https://github.com/kurrent-io/KurrentDB/issues/5379)

### **PR Type**
Bug fix


___

### **Description**
- Fixed stream existence filter to handle multi-stream transactions correctly

- Changed from only adding last prepare to adding all prepares with NoStream expectation

- Enhanced tests to verify reads work after cache clearing

- Exposed ReadIndex and cache properties for testing purposes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multi-stream Transaction"] -->|"Previously: Only last prepare added"| B["Incomplete Stream Filter"]
  A -->|"Now: All prepares checked"| C["Complete Stream Filter"]
  B -->|"Masked by LRU caches"| D["Incorrect behavior"]
  C -->|"Correct behavior"| E["Proper stream tracking"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LogV2StreamNameIndex.cs</strong><dd><code>Fix multi-stream prepare handling in existence filter</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/LogV2/LogV2StreamNameIndex.cs

<ul><li>Changed from only adding last prepare to iterating through all <br>prepares<br> <li> Now checks each prepare's ExpectedVersion individually for NoStream <br>condition<br> <li> Added comments explaining that prepares may be from different streams<br> <li> Maintains checkpoint update from last prepare for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5378/files#diff-771f09fce60780747d8a9e05b7a54b3aad70f5ab29914b54216dcd3f80f11528">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MultiStreamWritesTests.cs</strong><dd><code>Add cache-independent read verification tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs

<ul><li>Added verification that events can be read after multi-stream writes<br> <li> Added cache clearing tests to ensure stream existence filter works <br>independently<br> <li> Tests verify both streams return correct event numbers after cache <br>clear<br> <li> Applied same test pattern to both <code>succeeds</code> and <br><code>succeeds_with_aba_pattern</code> tests</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5378/files#diff-9803c4c40a9ce70e4c983fe6f4840f21defd6208c322648243c7ad65097559f2">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClusterVNode.cs</strong><dd><code>Expose ReadIndex property for testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/ClusterVNode.cs

<ul><li>Added abstract property <code>IReadIndex ReadIndex</code> to base class<br> <li> Implemented concrete property returning <code>_readIndex</code> instance<br> <li> Enables test access to read index and its backend caches</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5378/files#diff-f7d4c6ce44ecfbe1ec9d946df07fa60f60edb626595d28b7c0994c142ac23076">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IndexBackend.cs</strong><dd><code>Expose cache properties for test access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/Storage/ReaderIndex/IndexBackend.cs

<ul><li>Exposed <code>StreamLastEventNumberCache</code> as public property<br> <li> Exposed <code>StreamMetadataCache</code> as public property<br> <li> Allows tests to clear caches for verification purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5378/files#diff-f026b4fa4bc5921597f0bbfa7f98236b844f958522c1a0ec45840264e3c8b9a8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

