### PR TITLE
[DB-1856] Disable DATAS

### DIFF
--- a/src/KurrentDB/KurrentDB.csproj
+++ b/src/KurrentDB/KurrentDB.csproj
@@ -5,6 +5,7 @@
 		<ApplicationIcon>app2.ico</ApplicationIcon>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
 		<ServerGarbageCollection>true</ServerGarbageCollection>
+		<GarbageCollectionAdaptationMode>false</GarbageCollectionAdaptationMode>
 	</PropertyGroup>
 	<ItemGroup>
 		<RuntimeHostConfigurationOption Include="System.GC.HeapHardLimitPercent" Value="60" />


### PR DESCRIPTION
### **User description**
This is enabled in NET9+ by default. We keep the same behaviour as previous releases by keeping it disabled. Generally we expect our common use case not to benefit from DATAS, we want the server to hold on to the resources it needed for the previous peak load so that it remains ready for the next peak. Environments where this is not the case can still enable DATAS in their config.


___

### **Auto-created Ticket**

[#5471](https://github.com/kurrent-io/KurrentDB/issues/5471)

### **PR Type**
Enhancement


___

### **Description**
- Disable DATAS garbage collection adaptation mode in NET9+

- Maintains backward compatibility with previous release behavior

- Preserves server resources for handling peak loads

- Allows per-environment configuration overrides


___

### Diagram Walkthrough


```mermaid
flowchart LR
  NET9["NET9+ Default<br/>DATAS Enabled"] -- "Disable via config" --> KurrentDB["KurrentDB<br/>DATAS Disabled"]
  KurrentDB -- "Preserve resources<br/>for peak loads" --> Behavior["Consistent with<br/>Previous Releases"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KurrentDB.csproj</strong><dd><code>Disable DATAS in project configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KurrentDB/KurrentDB.csproj

<ul><li>Added <code>GarbageCollectionAdaptationMode</code> property set to <code>false</code><br> <li> Disables DATAS (Dynamic Adaptive Trimming of Segments) which is <br>enabled by default in NET9+<br> <li> Maintains resource retention strategy for peak load readiness<br> <li> Allows environment-specific overrides through configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5470/files#diff-1cc8fa02ee6f6282c79edcb5b3d090af3f3c63cc934aa70ae48b2021693d36c0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

