### PR TITLE
[DB-1597] Reinstate dynamic reader thread count default

### DIFF
--- a/src/KurrentDB.Common/Utils/ContainerizedEnvironment.cs
+++ b/src/KurrentDB.Common/Utils/ContainerizedEnvironment.cs
@@ -6,6 +6,7 @@ using System.Runtime;
 namespace KurrentDB.Common.Utils;
 
 public static class ContainerizedEnvironment {
+	public const int ReaderThreadCount = 4;
 	public const int StreamInfoCacheCapacity = 100000;
 
 	public static bool IsRunningInContainer() => RuntimeInformation.IsRunningInContainer;

--- a/src/KurrentDB.Core.Tests/Settings/ReaderThreadCountCalculatorTests.cs
+++ b/src/KurrentDB.Core.Tests/Settings/ReaderThreadCountCalculatorTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using KurrentDB.Core.Settings;
+using NUnit.Framework;
+
+namespace KurrentDB.Core.Tests.Settings;
+
+[TestFixture]
+public class ReaderThreadCountCalculatorTests {
+	[TestCase]
+	public void configured_takes_precedence() => Test(configuredCount: 1, processorCount: 4, isRunningInContainer: false, expected: 1);
+
+	[TestCase]
+	public void enforces_minimum() => Test(configuredCount: 0, processorCount: 1, isRunningInContainer: false, expected: 4);
+
+	[TestCase]
+	public void enforces_maximum() => Test(configuredCount: 0, processorCount: 20, isRunningInContainer: false, expected: 16);
+
+	[TestCase]
+	public void at_3_cores() => Test(configuredCount: 0, processorCount: 3, isRunningInContainer: false, expected: 6);
+
+	[TestCase]
+	public void at_4_cores() => Test(configuredCount: 0, processorCount: 4, isRunningInContainer: false, expected: 8);
+
+	[TestCase]
+	public void at_6_cores() => Test(configuredCount: 0, processorCount: 6, isRunningInContainer: false, expected: 12);
+
+	[TestCase]
+	public void running_in_docker_container_at_6_cores() => Test(configuredCount: 0, processorCount: 6, isRunningInContainer: true, expected: 4);
+
+	[TestCase]
+	public void running_in_docker_container_configured_takes_precedence() => Test(configuredCount: 1, processorCount: 4, isRunningInContainer: true, expected: 1);
+
+	public static void Test(int configuredCount, int processorCount, bool isRunningInContainer, int expected) =>
+		Assert.AreEqual(expected, ThreadCountCalculator.CalculateReaderThreadCount(configuredCount, processorCount, isRunningInContainer));
+}

--- a/src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
@@ -54,18 +54,4 @@ public class ClusterVNodeOptionsValidatorTests {
 			ClusterVNodeOptionsValidator.Validate(options);
 		});
 	}
