### PR TITLE
[DB-1792] Apply missed review suggestion from User Defined Indexes: return list rather than map

### DIFF
--- a/proto/kurrentdb/protocol/v2/indexes/queries.proto
+++ b/proto/kurrentdb/protocol/v2/indexes/queries.proto
@@ -10,7 +10,7 @@ message ListIndexesRequest {
 }
 
 message ListIndexesResponse {
-  map<string, Index> indexes = 1;
+  repeated Index indexes = 1;
 }
 
 message GetIndexRequest {
@@ -22,7 +22,8 @@ message GetIndexResponse {
 }
 
 message Index {
-  string filter = 1;
-  repeated IndexField fields = 2;
-  IndexState state = 3;
+  string name = 1;
+  string filter = 2;
+  repeated IndexField fields = 3;
+  IndexState state = 4;
 }

--- a/src/KurrentDB.Api.V2.Tests/Modules/Indexes/IndexesServiceHttpTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Indexes/IndexesServiceHttpTests.cs
@@ -69,7 +69,7 @@ public class IndexesServiceHttpTests {
 			new RestRequest($"/v2/indexes/"),
 			ct);
 
-		await Assert.That(response!.Indexes.TryGetValue(IndexName, out var indexState)).IsTrue();
+		var indexState = response!.Indexes.First(x => x.Name == IndexName);
 		await Assert.That(indexState!.Filter).IsEqualTo("rec => rec.type == 'my-event-type'");
 		await Assert.That(indexState!.Fields.Length).IsEqualTo(1);
 		await Assert.That(indexState!.Fields[0].Selector).IsEqualTo("rec => rec.number");
@@ -78,9 +78,10 @@ public class IndexesServiceHttpTests {
 	}
 
 	class ListResponse {
-		public Dictionary<string, IndexState> Indexes { get; set; } = [];
+		public IndexState[] Indexes { get; set; } = [];
 
 		public class IndexState {
+			public string Name { get; set; } = "";
 			public string Filter { get; set; } = "";
 			public Field[] Fields { get; set; } = [];
 			public string State { get; set; } = "";
@@ -133,7 +134,7 @@ public class IndexesServiceHttpTests {
 			new RestRequest($"/v2/indexes/"),
 			ct);
 
-		await Assert.That(listResponse!.Indexes).DoesNotContainKey(IndexName);
+		await Assert.That(listResponse!.Indexes).DoesNotContain(x => x.Name == IndexName);
 	}
 
 	async ValueTask can_get(string expectedState, CancellationToken ct) {
@@ -144,6 +145,7 @@ public class IndexesServiceHttpTests {
 		await Assert.That(response.Content).IsJson($$"""
 			{
 				"index": {
+					"name": "{{IndexName}}",
 					"filter": "rec => rec.type == 'my-event-type'",
 					"fields": [{
 						"name": "number",

--- a/src/KurrentDB.Api.V2.Tests/Modules/Indexes/IndexesServiceTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Indexes/IndexesServiceTests.cs
@@ -142,7 +142,7 @@ public class IndexesServiceTests {
 	public async ValueTask can_list(CancellationToken ct) {
 		var response = await IndexesClient.ListAsync(new(), cancellationToken: ct);
 
-		await Assert.That(response!.Indexes.TryGetValue(IndexName, out var indexState)).IsTrue();
+		var indexState = response!.Indexes.First(x => x.Name == IndexName);
 		await Assert.That(indexState!.Filter).IsEqualTo("rec => rec.type == 'my-event-type'");
 		await Assert.That(indexState!.Fields.Count).IsEqualTo(1);
 		await Assert.That(indexState!.Fields[0].Selector).IsEqualTo("rec => rec.number");
@@ -161,7 +161,7 @@ public class IndexesServiceTests {
 
 		// no longer listed
 		var response = await IndexesClient.ListAsync(new(), cancellationToken: ct);
-		await Assert.That(response!.Indexes).DoesNotContainKey(IndexName);
+		await Assert.That(response!.Indexes).DoesNotContain(x => x.Name == IndexName);
 	}
 
 	[Test]
@@ -329,6 +329,7 @@ public class IndexesServiceTests {
 		var response = await IndexesClient.GetAsync(
 			new() { Name = indexName },
 			cancellationToken: ct);
+		await Assert.That(response.Index.Name).IsEqualTo(indexName);
 		await Assert.That(response.Index.Filter).IsEqualTo("rec => rec.type == 'my-event-type'");
 		await Assert.That(response.Index.Fields.Count).IsEqualTo(1);
 		await Assert.That(response.Index.Fields[0].Selector).IsEqualTo("rec => rec.number");

--- a/src/KurrentDB.SecondaryIndexing/Indexes/User/Management/UserIndexReadsideService.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/User/Management/UserIndexReadsideService.cs
@@ -90,6 +90,7 @@ public class UserIndexReadsideService(
 	}
 
 	public record UserIndexState : State<UserIndexState> {
+		public string Name { get; init; } = "";
 		public string Filter { get; init; } = "";
 		public IList<IndexField> Fields { get; init; } = [];
 		public IndexState State { get; init; }
@@ -97,6 +98,7 @@ public class UserIndexReadsideService(
 		public UserIndexState() {
 			On<IndexCreated>((state, evt) =>
 				state with {
+					Name = evt.Name,
 					Filter = evt.Filter,
 					Fields = evt.Fields,
 					State = IndexState.Stopped,
@@ -138,6 +140,7 @@ public class UserIndexReadsideService(
 
 file static class Extensions {
 	public static Protocol.V2.Indexes.Index Convert(this UserIndexReadsideService.UserIndexState self) => new() {
+		Name = self.Name,
 		Filter = self.Filter,
 		Fields = { self.Fields },
 		State = self.State,
@@ -146,7 +149,7 @@ file static class Extensions {
 	public static ListIndexesResponse Convert(this UserIndexReadsideService.UserIndexesState self) {
 		var result = new ListIndexesResponse();
 		foreach (var (name, userIndex) in self.UserIndexes)
-			result.Indexes[name] = userIndex.Convert();
+			result.Indexes.Add(userIndex.Convert());
 		return result;
 	}
 }

--- a/src/KurrentDB/Components/Query/QueryHelpDialog.razor
+++ b/src/KurrentDB/Components/Query/QueryHelpDialog.razor
@@ -34,7 +34,7 @@ Query one or more available sources like streams, categories, or everything.
 |----------|------------|-------------|
 | `stream:<name>` | Query a stream | `select * from stream:Order-123` |
 | `category:<name>` | Query a category | `select * from category:Order where data->>'customerId'='bob'` |
-| `index:<name>` | Query a user index | `select * from index:orders-by-country where country='Mauritius'` |
+| `index:<name>` | Query a user index | `select * from index:orders-by-country where field_country='Mauritius'` |
 | `all_events` | Query all log records | `select * from all_events limit 10` |
 
 **Consider adding `limit` to the query to constrain the scan surface.**


### PR DESCRIPTION
### **Auto-created Ticket**

[#5418](https://github.com/kurrent-io/KurrentDB/issues/5418)

### **PR Type**
Enhancement


___

### **Description**
- Changed indexes response from map to list structure

- Added name field to Index protobuf message

- Updated test assertions to work with list-based indexes

- Fixed query example in documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Map-based<br/>Indexes Response"] -->|"Refactor to<br/>List Structure"| B["List-based<br/>Indexes Response"]
  B -->|"Add Name Field"| C["Index with<br/>Name Property"]
  D["Test Assertions<br/>Dictionary Methods"] -->|"Update to<br/>List Methods"| E["Test Assertions<br/>LINQ Methods"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>queries.proto</strong><dd><code>Convert indexes map to repeated list in protobuf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

proto/kurrentdb/protocol/v2/indexes/queries.proto

<ul><li>Changed <code>ListIndexesResponse.indexes</code> from <code>map<string, Index></code> to <br><code>repeated Index</code><br> <li> Added <code>name</code> field to <code>Index</code> message as field 1<br> <li> Renumbered existing fields (<code>filter</code>, <code>fields</code>, <code>state</code>) to accommodate new <br>name field</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5417/files#diff-28f66339895330e2087bb042fb97bf8d7e5d328fb618337c4dcf7c5dd40e2cd9">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserIndexReadsideService.cs</strong><dd><code>Add name field and convert to list-based response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.SecondaryIndexing/Indexes/User/Management/UserIndexReadsideService.cs

<ul><li>Added <code>Name</code> property to <code>UserIndexState</code> record<br> <li> Updated <code>IndexCreated</code> event handler to populate the <code>Name</code> field<br> <li> Modified <code>Convert()</code> extension method to include name in converted Index<br> <li> Changed <code>ListIndexesResponse</code> conversion from dictionary assignment to <br>list addition</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5417/files#diff-a331dd07f70cf1755ef7e12c2897a98956fea0a935dfde53cc5f4c39b8112248">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IndexesServiceHttpTests.cs</strong><dd><code>Update HTTP tests for list-based indexes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Api.V2.Tests/Modules/Indexes/IndexesServiceHttpTests.cs

<ul><li>Changed <code>ListResponse.Indexes</code> from <code>Dictionary<string, IndexState></code> to <br><code>IndexState[]</code><br> <li> Added <code>Name</code> property to <code>IndexState</code> class<br> <li> Updated test to use <code>First()</code> LINQ method instead of <code>TryGetValue()</code><br> <li> Changed assertion from <code>DoesNotContainKey()</code> to <code>DoesNotContain()</code> with <br>lambda predicate<br> <li> Added <code>name</code> field assertion in JSON response validation</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5417/files#diff-2f0cfe7ff03df4779569edd43ba76dae4c2a28920f49b7528676d5b6c2a3ea5c">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IndexesServiceTests.cs</strong><dd><code>Update integration tests for list-based indexes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Api.V2.Tests/Modules/Indexes/IndexesServiceTests.cs

<ul><li>Updated <code>can_list()</code> test to use <code>First()</code> instead of <code>TryGetValue()</code> for <br>finding indexes<br> <li> Changed <code>DoesNotContainKey()</code> assertion to <code>DoesNotContain()</code> with lambda <br>predicate<br> <li> Added assertion to verify <code>Name</code> property in <code>GetAsync()</code> response</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5417/files#diff-5ed998dd13379b04659ac505e8cee0203cab85118c1d6db3e202576c99fd9b06">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QueryHelpDialog.razor</strong><dd><code>Fix query example field name in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB/Components/Query/QueryHelpDialog.razor

<ul><li>Updated query example in documentation from <code>country='Mauritius'</code> to <br><code>field_country='Mauritius'</code></ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5417/files#diff-4700ee2e58f86c6c554bee55087a777f5f4d509f86fce890a50927fdfb9dcf70">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

