### PR TITLE
[DB-1825][24.10] Fix projection stall race condition when writing empty transactions (#5428)

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -484,7 +484,7 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 				new StorageMessage.EventCommitted(tfPos.CommitPosition, eventRecord.record, isTfEof: false));
 		}
 
-		_bus.Publish(new StorageMessage.TfEofAtNonCommitRecord());
+		_bus.Publish(new StorageMessage.IndexedToEndOfTransactionFile());
 
 		var firstEventNumber = list.Count - events.Length;
 		envelope?.ReplyWith(writeEventsCompleted(firstEventNumber, firstEventNumber + events.Length - 1));

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_commits_empty_transaction_at_end_of_log.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_commits_empty_transaction_at_end_of_log.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.IndexCommitter;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+public class when_index_committer_service_commits_empty_transaction_at_end_of_log<TLogFormat, TStreamId> : with_index_committer_service<TLogFormat, TStreamId> {
+	private readonly long _logPrePosition = 4000;
+	private readonly long _logPostPosition = 4001;
+
+	public override void Given() { }
+
+	public override void When() {
+		WriterCheckpoint.Write(_logPostPosition);
+		WriterCheckpoint.Flush();
+
+		// chase empty transaction into index committer service
+		Service.AddPendingPrepare(
+			transactionPosition: _logPrePosition,
+			prepares: [],
+			postPosition: _logPostPosition);
+
+		Service.Handle(new StorageMessage.CommitAck(Guid.NewGuid(), _logPrePosition, _logPrePosition, 0, 0));
+
+		// replicate it
+		ReplicationCheckpoint.Write(_logPostPosition);
+		ReplicationCheckpoint.Flush();
+		Service.Handle(new ReplicationTrackingMessage.ReplicatedTo(_logPostPosition));
+	}
+
+	[Test]
+	public void indexed_to_end_of_transaction_file_message_should_have_been_published() {
+		AssertEx.IsOrBecomesTrue(() => 1 == CommitReplicatedMgs.Count);
+		Assert.AreEqual(1, IndexedToEndOfTransactionFileMgs.Count);
+	}
+}

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/with_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/with_index_committer_service.cs
@@ -24,8 +24,9 @@ public abstract class with_index_committer_service<TLogFormat, TStreamId> {
 	protected ICheckpoint ReplicationCheckpoint;
 	protected ICheckpoint WriterCheckpoint;
 	protected SynchronousScheduler Publisher = new("publisher");
-	protected ConcurrentQueue<StorageMessage.CommitIndexed> CommitReplicatedMgs = new ConcurrentQueue<StorageMessage.CommitIndexed>();
-	protected ConcurrentQueue<ReplicationTrackingMessage.IndexedTo> IndexWrittenMgs = new ConcurrentQueue<ReplicationTrackingMessage.IndexedTo>();
+	protected ConcurrentQueue<StorageMessage.CommitIndexed> CommitReplicatedMgs = [];
+	protected ConcurrentQueue<StorageMessage.IndexedToEndOfTransactionFile> IndexedToEndOfTransactionFileMgs = [];
+	protected ConcurrentQueue<ReplicationTrackingMessage.IndexedTo> IndexWrittenMgs = [];
 
 	protected IndexCommitterService<TStreamId> Service;
 	protected FakeIndexCommitter<TStreamId> IndexCommitter;
@@ -41,6 +42,7 @@ public abstract class with_index_committer_service<TLogFormat, TStreamId> {
 		Service = new IndexCommitterService<TStreamId>(IndexCommitter, Publisher, WriterCheckpoint, ReplicationCheckpoint, TableIndex, new QueueStatsManager());
 		Service.Init(0);
 		Publisher.Subscribe(new AdHocHandler<StorageMessage.CommitIndexed>(m => CommitReplicatedMgs.Enqueue(m)));
+		Publisher.Subscribe(new AdHocHandler<StorageMessage.IndexedToEndOfTransactionFile>(m => IndexedToEndOfTransactionFileMgs.Enqueue(m)));
 		Publisher.Subscribe(new AdHocHandler<ReplicationTrackingMessage.IndexedTo>(m => IndexWrittenMgs.Enqueue(m)));
 		Publisher.Subscribe<ReplicationTrackingMessage.ReplicatedTo>(Service);
 		Given();
@@ -58,7 +60,7 @@ public abstract class with_index_committer_service<TLogFormat, TStreamId> {
 	protected void AddPendingPrepare(long transactionPosition, long postPosition = -1) {
 		postPosition = postPosition == -1 ? transactionPosition : postPosition;
 		var prepare = CreatePrepare(transactionPosition, transactionPosition);
-		Service.AddPendingPrepare(new[] { prepare }, postPosition);
+		Service.AddPendingPrepare(prepare.TransactionPosition, [prepare], postPosition);
 	}
 
 	protected void AddPendingPrepares(long transactionPosition, long[] logPositions) {
@@ -67,7 +69,7 @@ public abstract class with_index_committer_service<TLogFormat, TStreamId> {
 			prepares.Add(CreatePrepare(transactionPosition, pos));
 		}
 
-		Service.AddPendingPrepare(prepares.ToArray(), logPositions[^1]);
+		Service.AddPendingPrepare(prepares[0].TransactionPosition, prepares.ToArray(), logPositions[^1]);
 	}
 
 	private IPrepareLogRecord<TStreamId> CreatePrepare(long transactionPosition, long logPosition) {

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_commit_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_commit_event.cs
@@ -39,7 +39,7 @@ public class when_chaser_reads_commit_event<TLogFormat, TStreamId> : with_storag
 		Assert.True(Writer.Write(record, out _logPosition));
 		Writer.Flush();
 
-		IndexCommitter.AddPendingPrepare(new[] { record }, _logPosition);
+		IndexCommitter.AddPendingPrepare(record.TransactionPosition, [record], _logPosition);
 		var record2 = new CommitLogRecord(
 			logPosition: _logPosition,
 			correlationId: _transactionId,

--- a/src/EventStore.Core.Tests/Services/Storage/FakeIndexCommitterService.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeIndexCommitterService.cs
@@ -25,7 +25,7 @@ public class FakeIndexCommitterService<TStreamId> : IIndexCommitterService<TStre
 		PostPosition = postPosition;
 	}
 
-	public void AddPendingPrepare(IPrepareLogRecord<TStreamId>[] prepares, long postPosition) {
+	public void AddPendingPrepare(long transactionPosition, IPrepareLogRecord<TStreamId>[] prepares, long postPosition) {
 		if (prepares == null)
 			throw new InvalidOperationException("Cannot commit a null transaction");
 		if (prepares.Length <= 0)

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -249,9 +249,12 @@ public static partial class StorageMessage {
 		}
 	}
 
+	// This message is a notification that primary indexing has reached the end of the transaction log.
+	// Normally this is indicated with an EventCommitted message that has the TfEof flag set to true,
+	// but this message is sent instead when (1) the end of the log is not an Event at all (2) after the initial index catchup.
 	[DerivedMessage(CoreMessage.Storage)]
-	public partial class TfEofAtNonCommitRecord : Message {
-		public TfEofAtNonCommitRecord() {
+	public partial class IndexedToEndOfTransactionFile : Message {
+		public IndexedToEndOfTransactionFile() {
 		}
 	}
 

--- a/src/EventStore.Core/Services/AwakeReaderService/AwakeService.cs
+++ b/src/EventStore.Core/Services/AwakeReaderService/AwakeService.cs
@@ -10,10 +10,15 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.AwakeReaderService;
 
-public class AwakeService : IHandle<AwakeServiceMessage.SubscribeAwake>,
+// The AwakerService notifies subscribers when new events are committed to particular streams or $all
+// It calls the callbacks when it reaches the end of the log (or a threshold) rather than immediately on new event because
+// the subscriber will usually issue a read, so may as well wait until the events currently being written are available to
+// be returned in that read, saving multiple resubscriptions.
+public class AwakeService :
+	IHandle<AwakeServiceMessage.SubscribeAwake>,
 	IHandle<AwakeServiceMessage.UnsubscribeAwake>,
 	IHandle<StorageMessage.EventCommitted>,
-	IHandle<StorageMessage.TfEofAtNonCommitRecord> {
+	IHandle<StorageMessage.IndexedToEndOfTransactionFile> {
 	private readonly Dictionary<string, HashSet<AwakeServiceMessage.SubscribeAwake>> _subscribers =
 		new Dictionary<string, HashSet<AwakeServiceMessage.SubscribeAwake>>();
 
@@ -121,7 +126,7 @@ public class AwakeService : IHandle<AwakeServiceMessage.SubscribeAwake>,
 		}
 	}
 
-	public void Handle(StorageMessage.TfEofAtNonCommitRecord message) {
+	public void Handle(StorageMessage.IndexedToEndOfTransactionFile message) {
 		EndReplyBatch();
 		BeginReplyBatch();
 	}

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -220,7 +220,7 @@ public class IndexCommitter<TStreamId> : IndexCommitter, IIndexCommitter<TStream
 			Log.Debug("StreamExistenceFilter initialized. Time elapsed: {elapsed}.",
 				DateTime.UtcNow - startTime);
 
-			_bus.Publish(new StorageMessage.TfEofAtNonCommitRecord());
+			_bus.Publish(new StorageMessage.IndexedToEndOfTransactionFile());
 			_backend.SetSystemSettings(GetSystemSettings());
 		}
 		_indexRebuild = false;

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -14,10 +14,10 @@ namespace EventStore.Core.TransactionLog.LogRecords;
 [Flags]
 public enum PrepareFlags : ushort {
 	None = 0x00,
-	Data = 0x01, // prepare contains data
+	Data = 0x01, // prepare contains data, occupies an event number in its stream
 	TransactionBegin = 0x02, // prepare starts transaction
 	TransactionEnd = 0x04, // prepare ends transaction
-	StreamDelete = 0x08, // prepare deletes stream
+	StreamDelete = 0x08, // prepare hard deletes stream
 
 	IsCommitted = 0x20, // prepare should be considered committed immediately, no commit will follow in TF
 						//Update = 0x30,                  // prepare updates previous instance of the same event, DANGEROUS!
@@ -50,7 +50,10 @@ public class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, IPrepar
 	public PrepareFlags Flags { get; }
 	public long TransactionPosition { get; }
 	public int TransactionOffset { get; }
-	public long ExpectedVersion { get; } // if IsCommitted is set, this is final EventNumber
+	// if IsCommitted is set then ExpectedVersion is EventNumber - 1 else ExpectedVersion is Any (-2)
+	// we store the expected version instead of the event number directly because this record does not necessarily have one.
+	// (when uncommitted, also when neither PrepareFlags.Data nor PrepareFlags.StreamDelete)
+	public long ExpectedVersion { get; }
 	public string EventStreamId { get; }
 	private int? _eventStreamIdSize;
 	public Guid EventId { get; }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithExistingEvents.cs
@@ -46,7 +46,7 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Eve
 
 		AwakeService = new AwakeService();
 		_bus.Subscribe<StorageMessage.EventCommitted>(AwakeService);
-		_bus.Subscribe<StorageMessage.TfEofAtNonCommitRecord>(AwakeService);
+		_bus.Subscribe<StorageMessage.IndexedToEndOfTransactionFile>(AwakeService);
 		_bus.Subscribe<AwakeServiceMessage.SubscribeAwake>(AwakeService);
 		_bus.Subscribe<AwakeServiceMessage.UnsubscribeAwake>(AwakeService);
 		_bus.Subscribe(new UnwrapEnvelopeHandler());

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
@@ -104,7 +104,7 @@ public abstract class specification_with_projection_management_service<TLogForma
 
 		AwakeService = new AwakeService();
 		_bus.Subscribe<StorageMessage.EventCommitted>(AwakeService);
-		_bus.Subscribe<StorageMessage.TfEofAtNonCommitRecord>(AwakeService);
+		_bus.Subscribe<StorageMessage.IndexedToEndOfTransactionFile>(AwakeService);
 		_bus.Subscribe<AwakeServiceMessage.SubscribeAwake>(AwakeService);
 		_bus.Subscribe<AwakeServiceMessage.UnsubscribeAwake>(AwakeService);
 

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -202,7 +202,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 	private static void CreateAwakerService(StandardComponents standardComponents) {
 		var awakeReaderService = new AwakeService();
 		standardComponents.MainBus.Subscribe<StorageMessage.EventCommitted>(awakeReaderService);
-		standardComponents.MainBus.Subscribe<StorageMessage.TfEofAtNonCommitRecord>(awakeReaderService);
+		standardComponents.MainBus.Subscribe<StorageMessage.IndexedToEndOfTransactionFile>(awakeReaderService);
 		standardComponents.MainBus.Subscribe<AwakeServiceMessage.SubscribeAwake>(awakeReaderService);
 		standardComponents.MainBus.Subscribe<AwakeServiceMessage.UnsubscribeAwake>(awakeReaderService);
 	}


### PR DESCRIPTION
Fixed: projection stall race condition when writing empty transactions

### **User description**
backport from #5428

If a projection had finished processing all events in its input stream, and then another event was written to its input stream, under certain conditions a race condition meant that the projection would remain idle and not process that new event.

The projection would process that new event (and any subsequent events) if any event was written to any stream. i.e. the stalled projection could be recovered by writing any event to any stream.

The stall requires transactions without any events in to be written.

When a projection reaches the end of its input stream, it subscribes to the AwakerService to be notified when there are more events to process.

When a new event is committed, AwakerService decides which subscribers need to be notified. However, it only notifies them when the indexing process reaches the end of the log or a threshold is reached. (This prevents unnecessary notifications and resubscriptions).

Unfortunately, the AwakerService was only notified when the indexing process reaches the end of the log if the last record in the log was an event. This was almost always the case, but is not the case if the last record is an empty transaction containing no events (i.e. the client sent an append request with 0 events in).

A stall could therefore occur if a projection has subscribed to the AwakerService, then an event E that it is interested in is written, immediately followed by an empty transaction before E is indexed (this is the race). The AwakerService would then know that the projection needs notifying, but will not notify it, waiting instead to be notified that the indexing process has reached the end of the log, which it never will, unless another event is written.

This PR fixes the race condition by having the indexing process send a notification when the end of the log is reached, even if the last record is not an event.


___

### **Auto-created Ticket**

[#5455](https://github.com/kurrent-io/KurrentDB/issues/5455)

### **PR Type**
Bug fix


___

### **Description**
- Fix projection stall race condition with empty transactions

- Rename `TfEofAtNonCommitRecord` to `IndexedToEndOfTransactionFile` message

- Publish end-of-log notification even when last record is empty transaction

- Update `AddPendingPrepare` signature to accept explicit transaction position

- Refactor transaction tracking in `StorageChaser` to use nullable position


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Empty Transaction<br/>Written to Log"] -->|"Indexed by<br/>StorageChaser"| B["IndexCommitterService<br/>Processes Transaction"]
  B -->|"No events but<br/>at EOF"| C["Publish<br/>IndexedToEndOfTransactionFile"]
  C -->|"Notifies"| D["AwakeService"]
  D -->|"Triggers callbacks"| E["Projection Resumes<br/>Processing"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>StorageMessage.cs</strong><dd><code>Rename and document end-of-log notification message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-554a46f4a03c0aa83a51423398990efb32b0517dfdc2950c9af70a108c4c271a">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProjectionsSubsystem.cs</strong><dd><code>Update subsystem configuration for new message type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-d5aa11bac724645cfca1a197b7eaedecb009b40049a7e742018dee26de599643">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>AwakeService.cs</strong><dd><code>Handle new IndexedToEndOfTransactionFile message type</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-0a5cc5d0605840e0f112c792234243a4946a7c71ea0fe2b5df463bda801ec54f">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IndexCommitterService.cs</strong><dd><code>Publish notification for empty transactions at EOF</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-e53ef0a709e6bef12e1c57ff3677c0d43a88290a35e47c90433f1b0826d76650">+6/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StorageChaser.cs</strong><dd><code>Track transaction position explicitly for implicit transactions</code></dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-bfb166cf5091a584acf4eb82d475b1d9c77b1e3da93047c76c7ffde69596aa76">+9/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IndexCommitter.cs</strong><dd><code>Publish notification after initial index initialization</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-e0910e7a3bc706a34d9db459d6e3f84bdbdcf85b28f776c2cd7771c337f28b7c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>PrepareLogRecord.cs</strong><dd><code>Clarify documentation for prepare flags and version field</code></dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-cb378c0a464908f314366721eb636d62c386d99a8eeb45fc303d882ede956102">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>when_index_committer_service_commits_empty_transaction_at_end_of_log.cs</strong><dd><code>Add test for empty transaction at end of log</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-4bc93065679132812a9a199e846c4e3537325483b033f200571700f64607214b">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>with_index_committer_service.cs</strong><dd><code>Update test fixture for new message type and API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-6fa96413ddb5f4d5ed7f931e30105efadad63155af0f98b2fa581f1f7bbe9815">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>when_chaser_reads_commit_event.cs</strong><dd><code>Update test to use new AddPendingPrepare signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-db2448020c67ff288520520e33c35565d90a7f137afd34682179c9b1d88e5e72">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FakeIndexCommitterService.cs</strong><dd><code>Update fake service with new AddPendingPrepare signature</code>&nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-92d8d541c679b48046e2445b0dd7a593488a9a77e663177e1536aba6af38aa0d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TestFixtureWithExistingEvents.cs</strong><dd><code>Update test helper to use new message type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-1dab34fd8db18cc0f08f2f64e2c77a5c3ab1652405dcc42d87ae7448ecb6ddc0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TestFixtureWithExistingEvents.cs</strong><dd><code>Update projection test fixture for new message type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-96f9db06155c12f4210c230207f8ca06fc55751bd3bbafe6b9e3c913cef799de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>specification_with_projection_management_service.cs</strong><dd><code>Update projection manager test for new message type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5454/files#diff-b5b0165337fac07dae3f155434771e7ff6c38bc7ce9ba4b1e3d4ec5d3e6ea27f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