-
-	[Fact]
-	public void cannot_set_conflicting_concurrency_limits() {
-		var options = new ClusterVNodeOptions {
-			Database = new() {
-				ReaderThreadsCount = 3,
-				ConcurrentReadsLimit = 4,
-			}
-		};
-
-		Assert.Throws<InvalidConfigurationException>(() => {
-			ClusterVNodeOptionsValidator.Validate(options);
-		});
-	}
 }

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -399,11 +399,7 @@ public partial record ClusterVNodeOptions {
 		public int InitializationThreads { get; init; } = 1;
 
 		[Description("The number of reader threads to use for processing reads. Set to '0' to scale automatically (Default)")]
-		[Deprecated($"The ReaderThreadsCount parameter has been deprecated as of version 26.0.0. Set the value in {nameof(ConcurrentReadsLimit)} instead if still desired.")]
 		public int ReaderThreadsCount { get; init; } = 0;
-
-		[Description("The maximum number of read requests that can be processed concurrently. Set to '0' for unlimited (Default)")]
-		public long ConcurrentReadsLimit { get; set; } = 0;
 
 		[Description("During large Index Merge operations, writes may be slowed down. Set this to the maximum " +
 					 "index file level for which automatic merges should happen. Merging indexes above this level " +
@@ -630,11 +626,3 @@ public partial record ClusterVNodeOptions {
 	}
 }
 
-internal static class DatabaseOptionsExtensions {
-	extension(ClusterVNodeOptions.DatabaseOptions self) {
-		public long InternalConcurrentReadsLimit => self switch {
-			{ ReaderThreadsCount: > 0, ConcurrentReadsLimit: 0 } => self.ReaderThreadsCount,
-			_ => self.ConcurrentReadsLimit,
-		};
-	}
-}

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -112,8 +112,6 @@ public static class ClusterVNodeOptionsValidator {
 			throw new InvalidConfigurationException(
 				"The Archiving feature is not compatible with UnsafeIgnoreHardDelete.");
 		}
-
-		ValidateConcurrency(options.Database);
 	}
 
 	public static bool ValidateForStartup(ClusterVNodeOptions options) {
@@ -143,13 +141,5 @@ public static class ClusterVNodeOptionsValidator {
 		}
 
 		return true;
-	}
-
-	private static void ValidateConcurrency(ClusterVNodeOptions.DatabaseOptions options) {
-		if (options.ReaderThreadsCount > 0 && options.ConcurrentReadsLimit > 0 &&
-			options.ReaderThreadsCount != options.ConcurrentReadsLimit) {
-				throw new InvalidConfigurationException(
-					$"{nameof(options.ReaderThreadsCount)} and {nameof(options.ConcurrentReadsLimit)} cannot be set to different positive values.");
-		}
 	}
 }

--- a/src/KurrentDB.Core/Settings/ThreadCountCalculator.cs
+++ b/src/KurrentDB.Core/Settings/ThreadCountCalculator.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Common.Utils;
+using Serilog;
+
+namespace KurrentDB.Core.Settings;
+
+
+public static class ThreadCountCalculator {
+	private const int ReaderThreadCountFloor = 4;
+
+	public static int CalculateReaderThreadCount(int configuredCount, int processorCount,
+		bool isRunningInContainer) {
+		if (configuredCount > 0) {
+			Log.Information(
+				"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
+				"Calculated based on processor count of {processorCount:N0} and configured value of {configuredCount:N0}",
+				configuredCount,
+				processorCount, configuredCount);
+			return configuredCount;
+		}
+
+		if (isRunningInContainer) {
+			Log.Information(
+				"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
+				"Calculated based on containerized environment and configured value of {configuredCount:N0}",
+				ContainerizedEnvironment.ReaderThreadCount,
+				configuredCount);
+			return ContainerizedEnvironment.ReaderThreadCount;
+		}
+
+		var readerCount = Math.Clamp(processorCount * 2, ReaderThreadCountFloor, 16);
+		Log.Information(
+			"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
+			"Calculated based on processor count of {processorCount:N0} and configured value of {configuredCount:N0}",
+			readerCount,
+			processorCount, configuredCount);
+		return readerCount;
+	}
+}


### PR DESCRIPTION
### **User description**
We are not quite in a position to have it be unlimited by default. There is too much risk of the thread pool being overwhelemed by reads. To keep it simple I've removed the new ConcurrentReadsLimit option as well, which will make sense to reintroduce when we do change the default to unlimited in the future.


___

### **Auto-created Ticket**

