### PR TITLE
[DB-1831] Make the primary yaml file take priority over the json files

### DIFF
--- a/src/KurrentDB.Core/Configuration/KurrentConfiguration.cs
+++ b/src/KurrentDB.Core/Configuration/KurrentConfiguration.cs
@@ -34,7 +34,6 @@ public static class KurrentConfiguration {
 			// check for the existence of KurrentDB default locations
 			// if they do not exist, use the EventStore ones if the EventStore location exists.
 			.AddLegacyDefaultLocations(optionsWithLegacyDefaults)
-			.AddKurrentYamlConfigFile(configFile.Path, configFile.Optional)
 
 			.AddSection($"{KurrentConfigurationKeys.Prefix}:Metrics",
 				x => x.AddKurrentConfigFile("metricsconfig.json", true, true))
@@ -47,6 +46,7 @@ public static class KurrentConfiguration {
 			// directory. We use the subdirectory to ensure that we only load configuration files.
 			.AddLegacyEventStoreConfigFiles("*.json")
 			.AddKurrentConfigFiles("*.json")
+			.AddKurrentYamlConfigFile(configFile.Path, configFile.Optional)
 
 #if DEBUG
 			// load all json files in the current directory


### PR DESCRIPTION
### **User description**
So that users can override the settings from the default json files (logconfig.json, metricsconfig.json etc) in their yaml file, where user configuration most commonly lives

e.g.

```
Metrics:
  SlowMessageMilliseconds:
    MainBus: 48
```


___

### **Auto-created Ticket**

[#5443](https://github.com/kurrent-io/KurrentDB/issues/5443)

### **PR Type**
Enhancement


___

### **Description**
- Reorders configuration loading to prioritize YAML over JSON files

- Allows users to override default JSON settings via YAML configuration

- Moves YAML file loading to end of configuration builder chain


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Default Values"] --> B["Legacy Defaults"]
  B --> C["JSON Config Files"]
  C --> D["YAML Config File"]
  D --> E["Final Configuration"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KurrentConfiguration.cs</strong><dd><code>Reorder YAML loading for configuration priority</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Configuration/KurrentConfiguration.cs

<ul><li>Moved <code>AddKurrentYamlConfigFile()</code> call from early position to end of <br>configuration builder chain<br> <li> YAML configuration now loads after all JSON files, ensuring it takes <br>priority<br> <li> Maintains all other configuration sources in their original order</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5442/files#diff-6739115448e5f7df4bedd29633c95831a86272cb1c5cda0f17d68280c55cfa92">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

