### PR TITLE
[DB-1597] Revert single ptable handle

### DIFF
--- a/src/KurrentDB.Common/Utils/Empty.cs
+++ b/src/KurrentDB.Common/Utils/Empty.cs
@@ -6,9 +6,12 @@ using System;
 namespace KurrentDB.Common.Utils;
 
 public static class Empty {
-	public static byte[] ByteArray => [];
+	public static readonly byte[] ByteArray = new byte[0];
+	public static readonly string[] StringArray = new string[0];
+	public static readonly object[] ObjectArray = new object[0];
 
-	public static readonly object Result = new();
-	public static readonly string Xml = string.Empty;
+	public static readonly Action Action = () => { };
+	public static readonly object Result = new object();
+	public static readonly string Xml = String.Empty;
 	public static readonly string Json = "{}";
 }

--- a/src/KurrentDB.Core.Tests/Constants.cs
+++ b/src/KurrentDB.Core.Tests/Constants.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using KurrentDB.Core.Settings;
+using KurrentDB.Core.TransactionLog.Chunks;
+
+namespace KurrentDB.Core.Tests;
+
+public class Constants {
+	public const int PTableInitialReaderCount = ESConsts.PTableInitialReaderCount;
+
+	public const int PTableMaxReaderCountDefault = 1 /* StorageWriter */
+												   + 1 /* StorageChaser */
+												   + 1 /* Projections */
+												   + TFChunkScavenger.MaxThreadCount /* Scavenging (1 per thread) */
+												   + 1 /* Subscription LinkTos resolving */
+												   + 4 /* Reader Threads Count */
+												   + 5 /* just in case reserve :) */;
+}
+

--- a/src/KurrentDB.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_set.cs
+++ b/src/KurrentDB.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_set.cs
@@ -37,11 +37,11 @@ public abstract class when_max_auto_merge_level_is_set : SpecificationWithDirect
 		var first = _map;
 		if (_result != null)
 			first = _result.MergedMap;
-		var pTable = PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify);
+		var pTable = PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 		_result = first.AddAndMergePTable(pTable,
 			10, 20, _fileNameProvider, _ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		for (int i = 3; i <= count * 2; i += 2) {
-			pTable = PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify);
+			pTable = PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 			_result = _result.MergedMap.AddAndMergePTable(
 				pTable,
 				prepareCheckpoint: i * 10,

--- a/src/KurrentDB.Core.Tests/Index/IndexMapTestFactory.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexMapTestFactory.cs
@@ -13,8 +13,9 @@ public static class IndexMapTestFactory {
 		bool useBloomFilter = true,
 		int lruCacheSize = 1_000_000,
 		int threads = 1,
-		int maxAutoMergeLevel = int.MaxValue) {
+		int maxAutoMergeLevel = int.MaxValue,
+		int pTableMaxReaderCount = Constants.PTableMaxReaderCountDefault) {
 		return IndexMap.FromFile(filename, maxTablesPerLevel, loadPTables, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize, threads,
-			maxAutoMergeLevel);
+			maxAutoMergeLevel, pTableMaxReaderCount);
 	}
 }

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/PTableReadScenario.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/PTableReadScenario.cs
@@ -28,7 +28,7 @@ public abstract class PTableReadScenario : SpecificationWithFile {
 
 		AddItemsForScenario(table);
 
-		PTable = PTable.FromMemtable(table, Filename, cacheDepth: _midpointCacheDepth,
+		PTable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, cacheDepth: _midpointCacheDepth,
 			skipIndexVerify: _skipIndexVerify);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_four_tables_per_level_causes_merge.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_four_tables_per_level_causes_merge.cs
@@ -44,7 +44,7 @@ public class
 		memtable.Add(0, 1, 0);
 
 		_result = _map.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 1, 2,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 1, 2,
 			new GuidFilenameProvider(PathName),
 			_ptableVersion,
 			0,
@@ -52,19 +52,19 @@ public class
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 3, 4,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 3, 4,
 			new GuidFilenameProvider(PathName),
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 4, 5,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 4, 5,
 			new GuidFilenameProvider(PathName),
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 1,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 1,
 			new FakeFilenameProvider(_mergeFile),
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_two_tables_per_level_causes_double_merge.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_two_tables_per_level_causes_double_merge.cs
@@ -44,25 +44,25 @@ public class
 		memtable.Add(0, 1, 0);
 
 		_result = _map.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 			10, 20,
 			new GuidFilenameProvider(PathName), _ptableVersion, 0,
 			skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 			20, 30,
 			new GuidFilenameProvider(PathName), _ptableVersion, 0,
 			skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 			30, 40,
 			new GuidFilenameProvider(PathName), _ptableVersion, 0,
 			skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 			50, 60,
 			new FakeFilenameProvider(_mergeFile + ".firstmerge", _mergeFile), _ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/adding_item_to_empty_index_map.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/adding_item_to_empty_index_map.cs
@@ -41,7 +41,7 @@ public class adding_item_to_empty_index_map : SpecificationWithDirectoryPerTestF
 		_map = IndexMapTestFactory.FromFile(_filename, maxAutoMergeLevel: _maxAutoMergeIndexLevel);
 		var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 		memtable.Add(0, 1, 0);
-		var table = PTable.FromMemtable(memtable, _tablename, skipIndexVerify: _skipIndexVerify);
+		var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 		_result = _map.AddAndMergePTable(table, 7, 11,
 			new FakeFilenameProvider(_mergeFile), _ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		table.MarkForDestruction();

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/adding_sixteen_items_to_empty_index_map_with_four_tables_per_level_causes_double_merge.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/adding_sixteen_items_to_empty_index_map_with_four_tables_per_level_causes_double_merge.cs
@@ -47,82 +47,82 @@ public class
 		memtable.Add(0, 1, 0);
 		var guidFilename = new GuidFilenameProvider(PathName);
 		_result = _map.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 			guidFilename,
 			_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 1, 2,
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 1, 2,
 			new FakeFilenameProvider(_finalmergefile, _finalmergefile2), _ptableVersion, 0,
 			skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/adding_two_items_to_empty_index_map_with_two_tables_per_level_causes_merge.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/adding_two_items_to_empty_index_map_with_two_tables_per_level_causes_merge.cs
@@ -44,13 +44,13 @@ public class
 		memtable.Add(0, 1, 0);
 
 		_result = _map.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 			123, 321,
 			new GuidFilenameProvider(PathName), _ptableVersion, 0,
 			skipIndexVerify: _skipIndexVerify);
 		_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		_result = _result.MergedMap.AddAndMergePTable(
-			PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+			PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 			100, 400,
 			new FakeFilenameProvider(_mergeFile), _ptableVersion, 0,
 			skipIndexVerify: _skipIndexVerify);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/corrupt_index_should.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/corrupt_index_should.cs
@@ -23,7 +23,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		}
 
 		string pTableFilename = GetTempFilePath();
-		var pTable = PTable.FromMemtable(memTable, pTableFilename, depth);
+		var pTable = PTable.FromMemtable(memTable, pTableFilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth);
 		pTable.Dispose();
 		return pTableFilename;
 	}
@@ -184,7 +184,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		bool skipIndexVerify) {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "notMultipleIndexEntrySize");
-		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 	}
 
 	[TestCase(PTableVersions.IndexV2, false)]
@@ -197,7 +197,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		bool skipIndexVerify) {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
-		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 	}
 
 
@@ -207,7 +207,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		bool skipIndexVerify) {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "midpointItemIndexesNotAscendingOrder");
-		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 	}
 
 	[TestCase(PTableVersions.IndexV2, true)]
@@ -218,7 +218,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
 		//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-		PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+		PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 		Assert.Throws<MaybeCorruptIndexException>(() =>
 			pTable.GetRange(GetOriginalHash(numIndexEntries / 4, version), 1, 1));
 		pTable.Dispose();
@@ -232,7 +232,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "maxOutMiddleEntries");
 		//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-		PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+		PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 		Assert.Throws<MaybeCorruptIndexException>(() =>
 			pTable.GetRange(GetOriginalHash(numIndexEntries / 4, version), 1, 1));
 		pTable.Dispose();
@@ -246,7 +246,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
 		//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-		PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+		PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 		IndexEntry entry;
 		Assert.Throws<MaybeCorruptIndexException>(() =>
 			// changed 2 to 4 here because the corruption actually removes the stream at /2, so it isn't in the bloom filter
@@ -262,7 +262,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "maxOutMiddleEntries");
 		//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-		PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+		PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 		IndexEntry entry;
 		Assert.Throws<MaybeCorruptIndexException>(() =>
 			pTable.TryGetLatestEntry(GetOriginalHash(numIndexEntries / 4, version), out entry));
@@ -277,7 +277,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
 		//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-		PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+		PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 		IndexEntry entry;
 		Assert.Throws<MaybeCorruptIndexException>(() =>
 			pTable.TryGetOldestEntry(GetOriginalHash(numIndexEntries / 4, version), out entry));
@@ -292,7 +292,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "maxOutMiddleEntries");
 		//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-		PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+		PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 		IndexEntry entry;
 		Assert.Throws<MaybeCorruptIndexException>(() =>
 			pTable.TryGetOldestEntry(GetOriginalHash(numIndexEntries / 4, version), out entry));
@@ -307,7 +307,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
 		//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-		PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+		PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 		long position;
 		Assert.Throws<MaybeCorruptIndexException>(() =>
 			pTable.TryGetOneValue(GetOriginalHash(numIndexEntries / 4, version), 1, out position));
@@ -322,7 +322,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "maxOutMiddleEntries");
 		//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-		PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+		PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 		long position;
 		Assert.Throws<MaybeCorruptIndexException>(() =>
 			pTable.TryGetOneValue(GetOriginalHash(numIndexEntries / 4, version), 1, out position));
@@ -334,7 +334,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 	public void throw_exception_on_invalid_ptable_filenumber_in_footer(byte version, bool skipIndexVerify) {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "footerFileType");
-		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 	}
 
 	[TestCase(PTableVersions.IndexV4, false)]
@@ -342,7 +342,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 	public void throw_exception_on_header_footer_version_mismatch(byte version, bool skipIndexVerify) {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "footerVersion");
-		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 	}
 
 	[TestCase(PTableVersions.IndexV4, false)]
@@ -350,7 +350,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 	public void throw_exception_if_negative_index_entries_size(byte version, bool skipIndexVerify) {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "negativeIndexEntriesSize");
-		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 	}
 
 	[TestCase(PTableVersions.IndexV4, false)]
@@ -358,7 +358,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 	public void throw_exception_if_less_than_2_midpoints_cached(byte version, bool skipIndexVerify) {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "lessThan2Midpoints");
-		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 	}
 
 	[TestCase(PTableVersions.IndexV4, false)]
@@ -366,7 +366,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 	public void throw_exception_if_more_midpoints_than_index_entries(byte version, bool skipIndexVerify) {
 		string ptableFileName = ConstructPTable(version);
 		CorruptPTableFile(ptableFileName, version, "moreMidpointsThanIndexEntries");
-		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+		Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 	}
 
 	[TestCase(PTableVersions.IndexV4, false)]