[#5464](https://github.com/kurrent-io/KurrentDB/issues/5464)

### **PR Type**
Enhancement


___

### **Description**
- Reinstate dynamic reader thread count calculation with safety limits

- Remove unlimited concurrent reads option to prevent thread pool overwhelm

- Add ThreadCountCalculator for intelligent thread scaling based on environment

- Implement containerized environment detection with fixed thread count


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configuration Input"] -->|"ReaderThreadsCount"| B["ThreadCountCalculator"]
  C["Environment Detection"] -->|"ProcessorCount & Container"| B
  B -->|"Configured Value"| D["Use Configured Count"]
  B -->|"Container Detected"| E["Use Fixed Count: 4"]
  B -->|"Auto-scale"| F["ProcessorCount × 2<br/>Clamped 4-16"]
  D --> G["StorageReaderService"]
  E --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContainerizedEnvironment.cs</strong><dd><code>Add containerized environment reader thread constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Common/Utils/ContainerizedEnvironment.cs

<ul><li>Added constant <code>ReaderThreadCount</code> set to 4 for containerized <br>environments<br> <li> Provides default thread count when running in Docker containers</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5463/files#diff-a97596c9078b0df707eb5cf03d35fd6fa1f2a0e9ddd2acd461c3d2b359aa545a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClusterVNodeOptions.cs</strong><dd><code>Remove concurrent reads limit configuration option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs

<ul><li>Removed deprecated attribute from <code>ReaderThreadsCount</code> property<br> <li> Removed <code>ConcurrentReadsLimit</code> property entirely<br> <li> Removed <code>DatabaseOptionsExtensions</code> class that provided <br><code>InternalConcurrentReadsLimit</code> logic</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5463/files#diff-a3e9b69b82443b4366bd6c3c5c1c2eab7ca8c0e79e765b4f3646132306182187">+0/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ReaderThreadCountCalculatorTests.cs</strong><dd><code>Add comprehensive reader thread count calculator tests</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core.Tests/Settings/ReaderThreadCountCalculatorTests.cs

<ul><li>New test fixture with 9 test cases covering thread count calculation <br>logic<br> <li> Tests configured precedence, minimum/maximum enforcement, and <br>container detection<br> <li> Validates scaling at various processor counts (3, 4, 6 cores)</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5463/files#diff-76b7c4b2893a2078b978d11aa4a996a02cabd6cf2e3c300a418ac99a65f54396">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClusterVNodeOptionsValidatorTests.cs</strong><dd><code>Remove conflicting concurrency limits validation test</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs

<ul><li>Removed test validating conflicting concurrency limits configuration<br> <li> Simplifies validation as <code>ConcurrentReadsLimit</code> option is removed</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5463/files#diff-897fc7d4d143b9baa74b0c70f6c4de76dbe0eeb582511d1695451800af3b4f27">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClusterVNode.cs</strong><dd><code>Integrate dynamic reader thread count calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/ClusterVNode.cs

<ul><li>Modified <code>CreateDbConfig</code> method to calculate and return <br><code>readerThreadsCount</code><br> <li> Integrated <code>ThreadCountCalculator.CalculateReaderThreadCount</code> for <br>dynamic calculation<br> <li> Updated <code>StorageReaderService</code> instantiation to use calculated thread <br>count instead of <code>InternalConcurrentReadsLimit</code></ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5463/files#diff-f7d4c6ce44ecfbe1ec9d946df07fa60f60edb626595d28b7c0994c142ac23076">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ThreadCountCalculator.cs</strong><dd><code>Add thread count calculator with environment awareness</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Settings/ThreadCountCalculator.cs

<ul><li>New static utility class implementing intelligent reader thread count <br>calculation<br> <li> Respects configured values with highest precedence<br> <li> Returns fixed count of 4 for containerized environments<br> <li> Auto-scales to <code>ProcessorCount × 2</code> clamped between 4-16 for <br>non-containerized environments<br> <li> Includes detailed logging for thread count decisions</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5463/files#diff-64a31143b6c72b0518a5d65223d1fb5f244cb65efd8a7510e5614a7d37b97ed1">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClusterVNodeOptionsValidator.cs</strong><dd><code>Remove concurrency configuration validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB.Core/Configuration/ClusterVNodeOptionsValidator.cs

<ul><li>Removed <code>ValidateConcurrency</code> method that checked conflicting thread <br>count settings<br> <li> Removed call to <code>ValidateConcurrency</code> from <code>Validate</code> method<br> <li> Simplifies validation logic by eliminating conflicting option checks</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5463/files#diff-55246310a35a57a2000f09b8b8fc3bb1d5ea246cc03657828cf1f274ac6d771f">+0/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

