### PR TITLE
[DB-1765] Register legacy pipeline endpoints with routing

### DIFF
--- a/src/KurrentDB.Core/ApplicationBuilderExtensions.cs
+++ b/src/KurrentDB.Core/ApplicationBuilderExtensions.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+#nullable enable
+
+using System.Linq;
+using DotNext.Collections.Generic;
+using KurrentDB.Core.Services.Transport.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+namespace KurrentDB.Core;
+
+public static class ApplicationBuilderExtensions {
+	// Maps all the legacy pipeline routes to the legacy pipeline
+	// If we don't register them as routes MapStaticAssets intercepts some that it shouldn't
+	public static IEndpointRouteBuilder MapLegacyPipeline(
+		this IEndpointRouteBuilder app,
+		IHttpService httpService,
+		InternalDispatcherEndpoint internalDispatcher,
+		bool forcePlainTextMetrics) {
+
+		// map routes so that MapAssets doesn't intercept.
+		var legacyPipeline = ((IApplicationBuilder)app)
+			.New()
+			.UseLegacyPipeline(internalDispatcher, forcePlainTextMetrics)
+			.Build();
+
+		httpService
+			.Actions
+			.Select(action => ConvertToRoute(action.UriTemplate))
+			.Distinct()
+			.ForEach(pattern => {
+				app.Map(pattern, legacyPipeline);
+			});
+
+		return app;
+	}
+
+	static string ConvertToRoute(string uriTemplate) {
+		var route = uriTemplate.Split('?').First();
+		return System.Net.WebUtility.UrlDecode(route.EndsWith('/') ? route[..^1] : route);
+	}
+
+	static IApplicationBuilder UseLegacyPipeline(
+		this IApplicationBuilder app,
+		InternalDispatcherEndpoint internalDispatcher,
+		bool forcePlainTextMetrics) {
+
+		// Select an appropriate controller action and codec.
+		//    Success -> Add InternalContext (HttpEntityManager, urimatch, ...) to HttpContext
+		//    Fail -> Pipeline terminated with response.
+		app.UseMiddleware<KestrelToInternalBridgeMiddleware>();
+
+		// Looks up the InternalContext to perform the check.
+		// Terminal if auth check is not successful.
+		app.UseMiddleware<AuthorizationMiddleware>();
+
+			// Open telemetry currently guarded by our custom authz for consistency with stats
+		app.UseOpenTelemetryPrometheusScrapingEndpoint(x => {
+			if (x.Request.Path != "/metrics")
+				return false;
+
+			// Prometheus scrapes preferring application/openmetrics-text, but the prometheus exporter
+			// these days adds `_total` suffix to counters when outputting openmetrics format (as
+			// required by the spec). DisableTotalNameSuffixForCounters only affects plain text output.
+			// So if we are exporting legacy metrics, where we do not want the _total suffix for
+			// backwards compatibility, then force the exporter to respond with plain text metrics as it
+			// did in 23.10 and 24.10.
+			if (forcePlainTextMetrics)
+				x.Request.Headers.Remove("Accept");
+			return true;
+		});
+
+		// Internal dispatcher looks up the InternalContext to call the appropriate controller
+		app.Use((ctx, next) => internalDispatcher.InvokeAsync(ctx, next));
+
+		return app;
+	}
+}


### PR DESCRIPTION
### User description

Otherwise MapStaticAssets attempts to serve routes that should be served by the legacy pipeline

___

### **Description**
- Extract legacy pipeline middleware into reusable extension method

- Register legacy pipeline routes explicitly to prevent static asset interception

- Consolidate middleware configuration into dedicated MapLegacyPipeline method

- Convert URI templates to route patterns for proper endpoint mapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ClusterVNodeStartup.Configure"] -->|calls| B["MapLegacyPipeline"]
  B -->|extracts routes from| C["IHttpService.Actions"]
  B -->|converts URI templates| D["Route patterns"]
  B -->|maps each pattern| E["Legacy pipeline middleware"]
  E -->|includes| F["KestrelToInternalBridge"]
  E -->|includes| G["Authorization"]
  E -->|includes| H["OpenTelemetry metrics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApplicationBuilderExtensions.cs</strong><dd><code>New extension method for legacy pipeline route registration</code></dd></summary>
<hr>

src/KurrentDB.Core/ApplicationBuilderExtensions.cs

<ul><li>New file creating extension method <code>MapLegacyPipeline</code> for registering <br>legacy pipeline routes<br> <li> Extracts distinct URI template routes from <code>IHttpService.Actions</code> and <br>converts them to route patterns<br> <li> Consolidates middleware pipeline (KestrelToInternalBridge, <br>Authorization, OpenTelemetry, InternalDispatcher) into reusable method<br> <li> Implements <code>ConvertToRoute</code> helper to normalize URI templates by <br>removing query strings and trailing slashes</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5388/files#diff-6b75d219b0b3cb8a87a8703d056f998f085bd7dca107de2eee0717c5f8ad5719">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClusterVNodeStartup.cs</strong><dd><code>Refactor to use MapLegacyPipeline extension method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/ClusterVNodeStartup.cs

<ul><li>Removes inline middleware registration code (KestrelToInternalBridge, <br>Authorization, OpenTelemetry, InternalDispatcher)<br> <li> Replaces removed middleware stack with single call to <br><code>MapLegacyPipeline</code> extension method<br> <li> Simplifies Configure method by delegating legacy pipeline setup to <br>dedicated extension</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5388/files#diff-9a3838e0cc6fc7ffb8d72515dfba8076fcbde6d10d65b83e7a32c33830c03104">+1/-27</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

