### PR TITLE
[DB-1805] Clarify error message about ABA multi stream append pattern

### DIFF
--- a/src/KurrentDB.Api.V2/Modules/Streams/ApiErrors.cs
+++ b/src/KurrentDB.Api.V2/Modules/Streams/ApiErrors.cs
@@ -72,7 +72,7 @@ public static partial class ApiErrors {
 	public static RpcException StreamAlreadyInAppendSession(string stream) {
 		Debug.Assert(!string.IsNullOrWhiteSpace(stream), "The stream cannot be empty!");
 
-		var message = $"Stream '{stream}' is has a different group of messages in this session. " +
+		var message = $"Stream '{stream}' already has a different group of messages in this session. " +
 		              $"Appends for the same stream must currently be grouped together and not interleaved with appends for other streams.";
 
         //KurrentDB.Protocol.V2.Streams.Errors.StreamsError.StreamAlreadyInAppendSessionErrorDetails


### PR DESCRIPTION
### **User description**
Previous message caused some confusion making it sound like multi stream append only supports one message per stream.

It does support multiple messages per stream, but those messages must be grouped together.


___

### **Auto-created Ticket**

[#5433](https://github.com/kurrent-io/KurrentDB/issues/5433)

### **PR Type**
Documentation


___

### **Description**
- Clarifies error message about multi-stream append pattern

- Explains that messages must be grouped together

- Removes misleading "not supported" language


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldMsg["Old: 'multiple times not supported'"] -- "clarified to" --> newMsg["New: 'must be grouped together'"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApiErrors.cs</strong><dd><code>Clarify stream append grouping error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Api.V2/Modules/Streams/ApiErrors.cs

<ul><li>Updated <code>StreamAlreadyInAppendSession</code> error message to clarify <br>multi-stream append behavior<br> <li> Changed message from stating "multiple times not supported" to <br>explaining "must be grouped together"<br> <li> Clarified that the issue is interleaving appends, not the count of <br>messages per stream</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5432/files#diff-f00ecbd5c353e1f4301026d15a17c2422278097b56492a0c2e2a635ea7eeee0f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

