### PR TITLE
[DB-1915]: Use fixed behavior in PoolingBufferedStream class

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="DiffEngine" Version="16.7.1" />
     <PackageVersion Include="Dapper" Version="2.1.66" />
     <PackageVersion Include="DotNext" Version="5.26.3" />
-    <PackageVersion Include="DotNext.IO" Version="5.26.2" />
+    <PackageVersion Include="DotNext.IO" Version="5.26.3" />
     <PackageVersion Include="DotNext.Threading" Version="5.26.3" />
     <PackageVersion Include="DotNext.Unsafe" Version="5.26.2" />
     <PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />

--- a/src/KurrentDB.Plugins/Transforms/ChunkDataWriteStream.cs
+++ b/src/KurrentDB.Plugins/Transforms/ChunkDataWriteStream.cs
@@ -24,7 +24,6 @@ public class ChunkDataWriteStream(Stream chunkFileStream, IncrementalHash checks
 			ReadAndChecksum(count);
 
 			Debug.Assert(ChunkFileStream.Position == count);
-			ResetPoolingBufferedStreamReadBuffer(count);
 			_positionToHash = null;
 		}
 
@@ -49,7 +48,6 @@ public class ChunkDataWriteStream(Stream chunkFileStream, IncrementalHash checks
 		await ReadAndChecksumAsync(count, token);
 
 		Debug.Assert(ChunkFileStream.Position == count);
-		ResetPoolingBufferedStreamReadBuffer(count);
 		await ChunkFileStream.WriteAsync(buffer, token);
 		checksumAlgorithm.AppendData(buffer.Span);
 		_positionToHash = null;
@@ -96,16 +94,5 @@ public class ChunkDataWriteStream(Stream chunkFileStream, IncrementalHash checks
 
 			checksumAlgorithm.AppendData(buffer.Slice(0, bytesRead));
 		}
-	}
-
-	// Workaround PoolingBufferedStream behavior. If we leave the stream with bytes in its read buffer
-	// then when we flush it will discard those bytes and advance the Position to end of the read buffer.
-	// This would then result in attempts to write records to the wrong place in the chunk
-	// (which would be detected and rejected as a "Data sizes violation").
-	// Instead we flush here and restore the position so that the stream is set up for regular use.
-	// This can be removed if/when the PoolingBufferedStream flush behavior is updated.
-	private void ResetPoolingBufferedStreamReadBuffer(long position) {
-		ChunkFileStream.Flush();
-		ChunkFileStream.Position = position;
 	}
 }


### PR DESCRIPTION
Changed: Use fixed behavior in PoolingBufferedStream class.

Related PR #5490.