@@ -377,7 +377,7 @@ public class corrupt_index_should : SpecificationWithDirectoryPerTestFixture {
 		if (corrupt)
 			CorruptBloomFilter(PTable.GenBloomFilterFilename(ptableFileName));
 
-		var table = PTable.FromFile(ptableFileName, depth, skipIndexVerify: true);
+		var table = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify: true);
 		Assert.AreEqual(!corrupt, table.HasBloomFilter);
 	}
 }

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/destroying_ptable.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/destroying_ptable.cs
@@ -28,7 +28,7 @@ public class destroying_ptable : SpecificationWithFile {
 		var mtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 		mtable.Add(0x010100000000, 0x0001, 0x0001);
 		mtable.Add(0x010500000000, 0x0001, 0x0002);
-		_table = PTable.FromMemtable(mtable, Filename,
+		_table = PTable.FromMemtable(mtable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify,
 			useBloomFilter: true);
 		_table.MarkForDestruction();

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/index_map_should.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/index_map_should.cs
@@ -38,7 +38,7 @@ public class index_map_should : SpecificationWithDirectory {
 
 		var memTable = new HashListMemTable(_ptableVersion, maxSize: 10);
 		memTable.Add(0, 1, 2);
-		_ptable = PTable.FromMemtable(memTable, _ptableFileName);
+		_ptable = PTable.FromMemtable(memTable, _ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 	}
 
 	[TearDown]

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/index_map_should_detect_corruption.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/index_map_should_detect_corruption.cs
@@ -41,7 +41,7 @@ public class index_map_should_detect_corruption : SpecificationWithDirectory {
 		var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 		memtable.Add(0, 0, 0);
 		memtable.Add(1, 1, 100);
-		_ptable = PTable.FromMemtable(memtable, _ptableFileName, skipIndexVerify: _skipIndexVerify);
+		_ptable = PTable.FromMemtable(memtable, _ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 
 		indexMap = indexMap.AddAndMergePTable(_ptable, 0, 0,
 			new GuidFilenameProvider(PathName), _ptableVersion, 0, skipIndexVerify: _skipIndexVerify).MergedMap;

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/opening_a_ptable_with_more_than_32bits_of_records.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/opening_a_ptable_with_more_than_32bits_of_records.cs
@@ -36,7 +36,7 @@ public class opening_a_ptable_with_more_than_32bits_of_records : SpecificationWi
 		_size = _ptableCount * (long)_indexEntrySize + PTableHeader.Size + PTable.MD5Size;
 		Console.WriteLine("Creating PTable at {0}. Size of PTable: {1}", Filename, _size);
 		CreatePTableFile(Filename, _size, _indexEntrySize);
-		_ptable = PTable.FromFile(Filename, 22, false);
+		_ptable = PTable.FromFile(Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 22, false);
 	}
 
 	public static void CreatePTableFile(string filename, long ptableSize, int indexEntrySize, int cacheDepth = 16) {

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
@@ -50,7 +50,7 @@ public class ptable_midpoint_cache_should : SpecificationWithDirectory {
 			memTable.Add((uint)rnd.Next(), rnd.Next(0, 1 << 20), Math.Abs(rnd.Next() * rnd.Next()));
 		}
 
-		var ptable = PTable.FromMemtable(memTable, file, depth, skipIndexVerify: _skipIndexVerify);
+		var ptable = PTable.FromMemtable(memTable, file, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify: _skipIndexVerify);
 		return ptable;
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/ptable_range_query_tests.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/ptable_range_query_tests.cs
@@ -41,7 +41,7 @@ public class ptable_range_query_tests : SpecificationWithFilePerTestFixture {
 		table.Add(0x010300000000, 0x0001, 0xFFF1);
 		table.Add(0x010300000000, 0x0003, 0xFFF3);
 		table.Add(0x010300000000, 0x0005, 0xFFF5);
-		_ptable = PTable.FromMemtable(table, Filename, cacheDepth: 0,
+		_ptable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, cacheDepth: 0,
 			skipIndexVerify: _skipIndexVerify,
 			useBloomFilter: _useBloomFilter,
 			lruCacheSize: _lruCacheSize);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/ptable_should.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/ptable_should.cs
@@ -30,7 +30,7 @@ public class ptable_should : SpecificationWithFilePerTestFixture {
 
 		var table = new HashListMemTable(_ptableVersion, maxSize: 10);
 		table.Add(0x010100000000, 0x0001, 0x0001);
-		_ptable = PTable.FromMemtable(table, Filename, cacheDepth: 0, skipIndexVerify: _skipIndexVerify);
+		_ptable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, cacheDepth: 0, skipIndexVerify: _skipIndexVerify);
 	}
 
 	public override void TestFixtureTearDown() {

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/saving_index_with_single_item_to_a_file.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/saving_index_with_single_item_to_a_file.cs
@@ -38,7 +38,7 @@ public class saving_index_with_single_item_to_a_file : SpecificationWithDirector
 		_map = IndexMapTestFactory.FromFile(_filename, maxAutoMergeLevel: _maxAutoMergeIndexLevel);
 		var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 		memtable.Add(0, 2, 7);
-		var table = PTable.FromMemtable(memtable, _tablename);
+		var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 		_result = _map.AddAndMergePTable(table, 7, 11,
 			new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
 		_result.MergedMap.SaveToFile(_filename);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/saving_index_with_six_items_to_a_file.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/saving_index_with_six_items_to_a_file.cs
@@ -36,7 +36,7 @@ public class saving_index_with_six_items_to_a_file : SpecificationWithDirectory 
 		_map = IndexMapTestFactory.FromFile(_filename, maxTablesPerLevel: 4);
 		var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 		memtable.Add(0, 2, 123);
-		var table = PTable.FromMemtable(memtable, _tablename);
+		var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 		_result = _map.AddAndMergePTable(table, 0, 0,
 			new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
 		_result = _result.MergedMap.AddAndMergePTable(table, 0, 0,

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_on_range_query.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_on_range_query.cs
@@ -38,7 +38,7 @@ public class table_index_on_range_query : SpecificationWithDirectoryPerTestFixtu
 			() => new HashListMemTable(version: _ptableVersion, maxSize: 40),
 			new FakeTfReader(),
 			_ptableVersion,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 5,
 			skipIndexVerify: _skipIndexVerify);
 		_tableIndex.Initialize(long.MaxValue);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_on_try_get_one_value_query.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_on_try_get_one_value_query.cs
@@ -41,7 +41,7 @@ public class table_index_on_try_get_one_value_query : SpecificationWithDirectory
 			() => new HashListMemTable(_ptableVersion, maxSize: 10),
 			fakeReader,
 			_ptableVersion,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 5,
 			skipIndexVerify: _skipIndexVerify);
 		_tableIndex.Initialize(long.MaxValue);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_should.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_should.cs
@@ -35,7 +35,7 @@ public class table_index_should : SpecificationWithDirectoryPerTestFixture {
 			() => new HashListMemTable(_ptableVersion, maxSize: 20),
 			new FakeTfReader(),
 			_ptableVersion,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 10,
 			skipIndexVerify: _skipIndexVerify);
 		_tableIndex.Initialize(long.MaxValue);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_with_corrupt_index_entries_should.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_with_corrupt_index_entries_should.cs
@@ -29,7 +29,7 @@ public class table_index_with_corrupt_index_entries_should : SpecificationWithDi
 			() => new HashListMemTable(version, maxSize: NumIndexEntries),
 			fakeReader,
 			version,
-			int.MaxValue,
+			int.MaxValue, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: NumIndexEntries,
 			skipIndexVerify: skipIndexVerify);
 		_tableIndex.Initialize(long.MaxValue);
@@ -70,7 +70,7 @@ public class table_index_with_corrupt_index_entries_should : SpecificationWithDi
 			() => new HashListMemTable(version, maxSize: NumIndexEntries),
 			fakeReader,
 			version,
-			int.MaxValue,
+			int.MaxValue, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: NumIndexEntries,
 			skipIndexVerify: skipIndexVerify,
 			indexCacheDepth: 8);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_with_two_ptables_and_memtable_on_range_query.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/table_index_with_two_ptables_and_memtable_on_range_query.cs
@@ -40,7 +40,7 @@ public class table_index_with_two_ptables_and_memtable_on_range_query : Specific
 			() => new HashListMemTable(_ptableVersion, maxSize: 10),
 			fakeReader,
 			_ptableVersion,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 2,
 			skipIndexVerify: _skipIndexVerify);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_a_ptable_header_is_corrupt_on_disk.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_a_ptable_header_is_corrupt_on_disk.cs
@@ -29,7 +29,7 @@ public class when_a_ptable_header_is_corrupt_on_disk : SpecificationWithDirector
 		var mtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 		mtable.Add(0x010100000000, 0x0001, 0x0001);
 		mtable.Add(0x010500000000, 0x0001, 0x0002);
-		_table = PTable.FromMemtable(mtable, _filename);
+		_table = PTable.FromMemtable(mtable, _filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 		_table.Dispose();
 		File.Copy(_filename, _copiedfilename);
 		using (var f = new FileStream(_copiedfilename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite)) {
@@ -40,14 +40,14 @@ public class when_a_ptable_header_is_corrupt_on_disk : SpecificationWithDirector
 
 	[Test]
 	public void the_hash_is_invalid() {
-		var exc = Assert.Throws<CorruptIndexException>(() => _table = PTable.FromFile(_copiedfilename, 16, false));
+		var exc = Assert.Throws<CorruptIndexException>(() => _table = PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 16, false));
 		Assert.IsInstanceOf<HashValidationException>(exc.InnerException);
 	}
 
 	[Test]
 	public void no_error_if_index_verification_disabled() {
 		Assert.DoesNotThrow(
-			() => _table = PTable.FromFile(_copiedfilename, 16, true)
+			() => _table = PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 16, true)
 		);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_a_ptable_is_corrupt_on_disk.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_a_ptable_is_corrupt_on_disk.cs
@@ -31,7 +31,7 @@ public class when_a_ptable_is_corrupt_on_disk : SpecificationWithDirectory {
 		var mtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 		mtable.Add(0x010100000000, 0x0001, 0x0001);
 		mtable.Add(0x010500000000, 0x0001, 0x0002);
-		_table = PTable.FromMemtable(mtable, _filename);
+		_table = PTable.FromMemtable(mtable, _filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 		_table.Dispose();
 		File.Copy(_filename, _copiedfilename);
 		using (var f = new FileStream(_copiedfilename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite)) {
@@ -50,7 +50,7 @@ public class when_a_ptable_is_corrupt_on_disk : SpecificationWithDirectory {
 
 	[Test]
 	public void the_hash_is_invalid() {
-		var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(_copiedfilename, 16, false));
+		var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 16, false));
 		Assert.IsInstanceOf<HashValidationException>(exc.InnerException);
 	}
 }

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_a_ptable_is_loaded_from_disk.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_a_ptable_is_loaded_from_disk.cs
@@ -51,7 +51,7 @@ public class when_a_ptable_is_loaded_from_disk : SpecificationWithDirectory {
 			mtable.Add(streamId, eventNumber, logPosition);
 		}
 
-		_table = PTable.FromMemtable(mtable, _filename, skipIndexVerify: _skipIndexVerify);
+		_table = PTable.FromMemtable(mtable, _filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 		_table.Dispose();
 		File.Copy(_filename, _copiedfilename);
 	}
@@ -59,8 +59,8 @@ public class when_a_ptable_is_loaded_from_disk : SpecificationWithDirectory {
 	[Test]
 	public void same_midpoints_are_loaded_when_enabling_or_disabling_index_verification() {
 		for (int depth = 2; depth <= 20; depth++) {
-			var ptableWithMD5Verification = PTable.FromFile(_copiedfilename, depth, false);
-			var ptableWithoutVerification = PTable.FromFile(_copiedfilename, depth, true);
+			var ptableWithMD5Verification = PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, false);
+			var ptableWithoutVerification = PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, true);
 			var midPoints1 = ptableWithMD5Verification.GetMidPoints();
 			var midPoints2 = ptableWithoutVerification.GetMidPoints();
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_constructing_v1_ptable.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_constructing_v1_ptable.cs
@@ -13,7 +13,9 @@ public class when_constructing_v1_ptable : SpecificationWithDirectoryPerTestFixt
 		Assert.Throws<CorruptIndexException>(() => {
 			using var table = PTable.FromMemtable(
 				new HashListMemTable(PTableVersions.IndexV1, maxSize: 20),
-				GetTempFilePath());
+				GetTempFilePath(),
+				Constants.PTableInitialReaderCount,
+				Constants.PTableMaxReaderCountDefault);
 		});
 	}
 }

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_creating_ptable_from_memtable.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_creating_ptable_from_memtable.cs
@@ -27,21 +27,21 @@ public class when_creating_ptable_from_memtable : SpecificationWithFile {
 	[Test]
 	public void null_file_throws_null_exception() {
 		Assert.Throws<ArgumentNullException>(() =>
-			PTable.FromMemtable(new HashListMemTable(_ptableVersion, maxSize: 10), null,
+			PTable.FromMemtable(new HashListMemTable(_ptableVersion, maxSize: 10), null, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify));
 	}
 
 	[Test]
 	public void null_memtable_throws_null_exception() {
 		Assert.Throws<ArgumentNullException>(() =>
-			PTable.FromMemtable(null, "C:\\foo.txt", skipIndexVerify: _skipIndexVerify));
+			PTable.FromMemtable(null, "C:\\foo.txt", Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 	}
 
 	[Test]
 	public void wait_for_destroy_will_timeout() {
 		var table = new HashListMemTable(_ptableVersion, maxSize: 10);
 		table.Add(0x010100000000, 0x0001, 0x0001);
-		var ptable = PTable.FromMemtable(table, Filename, skipIndexVerify: _skipIndexVerify);
+		var ptable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 		Assert.Throws<TimeoutException>(() => ptable.WaitForDisposal(1));
 
 		// tear down
@@ -75,7 +75,7 @@ public class when_creating_ptable_from_memtable : SpecificationWithFile {
 		table.Add(0x010500000000, 0x0001, 0x0002);
 		table.Add(0x010200000000, 0x0001, 0x0003);
 		table.Add(0x010200000000, 0x0002, 0x0003);
-		using (var sstable = PTable.FromMemtable(table, Filename,
+		using (var sstable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify,
 			useBloomFilter: true)) {
 
@@ -110,7 +110,7 @@ public class when_creating_ptable_from_memtable : SpecificationWithFile {
 		table.Add(0x010200000000, 0x0001, 0x0003);
 		table.Add(0x010200000000, 0x0002, 0x0003);
 		Assert.DoesNotThrow(() => {
-			using (var sstable = PTable.FromMemtable(table, Filename, skipIndexVerify: false)) {
+			using (var sstable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: false)) {
 			}
 		});
 	}

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_merging_four_ptables.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_merging_four_ptables.cs
@@ -39,12 +39,12 @@ public class when_merging_four_ptables : SpecificationWithDirectoryPerTestFixtur
 				table.Add((ulong)(0x010100000000 << (j + 1)), i + 1, i * j);
 			}
 
-			_tables.Add(PTable.FromMemtable(table, _files[i], skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, _files[i], Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 		}
 
 		_files.Add(GetTempFilePath());
 		_newtable = PTable.MergeTo(_tables, _files[4],
-			_ptableVersion,
+			_ptableVersion, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_merging_ptables.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_merging_ptables.cs
@@ -36,17 +36,19 @@ public class when_merging_ptables : SpecificationWithDirectoryPerTestFixture {
 		table.Add(0x0102, 0, 0x0102);
 		table.Add(0x0103, 0, 0x0103);
 		table.Add(0x0104, 0, 0x0104);
-		_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 		table = new HashListMemTable(_ptableVersion, maxSize: 20);
 		table.Add(0x0105, 0, 0x0105);
 		table.Add(0x0106, 0, 0x0106);
 		table.Add(0x0107, 0, 0x0107);
 		table.Add(0x0108, 0, 0x0108);
-		_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 		_newtable = PTable.MergeTo(
 			tables: _tables,
 			outputFile: GetTempFilePath(),
 			version: PTableVersions.IndexV4,
+			initialReaders: Constants.PTableInitialReaderCount,
+			maxReaders: Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify,
 			useBloomFilter: true);
 	}

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_merging_ptables_with_entries_to_nonexisting_record.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_merging_ptables_with_entries_to_nonexisting_record.cs
@@ -39,12 +39,12 @@ public class
 				table.Add((ulong)(0x010100000000 << i), j, i * 10 + j);
 			}
 
-			_tables.Add(PTable.FromMemtable(table, _files[i], skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, _files[i], Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 		}
 
 		_files.Add(GetTempFilePath());
 		_newtable = PTable.MergeTo(_tables, _files[4],
-			_ptableVersion,
+			_ptableVersion, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_merging_two_ptables.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_merging_two_ptables.cs
@@ -43,13 +43,13 @@ public class when_merging_two_ptables : SpecificationWithDirectoryPerTestFixture
 				table.Add((ulong)(0x010100000000 << (j + 1)), i + 1, i * j);
 			}
 
-			_tables.Add(PTable.FromMemtable(table, _files[i],
+			_tables.Add(PTable.FromMemtable(table, _files[i], Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify, useBloomFilter: true));
 		}
 
 		_files.Add(GetTempFilePath());
 		_newtable = PTable.MergeTo(_tables, _files[2],
-			_ptableVersion,
+			_ptableVersion, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify, useBloomFilter: true);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_latest_entry.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_latest_entry.cs
@@ -36,6 +36,8 @@ public class when_trying_to_get_latest_entry : SpecificationWithFile {
 		return PTable.FromMemtable(
 			memTable,
 			Filename,
+			Constants.PTableInitialReaderCount,
+			Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify,
 			useBloomFilter: _useBloomFilter,
 			lruCacheSize: _lruCacheSize);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_latest_entry_before_position.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_latest_entry_before_position.cs
@@ -58,6 +58,8 @@ public class when_trying_to_get_latest_entry_before_position : SpecificationWith
 		_pTable = PTable.FromMemtable(
 			table: _memTable,
 			filename: Filename,
+			initialReaders: Constants.PTableInitialReaderCount,
+			maxReaders: Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_next_entry.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_next_entry.cs
@@ -52,6 +52,8 @@ public class when_trying_to_get_next_entry : SpecificationWithFile {
 		_pTable = PTable.FromMemtable(
 			table: _memTable,
 			filename: Filename,
+			initialReaders: Constants.PTableInitialReaderCount,
+			maxReaders: Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_oldest_entry.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_oldest_entry.cs
@@ -36,6 +36,8 @@ public class when_trying_to_get_oldest_entry : SpecificationWithFile {
 		return PTable.FromMemtable(
 			memTable,
 			Filename,
+			Constants.PTableInitialReaderCount,
+			Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify,
 			useBloomFilter: _useBloomFilter,
 			lruCacheSize: _lruCacheSize);

--- a/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_previous_entry.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV1/when_trying_to_get_previous_entry.cs
@@ -52,6 +52,8 @@ public class when_trying_to_get_previous_entry : SpecificationWithFile {
 		_pTable = PTable.FromMemtable(
 			table: _memTable,
 			filename: Filename,
+			initialReaders: Constants.PTableInitialReaderCount,
+			maxReaders: Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
@@ -37,7 +37,7 @@ public class when_upgrading_index_to_64bit_stream_version : SpecificationWithDir
 			() => new HashListMemTable(PTableVersions.IndexV2, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV2,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 5,
 			maxTablesPerLevel: 2);
 		_tableIndex.Initialize(long.MaxValue);
@@ -54,7 +54,7 @@ public class when_upgrading_index_to_64bit_stream_version : SpecificationWithDir
 			() => new HashListMemTable(_ptableVersion, maxSize: 5),
 			fakeReader,
 			_ptableVersion,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 5,
 			maxTablesPerLevel: 2);
 		_tableIndex.Initialize(long.MaxValue);

--- a/src/KurrentDB.Core.Tests/Index/IndexV4/when_merging_ptables_vx_to_v4.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexV4/when_merging_ptables_vx_to_v4.cs
@@ -46,7 +46,7 @@ public class when_merging_ptables_vx_to_v4 : SpecificationWithDirectoryPerTestFi
 			table.Add(0x0104, 0, 0x0104);
 		}
 
-		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 		table = new HashListMemTable(_fromVersion, maxSize: 20);
 
 		if (_fromVersion == PTableVersions.IndexV1) {
@@ -61,10 +61,10 @@ public class when_merging_ptables_vx_to_v4 : SpecificationWithDirectoryPerTestFi
 			table.Add(0x0108, 0, 0x0108);
 		}
 
-		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 		_newtableFile = GetTempFilePath();
 		_newtable = PTable.MergeTo(_tables, _newtableFile,
-			PTableVersions.IndexV4,
+			PTableVersions.IndexV4, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 			skipIndexVerify: _skipIndexVerify);
 	}
 
@@ -96,14 +96,16 @@ public class when_merging_ptables_vx_to_v4 : SpecificationWithDirectoryPerTestFi
 		var newTableFileCopy = GetTempFilePath();
 		File.Copy(_newtableFile, newTableFileCopy);
 		using (var filestream = File.Open(newTableFileCopy, FileMode.Open, FileAccess.Read)) {
-			var footerSize = PTableFooter.Size;
+			var footerSize = PTableFooter.GetSize(PTableVersions.IndexV4);
 			Assert.AreEqual(filestream.Length,
 				PTableHeader.Size + numIndexEntries * PTable.IndexEntryV4Size +
 				requiredMidpoints * PTable.IndexEntryV4Size + footerSize + PTable.MD5Size);
-			var footerOffset = PTableHeader.Size + numIndexEntries * PTable.IndexEntryV4Size +
-			               requiredMidpoints * PTable.IndexEntryV4Size;
+			filestream.Seek(
+				PTableHeader.Size + numIndexEntries * PTable.IndexEntryV4Size +
+				requiredMidpoints * PTable.IndexEntryV4Size, SeekOrigin.Begin);
 
-			var ptableFooter = PTableFooter.Parse(filestream.SafeFileHandle, footerOffset);
+			var ptableFooter = PTableFooter.FromStream(filestream);
+			Assert.AreEqual(FileType.PTableFile, ptableFooter.FileType);
 			Assert.AreEqual(PTableVersions.IndexV4, ptableFooter.Version);
 			Assert.AreEqual(requiredMidpoints, ptableFooter.NumMidpointsCached);
 		}
@@ -165,24 +167,24 @@ public class when_merging_to_ptable_v4_with_deleted_entries : SpecificationWithD
 		table.Add(0x010200000000, 0, 2);
 		table.Add(0x010300000000, 0, 3);
 		table.Add(0x010300000000, 1, 4);
-		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 		table = new HashListMemTable(_fromVersion, maxSize: 20);
 		table.Add(0x010100000000, 2, 5);
 		table.Add(0x010200000000, 1, 6);
 		table.Add(0x010200000000, 2, 7);
 		table.Add(0x010400000000, 0, 8);
 		table.Add(0x010400000000, 1, 9);
-		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 		table = new HashListMemTable(_fromVersion, maxSize: 20);
 		table.Add(0x010100000000, 1, 10);
 		table.Add(0x010100000000, 2, 11);
 		table.Add(0x010500000000, 1, 12);
 		table.Add(0x010500000000, 2, 13);
 		table.Add(0x010500000000, 3, 14);
-		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+		_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 		_newtableFile = GetTempFilePath();
 		_newtable = PTable.MergeTo(_tables, _newtableFile,
-			PTableVersions.IndexV4, skipIndexVerify: _skipIndexVerify);
+			PTableVersions.IndexV4, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 	}
 
 	[OneTimeTearDown]
@@ -213,14 +215,16 @@ public class when_merging_to_ptable_v4_with_deleted_entries : SpecificationWithD
 		var newTableFileCopy = GetTempFilePath();
 		File.Copy(_newtableFile, newTableFileCopy);
 		using (var filestream = File.Open(newTableFileCopy, FileMode.Open, FileAccess.Read)) {
-			var footerSize = PTableFooter.Size;
+			var footerSize = PTableFooter.GetSize(PTableVersions.IndexV4);
 			Assert.AreEqual(filestream.Length,
 				PTableHeader.Size + numIndexEntries * PTable.IndexEntryV4Size +
 				requiredMidpoints * PTable.IndexEntryV4Size + footerSize + PTable.MD5Size);
-			var footerOffset = PTableHeader.Size + numIndexEntries * PTable.IndexEntryV4Size +
-			                   requiredMidpoints * PTable.IndexEntryV4Size;
+			filestream.Seek(
+				PTableHeader.Size + numIndexEntries * PTable.IndexEntryV4Size +
+				requiredMidpoints * PTable.IndexEntryV4Size, SeekOrigin.Begin);
 
-			var ptableFooter = PTableFooter.Parse(filestream.SafeFileHandle, footerOffset);
+			var ptableFooter = PTableFooter.FromStream(filestream);
+			Assert.AreEqual(FileType.PTableFile, ptableFooter.FileType);
 			Assert.AreEqual(PTableVersions.IndexV4, ptableFooter.Version);
 			Assert.AreEqual(requiredMidpoints, ptableFooter.NumMidpointsCached);
 		}

--- a/src/KurrentDB.Core.Tests/Index/IndexVAny/when_opening_ptable_without_right_flag_in_header.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexVAny/when_opening_ptable_without_right_flag_in_header.cs
@@ -23,7 +23,7 @@ public class when_opening_ptable_without_right_flag_in_header : SpecificationWit
 
 	[Test]
 	public void the_invalid_file_exception_is_thrown() {
-		var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(Filename, 16, false));
+		var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 16, false));
 		Assert.IsInstanceOf<InvalidFileException>(exc.InnerException);
 	}
 }

--- a/src/KurrentDB.Core.Tests/Index/IndexVAny/when_opening_v1_indexmap.cs
+++ b/src/KurrentDB.Core.Tests/Index/IndexVAny/when_opening_v1_indexmap.cs
@@ -54,7 +54,7 @@ public class when_opening_indexmap_with_auto_merge_level_set : SpecificationWith
 		await base.TestFixtureSetUp();
 
 		_filename = GetFilePathFor("indexfile");
-		var empty = IndexMap.CreateEmpty(2, 4);
+		var empty = IndexMap.CreateEmpty(2, 4, Constants.PTableMaxReaderCountDefault);
 		empty.SaveToFile(_filename);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index.cs
@@ -43,7 +43,7 @@ class when_scavenging_a_table_index : SpecificationWithDirectoryPerTestFixture {
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5, skipIndexVerify: _skipIndexVerify,
 			useBloomFilter: _useBloomFilter);
@@ -67,7 +67,7 @@ class when_scavenging_a_table_index : SpecificationWithDirectoryPerTestFixture {
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5,
 			useBloomFilter: _useBloomFilter);

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_and_another_table_is_completed_during.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_and_another_table_is_completed_during.cs
@@ -50,7 +50,7 @@ class
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5,
 			useBloomFilter: _useBloomFilter);
@@ -83,7 +83,7 @@ class
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5,
 			useBloomFilter: _useBloomFilter);

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_scavenging_table.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_scavenging_table.cs
@@ -39,7 +39,7 @@ class when_scavenging_a_table_index_cancelled_while_scavenging_table : Specifica
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5);
 		_tableIndex.Initialize(long.MaxValue);
@@ -64,7 +64,7 @@ class when_scavenging_a_table_index_cancelled_while_scavenging_table : Specifica
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5);
 

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_waiting_for_lock.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_waiting_for_lock.cs
@@ -33,7 +33,7 @@ class when_scavenging_a_table_index_cancelled_while_waiting_for_lock : Specifica
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5);
 		_tableIndex.Initialize(long.MaxValue);
@@ -60,7 +60,7 @@ class when_scavenging_a_table_index_cancelled_while_waiting_for_lock : Specifica
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5);
 

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_fails.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_fails.cs
@@ -40,7 +40,7 @@ class when_scavenging_a_table_index_fails : SpecificationWithDirectoryPerTestFix
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader /* throw an exception when the first PTable scavenge starts and tries to acquire a reader */,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5,
 			useBloomFilter: _useBloomFilter);
@@ -64,7 +64,7 @@ class when_scavenging_a_table_index_fails : SpecificationWithDirectoryPerTestFix
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 			fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 2,
 			maxTablesPerLevel: 5,
 			useBloomFilter: _useBloomFilter);

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_an_index.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_an_index.cs
@@ -35,12 +35,13 @@ public class when_scavenging_an_index : SpecificationWithDirectoryPerTestFixture
 		table.Add(0x010200000000, 0, 2);
 		table.Add(0x010300000000, 0, 3);
 		table.Add(0x010300000000, 1, 4);
-		_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+		_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 		Func<IndexEntry, bool> existsAt = x => x.Position % 2 == 0;
 
 		(_newtable, _) = await PTable.Scavenged(_oldTable, GetTempFilePath(),
 			PTableVersions.IndexV4, existsAt.ToAsync(), skipIndexVerify: _skipIndexVerify,
+			initialReaders: Constants.PTableInitialReaderCount, maxReaders: Constants.PTableMaxReaderCountDefault,
 			useBloomFilter: true);
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_an_index_fails.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_an_index_fails.cs
@@ -24,13 +24,14 @@ public class when_scavenging_an_index_fails : SpecificationWithDirectoryPerTestF
 		table.Add(0x010200000000, 0, 2);
 		table.Add(0x010300000000, 0, 3);
 		table.Add(0x010300000000, 1, 4);
-		_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+		_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 		Func<IndexEntry, bool> existsAt = x => { throw new Exception("Expected exception"); };
 
 		_expectedOutputFile = GetTempFilePath();
 		var ex = Assert.ThrowsAsync<Exception>(async () => await PTable.Scavenged(_oldTable, _expectedOutputFile,
-			PTableVersions.IndexV4, existsAt.ToAsync(),
+			PTableVersions.IndexV4, existsAt.ToAsync(), initialReaders: Constants.PTableInitialReaderCount,
+			maxReaders: Constants.PTableMaxReaderCountDefault,
 			useBloomFilter: true));
 
 		Assert.AreEqual("Expected exception", ex?.Message);

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_an_index_is_cancelled.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_an_index_is_cancelled.cs
@@ -25,7 +25,7 @@ public class when_scavenging_an_index_is_cancelled : SpecificationWithDirectoryP
 		table.Add(0x010200000000, 0, 2);
 		table.Add(0x010300000000, 0, 3);
 		table.Add(0x010300000000, 1, 4);
-		_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+		_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 		var cancellationTokenSource = new CancellationTokenSource();
 		Func<IndexEntry, bool> existsAt = x => {
@@ -36,6 +36,7 @@ public class when_scavenging_an_index_is_cancelled : SpecificationWithDirectoryP
 		_expectedOutputFile = GetTempFilePath();
 		Assert.ThrowsAsync<TaskCanceledException>(async () => await PTable.Scavenged(_oldTable, _expectedOutputFile,
 			PTableVersions.IndexV4, existsAt.ToAsync(), ct: cancellationTokenSource.Token,
+			initialReaders: Constants.PTableInitialReaderCount, maxReaders: Constants.PTableMaxReaderCountDefault,
 			useBloomFilter: true));
 	}
 

--- a/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_an_index_removes_nothing.cs
+++ b/src/KurrentDB.Core.Tests/Index/Scavenge/when_scavenging_an_index_removes_nothing.cs
@@ -37,13 +37,14 @@ public class when_scavenging_an_index_removes_nothing : SpecificationWithDirecto
 		table.Add(0x010200000000, 0, 2);
 		table.Add(0x010300000000, 0, 3);
 		table.Add(0x010300000000, 1, 4);
-		_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+		_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 		Func<IndexEntry, bool> existsAt = x => true;
 
 		_expectedOutputFile = GetTempFilePath();
 		(_newtable, var spaceSaved) = await PTable.Scavenged(_oldTable, _expectedOutputFile,
-			PTableVersions.IndexV4, existsAt.ToAsync(), skipIndexVerify: _skipIndexVerify);
+			PTableVersions.IndexV4, existsAt.ToAsync(), skipIndexVerify: _skipIndexVerify,
+			initialReaders: Constants.PTableInitialReaderCount, maxReaders: Constants.PTableMaxReaderCountDefault);
 	}
 
 	[OneTimeTearDown]

--- a/src/KurrentDB.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -143,6 +143,7 @@ public abstract class DuplicateReadIndexTestScenario<TLogFormat, TStreamId> : Sp
 			reader,
 			IndexBitnessVersion,
 			int.MaxValue,
+			Constants.PTableMaxReaderCountDefault,
 			MaxEntriesInMemTable);
 		_logFormat.StreamNamesProvider.SetTableIndex(_tableIndex);
 
