### PR TITLE
[DB-1895] Update version scheme

### DIFF
--- a/docs/server/release-schedule/README.md
+++ b/docs/server/release-schedule/README.md
@@ -20,13 +20,14 @@ Note that the version scheme is not `SemVer`.
 
 Examples:
 
-| Version  | Type | Description             |
-|----------|------|-------------------------|
-| `26.0.0` | LTS  | 2026 LTS release.       |
-| `26.0.1` | LTS  | A patch to 26.0.0.      |
-| `26.1.0` | STS  | First 2026 STS release  |
-| `26.2.0` | STS  | Second 2026 STS release |
-| `27.0.0` | LTS  | 2027 LTS release.       |
+| Version  | Type | Description              |
+|----------|------|--------------------------|
+| `26.0.0` | LTS  | 2026 LTS release.        |
+| `26.0.1` | LTS  | A patch to `26.0.0`.     |
+| `26.1.0` | STS  | First 2026 STS release.  |
+| `26.2.0` | STS  | Second 2026 STS release. |
+| `26.2.1` | STS  | A patch to `26.2.0`.     |
+| `27.0.0` | LTS  | 2027 LTS release.        |
 
 ## Long term support releases
 

--- a/docs/server/release-schedule/README.md
+++ b/docs/server/release-schedule/README.md
@@ -14,7 +14,7 @@ KurrentDB production release version numbers are of the form `Major.Minor.Patch`
     * Indicates whether the release is an [LTS](#long-term-support-releases) or an [STS](#short-term-support-releases).
     * Starting with `26.0`, LTS releases have minor number `0`. Previously they had minor number `10` (e.g. `23.10`, `24.10`).
 * `Patch`
-    * Is incremented for bug fixes and small features.
+    * Is incremented for bug fixes and occasionally small features.
 
 Note that the version scheme is not `SemVer`.
 

--- a/docs/server/release-schedule/README.md
+++ b/docs/server/release-schedule/README.md
@@ -6,57 +6,38 @@ dir:
 
 # Release schedule
 
-## KurrentDB versioning and release schedule
-
-There are two categories of release for KurrentDB:
-* Long term support (LTS) releases.
-* Short term support (STS) releases.
-
-The version number reflects whether a release is an LTS or STS release. LTS releases have _even_ major numbers, and STS releases have _odd_ major numbers.
-
-### Versioning scheme
-
-The version scheme for KurrentDB is `Major.Minor.Patch` where:
+KurrentDB production release version numbers are of the form `Major.Minor.Patch`.
 
 * `Major`
-    * Is _even_ for LTS releases.
-    * Is _odd_ for STS releases.
+    * Corresponds to the year in which a release was released.
 * `Minor`
-    * Increments with scope changes or new features.
-    * Is typically `0` for LTS releases, but may be incremented in rare cases.
-* `Patch` for bug fixes.
+    * Indicates whether the release is an [LTS](#long-term-support-releases) or an [STS](#short-term-support-releases).
+    * Starting with `26.0`, LTS releases have minor number `0`. Previously they had minor number `10` (e.g. `23.10`, `24.10`).
+* `Patch`
+    * Is incremented for bug fixes and small features.
 
-As an example, the future releases of KurrentDB may look like this:
+Note that the version scheme is not `SemVer`.
 
-| Version  | Type    | Description |
-|----------|---------|-------------|
-| `25.0.0` | STS     | The first release of KurrentDB. |
-| `25.1.0` | STS     | New features added. |
-| `26.0.0` | LTS     | The first LTS release of KurrentDB. |
-| `26.0.1` | LTS     | A patch to 26.0.0. |
-| `27.0.0` | STS     | New features added. |
+Examples:
 
-### Long term support releases
+| Version  | Type | Description             |
+|----------|------|-------------------------|
+| `26.0.0` | LTS  | 2026 LTS release.       |
+| `26.0.1` | LTS  | A patch to 26.0.0.      |
+| `26.1.0` | STS  | First 2026 STS release  |
+| `26.2.0` | STS  | Second 2026 STS release |
+| `27.0.0` | LTS  | 2027 LTS release.       |
 
-There will be approximately one LTS release of KurrentDB per year.
+## Long term support releases
+
+There will be one LTS release of KurrentDB per year, released in or around January.
 
 These versions will be supported for a minimum of two years, with a two month grace period for organizing upgrades when the LTS goes out of support.
 
-LTS versions of KurrentDB start with an even major number.
-
-### Short term support releases
+## Short term support releases
 
 STS releases will be published as new features are added to KurrentDB.
 
 These versions will be supported until the next STS or LTS release of KurrentDB.
 
-STS versions of KurrentDB start with an odd major number.
-
-## Supported EventStoreDB versions
-
-EventStoreDB had a different versioning scheme to KurrentDB, where the LTS release always had a minor version of `10`.
-
-The LTS versions of EventStoreDB will still be supported for two years from their release date. This means the following versions of EventStoreDB are still within Kurrent's support window:
-
-* [EventStoreDB 24.10](https://docs.kurrent.io/server/v24.10/quick-start/) supported until October 2026.
-* [EventStoreDB 23.10](https://docs.kurrent.io/server/v23.10/quick-start/) supported until October 2025.
+There are typically one or two STS releases per year.


### PR DESCRIPTION
### **User description**
Motiviated by concerns that the previous scheme will be too confusing (specifically when we release v27.0.0 in 2026)

This new scheme is compatible with the releases that we put out under the previous schema (25.0, 25.1, 26.0), and is similar to the scheme we had before that, so the change shouldn't be too jarring.


___

### **Pr ticket**
{'summary': 'Transition KurrentDB versioning from odd/even scheme to year-based format\n', 'description': '**Description**\n- Current versioning scheme using odd/even major numbers will become confusing when releasing v27.0.0 in 2026\n- Need clearer, more intuitive versioning that aligns with release years\n- Maintain backward compatibility with existing releases (25.0, 25.1, 26.0)\n- Simplify understanding of LTS vs STS releases through version numbers\n\n**Deliverables**\n- **Year-based Major**: Major version corresponds to release year (e.g., 26 for 2026)\n- **Type Indicator**: Minor version indicates release type (0 for LTS, 1+ for STS)\n- **Documentation Update**: Update release schedule documentation with new scheme and examples\n- **Legacy Cleanup**: Remove outdated EventStoreDB version support references\n'}


___

### **PR Type**
Documentation


___

### **Description**
- Changed versioning scheme from odd/even major numbers to year-based

- Major version now corresponds to release year instead of LTS/STS indicator

- Minor version now indicates LTS (0) or STS (1+) release type

- Removed EventStoreDB legacy version support documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Scheme<br/>Odd/Even Major"] -->|"Major = Year"| B["New Scheme<br/>Year.Type.Patch"]
  B -->|"Minor 0"| C["LTS Release"]
  B -->|"Minor 1+"| D["STS Release"]
  E["v25.0.0 STS"] -->|"Migrate to"| F["v26.0.0 LTS<br/>v26.1.0 STS"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Transition to year-based versioning scheme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/server/release-schedule/README.md

<ul><li>Replaced odd/even major version scheme with year-based versioning<br> <li> Major version now represents release year; minor version indicates LTS <br>(0) or STS (1+)<br> <li> Updated version examples to reflect new scheme (26.0.0 LTS, 26.1.0 <br>STS, 27.0.0 LTS)<br> <li> Removed EventStoreDB legacy version support section and historical <br>context<br> <li> Clarified that versioning is not SemVer compliant</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB/pull/5486/files#diff-6b555c4ce5de3f5b4a063b55069b041bf37f74008e829a7e3d2247d06d73eddc">+20/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

