### PR TITLE
Fix query ui

### DIFF
--- a/src/KurrentDB/Components/Query/QueryHelpDialog.razor
+++ b/src/KurrentDB/Components/Query/QueryHelpDialog.razor
@@ -34,7 +34,7 @@ Query one or more available sources like streams, categories, or everything.
 |----------|------------|-------------|
 | `stream:<name>` | Query a stream | `select * from stream:Order-123` |
 | `category:<name>` | Query a category | `select * from category:Order where data->>'customerId'='bob'` |
-| `index:<name>` | Query a custom index | `select * from index:orders-by-country where country='Mauritius'` |
+| `index:<name>` | Query a user index | `select * from index:orders-by-country where country='Mauritius'` |
 | `all_events` | Query all log records | `select * from all_events limit 10` |
 
 **Consider adding `limit` to the query to constrain the scan surface.**

--- a/src/KurrentDB/Components/Query/QueryService.cs
+++ b/src/KurrentDB/Components/Query/QueryService.cs
@@ -28,10 +28,10 @@ public static partial class QueryService {
 			string cte;
 			switch (tokens[0]) {
 				case "stream":
-					cte = string.Format(AllCteTemplate, cteName, $"stream = '{tokens[1]}'");
+					cte = string.Format(AllCteTemplate, cteName, $"where stream = '{tokens[1]}'");
 					break;
 				case "category":
-					cte = string.Format(AllCteTemplate, cteName, $"category = '{tokens[1]}'");
+					cte = string.Format(AllCteTemplate, cteName, $"where category = '{tokens[1]}'");
 					break;
 				case "index":
 					var indexName = tokens[1];


### PR DESCRIPTION
### **Auto-created Ticket**

[#5412](https://github.com/kurrent-io/KurrentDB/issues/5412)

### **PR Type**
Bug fix


___

### **Description**
- Add missing `where` keyword to stream and category query filters

- Update documentation to clarify index query terminology


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query Service"] -->|"Add WHERE keyword"| B["Stream/Category Filters"]
  C["Query Help Dialog"] -->|"Update terminology"| D["Index Documentation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QueryService.cs</strong><dd><code>Add WHERE keyword to query filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB/Components/Query/QueryService.cs

<ul><li>Add <code>where</code> keyword to stream filter CTE template<br> <li> Add <code>where</code> keyword to category filter CTE template<br> <li> Ensures proper SQL syntax for generated Common Table Expressions</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5411/files#diff-218ce249698556c451cd1ee69a80127b1a6c41306578e0544d5c3de187a4b9b6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QueryHelpDialog.razor</strong><dd><code>Update index documentation terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB/Components/Query/QueryHelpDialog.razor

<ul><li>Change "custom index" to "user index" in documentation table<br> <li> Clarifies terminology for user-created indexes</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5411/files#diff-4700ee2e58f86c6c554bee55087a777f5f4d509f86fce890a50927fdfb9dcf70">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