@@ -191,6 +192,7 @@ public abstract class DuplicateReadIndexTestScenario<TLogFormat, TStreamId> : Sp
 			reader,
 			IndexBitnessVersion,
 			int.MaxValue,
+			Constants.PTableMaxReaderCountDefault,
 			MaxEntriesInMemTable);
 
 		readIndex = new ReadIndex<TStreamId>(new NoopPublisher(),

--- a/src/KurrentDB.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
@@ -62,7 +62,7 @@ public class HashCollisionTestFixture : SpecificationWithDirectoryPerTestFixture
 			() => new HashListMemTable(PTableVersions.IndexV4, maxSize: _maxMemTableSize),
 			_fakeReader,
 			PTableVersions.IndexV4,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: _maxMemTableSize,
 			maxTablesPerLevel: 2);
 		_logFormat.StreamNamesProvider.SetTableIndex(_tableIndex);
@@ -319,7 +319,7 @@ public class
 			() => new HashListMemTable(PTableVersions.IndexV2, maxSize: _maxMemTableSize),
 			_fakeReader,
 			PTableVersions.IndexV2,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: _maxMemTableSize,
 			maxTablesPerLevel: 2);
 		_tableIndex.Initialize(long.MaxValue);

--- a/src/KurrentDB.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -115,6 +115,7 @@ public abstract class ReadIndexTestScenario<TLogFormat, TStreamId> : Specificati
 			reader,
 			IndexBitnessVersion,
 			int.MaxValue,
+			Constants.PTableMaxReaderCountDefault,
 			MaxEntriesInMemTable));
 		_logFormat.StreamNamesProvider.SetTableIndex(TableIndex);
 

--- a/src/KurrentDB.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -65,6 +65,7 @@ public abstract class RepeatableDbTestScenario<TLogFormat, TStreamId> : Specific
 			reader,
 			PTableVersions.IndexV3,
 			int.MaxValue,
+			Constants.PTableMaxReaderCountDefault,
 			MaxEntriesInMemTable);
 		_logFormat.StreamNamesProvider.SetTableIndex(TableIndex);
 

--- a/src/KurrentDB.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -64,6 +64,7 @@ public abstract class SimpleDbTestScenario<TLogFormat, TStreamId> : Specificatio
 			reader,
 			PTableVersions.IndexV2,
 			int.MaxValue,
+			Constants.PTableMaxReaderCountDefault,
 			MaxEntriesInMemTable);
 		_logFormat.StreamNamesProvider.SetTableIndex(TableIndex);
 

--- a/src/KurrentDB.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
@@ -39,7 +39,7 @@ public class when_rebuilding_index_for_partially_persisted_transaction<TLogForma
 			() => new HashListMemTable(PTableVersions.IndexV2, maxSize: MaxEntriesInMemTable * 2),
 			reader,
 			PTableVersions.IndexV2,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			MaxEntriesInMemTable);
 		var readIndex = new ReadIndex<TStreamId>(new NoopPublisher(),
 			reader,

--- a/src/KurrentDB.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/KurrentDB.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -67,7 +67,7 @@ public abstract class ScavengeTestScenario<TLogFormat, TStreamId> : Specificatio
 			() => new HashListMemTable(PTableVersions.IndexV3, maxSize: 200),
 			reader,
 			PTableVersions.IndexV3,
-			5,
+			5, Constants.PTableMaxReaderCountDefault,
 			maxSizeForMemory: 100,
 			maxTablesPerLevel: 2);
 		_logFormat.StreamNamesProvider.SetTableIndex(tableIndex);

--- a/src/KurrentDB.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/KurrentDB.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -42,6 +42,7 @@ public abstract class TruncateAndReOpenDbScenario<TLogFormat, TStreamId> : Trunc
 			reader,
 			PTableVersions.IndexV3,
 			int.MaxValue,
