### PR TITLE
[DB-1760] Fix persistent subscription stall if client sends no Acks or Nacks (#5382)

### DIFF
--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -661,8 +661,8 @@ public class PersistentSubscription {
 
 			TryPushingMessagesToClients();
 			TryMarkCheckpoint(true);
-			if ((_state & PersistentSubscriptionState.Behind |
-				 PersistentSubscriptionState.OutstandingPageRequest) ==
+			if ((_state & (PersistentSubscriptionState.Behind |
+				 PersistentSubscriptionState.OutstandingPageRequest)) ==
 				PersistentSubscriptionState.Behind)
 				TryReadingNewBatch();
 		}


### PR DESCRIPTION
### **User description**
cherry pick of #5382

If a client is subscribed with a persistent subscription but neither ACKS or NAKS any events, the server will continue to retry them per the settings and eventually park them. However, during the process no additional reads top up the serverside historic buffer of events. Eventually the buffer will become empty and the subscription will stall until the leader changes or the subsystem is restarted.

This fix adds in the reads that were supposed to happen in these circumstances (there were missing parenthsis in the branch condition), so now the subscription will not stall and will continue to park the events.

Note that the stall can only manifest if the client doesn't send any ACKS or NACKS, which is an indicator of a problem in the client code.

(tests in master)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix persistent subscription stall caused by missing parentheses

- Corrects bitwise operation precedence in state condition check

- Ensures buffer reads occur when client sends no Acks/Nacks

- Prevents subscription from stalling until leader change/restart


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bitwise operation<br/>precedence issue"] -->|Add parentheses| B["Correct state<br/>condition evaluation"]
  B -->|Enable reads| C["Buffer replenished<br/>subscription continues"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PersistentSubscription.cs</strong><dd><code>Add parentheses to fix bitwise operation precedence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs

<ul><li>Added missing parentheses around bitwise OR operation in state <br>condition<br> <li> Fixes operator precedence to correctly evaluate <code>Behind | </code><br><code>OutstandingPageRequest</code> states<br> <li> Ensures <code>TryReadingNewBatch()</code> is called when subscription is behind<br> <li> Prevents buffer stall when clients don't send Acks or Nacks</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5383/files#diff-cc022709b34ac1dbf40f530b8d83772e803420a02202ff176451755de7ecec7f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

