### PR TITLE
Make blazor work in net10

### DIFF
--- a/src/KurrentDB.Core/ClusterVNodeStartup.cs
+++ b/src/KurrentDB.Core/ClusterVNodeStartup.cs
@@ -139,7 +139,6 @@ public class ClusterVNodeStartup<TStreamId>
 			component.ConfigureApplication(app, _configuration);
 
 		_authenticationProvider.ConfigureEndpoints(app);
-		app.UseStaticFiles();
 
 		// Select an appropriate controller action and codec.
 		//    Success -> Add InternalContext (HttpEntityManager, urimatch, ...) to HttpContext

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -265,6 +265,7 @@ try {
 			}
 
 			hostedService.Node.Startup.Configure(app);
+			app.MapStaticAssets();
 			app.MapRazorComponents<App>()
 				.DisableAntiforgery()
 				.AddInteractiveServerRenderMode()


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace `UseStaticFiles()` with `MapStaticAssets()` for .NET 10 compatibility

- Aligns with modern ASP.NET Core static file handling patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UseStaticFiles<br/>deprecated"] -- "migrate to" --> B["MapStaticAssets<br/>.NET 10 compatible"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClusterVNodeStartup.cs</strong><dd><code>Update static file middleware for .NET 10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/ClusterVNodeStartup.cs

<ul><li>Replaced <code>app.UseStaticFiles()</code> with <code>app.MapStaticAssets()</code> in the <br><code>Configure</code> method<br> <li> Updates static file middleware to use the modern .NET 10 API<br> <li> Maintains existing application configuration flow and ordering</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5385/files#diff-9a3838e0cc6fc7ffb8d72515dfba8076fcbde6d10d65b83e7a32c33830c03104">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