+			Constants.PTableMaxReaderCountDefault,
 			MaxEntriesInMemTable);
 		_logFormat.StreamNamesProvider.SetTableIndex(TableIndex);
 		var readIndex = new ReadIndex<TStreamId>(new NoopPublisher(),

--- a/src/KurrentDB.Core.XUnit.Tests/LogV2/LogV2StreamExistenceFilterInitializerTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/LogV2/LogV2StreamExistenceFilterInitializerTests.cs
@@ -35,7 +35,8 @@ public class LogV2StreamExistenceFilterInitializerTests : DirectoryPerTest<LogV2
 			maxSizeForMemory: 100_000,
 			tfReader: _log,
 			ptableVersion: PTableVersions.IndexV4,
-			maxAutoMergeIndexLevel: int.MaxValue);
+			maxAutoMergeIndexLevel: int.MaxValue,
+			pTableMaxReaderCount: 5);
 		_tableIndex.Initialize(0);
 
 		_sut = new LogV2StreamExistenceFilterInitializer(
@@ -187,7 +188,8 @@ public class LogV2StreamExistenceFilterInitializerTests : DirectoryPerTest<LogV2
 				maxSize: 1_000_000 * 2),
 			new FakeTfReader(),
 			ptableVersion: PTableVersions.IndexV1,
