### PR TITLE
[DB-1760] Fix persistent subscription stall if client sends no Acks or Nacks (#5382) (#5383)

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -661,8 +661,8 @@ public class PersistentSubscription {
 
 			TryPushingMessagesToClients();
 			TryMarkCheckpoint(true);
-			if ((_state & PersistentSubscriptionState.Behind |
-				 PersistentSubscriptionState.OutstandingPageRequest) ==
+			if ((_state & (PersistentSubscriptionState.Behind |
+				 PersistentSubscriptionState.OutstandingPageRequest)) ==
 				PersistentSubscriptionState.Behind)
 				TryReadingNewBatch();
 		}


### PR DESCRIPTION
Fixed: Persistent Subscription stall when client sends no Acks or Naks

### **User description**
cherrypick of #5382

If a client is subscribed with a persistent subscription but neither ACKS or NAKS any events, the server will continue to retry them per the settings and eventually park them. However, during the process no additional reads top up the serverside historic buffer of events. Eventually the buffer will become empty and the subscription will stall until the leader changes or the subsystem is restarted.

This fix adds in the reads that were supposed to happen in these circumstances (there were missing parenthsis in the branch condition), so now the subscription will not stall and will continue to park the events.

Note that the stall can only manifest if the client doesn't send any ACKS or NACKS, which is an indicator of a problem in the client code.

(tests in master)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix persistent subscription stall caused by missing parentheses in branch condition

- Ensures reads continue when client sends no Acks or Nacks

- Prevents server-side historic buffer from becoming empty

- Subscription now continues to park events instead of stalling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Branch Condition<br/>Missing Parentheses"] -->|Fixed| B["Correct Bitwise<br/>Operation"]
  B -->|Enables| C["TryReadingNewBatch<br/>Executes"]
  C -->|Maintains| D["Historic Buffer<br/>Populated"]
  D -->|Prevents| E["Subscription<br/>Stall"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PersistentSubscription.cs</strong><dd><code>Add missing parentheses to fix state condition logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs

<ul><li>Added missing parentheses around bitwise OR operation in branch <br>condition<br> <li> Corrects operator precedence to properly evaluate subscription state <br>flags<br> <li> Ensures <code>TryReadingNewBatch()</code> is called when subscription is Behind or <br>has OutstandingPageRequest<br> <li> Fixes logic that was preventing reads from topping up server-side <br>historic buffer</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5384/files#diff-f5532b1e5c29499e6d0462a7d2cffed3deb35b95153428ae0c99b1e0ee343adf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

