### PR TITLE
Improve the way enterprise functionality is described

### DIFF
--- a/docs/server/quick-start/README.md
+++ b/docs/server/quick-start/README.md
@@ -13,10 +13,10 @@ Welcome to the KurrentDB documentation.
 
 KurrentDB is a database that's engineered for modern software applications and event-driven architectures. Its event-native design simplifies data modeling and preserves data integrity while the integrated streaming engine solves distributed messaging challenges and ensures data consistency.
 
-KurrentDB is licensed under [Kurrent License v1 (KLv1)](https://github.com/EventStore/EventStore/blob/master/LICENSE.md), meaning that anyone can access and use it, but enterprise features are only enabled with a valid [license key](./installation.md#license-keys).
+KurrentDB is licensed under [Kurrent License v1 (KLv1)](https://github.com/kurrent-io/KurrentDB/blob/master/LICENSE.md), meaning that anyone can access and use it, additionally [enterprise features](https://www.kurrent.io/kurrent-platform-editions) can be enabled with a valid [license key](./installation.md#license-keys).
 
 ::: note
-Although the source code for KurrentDB is available to view, the [KLv1 license](https://github.com/EventStore/EventStore/blob/master/LICENSE.md) is not an OSI-approved Open Source License.
+Although the source code for KurrentDB is available to view, the [KLv1 license](https://github.com/kurrent-io/KurrentDB/blob/master/LICENSE.md) is not an OSI-approved Open Source License.
 :::
 
 ## What's new


### PR DESCRIPTION
### **User description**
Original PR: https://github.com/kurrent-io/KurrentDB/pull/5256

I saw that the cherry-pick command has failed, so creating this PR against v25.0 – have carried over the 24.10 tag and have added 25.1 too.

If the script fails again, I will manually open PRs against these two versions.


___

### **Pr ticket**
{'summary': 'Improve enterprise features description and correct license documentation links\n', 'description': '**Description**\n- The documentation contained outdated GitHub repository references pointing to the old EventStore organization instead of the current kurrent-io organization\n- Enterprise features description needed clarification to better communicate availability and licensing options\n- Documentation should include direct reference to enterprise editions information\n\n**Deliverables**\n- **Update URLs**: Correct all license documentation links to point to kurrent-io/KurrentDB repository\n- **Enhance Description**: Add hyperlink to enterprise editions page and improve wording clarity\n- **Clarify Language**: Change "only enabled" to "can be enabled" for more accurate feature availability messaging\n'}


___

### **PR Type**
Documentation


___

### **Description**
- Updated license URL references from EventStore to kurrent-io organization

- Improved enterprise features description with direct link to editions page

- Changed wording from "only enabled" to "can be enabled" for clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["License URL References"] -->|"Update to kurrent-io"| B["GitHub Links"]
  C["Enterprise Features Text"] -->|"Add editions link"| D["Enhanced Description"]
  E["Licensing Language"] -->|"Clarify availability"| F["Better Wording"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update license URLs and improve enterprise features wording</code></dd></summary>
<hr>

docs/server/quick-start/README.md

<ul><li>Updated GitHub license URL from <code>EventStore/EventStore</code> to <br><code>kurrent-io/KurrentDB</code> repository (2 occurrences)<br> <li> Added hyperlink to enterprise features page <br>(https://www.kurrent.io/kurrent-platform-editions)<br> <li> Changed wording from "enterprise features are only enabled" to <br>"enterprise features can be enabled" for improved clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5484/files#diff-b1a68271a3c5ec67cb408d7b635cdb123f72a82f8f69341bb30575aaaf6bae31">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

