### PR TITLE
Fix memory limit calculation

### DIFF
--- a/src/KurrentDB.Core/DuckDB/DuckDBConnectionPoolLifetime.cs
+++ b/src/KurrentDB.Core/DuckDB/DuckDBConnectionPoolLifetime.cs
@@ -36,7 +36,7 @@ public class DuckDBConnectionPoolLifetime : Disposable {
 		}
 
 		var total = CalculateRam();
-		var duckDbRam = (int)total * 0.25;
+		var duckDbRam = (int)(total * 0.25);
 		var settings = new Dictionary<string, string> {
 			["memory_limit"] = $"{duckDbRam}MB"
 		};


### PR DESCRIPTION
### **User description**
The previous implementation has a bug as it produces a double number which causes DuckDB to complain that the limit is not correct when we attempt to set the limit to a non-integer number with decimals


___

### **Auto-created Ticket**

[#5408](https://github.com/kurrent-io/KurrentDB/issues/5408)

### **PR Type**
Bug fix


___

### **Description**
- Fix operator precedence in memory limit calculation

- Ensure integer conversion happens after multiplication

- Prevent DuckDB from receiving decimal memory limit values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Memory calculation<br/>(total * 0.25)"] -->|"Cast to int<br/>after multiply"| B["Correct integer<br/>memory limit"]
  C["Old: cast first<br/>then multiply"] -->|"Produces decimal"| D["DuckDB error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DuckDBConnectionPoolLifetime.cs</strong><dd><code>Fix memory limit calculation parentheses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/DuckDB/DuckDBConnectionPoolLifetime.cs

<ul><li>Fixed operator precedence in memory limit calculation by moving <br>parentheses<br> <li> Changed from <code>(int)total * 0.25</code> to <code>(int)(total * 0.25)</code><br> <li> Ensures multiplication occurs before integer conversion, preventing <br>decimal values<br> <li> Resolves DuckDB validation error for non-integer memory limits</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5407/files#diff-b7624c4b9b4dcbf9b07251a40520bec7648aa5bbcaa7572bb5879f96bd32f1ce">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