-			maxAutoMergeIndexLevel: int.MaxValue);
+			maxAutoMergeIndexLevel: int.MaxValue,
+			pTableMaxReaderCount: 5);
 		tableIndex.Initialize(0);
 
 		var sut = new LogV2StreamExistenceFilterInitializer(

--- a/src/KurrentDB.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -317,6 +317,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario {
 			reader,
 			ptableVersion: PTableVersions.IndexV4,
 			maxAutoMergeIndexLevel: int.MaxValue,
+			pTableMaxReaderCount: ESConsts.PTableInitialReaderCount,
 			maxSizeForMemory: _skipIndexCheck
 				? 1_000_000 // we aren't going to check the index so no need to convert to ptables
 				: 1, // convert everything to ptables immediately so we can check the index

--- a/src/KurrentDB.Core/Index/IndexMap.cs
+++ b/src/KurrentDB.Core/Index/IndexMap.cs
@@ -30,9 +30,10 @@ public class IndexMap {
 	private readonly List<List<PTable>> _map;
 	private readonly int _maxTablesPerLevel;
 	private readonly int _maxTableLevelsForAutomaticMerge;
+	private readonly int _pTableMaxReaderCount;
 
 	private IndexMap(int version, List<List<PTable>> tables, long prepareCheckpoint, long commitCheckpoint,
-		int maxTablesPerLevel, int maxTableLevelsForAutomaticMerge) {
+		int maxTablesPerLevel, int maxTableLevelsForAutomaticMerge, int pTableMaxReaderCount) {
 		Ensure.Nonnegative(version, "version");
 		if (prepareCheckpoint < -1)
 			throw new ArgumentOutOfRangeException("prepareCheckpoint");
@@ -49,6 +50,7 @@ public class IndexMap {
 		_map = CopyFrom(tables);
 		_maxTablesPerLevel = maxTablesPerLevel;
 		_maxTableLevelsForAutomaticMerge = maxTableLevelsForAutomaticMerge;
+		_pTableMaxReaderCount = pTableMaxReaderCount;
 		VerifyStructure();
 	}
 
@@ -116,9 +118,9 @@ public class IndexMap {
 			   select table.Filename;
 	}
 
-	public static IndexMap CreateEmpty(int maxTablesPerLevel, int maxTableLevelsForAutomaticMerge) {
+	public static IndexMap CreateEmpty(int maxTablesPerLevel, int maxTableLevelsForAutomaticMerge, int pTableMaxReaderCount) {
 		return new IndexMap(IndexMapVersion, new List<List<PTable>>(), -1, -1, maxTablesPerLevel,
-			maxTableLevelsForAutomaticMerge);
+			maxTableLevelsForAutomaticMerge, pTableMaxReaderCount);
 	}
 
 	public static IndexMap FromFile(
@@ -130,9 +132,10 @@ public class IndexMap {
 		bool useBloomFilter,
 		int lruCacheSize,
 		int threads,
-		int maxAutoMergeLevel) {
+		int maxAutoMergeLevel,
+		int pTableMaxReaderCount) {
 		if (!File.Exists(filename))
-			return CreateEmpty(maxTablesPerLevel, maxAutoMergeLevel);
+			return CreateEmpty(maxTablesPerLevel, maxAutoMergeLevel, pTableMaxReaderCount);
 
 		using (var f = File.OpenRead(filename)) {
 			// calculate real MD5 hash except first 32 bytes which are string representation of stored hash
@@ -161,7 +164,7 @@ public class IndexMap {
 				//we are doing a logical upgrade of the version to have the new data, so we will change the version to match so that new files are saved with the right version
 				version = IndexMapVersion;
 				var tables = loadPTables
-					? LoadPTables(reader, filename, checkpoints, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize, threads)
+					? LoadPTables(reader, filename, checkpoints, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize, threads, pTableMaxReaderCount)
 					: new List<List<PTable>>();
 
 				if (!loadPTables && reader.ReadLine() != null)
@@ -170,7 +173,7 @@ public class IndexMap {
 							checkpoints));
 
 				return new IndexMap(version, tables, prepareCheckpoint, commitCheckpoint, maxTablesPerLevel,
-					maxAutoMergeLevel);
+					maxAutoMergeLevel, pTableMaxReaderCount);
 			}
 		}
 	}
@@ -252,7 +255,8 @@ public class IndexMap {
 	private static List<List<PTable>> LoadPTables(StreamReader reader, string indexmapFilename, TFPos checkpoints,
 		int cacheDepth, bool skipIndexVerify,
 		bool useBloomFilter, int lruCacheSize,
-		int threads) {
+		int threads,
+		int pTableMaxReaderCount) {
 		var tables = new List<List<PTable>>();
 		try {
 			try {
@@ -275,8 +279,7 @@ public class IndexMap {
 							var path = Path.GetDirectoryName(indexmapFilename);
 							var ptablePath = Path.Combine(path, file);
 
-							ptable = PTable.FromFile(ptablePath, cacheDepth, skipIndexVerify, useBloomFilter,
-								lruCacheSize);
+							ptable = PTable.FromFile(ptablePath, ESConsts.PTableInitialReaderCount, pTableMaxReaderCount, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
 
 							lock (tables) {
 								InsertTableToTables(tables, level, position, ptable);
@@ -391,7 +394,7 @@ public class IndexMap {
 		AddTableToTables(tables, 0, tableToAdd);
 
 		var indexMap = new IndexMap(Version, tables, prepareCheckpoint, commitCheckpoint, _maxTablesPerLevel,
-			_maxTableLevelsForAutomaticMerge);
+			_maxTableLevelsForAutomaticMerge, _pTableMaxReaderCount);
 
 		var canMergeAny = false;
 		var maxTableLevelsToMerge = Math.Min(tables.Count, _maxTableLevelsForAutomaticMerge);
@@ -430,6 +433,8 @@ public class IndexMap {
 					tables[level],
 					filename,
 					version,
+					ESConsts.PTableInitialReaderCount,
+					_pTableMaxReaderCount,
 					indexCacheDepth,
 					skipIndexVerify,
 					useBloomFilter,
@@ -443,7 +448,7 @@ public class IndexMap {
 		}
 
 		var indexMap = new IndexMap(Version, tables, PrepareCheckpoint, CommitCheckpoint, _maxTablesPerLevel,
-			_maxTableLevelsForAutomaticMerge);
+			_maxTableLevelsForAutomaticMerge, _pTableMaxReaderCount);
 		return new MergeResult(indexMap, toDelete, hasMergedAny, canMergeAny);
 	}
 
@@ -471,6 +476,8 @@ public class IndexMap {
 			tablesToMerge,
 			filename,
 			version,
+			ESConsts.PTableInitialReaderCount,
+			_pTableMaxReaderCount,
 			indexCacheDepth,
 			skipIndexVerify,
 			useBloomFilter,
@@ -485,7 +492,7 @@ public class IndexMap {
 		toDelete.AddRange(tablesToMerge);
 
 		var indexMap = new IndexMap(Version, tables, PrepareCheckpoint, CommitCheckpoint, _maxTablesPerLevel,
-			_maxTableLevelsForAutomaticMerge);
+			_maxTableLevelsForAutomaticMerge, _pTableMaxReaderCount);
 		return new MergeResult(indexMap, toDelete, true, false);
 	}
 
@@ -510,6 +517,8 @@ public class IndexMap {
 						filename,
 						version,
 						shouldKeep,
+						ESConsts.PTableInitialReaderCount,
+						_pTableMaxReaderCount,
 						indexCacheDepth,
 						skipIndexVerify,
 						useBloomFilter,
@@ -523,7 +532,7 @@ public class IndexMap {
 					scavengedMap[level][i] = scavenged;
 
 					var indexMap = new IndexMap(Version, scavengedMap, PrepareCheckpoint, CommitCheckpoint,
-						_maxTablesPerLevel, _maxTableLevelsForAutomaticMerge);
+						_maxTablesPerLevel, _maxTableLevelsForAutomaticMerge, _pTableMaxReaderCount);
 
 					return ScavengeResult.Success(indexMap, oldTable, scavenged, spaceSaved, level, i);
 				}

--- a/src/KurrentDB.Core/Index/PTable.cs
+++ b/src/KurrentDB.Core/Index/PTable.cs
@@ -332,7 +332,7 @@ public partial class PTable : ISearchTable, IDisposable {
 										   _midpointsCacheSize;
 						stream.Seek(startOffset, SeekOrigin.Begin);
 						for (int k = 0; k < (int)_midpointsCached; k++) {
-							stream.Read(buffer, 0, _indexEntrySize);
+							stream.ReadExactly(buffer, 0, _indexEntrySize);
 							IndexEntryKey key;
 							long index;
 							if (_version == PTableVersions.IndexV4) {
@@ -367,7 +367,7 @@ public partial class PTable : ISearchTable, IDisposable {
 
 				if (!skipIndexVerify) {
 					stream.Seek(0, SeekOrigin.Begin);
-					stream.Read(buffer, 0, PTableHeader.Size);
+					stream.ReadExactly(buffer, 0, PTableHeader.Size);
 					md5.TransformBlock(buffer, 0, PTableHeader.Size, null, 0);
 				}
 
@@ -378,11 +378,11 @@ public partial class PTable : ISearchTable, IDisposable {
 					if (previousNextIndex != nextIndex) {
 						if (!skipIndexVerify) {
 							ReadUntilWithMd5(PTableHeader.Size + _indexEntrySize * nextIndex, stream, md5);
-							stream.Read(buffer, 0, _indexKeySize);
+							stream.ReadExactly(buffer, 0, _indexKeySize);
 							md5.TransformBlock(buffer, 0, _indexKeySize, null, 0);
 						} else {
 							stream.Seek(PTableHeader.Size + _indexEntrySize * nextIndex, SeekOrigin.Begin);
-							stream.Read(buffer, 0, _indexKeySize);
+							stream.ReadExactly(buffer, 0, _indexKeySize);
 						}
 
 						IndexEntryKey key;
@@ -423,7 +423,7 @@ public partial class PTable : ISearchTable, IDisposable {
 					//verify hash (should be at stream.length - MD5Size)
 					md5.TransformFinalBlock(Empty.ByteArray, 0, 0);
 					var fileHash = new byte[MD5Size];
-					stream.Read(fileHash, 0, MD5Size);
+					stream.ReadExactly(fileHash, 0, MD5Size);
 					ValidateHash(md5.Hash, fileHash);
 				}
 

--- a/src/KurrentDB.Core/Index/PTable.cs
+++ b/src/KurrentDB.Core/Index/PTable.cs
@@ -2,27 +2,22 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using DotNext;
-using DotNext.Buffers;
-using DotNext.Buffers.Text;
-using DotNext.Diagnostics;
-using DotNext.IO;
-using DotNext.Threading;
 using KurrentDB.Common.Utils;
 using KurrentDB.Core.DataStructures;
 using KurrentDB.Core.DataStructures.ProbabilisticFilter;
 using KurrentDB.Core.Exceptions;
 using KurrentDB.Core.TransactionLog.Unbuffered;
-using Microsoft.Win32.SafeHandles;
 using ILogger = Serilog.ILogger;
+using MD5 = KurrentDB.Core.Hashing.MD5;
 using Range = KurrentDB.Core.Data.Range;
+using RuntimeInformation = System.Runtime.RuntimeInformation;
 
 namespace KurrentDB.Core.Index;
 
@@ -51,8 +46,8 @@ public partial class PTable : ISearchTable, IDisposable {
 	public const int IndexKeyV3Size = sizeof(long) + sizeof(long);
 	public const int IndexKeyV4Size = IndexKeyV3Size;
 	public const int MD5Size = 16;
-	private const int DefaultBufferSize = 8192;
-	private const int DefaultSequentialBufferSize = 65536;
+	public const int DefaultBufferSize = 8192;
+	public const int DefaultSequentialBufferSize = 65536;
 	private static readonly ILogger Log = Serilog.Log.ForContext<PTable>();
 
 	public Guid Id {
@@ -102,32 +97,35 @@ public partial class PTable : ISearchTable, IDisposable {
 	private readonly LRUCache<StreamHash, bool> _lruConfirmedNotPresent;
 
 	private readonly IndexEntryKey _minEntry, _maxEntry;
-
-	// Handle lifetime is managed by AcquireFileHandle() and ReleaseFileHandle() methods
-	// and built-in reference counting mechanism provided by SafeHandle class
-	private readonly SafeFileHandle _handle;
+	private readonly ObjectPool<WorkItem> _workItems;
 	private readonly byte _version;
 	private readonly int _indexEntrySize;
 	private readonly int _indexKeySize;
 
-	private readonly ManualResetEventSlim _destroyEvent = new(initialState: false);
+	private readonly ManualResetEventSlim _destroyEvent = new ManualResetEventSlim(false);
 	private volatile bool _deleteFile;
 	private bool _disposed;
-	private Atomic.Boolean _cleanupBarrier;
 
-	public ReadOnlySpan<Midpoint> GetMidPoints()
-		=> _midpoints is null ? [] : _midpoints.AsSpan();
+	public ReadOnlySpan<Midpoint> GetMidPoints() {
+		if (_midpoints == null)
+			return ReadOnlySpan<Midpoint>.Empty;
+
+		return _midpoints.AsSpan();
+	}
 
 	private PTable(string filename,
 		Guid id,
+		int initialReaders,
+		int maxReaders,
 		int depth = 16,
 		bool skipIndexVerify = false,
 		bool useBloomFilter = true,
 		int lruCacheSize = 1_000_000) {
 
-		ArgumentException.ThrowIfNullOrWhiteSpace(filename);
-		ArgumentOutOfRangeException.ThrowIfEqual(id, Guid.Empty);
-		ArgumentOutOfRangeException.ThrowIfNegative(depth);
+		Ensure.NotNullOrEmpty(filename, "filename");
+		Ensure.NotEmptyGuid(id, "id");
+		Ensure.Positive(maxReaders, "maxReaders");
+		Ensure.Nonnegative(depth, "depth");
 
 		if (!File.Exists(filename))
 			throw new CorruptIndexException(new PTableNotFoundException(filename));
@@ -137,87 +135,121 @@ public partial class PTable : ISearchTable, IDisposable {
 
 		Log.Debug("Loading " + (skipIndexVerify ? "" : "and Verification ") + "of PTable '{pTable}' started...",
 			Path.GetFileName(Filename));
-		var sw = new Timestamp();
-		_handle = File.OpenHandle(filename, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.RandomAccess);
-		_size = RandomAccess.GetLength(_handle);
+		var sw = Stopwatch.StartNew();
+		_size = new FileInfo(_filename).Length;
 
-		Helper.EatException(_handle, static handle => {
+		Helper.EatException(_filename, static filename => {
 			// this action will fail if the file is created on a Unix system that does not have permissions to make files read-only
-			File.SetAttributes(handle, FileAttributes.ReadOnly | FileAttributes.NotContentIndexed);
+			File.SetAttributes(filename, FileAttributes.ReadOnly | FileAttributes.NotContentIndexed);
 		});
 
+		_workItems = new ObjectPool<WorkItem>(string.Format("PTable {0} work items", _id),
+			initialReaders,
+			maxReaders,
+			() => new WorkItem(filename, DefaultBufferSize),
+			workItem => workItem.Dispose(),
+			pool => OnAllWorkItemsDisposed());
+
+		var readerWorkItem = GetWorkItem();
 		try {
-			var header = PTableHeader.Parse(_handle, fileOffset: 0L);
-			long indexEntriesTotalSize = _size - PTableHeader.Size - MD5Size;
-			switch (_version = header.Version) {
-				case PTableVersions.IndexV1:
-					throw new CorruptIndexException(new UnsupportedFileVersionException(
-						_filename, header.Version, Version,
-						"Detected a V1 index file, which is no longer supported. " +
-						"The index will be backed up and rebuilt in a supported format. " +
-						"This may take a long time for large databases. " +
-						"You can also use a version of ESDB (>= 3.9.0 and < 24.10.0) to upgrade the " +
-						"indexes to a supported format by performing an index merge."));
-				case PTableVersions.IndexV2:
-					_indexEntrySize = IndexEntryV2Size;
-					_indexKeySize = IndexKeyV2Size;
-					break;
-				case PTableVersions.IndexV3:
-					_indexEntrySize = IndexEntryV3Size;
-					_indexKeySize = IndexKeyV3Size;
-					break;
-				case >= PTableVersions.IndexV4:
-					//read the PTable footer
-					var footer = PTableFooter.Parse(_handle, _size - MD5Size - PTableFooter.Size);
-					if (footer.Version != header.Version)
-						throw new CorruptIndexException(
-							$"PTable header/footer version mismatch: {header.Version}/{footer.Version}",
-							new InvalidFileException("Invalid PTable file."));
+			readerWorkItem.Stream.Seek(0, SeekOrigin.Begin);
+			var header = PTableHeader.FromStream(readerWorkItem.Stream);
 
-					_indexEntrySize = IndexEntryV4Size;
-					_indexKeySize = IndexKeyV4Size;
-
-					_midpointsCached = footer.NumMidpointsCached;
-					_midpointsCacheSize = _midpointsCached * _indexEntrySize;
-					indexEntriesTotalSize = indexEntriesTotalSize - PTableFooter.Size - _midpointsCacheSize;
-					break;
-				default:
-					throw new CorruptIndexException(
-						new UnsupportedFileVersionException(_filename, header.Version, Version));
+			if (header.Version == PTableVersions.IndexV1) {
+				throw new CorruptIndexException(new UnsupportedFileVersionException(
+					_filename, header.Version, Version,
+					"Detected a V1 index file, which is no longer supported. " +
+					"The index will be backed up and rebuilt in a supported format. " +
+					"This may take a long time for large databases. " +
+					"You can also use a version of ESDB (>= 3.9.0 and < 24.10.0) to upgrade the " +
+					"indexes to a supported format by performing an index merge."));
 			}
 
+			if ((header.Version != PTableVersions.IndexV2) &&
+				(header.Version != PTableVersions.IndexV3) &&
+				(header.Version != PTableVersions.IndexV4))
+				throw new CorruptIndexException(new UnsupportedFileVersionException(_filename, header.Version, Version));
+			_version = header.Version;
+
+			if (_version == PTableVersions.IndexV1) {
+				_indexEntrySize = IndexEntryV1Size;
+				_indexKeySize = IndexKeyV1Size;
+			}
+
+			if (_version == PTableVersions.IndexV2) {
+				_indexEntrySize = IndexEntryV2Size;
+				_indexKeySize = IndexKeyV2Size;
+			}
+
+			if (_version == PTableVersions.IndexV3) {
+				_indexEntrySize = IndexEntryV3Size;
+				_indexKeySize = IndexKeyV3Size;
+			}
+
+			if (_version >= PTableVersions.IndexV4) {
+				//read the PTable footer
+				var previousPosition = readerWorkItem.Stream.Position;
+				readerWorkItem.Stream.Seek(readerWorkItem.Stream.Length - MD5Size - PTableFooter.GetSize(_version),
+					SeekOrigin.Begin);
+				var footer = PTableFooter.FromStream(readerWorkItem.Stream);
+				if (footer.Version != header.Version)
+					throw new CorruptIndexException(
+						String.Format("PTable header/footer version mismatch: {0}/{1}", header.Version,
+							footer.Version), new InvalidFileException("Invalid PTable file."));
+
+				if (_version == PTableVersions.IndexV4) {
+					_indexEntrySize = IndexEntryV4Size;
+					_indexKeySize = IndexKeyV4Size;
+				} else
+					throw new InvalidOperationException("Unknown PTable version: " + _version);
+
+				_midpointsCached = footer.NumMidpointsCached;
+				_midpointsCacheSize = _midpointsCached * _indexEntrySize;
+				readerWorkItem.Stream.Seek(previousPosition, SeekOrigin.Begin);
+			}
+
+			long indexEntriesTotalSize = (_size - PTableHeader.Size - _midpointsCacheSize -
+										  PTableFooter.GetSize(_version) - MD5Size);
+
 			if (indexEntriesTotalSize < 0) {
-				throw new CorruptIndexException(
-					$"Total size of index entries < 0: {indexEntriesTotalSize}. _size: {_size}, header size: {PTableHeader.Size}, _midpointsCacheSize: {_midpointsCacheSize}, version: {_version}, md5 size: {MD5Size}");
-			} else if (indexEntriesTotalSize % _indexEntrySize is not 0) {
-				throw new CorruptIndexException(
-					$"Total size of index entries: {indexEntriesTotalSize} is not divisible by index entry size: {_indexEntrySize}");
+				throw new CorruptIndexException(String.Format(
+					"Total size of index entries < 0: {0}. _size: {1}, header size: {2}, _midpointsCacheSize: {3}, footer size: {4}, md5 size: {5}",
+					indexEntriesTotalSize, _size, PTableHeader.Size, _midpointsCacheSize,
+					PTableFooter.GetSize(_version), MD5Size));
+			} else if (indexEntriesTotalSize % _indexEntrySize != 0) {
+				throw new CorruptIndexException(String.Format(
+					"Total size of index entries: {0} is not divisible by index entry size: {1}",
+					indexEntriesTotalSize, _indexEntrySize));
 			}
 
 			_count = indexEntriesTotalSize / _indexEntrySize;
 
-			if (_version >= PTableVersions.IndexV4 && _count > 0 && _midpointsCached is > 0 and < 2) {
+			if (_version >= PTableVersions.IndexV4 && _count > 0 && _midpointsCached > 0 && _midpointsCached < 2) {
 				//if there is at least 1 index entry with version>=4 and there are cached midpoints, there should always be at least 2 midpoints cached
-				throw new CorruptIndexException(
-					$"Less than 2 midpoints cached in PTable. Index entries: {_count}, Midpoints cached: {_midpointsCached}");
+				throw new CorruptIndexException(String.Format(
+					"Less than 2 midpoints cached in PTable. Index entries: {0}, Midpoints cached: {1}", _count,
+					_midpointsCached));
 			} else if (_count >= 2 && _midpointsCached > _count) {
 				//if there are at least 2 index entries, midpoints count should be at most the number of index entries
-				throw new CorruptIndexException(
-					$"More midpoints cached in PTable than index entries. Midpoints: {_midpointsCached} , Index entries: {_count}");
+				throw new CorruptIndexException(String.Format(
+					"More midpoints cached in PTable than index entries. Midpoints: {0} , Index entries: {1}",
+					_midpointsCached, _count));
 			}
 
-			if (Count is 0) {
+			if (Count == 0) {
 				_minEntry = new IndexEntryKey(ulong.MaxValue, long.MaxValue);
 				_maxEntry = new IndexEntryKey(ulong.MinValue, long.MinValue);
 			} else {
-				var minEntry = ReadEntry(_handle, _indexEntrySize, Count - 1, _version);
+				var minEntry = ReadEntry(_indexEntrySize, Count - 1, readerWorkItem, _version);
 				_minEntry = new IndexEntryKey(minEntry.Stream, minEntry.Version);
-				var maxEntry = ReadEntry(_handle, _indexEntrySize, 0, _version);
+				var maxEntry = ReadEntry(_indexEntrySize, 0, readerWorkItem, _version);
 				_maxEntry = new IndexEntryKey(maxEntry.Stream, maxEntry.Version);
 			}
 		} catch (Exception) {
 			Dispose();
 			throw;
+		} finally {
+			ReturnWorkItem(readerWorkItem);
 		}
 
 		int calcdepth = 0;
@@ -256,135 +288,147 @@ public partial class PTable : ISearchTable, IDisposable {
 
 	~PTable() => Dispose(false);
 
-	private UnmanagedMemoryAppendOnlyList<Midpoint> CacheMidpointsAndVerifyHash(int depth, bool skipIndexVerify) {
-		if (depth is < 0 or > 30)
-			throw new ArgumentOutOfRangeException(nameof(depth));
-
+	internal UnmanagedMemoryAppendOnlyList<Midpoint> CacheMidpointsAndVerifyHash(int depth, bool skipIndexVerify) {
+		var buffer = new byte[4096];
+		if (depth < 0 || depth > 30)
+			throw new ArgumentOutOfRangeException("depth");
 		var count = Count;
-		if (count is 0 || depth is 0)
+		if (count == 0 || depth == 0)
 			return null;
 
 		if (skipIndexVerify) {
 			Log.Debug("Disabling Verification of PTable");
 		}
 
-		var stream = OperatingSystem.IsWindows()
-			? UnbufferedFileStream.Create(_filename, FileMode.Open, FileAccess.Read, FileShare.Read,
-				4096, 4096, false, 4096)
-			: _handle.AsUnbufferedStream(FileAccess.Read);
+		Stream stream = null;
+		WorkItem workItem = null;
+		if (RuntimeInformation.IsUnix) {
+			workItem = GetWorkItem();
+			stream = workItem.Stream;
+		} else {
+			stream = UnbufferedFileStream.Create(_filename, FileMode.Open, FileAccess.Read, FileShare.Read,
+				4096, 4096, false, 4096);
+		}
 
 		UnmanagedMemoryAppendOnlyList<Midpoint> midpoints = null;
 
-		var md5 = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
-		Span<byte> buffer = stackalloc byte[PTableHeader.Size];
-		Debug.Assert(buffer.Length >= _indexEntrySize);
-		Debug.Assert(buffer.Length >= _indexKeySize);
-
-		var tmpBuffer = new SpanOwner<byte>(DefaultBufferSize, exactSize: false);
 		try {
-			int midpointsCount;
-			try {
-				midpointsCount = (int)Math.Max(2L, Math.Min((long)1 << depth, count));
-				midpoints = new UnmanagedMemoryAppendOnlyList<Midpoint>(midpointsCount);
-			} catch (OutOfMemoryException exc) {
-				throw new PossibleToHandleOutOfMemoryException("Failed to allocate memory for Midpoint cache.",
-					exc);
-			}
+			using (var md5 = MD5.Create()) {
+				int midpointsCount;
+				try {
+					midpointsCount = (int)Math.Max(2L, Math.Min((long)1 << depth, count));
+					midpoints = new UnmanagedMemoryAppendOnlyList<Midpoint>(midpointsCount);
+				} catch (OutOfMemoryException exc) {
+					throw new PossibleToHandleOutOfMemoryException("Failed to allocate memory for Midpoint cache.",
+						exc);
+				}
 
-			switch (skipIndexVerify) {
-				case true when _version >= PTableVersions.IndexV4:
+				if (skipIndexVerify && (_version >= PTableVersions.IndexV4)) {
 					if (_midpointsCached == midpointsCount) {
 						//index verification is disabled and cached midpoints with the same depth requested are available
 						//so, we can load them directly from the PTable file
 						Log.Debug("Loading {midpointsCached} cached midpoints from PTable", _midpointsCached);
-						long startOffset = stream.Length - MD5Size - PTableFooter.Size -
-						                   _midpointsCacheSize;
+						long startOffset = stream.Length - MD5Size - PTableFooter.GetSize(_version) -
+										   _midpointsCacheSize;
 						stream.Seek(startOffset, SeekOrigin.Begin);
 						for (int k = 0; k < (int)_midpointsCached; k++) {
-							stream.ReadExactly(buffer.Slice(0, _indexEntrySize));
-							var key = new IndexEntryKey(BinaryPrimitives.ReadUInt64LittleEndian(buffer.Slice(sizeof(long))),
-								BinaryPrimitives.ReadInt64LittleEndian(buffer));
-							var index = BinaryPrimitives.ReadInt64LittleEndian(
-								buffer.Slice(sizeof(long) + sizeof(long)));
+							stream.Read(buffer, 0, _indexEntrySize);
+							IndexEntryKey key;
+							long index;
+							if (_version == PTableVersions.IndexV4) {
+								key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 8),
+									BitConverter.ToInt64(buffer, 0));
+								index = BitConverter.ToInt64(buffer, 8 + 8);
+							} else
+								throw new InvalidOperationException("Unknown PTable version: " + _version);
 
 							midpoints.Add(new Midpoint(key, index));
 
 							if (k > 0) {
 								if (midpoints[k].Key.GreaterThan(midpoints[k - 1].Key)) {
-									throw new CorruptIndexException(
-										$"Index entry key for midpoint {k - 1} (stream: {midpoints[k - 1].Key.Stream}, version: {midpoints[k - 1].Key.Version}) < index entry key for midpoint {k} (stream: {midpoints[k].Key.Stream}, version: {midpoints[k].Key.Version})");
+									throw new CorruptIndexException(String.Format(
+										"Index entry key for midpoint {0} (stream: {1}, version: {2}) < index entry key for midpoint {3} (stream: {4}, version: {5})",
+										k - 1, midpoints[k - 1].Key.Stream, midpoints[k - 1].Key.Version, k,
+										midpoints[k].Key.Stream, midpoints[k].Key.Version));
 								} else if (midpoints[k - 1].ItemIndex > midpoints[k].ItemIndex) {
-									throw new CorruptIndexException(
-										$"Item index for midpoint {k - 1} ({midpoints[k - 1].ItemIndex}) > Item index for midpoint {k} ({midpoints[k].ItemIndex})");
+									throw new CorruptIndexException(String.Format(
+										"Item index for midpoint {0} ({1}) > Item index for midpoint {2} ({3})",
+										k - 1, midpoints[k - 1].ItemIndex, k, midpoints[k].ItemIndex));
 								}
 							}
 						}
 
 						return midpoints;
-					}
+					} else
+						Log.Debug(
+							"Skipping loading of cached midpoints from PTable due to count mismatch, cached midpoints: {midpointsCached} / required midpoints: {midpointsCount}",
+							_midpointsCached, midpointsCount);
+				}
 
-					Log.Debug(
-						"Skipping loading of cached midpoints from PTable due to count mismatch, cached midpoints: {midpointsCached} / required midpoints: {midpointsCount}",
-						_midpointsCached, midpointsCount);
-					break;
-				case false:
+				if (!skipIndexVerify) {
 					stream.Seek(0, SeekOrigin.Begin);
-					stream.ReadExactly(buffer.Slice(0, PTableHeader.Size));
-					md5.AppendData(buffer.Slice(0, PTableHeader.Size));
-					break;
-			}
+					stream.Read(buffer, 0, PTableHeader.Size);
+					md5.TransformBlock(buffer, 0, PTableHeader.Size, null, 0);
+				}
 
-			long previousNextIndex = long.MinValue;
-			var previousKey = new IndexEntryKey(long.MaxValue, long.MaxValue);
-			for (int k = 0; k < midpointsCount; ++k) {
-				long nextIndex = GetMidpointIndex(k, count, midpointsCount);
-				if (previousNextIndex != nextIndex) {
-					if (!skipIndexVerify) {
-						ReadUntilWithMd5(PTableHeader.Size + _indexEntrySize * nextIndex, stream, md5, tmpBuffer.Span);
-						stream.ReadExactly(buffer.Slice(0, _indexKeySize));
-						md5.AppendData(buffer.Slice(0, _indexKeySize));
+				long previousNextIndex = long.MinValue;
+				var previousKey = new IndexEntryKey(long.MaxValue, long.MaxValue);
+				for (int k = 0; k < midpointsCount; ++k) {
+					long nextIndex = GetMidpointIndex(k, count, midpointsCount);
+					if (previousNextIndex != nextIndex) {
+						if (!skipIndexVerify) {
+							ReadUntilWithMd5(PTableHeader.Size + _indexEntrySize * nextIndex, stream, md5);
+							stream.Read(buffer, 0, _indexKeySize);
+							md5.TransformBlock(buffer, 0, _indexKeySize, null, 0);
+						} else {
+							stream.Seek(PTableHeader.Size + _indexEntrySize * nextIndex, SeekOrigin.Begin);
+							stream.Read(buffer, 0, _indexKeySize);
+						}
+
+						IndexEntryKey key;
+						if (_version == PTableVersions.IndexV1) {
+							key = new IndexEntryKey(BitConverter.ToUInt32(buffer, 4),
+								BitConverter.ToInt32(buffer, 0));
+						} else if (_version == PTableVersions.IndexV2) {
+							key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 4),
+								BitConverter.ToInt32(buffer, 0));
+						} else {
+							key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 8),
+								BitConverter.ToInt64(buffer, 0));
+						}
+
+						midpoints.Add(new Midpoint(key, nextIndex));
+						previousNextIndex = nextIndex;
+						previousKey = key;
 					} else {
-						stream.Seek(PTableHeader.Size + _indexEntrySize * nextIndex, SeekOrigin.Begin);
-						stream.ReadExactly(buffer.Slice(0, _indexKeySize));
+						midpoints.Add(new Midpoint(previousKey, previousNextIndex));
 					}
 
-					IndexEntryKey key = _version switch {
-						PTableVersions.IndexV1 => new IndexEntryKey(
-							BinaryPrimitives.ReadUInt32LittleEndian(buffer.Slice(sizeof(int))),
-							BinaryPrimitives.ReadInt32LittleEndian(buffer)),
-						PTableVersions.IndexV2 => new IndexEntryKey(
-							BinaryPrimitives.ReadUInt64LittleEndian(buffer.Slice(sizeof(int))),
-							BinaryPrimitives.ReadInt32LittleEndian(buffer)),
-						_ => new IndexEntryKey(BinaryPrimitives.ReadUInt64LittleEndian(buffer.Slice(sizeof(long))),
-							BinaryPrimitives.ReadInt64LittleEndian(buffer))
-					};
-
-					midpoints.Add(new Midpoint(key, nextIndex));
-					previousNextIndex = nextIndex;
-					previousKey = key;
-				} else {
-					midpoints.Add(new Midpoint(previousKey, previousNextIndex));
-				}
-
-				if (k > 0) {
-					if (midpoints[k].Key.GreaterThan(midpoints[k - 1].Key)) {
-						throw new CorruptIndexException(String.Format(
-							"Index entry key for midpoint {0} (stream: {1}, version: {2}) < index entry key for midpoint {3} (stream: {4}, version: {5})",
-							k - 1, midpoints[k - 1].Key.Stream, midpoints[k - 1].Key.Version, k,
-							midpoints[k].Key.Stream, midpoints[k].Key.Version));
-					} else if (midpoints[k - 1].ItemIndex > midpoints[k].ItemIndex) {
-						throw new CorruptIndexException(String.Format(
-							"Item index for midpoint {0} ({1}) > Item index for midpoint {2} ({3})", k - 1,
-							midpoints[k - 1].ItemIndex, k, midpoints[k].ItemIndex));
+					if (k > 0) {
+						if (midpoints[k].Key.GreaterThan(midpoints[k - 1].Key)) {
+							throw new CorruptIndexException(String.Format(
+								"Index entry key for midpoint {0} (stream: {1}, version: {2}) < index entry key for midpoint {3} (stream: {4}, version: {5})",
+								k - 1, midpoints[k - 1].Key.Stream, midpoints[k - 1].Key.Version, k,
+								midpoints[k].Key.Stream, midpoints[k].Key.Version));
+						} else if (midpoints[k - 1].ItemIndex > midpoints[k].ItemIndex) {
+							throw new CorruptIndexException(String.Format(
+								"Item index for midpoint {0} ({1}) > Item index for midpoint {2} ({3})", k - 1,
+								midpoints[k - 1].ItemIndex, k, midpoints[k].ItemIndex));
+						}
 					}
 				}
-			}
 
-			if (!skipIndexVerify) {
-				ValidateHash(stream, md5, tmpBuffer.Span);
-			}
+				if (!skipIndexVerify) {
+					ReadUntilWithMd5(stream.Length - MD5Size, stream, md5);
+					//verify hash (should be at stream.length - MD5Size)
+					md5.TransformFinalBlock(Empty.ByteArray, 0, 0);
+					var fileHash = new byte[MD5Size];
+					stream.Read(fileHash, 0, MD5Size);
+					ValidateHash(md5.Hash, fileHash);
+				}
 
-			return midpoints;
+				return midpoints;
+			}
 		} catch (PossibleToHandleOutOfMemoryException) {
 			midpoints?.Dispose();
 			throw;
@@ -393,30 +437,12 @@ public partial class PTable : ISearchTable, IDisposable {
 			Dispose();
 			throw;
 		} finally {
-			md5.Dispose();
-			stream.Dispose();
-			tmpBuffer.Dispose();
-		}
-	}
-
-	private void AcquireFileHandle() {
-		var acquired = false;
-		try {
-			_handle.DangerousAddRef(ref acquired);
-		} catch (ObjectDisposedException) {
-			if (_cleanupBarrier.FalseToTrue()) {
-				DeleteFileIfNeeded();
+			if (RuntimeInformation.IsUnix) {
+				if (workItem != null)
+					ReturnWorkItem(workItem);
+			} else {
+				stream?.Dispose();
 			}
-
-			throw new FileBeingDeletedException();
-		}
-	}
-
-	private void ReleaseFileHandle() {
-		_handle.DangerousRelease();
-
-		if (_handle.IsClosed && _cleanupBarrier.FalseToTrue()) {
-			DeleteFileIfNeeded();
 		}
 	}
 
@@ -447,50 +473,56 @@ public partial class PTable : ISearchTable, IDisposable {
 		}
 	}
 
-	private static void ReadUntilWithMd5(long nextPos, Stream fileStream, IncrementalHash md5, Span<byte> tmpBuffer) {
+	private readonly byte[] TmpReadBuf = new byte[DefaultBufferSize];
+
+	private void ReadUntilWithMd5(long nextPos, Stream fileStream, HashAlgorithm md5) {
 		long toRead = nextPos - fileStream.Position;
 		if (toRead < 0)
 			throw new Exception("should not do negative reads.");
 		while (toRead > 0) {
-			int read = fileStream.Read(tmpBuffer.TrimLength(int.CreateSaturating(toRead)));
-			md5.AppendData(tmpBuffer.Slice(0, read));
+			var localReadCount = Math.Min(toRead, TmpReadBuf.Length);
+			int read = fileStream.Read(TmpReadBuf, 0, (int)localReadCount);
+			md5.TransformBlock(TmpReadBuf, 0, read, null, 0);
 			toRead -= read;
 		}
 	}
 
-	private static void ValidateHash(Stream stream, IncrementalHash actual, Span<byte> buffer) {
-		ReadUntilWithMd5(stream.Length - MD5Size, stream, actual, buffer);
-		//verify hash (should be at stream.length - MD5Size)
-		Span<byte> fileHash = stackalloc byte[MD5Size];
-		stream.ReadExactly(fileHash);
-		ValidateHash(fileHash, actual);
-	}
+	void ValidateHash(byte[] fromFile, byte[] computed) {
+		if (computed == null)
+			throw new CorruptIndexException(new HashValidationException("Calculated MD5 hash is null!"));
+		if (fromFile == null)
+			throw new CorruptIndexException(new HashValidationException("Read from file MD5 hash is null!"));
 
-	private static void ValidateHash(Span<byte> expected, IncrementalHash actual) {
-		Debug.Assert(actual is not null);
-
-		Span<byte> actualHash = stackalloc byte[MD5Size];
-		var bytesWritten = actual.GetCurrentHash(actualHash);
-		Debug.Assert(bytesWritten is MD5Size);
-
-		// Perf: use hardware accelerated byte array comparison
-		if (!expected.SequenceEqual(actualHash)) {
+		if (computed.Length != fromFile.Length)
 			throw new CorruptIndexException(
 				new HashValidationException(
-					$"Hashes are different! computed: {Hex.EncodeToUtf16(actualHash)}, hash: {Hex.EncodeToUtf16(expected)}."));
+					string.Format(
+						"Hash sizes differ! FileHash({0}): {1}, hash({2}): {3}.",
+						computed.Length,
+						BitConverter.ToString(computed),
+						fromFile.Length,
+						BitConverter.ToString(fromFile))));
+
+		for (int i = 0; i < fromFile.Length; i++) {
+			if (fromFile[i] != computed[i])
+				throw new CorruptIndexException(
+					new HashValidationException(
+						string.Format(
+							"Hashes are different! computed: {0}, hash: {1}.",
+							BitConverter.ToString(computed),
+							BitConverter.ToString(fromFile))));
 		}
 	}
 
 	public IEnumerable<IndexEntry> IterateAllInOrder() {
-		AcquireFileHandle();
+		var workItem = GetWorkItem();
 		try {
-			long fileOffset = PTableHeader.Size;
+			workItem.Stream.Position = PTableHeader.Size;
 			for (long i = 0, n = Count; i < n; i++) {
-				yield return ReadEntry(_handle, fileOffset, _version, out var bytesRead);
-				fileOffset += bytesRead;
+				yield return ReadNextNoSeek(workItem, _version);
 			}
 		} finally {
-			ReleaseFileHandle();
+			ReturnWorkItem(workItem);
 		}
 	}
 
@@ -516,7 +548,7 @@ public partial class PTable : ISearchTable, IDisposable {
 			return false;
 		}
 
-		entry = ReadEntry(value.LatestOffset);
+		entry = ReadEntry(_indexEntrySize, value.LatestOffset, _version);
 		return true;
 	}
 
@@ -538,7 +570,7 @@ public partial class PTable : ISearchTable, IDisposable {
 		if (!MightContainStream(streamHash))
 			return null;
 
-		AcquireFileHandle();
+		var workItem = GetWorkItem();
 		try {
 			var recordRange = LocateRecordRange(endKey, startKey, out var lowBoundsCheck, out var highBoundsCheck);
 
@@ -550,6 +582,7 @@ public partial class PTable : ISearchTable, IDisposable {
 					recordRange,
 					lowBoundsCheck,
 					highBoundsCheck,
+					workItem,
 					token);
 			} catch (HashCollisionException) {
 				// fall back to linear search if there's a hash collision
@@ -560,10 +593,11 @@ public partial class PTable : ISearchTable, IDisposable {
 					recordRange,
 					lowBoundsCheck,
 					highBoundsCheck,
+					workItem,
 					token);
 			}
 		} finally {
-			ReleaseFileHandle();
+			ReturnWorkItem(workItem);
 		}
 	}
 
@@ -576,13 +610,14 @@ public partial class PTable : ISearchTable, IDisposable {
 		Range recordRange,
 		IndexEntryKey lowBoundsCheck,
 		IndexEntryKey highBoundsCheck,
+		WorkItem workItem,
 		CancellationToken token) {
 
 		long maxBeforePosition = long.MinValue;
 		IndexEntry maxEntry = default;
 
 		for (var idx = recordRange.Lower; idx <= recordRange.Upper; idx++) {
-			var candidateEntry = ReadEntry(idx);
+			var candidateEntry = ReadEntry(_indexEntrySize, idx, workItem, _version);
 			var candidateEntryKey = new IndexEntryKey(candidateEntry.Stream, candidateEntry.Version);
 
 			if (candidateEntryKey.GreaterThan(lowBoundsCheck)) {
@@ -617,6 +652,7 @@ public partial class PTable : ISearchTable, IDisposable {
 		Range recordRange,
 		IndexEntryKey lowBoundsCheck,
 		IndexEntryKey highBoundsCheck,
+		WorkItem workItem,
 		CancellationToken token) {
 
 		var startKey = BuildKey(stream, 0);
@@ -627,7 +663,7 @@ public partial class PTable : ISearchTable, IDisposable {
 
 		while (low < high) {
 			var mid = low + (high - low) / 2;
-			IndexEntry midpoint = ReadEntry(mid);
+			IndexEntry midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
 
 			var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
 			if (midpointKey.GreaterThan(lowBoundsCheck)) {
@@ -670,7 +706,7 @@ public partial class PTable : ISearchTable, IDisposable {
 			}
 		}
 
-		var candidateEntry = ReadEntry(high);
+		var candidateEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
 
 		// index entry is for a different hash
 		if (candidateEntry.Stream != stream.Hash)
@@ -714,15 +750,16 @@ public partial class PTable : ISearchTable, IDisposable {
 			return false;
 		}
 
-		AcquireFileHandle();
+		var workItem = GetWorkItem();
 		try {
-			var high = ChopForLatest(endKey);
-			var candEntry = ReadEntry(high);
+			var high = ChopForLatest(workItem, endKey);
+			var candEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
 			var candKey = new IndexEntryKey(candEntry.Stream, candEntry.Version);
 
 			if (candKey.GreaterThan(endKey))
-				throw new MaybeCorruptIndexException(
-					$"candEntry ({candEntry.Stream}@{candEntry.Version}) > startKey {startKey}, stream {stream}, startNum {startNumber}, endNum {endNumber}, PTable: {Filename}.");
+				throw new MaybeCorruptIndexException(string.Format(
+					"candEntry ({0}@{1}) > startKey {2}, stream {3}, startNum {4}, endNum {5}, PTable: {6}.",
+					candEntry.Stream, candEntry.Version, startKey, stream, startNumber, endNumber, Filename));
 			if (candKey.SmallerThan(startKey)) {
 				offset = default;
 				return false;
@@ -732,7 +769,7 @@ public partial class PTable : ISearchTable, IDisposable {
 			offset = high;
 			return true;
 		} finally {
-			ReleaseFileHandle();
+			ReturnWorkItem(workItem);
 		}
 	}
 
@@ -748,7 +785,7 @@ public partial class PTable : ISearchTable, IDisposable {
 			return false;
 		}
 
-		entry = ReadEntry(value.OldestOffset);
+		entry = ReadEntry(_indexEntrySize, value.OldestOffset, _version);
 		return true;
 	}
 
@@ -794,10 +831,10 @@ public partial class PTable : ISearchTable, IDisposable {
 			return false;
 		}
 
-		AcquireFileHandle();
+		var workItem = GetWorkItem();
 		try {
-			var high = ChopForOldest(startKey);
-			var candEntry = ReadEntry(high);
+			var high = ChopForOldest(workItem, startKey);
+			var candEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
 			var candidateKey = new IndexEntryKey(candEntry.Stream, candEntry.Version);
 			if (candidateKey.SmallerThan(startKey))
 				throw new MaybeCorruptIndexException(string.Format(
@@ -812,13 +849,13 @@ public partial class PTable : ISearchTable, IDisposable {
 			offset = high;
 			return true;
 		} finally {
-			ReleaseFileHandle();
+			ReturnWorkItem(workItem);
 		}
 	}
 
 	public IReadOnlyList<IndexEntry> GetRange(ulong stream, long startNumber, long endNumber, int? limit = null) {
-		ArgumentOutOfRangeException.ThrowIfNegative(startNumber);
-		ArgumentOutOfRangeException.ThrowIfNegative(endNumber);
+		Ensure.Nonnegative(startNumber, "startNumber");
+		Ensure.Nonnegative(endNumber, "endNumber");
 
 		return _lruCache is null
 			? GetRangeNoCache(GetHash(stream), startNumber, endNumber, limit)
@@ -887,71 +924,58 @@ public partial class PTable : ISearchTable, IDisposable {
 		return r;
 	}
 
-	private static long PositionAtEntry(int indexEntrySize, long indexNum)
-		=> indexEntrySize * indexNum + PTableHeader.Size;
+	private static void PositionAtEntry(int indexEntrySize, long indexNum, WorkItem workItem) {
+		workItem.Stream.Seek(indexEntrySize * indexNum + PTableHeader.Size, SeekOrigin.Begin);
+	}
 
-	private static IndexEntry ReadEntry(SafeFileHandle handle, int indexEntrySize, long indexNum, byte ptableVersion)
-		=> ReadEntry(handle, PositionAtEntry(indexEntrySize, indexNum), ptableVersion, out _);
+	private static IndexEntry ReadEntry(int indexEntrySize, long indexNum, WorkItem workItem, int ptableVersion) {
+		long seekTo = indexEntrySize * indexNum + PTableHeader.Size;
+		workItem.Stream.Seek(seekTo, SeekOrigin.Begin);
+		return ReadNextNoSeek(workItem, ptableVersion);
+	}
 
-	private IndexEntry ReadEntry(long indexNum) {
-		AcquireFileHandle();
+	private IndexEntry ReadEntry(int indexEntrySize, long indexNum, int ptableVersion) {
+		var workItem = GetWorkItem();
 		try {
-			return ReadEntry(_handle, _indexEntrySize, indexNum, _version);
+			return ReadEntry(_indexEntrySize, indexNum, workItem, ptableVersion);
 		} finally {
-			ReleaseFileHandle();
+			ReturnWorkItem(workItem);
 		}
 	}
 
-	private static IndexEntry ReadEntry(SafeFileHandle handle, long fileOffset, byte ptableVersion, out int bytesRead) {
-		// allocate buffer for the worst case
-		Span<byte> buffer = stackalloc byte[IndexEntryV4Size];
-		var reader = new SpanReader<byte>(buffer);
-		long version;
-		ulong stream;
-		switch (ptableVersion) {
-			case PTableVersions.IndexV1:
-				buffer = buffer.Slice(0, IndexEntryV1Size);
-				RandomAccess.Read(handle, buffer, fileOffset);
-				version = reader.ReadLittleEndian<int>();
-				stream = reader.ReadLittleEndian<uint>();
-				break;
-			case PTableVersions.IndexV2:
-				buffer = buffer.Slice(0, IndexEntryV2Size);
-				RandomAccess.Read(handle, buffer, fileOffset);
-				version = reader.ReadLittleEndian<int>();
-				stream = reader.ReadLittleEndian<ulong>();
-				break;
-			default:
-				// V3 or higher
-				RandomAccess.Read(handle, buffer, fileOffset);
-				version = reader.ReadLittleEndian<long>();
-				stream = reader.ReadLittleEndian<ulong>();
-				break;
-		}
-
-		var position = reader.ReadLittleEndian<long>();
-		bytesRead = reader.ConsumedCount;
-
-		Debug.Assert(bytesRead == GetIndexEntrySize(ptableVersion));
-		return new(stream, version, position);
+	private static IndexEntry ReadNextNoSeek(WorkItem workItem, int ptableVersion) {
+		long version = (ptableVersion >= PTableVersions.IndexV3)
+			? workItem.Reader.ReadInt64()
+			: workItem.Reader.ReadInt32();
+		ulong stream = ptableVersion == PTableVersions.IndexV1
+			? workItem.Reader.ReadUInt32()
+			: workItem.Reader.ReadUInt64();
+		long position = workItem.Reader.ReadInt64();
+		return new IndexEntry(stream, version, position);
 	}
 
-	private void DisposeFileHandle() {
-		_handle.Dispose(); // it decrements the counter
-
-		if (_handle.IsClosed && _cleanupBarrier.FalseToTrue()) {
-			DeleteFileIfNeeded();
+	private WorkItem GetWorkItem() {
+		try {
+			return _workItems.Get();
+		} catch (ObjectPoolDisposingException) {
+			throw new FileBeingDeletedException();
+		} catch (ObjectPoolMaxLimitReachedException) {
+			throw new Exception("Unable to acquire work item.");
 		}
+	}
+
+	private void ReturnWorkItem(WorkItem workItem) {
+		_workItems.Return(workItem);
 	}
 
 	public void MarkForDestruction() {
 		_deleteFile = true;
-		DisposeFileHandle();
+		_workItems.MarkForDisposal();
 	}
 
 	public void Dispose() {
 		_deleteFile = false;
-		DisposeFileHandle();
+		_workItems.MarkForDisposal();
 	}
 
 	protected virtual void Dispose(bool disposing) {
@@ -968,7 +992,7 @@ public partial class PTable : ISearchTable, IDisposable {
 		_disposed = true;
 	}
 
-	private void DeleteFileIfNeeded() {
+	private void OnAllWorkItemsDisposed() {
 		File.SetAttributes(_filename, FileAttributes.Normal);
 		if (_deleteFile) {
 			_bloomFilter?.Dispose();
@@ -1028,27 +1052,27 @@ public partial class PTable : ISearchTable, IDisposable {
 		if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry))
 			return result;
 
-		AcquireFileHandle();
+		var workItem = GetWorkItem();
 		try {
-			var high = tableLatestOffset ?? ChopForLatest(endKey);
-			result = ReadForward(PositionAtEntry(_indexEntrySize, high), high, startKey, endKey, limit);
+			var high = tableLatestOffset ?? ChopForLatest(workItem, endKey);
+			PositionAtEntry(_indexEntrySize, high, workItem);
+			result = ReadForward(workItem, high, startKey, endKey, limit);
 			return result;
 		} catch (MaybeCorruptIndexException ex) {
 			throw new MaybeCorruptIndexException(
 				$"{ex.Message}. stream {stream}, startNum {startNumber}, endNum {endNumber}, PTable: {Filename}.");
 		} finally {
-			ReleaseFileHandle();
+			ReturnWorkItem(workItem);
 		}
 	}
 
 	// forward here meaning forward in the file. towards the older records.
-	private List<IndexEntry> ReadForward(long position, long high, IndexEntryKey startKey, IndexEntryKey endKey, int? limit) {
+	private List<IndexEntry> ReadForward(WorkItem workItem, long high, IndexEntryKey startKey, IndexEntryKey endKey, int? limit) {
 
 		var result = new List<IndexEntry>();
 
 		for (long i = high, n = Count; i < n; ++i) {
-			var entry = ReadEntry(_handle, position, _version, out var bytesRead);
-			position += bytesRead;
+			var entry = ReadNextNoSeek(workItem, _version);
 
 			var candidateKey = new IndexEntryKey(entry.Stream, entry.Version);
 
@@ -1067,13 +1091,13 @@ public partial class PTable : ISearchTable, IDisposable {
 		return result;
 	}
 
-	private long ChopForLatest(IndexEntryKey endKey) {
+	private long ChopForLatest(WorkItem workItem, IndexEntryKey endKey) {
 		var recordRange = LocateRecordRange(endKey, out var lowBoundsCheck, out var highBoundsCheck);
 		long low = recordRange.Lower;
 		long high = recordRange.Upper;
 		while (low < high) {
 			var mid = low + (high - low) / 2;
-			var midpoint = ReadEntry(mid);
+			var midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
 			var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
 
 			if (midpointKey.GreaterThan(lowBoundsCheck)) {
@@ -1098,21 +1122,23 @@ public partial class PTable : ISearchTable, IDisposable {
 		return high;
 	}
 
-	private long ChopForOldest(IndexEntryKey startKey) {
+	private long ChopForOldest(WorkItem workItem, IndexEntryKey startKey) {
 		var recordRange = LocateRecordRange(startKey, out var lowBoundsCheck, out var highBoundsCheck);
 		long low = recordRange.Lower;
 		long high = recordRange.Upper;
 		while (low < high) {
 			var mid = low + (high - low + 1) / 2;
-			var midpoint = ReadEntry(mid);
+			var midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
 			var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
 
 			if (midpointKey.GreaterThan(lowBoundsCheck)) {
-				throw new MaybeCorruptIndexException(
-					$"Midpoint key (stream: {midpointKey.Stream}, version: {midpointKey.Version}) > low bounds check key (stream: {lowBoundsCheck.Stream}, version: {lowBoundsCheck.Version})");
+				throw new MaybeCorruptIndexException(String.Format(
+					"Midpoint key (stream: {0}, version: {1}) > low bounds check key (stream: {2}, version: {3})",
+					midpointKey.Stream, midpointKey.Version, lowBoundsCheck.Stream, lowBoundsCheck.Version));
 			} else if (!midpointKey.GreaterEqualsThan(highBoundsCheck)) {
-				throw new MaybeCorruptIndexException(
-					$"Midpoint key (stream: {midpointKey.Stream}, version: {midpointKey.Version}) < high bounds check key (stream: {highBoundsCheck.Stream}, version: {highBoundsCheck.Version})");
+				throw new MaybeCorruptIndexException(String.Format(
+					"Midpoint key (stream: {0}, version: {1}) < high bounds check key (stream: {2}, version: {3})",
+					midpointKey.Stream, midpointKey.Version, highBoundsCheck.Stream, highBoundsCheck.Version));
 			}
 
 			if (midpointKey.SmallerThan(startKey)) {
@@ -1196,22 +1222,26 @@ public partial class PTable : ISearchTable, IDisposable {
 
 		// with a workitem checked out the ptable (and bloom filter specifically)
 		// wont get disposed
-		AcquireFileHandle();
+		var workItem = GetWorkItem();
 		try {
-			return _bloomFilter.MightContain(Span.AsReadOnlyBytes(in stream.Hash));
+			var streamHash = stream.Hash;
+			return _bloomFilter.MightContain(GetSpan(ref streamHash));
 		} finally {
-			ReleaseFileHandle();
+			ReturnWorkItem(workItem);
 		}
 	}
+
+	private static ReadOnlySpan<byte> GetSpan(ref ulong streamHash) =>
+		MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref streamHash, 1));
 
 	// construct this struct with a 64 bit hash and it will convert it to a hash
 	// for the specified table version
 	public readonly struct StreamHash : IEquatable<StreamHash> {
-		public readonly ulong Hash;
-
 		public StreamHash(byte version, ulong hash) {
-			Hash = version is PTableVersions.IndexV1 ? hash >> 32 : hash;
+			Hash = version == PTableVersions.IndexV1 ? hash >> 32 : hash;
 		}
+
+		public ulong Hash { get; init; }
 
 		public override int GetHashCode() =>
 			Hash.GetHashCode();
@@ -1290,6 +1320,33 @@ public partial class PTable : ISearchTable, IDisposable {
 
 		public override string ToString() {
 			return string.Format("Stream: {0}, Version: {1}", Stream, Version);
+		}
+	}
+
+	private class WorkItem : IDisposable {
+		public readonly FileStream Stream;
+		public readonly BinaryReader Reader;
+
+		public WorkItem(string filename, int bufferSize) {
+			Stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize,
+				FileOptions.RandomAccess);
+			Reader = new BinaryReader(Stream);
+		}
+
+		~WorkItem() {
+			Dispose(false);
+		}
+
+		public void Dispose() {
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		private void Dispose(bool disposing) {
+			if (disposing) {
+				Stream.Dispose();
+				Reader.Dispose();
+			}
 		}
 	}
 }

--- a/src/KurrentDB.Core/Index/PTableConstruction.cs
+++ b/src/KurrentDB.Core/Index/PTableConstruction.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using DotNext;
 using KurrentDB.Common.Utils;
 using KurrentDB.Core.DataStructures;
 using KurrentDB.Core.DataStructures.ProbabilisticFilter;
@@ -19,12 +18,12 @@ using MD5 = KurrentDB.Core.Hashing.MD5;
 namespace KurrentDB.Core.Index;
 
 public partial class PTable {
-	public static PTable FromFile(string filename,
+	public static PTable FromFile(string filename, int initialReaders, int maxReaders,
 		int cacheDepth, bool skipIndexVerify,
 		bool useBloomFilter = true,
 		int lruCacheSize = 1_000_000) {
 
-		return new PTable(filename, Guid.NewGuid(),
+		return new PTable(filename, Guid.NewGuid(), initialReaders, maxReaders,
 			cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
 	}
 
@@ -55,7 +54,7 @@ public partial class PTable {
 		}
 	}
 
-	public static PTable FromMemtable(IMemTable table, string filename,
+	public static PTable FromMemtable(IMemTable table, string filename, int initialReaders, int maxReaders,
 		int cacheDepth = 16,
 		bool skipIndexVerify = false,
 		bool useBloomFilter = true,
@@ -106,7 +105,8 @@ public partial class PTable {
 					// WRITE BLOOM FILTER ENTRY
 					if (bloomFilter != null && rec.Stream != previousHash) {
 						// we are creating a PTable of the same version as the Memtable. therefore the hash is the right format
-						bloomFilter.Add(Span.AsReadOnlyBytes(in rec.Stream));
+						var streamHash = rec.Stream;
+						bloomFilter.Add(GetSpan(ref streamHash));
 						previousHash = rec.Stream;
 					}
 
@@ -149,13 +149,15 @@ public partial class PTable {
 		}
 
 		Log.Debug("Dumped MemTable [{id}, {table} entries] in {elapsed}.", table.Id, table.Count, sw.Elapsed);
-		return new PTable(filename, table.Id, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
+		return new PTable(filename, table.Id, initialReaders, maxReaders, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
 	}
 
 	public static PTable MergeTo(
 		IList<PTable> tables,
 		string outputFile,
 		byte version,
+		int initialReaders,
+		int maxReaders,
 		int cacheDepth = 16,
 		bool skipIndexVerify = false,
 		bool useBloomFilter = true,
@@ -174,7 +176,7 @@ public partial class PTable {
 		var fileSizeUpToIndexEntries = GetFileSizeUpToIndexEntries(numIndexEntries, version);
 		if (tables.Count == 2)
 			return MergeTo2(tables, numIndexEntries, indexEntrySize, outputFile,
-				version, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize); // special case
+				version, initialReaders, maxReaders, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize); // special case
 
 		Log.Debug("PTables merge started.");
 		var watch = Stopwatch.StartNew();
@@ -225,7 +227,8 @@ public partial class PTable {
 
 						// WRITE BLOOM FILTER ENTRY
 						if (bloomFilter != null && current.Stream != previousHash) {
-							bloomFilter.Add(Span.AsReadOnlyBytes(in current.Stream));
+							var streamHash = current.Stream;
+							bloomFilter.Add(GetSpan(ref streamHash));
 							previousHash = current.Stream;
 						}
 
@@ -276,7 +279,7 @@ public partial class PTable {
 			Log.Debug(
 				"PTables merge finished in {elapsed} ([{entryCount}] entries merged into {dumpedEntryCount}).",
 				watch.Elapsed, string.Join(", ", tables.Select(x => x.Count)), dumpedEntryCount);
-			return new PTable(outputFile, Guid.NewGuid(), cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
+			return new PTable(outputFile, Guid.NewGuid(), initialReaders, maxReaders, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
 		} finally {
 			foreach (var enumerableTable in enumerators) {
 				enumerableTable.Dispose();
@@ -284,16 +287,25 @@ public partial class PTable {
 		}
 	}
 
-	private static int GetIndexEntrySize(byte version) => version switch {
-		PTableVersions.IndexV1 => IndexEntryV1Size,
-		PTableVersions.IndexV2 => IndexEntryV2Size,
-		PTableVersions.IndexV3 => IndexEntryV3Size,
-		_ => IndexEntryV4Size
-	};
+	public static int GetIndexEntrySize(byte version) {
+		if (version == PTableVersions.IndexV1) {
+			return IndexEntryV1Size;
+		}
+
+		if (version == PTableVersions.IndexV2) {
+			return IndexEntryV2Size;
+		}
+
+		if (version == PTableVersions.IndexV3) {
+			return IndexEntryV3Size;
+		}
+
+		return IndexEntryV4Size;
+	}
 
 	private static PTable MergeTo2(IList<PTable> tables, long numIndexEntries, int indexEntrySize,
 		string outputFile,
-		byte version,
+		byte version, int initialReaders, int maxReaders,
 		int cacheDepth, bool skipIndexVerify,
 		bool useBloomFilter, int lruCacheSize) {
 
@@ -357,7 +369,8 @@ public partial class PTable {
 						// WRITE BLOOM FILTER ENTRY
 						if (bloomFilter != null && current.Stream != previousHash) {
 							// upgradeHash has already ensured the hash is in the right format for the target
-							bloomFilter.Add(Span.AsReadOnlyBytes(in current.Stream));
+							var streamHash = current.Stream;
+							bloomFilter.Add(GetSpan(ref streamHash));
 							previousHash = current.Stream;
 						}
 
@@ -402,7 +415,7 @@ public partial class PTable {
 			Log.Debug(
 				"PTables merge finished in {elapsed} ([{entryCount}] entries merged into {dumpedEntryCount}).",
 				watch.Elapsed, string.Join(", ", tables.Select(x => x.Count)), dumpedEntryCount);
-			return new PTable(outputFile, Guid.NewGuid(), cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
+			return new PTable(outputFile, Guid.NewGuid(), initialReaders, maxReaders, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
 		} finally {
 			foreach (var enumerator in enumerators) {
 				enumerator.Dispose();
@@ -415,6 +428,8 @@ public partial class PTable {
 		string outputFile,
 		byte version,
 		Func<IndexEntry, CancellationToken, ValueTask<bool>> shouldKeep,
+		int initialReaders,
+		int maxReaders,
 		int cacheDepth = 16,
 		bool skipIndexVerify = false,
 		bool useBloomFilter = true,
@@ -460,7 +475,8 @@ public partial class PTable {
 								AppendRecordTo(bs, buffer, version, enumerator.Current, indexEntrySize);
 								// WRITE BLOOM FILTER ENTRY
 								if (bloomFilter != null && current.Stream != previousHash) {
-									bloomFilter.Add(Span.AsReadOnlyBytes(in current.Stream));
+									var streamHash = current.Stream;
+									bloomFilter.Add(GetSpan(ref streamHash));
 									previousHash = current.Stream;
 								}
 								keptCount++;
@@ -530,7 +546,7 @@ public partial class PTable {
 				"PTable scavenge finished in {elapsed} ({droppedCount} entries removed, {keptCount} remaining).",
 				watch.Elapsed,
 				droppedCount, keptCount);
-			var scavengedTable = new PTable(outputFile, Guid.NewGuid(), cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
+			var scavengedTable = new PTable(outputFile, Guid.NewGuid(), initialReaders, maxReaders, cacheDepth, skipIndexVerify, useBloomFilter, lruCacheSize);
 			return (scavengedTable, table._size - scavengedTable._size);
 		} catch (Exception) {
 			try {

--- a/src/KurrentDB.Core/Index/PTableFooter.cs
+++ b/src/KurrentDB.Core/Index/PTableFooter.cs
@@ -52,7 +52,7 @@ public class PTableFooter {
 				new InvalidFileException("Invalid PTable file."));
 
 		byte[] buffer = new byte[4];
-		stream.Read(buffer, 0, 4);
+		stream.ReadExactly(buffer, 0, 4);
 		uint numMidpointsCached = BitConverter.ToUInt32(buffer, 0);
 
 		return new PTableFooter((byte)version, numMidpointsCached);

--- a/src/KurrentDB.Core/Index/PTableFooter.cs
+++ b/src/KurrentDB.Core/Index/PTableFooter.cs
@@ -3,67 +3,58 @@
 
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
-using DotNext.Buffers;
-using DotNext.Buffers.Binary;
 using KurrentDB.Core.Exceptions;
-using Microsoft.Win32.SafeHandles;
 
 namespace KurrentDB.Core.Index;
 
-[StructLayout(LayoutKind.Auto)]
-public readonly struct PTableFooter : IBinaryFormattable<PTableFooter> {
-	public const int Size = 128;
-	private const byte FileType = (byte)Index.FileType.PTableFile;
-
+public class PTableFooter {
+	private const int Size = 128;
+	public readonly FileType FileType;
 	public readonly byte Version;
 	public readonly uint NumMidpointsCached;
 
+	public static int GetSize(byte version) {
+		if (version >= PTableVersions.IndexV4)
+			return Size;
+		return 0;
+	}
+
 	public PTableFooter(byte version, uint numMidpointsCached) {
+		FileType = FileType.PTableFile;
 		Version = version;
 		NumMidpointsCached = numMidpointsCached;
 	}
 
-	private PTableFooter(ref SpanReader<byte> reader) {
-		if (reader.Read() is not FileType)
-			throw new CorruptIndexException("Corrupted PTable.", new InvalidFileException("Wrong type of PTable."));
+	public byte[] AsByteArray() {
+		var array = new byte[Size];
+		array[0] = (byte)FileType.PTableFile;
+		array[1] = Version;
+		uint numMidpoints = NumMidpointsCached;
+		for (int i = 0; i < 4; i++) {
+			array[i + 2] = (byte)(numMidpoints & 0xFF);
+			numMidpoints >>= 8;
+		}
 
-		Version = reader.Read();
-		if (Version < PTableVersions.IndexV4)
+		return array;
+	}
+
+	public static PTableFooter FromStream(Stream stream) {
+		var type = stream.ReadByte();
+		if (type != (int)FileType.PTableFile)
+			throw new CorruptIndexException("Corrupted PTable.", new InvalidFileException("Wrong type of PTable."));
+		var version = stream.ReadByte();
+		if (version == -1)
+			throw new CorruptIndexException("Couldn't read version of PTable from footer.",
+				new InvalidFileException("Invalid PTable file."));
+		if (!(version >= PTableVersions.IndexV4))
 			throw new CorruptIndexException(
 				"PTable footer with version < 4 found. PTable footers are supported as from version 4.",
 				new InvalidFileException("Invalid PTable file."));
 
-		NumMidpointsCached = reader.ReadLittleEndian<uint>();
-	}
+		byte[] buffer = new byte[4];
+		stream.Read(buffer, 0, 4);
+		uint numMidpointsCached = BitConverter.ToUInt32(buffer, 0);
 
-	public static int GetSize(byte version)
-		=> version >= PTableVersions.IndexV4 ? Size : 0;
-
-	static int IBinaryFormattable<PTableFooter>.Size => Size;
-
-	public static PTableFooter Parse(ReadOnlySpan<byte> source) {
-		var reader = new SpanReader<byte>(source);
-		return new(ref reader);
-	}
-
-	public static PTableFooter Parse(SafeFileHandle handle, long fileOffset) {
-		Span<byte> buffer = stackalloc byte[Size];
-		return RandomAccess.Read(handle, buffer, fileOffset) == buffer.Length
-			? Parse(buffer)
-			: throw new CorruptIndexException("Corrupted PTable footer.", new InvalidFileException("Wrong file size."));
-	}
-
-	public void Format(Span<byte> buffer) {
-		var writer = new SpanWriter<byte>(buffer);
-		writer.Add(FileType);
-		writer.Add(Version);
-		writer.WriteLittleEndian(NumMidpointsCached);
-	}
-
-	public byte[] AsByteArray() {
-		var result = new byte[Size];
-		Format(result);
-		return result;
+		return new PTableFooter((byte)version, numMidpointsCached);
 	}
 }

--- a/src/KurrentDB.Core/Index/PTableHeader.cs
+++ b/src/KurrentDB.Core/Index/PTableHeader.cs
@@ -1,57 +1,37 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
-using System;
 using System.IO;
-using System.Runtime.InteropServices;
-using DotNext.Buffers;
-using DotNext.Buffers.Binary;
 using KurrentDB.Core.Exceptions;
-using Microsoft.Win32.SafeHandles;
 
 namespace KurrentDB.Core.Index;
 
-[StructLayout(LayoutKind.Auto)]
-public readonly struct PTableHeader : IBinaryFormattable<PTableHeader> {
+public class PTableHeader {
 	public const int Size = 128;
-	private const byte FileType = (byte)Index.FileType.PTableFile;
 
+	public readonly FileType FileType;
 	public readonly byte Version;
 
 	public PTableHeader(byte version) {
+		FileType = FileType.PTableFile;
 		Version = version;
 	}
 
-	private PTableHeader(ref SpanReader<byte> reader) {
-		if (reader.Read() is not FileType)
-			throw new CorruptIndexException("Corrupted PTable.", new InvalidFileException("Wrong type of PTable."));
-
-		Version = reader.Read();
-	}
-
-	public void Format(Span<byte> destination) {
-		var writer = new SpanWriter<byte>(destination);
-		writer.Add(FileType);
-		writer.Add(Version);
-	}
-
 	public byte[] AsByteArray() {
-		var result = new byte[Size];
-		Format(result);
-		return result;
+		var array = new byte[Size];
+		array[0] = (byte)FileType.PTableFile;
+		array[1] = Version;
+		return array;
 	}
 
-	public static PTableHeader Parse(ReadOnlySpan<byte> source) {
-		var reader = new SpanReader<byte>(source);
-		return new(ref reader);
+	public static PTableHeader FromStream(Stream stream) {
+		var type = stream.ReadByte();
+		if (type != (int)FileType.PTableFile)
+			throw new CorruptIndexException("Corrupted PTable.", new InvalidFileException("Wrong type of PTable."));
+		var version = stream.ReadByte();
+		if (version == -1)
+			throw new CorruptIndexException("Couldn't read version of PTable from header.",
+				new InvalidFileException("Invalid PTable file."));
+		return new PTableHeader((byte)version);
 	}
-
-	public static PTableHeader Parse(SafeFileHandle handle, long fileOffset) {
-		Span<byte> buffer = stackalloc byte[Size];
-		return RandomAccess.Read(handle, buffer, fileOffset) == buffer.Length
-			? Parse(buffer)
-			: throw new CorruptIndexException("Corrupted PTable header.", new InvalidFileException("Wrong file size."));
-	}
-
-	static int IBinaryFormattable<PTableHeader>.Size => Size;
 }

--- a/src/KurrentDB.Core/Index/TableIndex.cs
+++ b/src/KurrentDB.Core/Index/TableIndex.cs
@@ -72,6 +72,7 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 
 	private bool _initialized;
 	private readonly int _maxAutoMergeIndexLevel;
+	private readonly int _pTableMaxReaderCount;
 
 	public TableIndex(string directory,
 		IHasher<TStreamId> lowHasher,
@@ -81,6 +82,7 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 		ITransactionFileReader tfReader,
 		byte ptableVersion,
 		int maxAutoMergeIndexLevel,
+		int pTableMaxReaderCount,
 		int maxSizeForMemory = 1000000,
 		int maxTablesPerLevel = 4,
 		bool additionalReclaim = false,
@@ -98,6 +100,7 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 		Ensure.NotNull(highHasher, "highHasher");
 		ArgumentNullException.ThrowIfNull(tfReader);
 		Ensure.Positive(initializationThreads, "initializationThreads");
+		Ensure.Positive(pTableMaxReaderCount, "pTableMaxReaderCount");
 
 		ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxTablesPerLevel, 1);
 
@@ -126,6 +129,7 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 		_emptyStreamId = emptyStreamId;
 
 		_maxAutoMergeIndexLevel = maxAutoMergeIndexLevel;
+		_pTableMaxReaderCount = pTableMaxReaderCount;
 	}
 
 	public void Initialize(long chaserCheckpoint) {
@@ -137,7 +141,7 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 		_initialized = true;
 
 		if (_inMem) {
-			_indexMap = IndexMap.CreateEmpty(_maxTablesPerLevel, int.MaxValue);
+			_indexMap = IndexMap.CreateEmpty(_maxTablesPerLevel, int.MaxValue, _pTableMaxReaderCount);
 			_prepareCheckpoint = _indexMap.PrepareCheckpoint;
 			_commitCheckpoint = _indexMap.CommitCheckpoint;
 			return;
@@ -159,7 +163,8 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 				useBloomFilter: _useBloomFilter,
 				lruCacheSize: _lruCacheSize,
 				threads: _initializationThreads,
-				maxAutoMergeLevel: _maxAutoMergeIndexLevel);
+				maxAutoMergeLevel: _maxAutoMergeIndexLevel,
+				pTableMaxReaderCount: _pTableMaxReaderCount);
 			if (_indexMap.CommitCheckpoint >= chaserCheckpoint) {
 				_indexMap.Dispose(TimeSpan.FromMilliseconds(5000));
 				throw new CorruptIndexException(String.Format(
@@ -181,7 +186,8 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 				useBloomFilter: _useBloomFilter,
 				lruCacheSize: _lruCacheSize,
 				threads: _initializationThreads,
-				maxAutoMergeLevel: _maxAutoMergeIndexLevel);
+				maxAutoMergeLevel: _maxAutoMergeIndexLevel,
+				pTableMaxReaderCount: _pTableMaxReaderCount);
 		}
 
 		_prepareCheckpoint = _indexMap.PrepareCheckpoint;
@@ -337,6 +343,8 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 				if (memtable != null) {
 					memtable.MarkForConversion();
 					ptable = PTable.FromMemtable(memtable, _fileNameProvider.GetFilenameNewTable(),
+						ESConsts.PTableInitialReaderCount,
+						_pTableMaxReaderCount,
 						_indexCacheDepth,
 						_skipIndexVerify,
 						useBloomFilter: _useBloomFilter,
@@ -503,6 +511,8 @@ public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
 			Log.Debug("Putting awaiting file as PTable instead of MemTable [{id}].", memtable.Id);
 
 			var ptable = PTable.FromMemtable(memtable, _fileNameProvider.GetFilenameNewTable(),
+				ESConsts.PTableInitialReaderCount,
+				_pTableMaxReaderCount,
 				_indexCacheDepth,
 				_skipIndexVerify,
 				useBloomFilter: _useBloomFilter,


### PR DESCRIPTION
### **User description**

This reverts commit 728db70d0ea3eaf287e3690596e9d46ef2ac7e56.

This was causing a performance regression that we can investigate after 26.0.0. This change isn't currently critical since concurrent reads is also no longer unlimited by default

```
wrfl 10 1m 10 4 1 t

then

rdfl 10 1000000 10 t

before this pr rfdl gave 45,985.47 requests per second
after this pr it gives 185,253.80 requests per second, in line with previous versions
```

---

### **PR Type**

Enhancement, Tests

---

### **Description**

* Reverted from single `SafeFileHandle` to object pool-based `WorkItem` pattern for managing multiple file streams in `PTable`
* Replaced `DotNext` library dependencies with standard .NET APIs (`BinaryReader`, `BitConverter`, `MemoryMarshal`)
* Converted `PTableHeader` and `PTableFooter` from structs to classes with stream-based parsing instead of `RandomAccess`
* Added configurable reader thread count calculation via new `ThreadCountCalculator` utility class
* Introduced `initialReaders` and `maxReaders` parameters throughout the indexing system for pool configuration
* Propagated reader count configuration through `IndexMap`, `TableIndex`, and `ClusterVNode` initialization
* Updated 50+ test files to pass reader count parameters to `PTable` and `TableIndex` constructors
* Added comprehensive test coverage for `ThreadCountCalculator` with various processor counts and containerized environments
* Added `ReaderThreadCount` constant to `ContainerizedEnvironment` for container detection
* Minor refactoring of `Empty` utility class field initialization

---

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Single SafeFileHandle"] -->|Revert| B["WorkItem Pool Pattern"]
  C["DotNext APIs"] -->|Replace| D["Standard .NET APIs"]
  E["RandomAccess/IncrementalHash"] -->|Convert| F["Stream-based Reading"]
  G["ThreadCountCalculator"] -->|Calculate| H["Reader Thread Count"]
  H -->|Configure| I["PTable Reader Pool"]
  J["IndexMap/TableIndex"] -->|Propagate| I
```

<details><summary>File Walkthrough</summary>

<!-- linear:table-colwidths:200,200 -->
|  | Relevant files |
| -- | -- |
| **Enhancement** | ++++ 56 files |
| **Tests** | ++++ 13 files |
| **Configuration changes** | ++++ 2 files |
| **Formatting** | ++++ 1 files |
| **Additional files** | ++++ 3 files |

</details>

---