### PR TITLE
[DB-1951] Treat writes as idempotent if all events were previously written, even with check-only streams

### DIFF
--- a/src/KurrentDB.Core.Tests/Services/Storage/FakeIndexWriter.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/FakeIndexWriter.cs
@@ -29,12 +29,12 @@ public class FakeIndexWriter<TStreamId> : IIndexWriter<TStreamId> {
 	}
 
 	public ValueTask<CommitCheckResult<TStreamId>> CheckCommitStartingAt(long transactionPosition, long commitPosition, CancellationToken token) {
-		return ValueTask.FromResult(new CommitCheckResult<TStreamId>(CommitDecision.Ok, GetFakeStreamId(), ExpectedVersion.Invalid, -1, -1, -1, false));
+		return ValueTask.FromResult(new CommitCheckResult<TStreamId>(CommitDecision.Ok, 0, GetFakeStreamId(), ExpectedVersion.Invalid, -1, -1, -1, false));
 	}
 
 	public ValueTask<CommitCheckResult<TStreamId>> CheckCommit(TStreamId streamId, long expectedVersion, LowAllocReadOnlyMemory<Guid> eventIds, bool streamMightExist,
 		CancellationToken token) {
-		return ValueTask.FromResult(new CommitCheckResult<TStreamId>(CommitDecision.Ok, streamId, expectedVersion, expectedVersion, -1, -1, false));
+		return ValueTask.FromResult(new CommitCheckResult<TStreamId>(CommitDecision.Ok, eventIds.Length, streamId, expectedVersion, expectedVersion, -1, -1, false));
 	}
 
 	public ValueTask PreCommit(CommitLogRecord commit, CancellationToken token)

--- a/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
@@ -1269,8 +1269,8 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 	// to be applicable), then retries according to the Idempotency type:
 	//   Full:                same events, same expected version → should succeed (idempotent)
 	//   Partial:             first event same, second is new → corrupted idempotency → should fail
-	//   WithFailedCheck:     same events, but adds a failing check-only stream → fails
-	//   WithSuccessfulCheck: same events, but adds a successful check-only stream → fails
+	//   WithFailedCheck:     same events, but adds a failing check-only stream → should succeed (idempotent)
+	//   WithSuccessfulCheck: same events, but adds a successful check-only stream → should succeed (idempotent)
 	//
 	// Only (ExpectedVersion, StreamState) combos where the initial write succeeds are applicable.
 	// Participation is always WriteTo.
@@ -1278,32 +1278,32 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 		// ExpectedVersion.Any
 		{ ExpectedVersion.Any, StreamState.NeverExisted, IdempotencyKind.Full, OperationResult.Success },
 		{ ExpectedVersion.Any, StreamState.NeverExisted, IdempotencyKind.Partial, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.Any, StreamState.NeverExisted, IdempotencyKind.WithFailedCheck, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.Any, StreamState.NeverExisted, IdempotencyKind.WithSuccessfulCheck, OperationResult.WrongExpectedVersion },
+		{ ExpectedVersion.Any, StreamState.NeverExisted, IdempotencyKind.WithFailedCheck, OperationResult.Success },
+		{ ExpectedVersion.Any, StreamState.NeverExisted, IdempotencyKind.WithSuccessfulCheck, OperationResult.Success },
 		{ ExpectedVersion.Any, StreamState.ExistsAtV2, IdempotencyKind.Full, OperationResult.Success },
 		{ ExpectedVersion.Any, StreamState.ExistsAtV2, IdempotencyKind.Partial, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.Any, StreamState.ExistsAtV2, IdempotencyKind.WithFailedCheck, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.Any, StreamState.ExistsAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.WrongExpectedVersion },
+		{ ExpectedVersion.Any, StreamState.ExistsAtV2, IdempotencyKind.WithFailedCheck, OperationResult.Success },
+		{ ExpectedVersion.Any, StreamState.ExistsAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.Success },
 		{ ExpectedVersion.Any, StreamState.SoftDeletedAtV2, IdempotencyKind.Full, OperationResult.Success },
 		{ ExpectedVersion.Any, StreamState.SoftDeletedAtV2, IdempotencyKind.Partial, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.Any, StreamState.SoftDeletedAtV2, IdempotencyKind.WithFailedCheck, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.Any, StreamState.SoftDeletedAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.WrongExpectedVersion },
+		{ ExpectedVersion.Any, StreamState.SoftDeletedAtV2, IdempotencyKind.WithFailedCheck, OperationResult.Success },
+		{ ExpectedVersion.Any, StreamState.SoftDeletedAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.Success },
 		// { ExpectedVersion.Any, StreamState.Tombstoned } not applicable
 
 		// ExpectedVersion.StreamExists
 		// { ExpectedVersion.StreamExists, StreamState.NeverExisted } not applicable
 		{ ExpectedVersion.StreamExists, StreamState.ExistsAtV2, IdempotencyKind.Full, OperationResult.Success },
 		{ ExpectedVersion.StreamExists, StreamState.ExistsAtV2, IdempotencyKind.Partial, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.StreamExists, StreamState.ExistsAtV2, IdempotencyKind.WithFailedCheck, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.StreamExists, StreamState.ExistsAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.WrongExpectedVersion },
+		{ ExpectedVersion.StreamExists, StreamState.ExistsAtV2, IdempotencyKind.WithFailedCheck, OperationResult.Success },
+		{ ExpectedVersion.StreamExists, StreamState.ExistsAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.Success },
 		// { ExpectedVersion.StreamExists, StreamState.SoftDeletedAtV2 } not applicable
 		// { ExpectedVersion.StreamExists, StreamState.Tombstoned } not applicable
 
 		// ExpectedVersion.NoStream
 		{ ExpectedVersion.NoStream, StreamState.NeverExisted, IdempotencyKind.Full, OperationResult.Success },
 		{ ExpectedVersion.NoStream, StreamState.NeverExisted, IdempotencyKind.Partial, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.NoStream, StreamState.NeverExisted, IdempotencyKind.WithFailedCheck, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.NoStream, StreamState.NeverExisted, IdempotencyKind.WithSuccessfulCheck, OperationResult.WrongExpectedVersion },
+		{ ExpectedVersion.NoStream, StreamState.NeverExisted, IdempotencyKind.WithFailedCheck, OperationResult.Success },
+		{ ExpectedVersion.NoStream, StreamState.NeverExisted, IdempotencyKind.WithSuccessfulCheck, OperationResult.Success },
 		// { ExpectedVersion.NoStream, StreamState.ExistsAtV2 } not applicable
 		// next case is long standing behaviour but a case could be made that this retry should succeed.
 		{ ExpectedVersion.NoStream, StreamState.SoftDeletedAtV2, IdempotencyKind.Full, OperationResult.WrongExpectedVersion },
@@ -1317,8 +1317,8 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 		// { ExpectedVersion.SoftDeleted, StreamState.ExistsAtV2 } not applicable
 		{ ExpectedVersion.SoftDeleted, StreamState.SoftDeletedAtV2, IdempotencyKind.Full, OperationResult.Success },
 		{ ExpectedVersion.SoftDeleted, StreamState.SoftDeletedAtV2, IdempotencyKind.Partial, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.SoftDeleted, StreamState.SoftDeletedAtV2, IdempotencyKind.WithFailedCheck, OperationResult.WrongExpectedVersion },
-		{ ExpectedVersion.SoftDeleted, StreamState.SoftDeletedAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.WrongExpectedVersion },
+		{ ExpectedVersion.SoftDeleted, StreamState.SoftDeletedAtV2, IdempotencyKind.WithFailedCheck, OperationResult.Success },
+		{ ExpectedVersion.SoftDeleted, StreamState.SoftDeletedAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.Success },
 		// { ExpectedVersion.SoftDeleted, StreamState.Tombstoned } not applicable
 
 		// EventNumber.DeletedStream: not applicable
@@ -1329,12 +1329,12 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 		// { 2, StreamState.NeverExisted } not applicable
 		{ 2, StreamState.ExistsAtV2, IdempotencyKind.Full, OperationResult.Success },
 		{ 2, StreamState.ExistsAtV2, IdempotencyKind.Partial, OperationResult.WrongExpectedVersion },
-		{ 2, StreamState.ExistsAtV2, IdempotencyKind.WithFailedCheck, OperationResult.WrongExpectedVersion },
-		{ 2, StreamState.ExistsAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.WrongExpectedVersion },
+		{ 2, StreamState.ExistsAtV2, IdempotencyKind.WithFailedCheck, OperationResult.Success },
+		{ 2, StreamState.ExistsAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.Success },
 		{ 2, StreamState.SoftDeletedAtV2, IdempotencyKind.Full, OperationResult.Success },
 		{ 2, StreamState.SoftDeletedAtV2, IdempotencyKind.Partial, OperationResult.WrongExpectedVersion },
-		{ 2, StreamState.SoftDeletedAtV2, IdempotencyKind.WithFailedCheck, OperationResult.WrongExpectedVersion },
-		{ 2, StreamState.SoftDeletedAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.WrongExpectedVersion },
+		{ 2, StreamState.SoftDeletedAtV2, IdempotencyKind.WithFailedCheck, OperationResult.Success },
+		{ 2, StreamState.SoftDeletedAtV2, IdempotencyKind.WithSuccessfulCheck, OperationResult.Success },
 		// { 2, StreamState.Tombstoned } not applicable
 
 		// EV.3: not applicable

--- a/src/KurrentDB.Core/Services/Storage/ReaderIndex/CommitCheckResult.cs
+++ b/src/KurrentDB.Core/Services/Storage/ReaderIndex/CommitCheckResult.cs
@@ -4,9 +4,10 @@
 namespace KurrentDB.Core.Services.Storage.ReaderIndex;
 
 public readonly struct CommitCheckResult<TStreamId>(
-	CommitDecision decision,
-	TStreamId eventStreamId,
-	long expectedVersion,
+	CommitDecision decision, // it is ok/not ok/idempotent etc
+	int eventCount,          // to write this many events
+	TStreamId eventStreamId, // to this stream
+	long expectedVersion,    // at this expected version.
 	long currentVersion,
 	long startEventNumber,
 	long endEventNumber,
@@ -14,6 +15,7 @@ public readonly struct CommitCheckResult<TStreamId>(
 	long idempotentLogPosition = -1) {
 
 	public readonly CommitDecision Decision = decision;
+	public readonly int EventCount = eventCount;
 	public readonly TStreamId EventStreamId = eventStreamId;
 	public readonly long ExpectedVersion = expectedVersion;
 	public readonly long CurrentVersion = currentVersion;
@@ -28,4 +30,9 @@ public readonly struct CommitCheckResult<TStreamId>(
 	public readonly bool? IsSoftDeleted = isSoftDeleted;
 
 	public readonly long IdempotentLogPosition = idempotentLogPosition;
+
+	/// <summary>
+	/// Whether this stream has events to write (as opposed to a check-only stream).
+	/// </summary>
+	public bool HasEventsToWrite => EventCount > 0;
 }

--- a/src/KurrentDB.Core/Services/Storage/ReaderIndex/IndexWriter.cs
+++ b/src/KurrentDB.Core/Services/Storage/ReaderIndex/IndexWriter.cs
@@ -120,7 +120,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 			streamId = prepare.EventStreamId;
 			expectedVersion = prepare.ExpectedVersion;
 		} catch (InvalidOperationException) {
-			return new(CommitDecision.InvalidTransaction, _emptyStreamId, ExpectedVersion.Invalid, -1, -1, -1, isSoftDeleted: null);
+			return new(CommitDecision.InvalidTransaction, 0, _emptyStreamId, ExpectedVersion.Invalid, -1, -1, -1, isSoftDeleted: null);
 		}
 
 		// we should skip prepares without data, as they don't mean anything for idempotency
@@ -145,7 +145,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 	// see commit c73a1c8d19197bec4f9affbe4ced9346a3e4777d
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static CommitCheckResult<TStreamId> CommitOk(TStreamId streamId, long expectedVersion, long curVersion, int eventCount, bool? isSoftDeleted) =>
-		new(CommitDecision.Ok, streamId, expectedVersion, curVersion,
+		new(CommitDecision.Ok, eventCount, streamId, expectedVersion, curVersion,
 			startEventNumber: curVersion + 1,
 			endEventNumber: curVersion + eventCount,
 			isSoftDeleted: isSoftDeleted);
@@ -155,7 +155,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 		if (expectedVersion is ExpectedVersion.Any or ExpectedVersion.NoStream) {
 			return CommitOk(streamId, expectedVersion, curVersion, eventCount, isSoftDeleted: false);
 		} else {
-			return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: false);
+			return new(CommitDecision.ConsistencyCheckFailure, eventCount, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: false);
 		}
 	}
 
@@ -171,7 +171,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 			case EventNumber.DeletedStream:
 				if (eventIds.Length > 0)
 					// we're trying to append events to the hard deleted stream - that's not possible regardless of the specified expected version
-					return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: false);
+					return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: false);
 
 				// we're not appending any events to the hard deleted stream - we're only doing a consistency check on the stream's version
 				if (expectedVersion is ExpectedVersion.Any or ExpectedVersion.NoStream or EventNumber.DeletedStream)
@@ -179,19 +179,19 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 					return CommitOk(streamId, expectedVersion, curVersion, eventCount: 0, isSoftDeleted: false);
 
 				// the specified expected version doesn't match the stream's current state
-				return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: false);
+				return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: false);
 			case EventNumber.Invalid:
-				return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
+				return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
 		}
 
 		if (expectedVersion is ExpectedVersion.StreamExists) {
 			if (await IsSoftDeleted(streamId, token))
-				return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: true);
+				return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: true);
 
 			if (curVersion < 0) {
 				var metadataVersion = await GetStreamLastEventNumber(_systemStreams.MetaStreamOf(streamId), token);
 				if (metadataVersion < 0)
-					return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: false);
+					return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: false);
 			}
 		}
 
@@ -218,12 +218,12 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 
 				// found an event that isn't already written
 				if (!first)
-					return new(CommitDecision.CorruptedIdempotency, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
+					return new(CommitDecision.CorruptedIdempotency, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
 
 				// the first event in the write is not already written
 				var isSoftDeleted = await IsSoftDeleted(streamId, token);
 				if (expectedVersion is ExpectedVersion.SoftDeleted && !isSoftDeleted)
-					return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted);
+					return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted);
 
 				return CommitOk(streamId, expectedVersion, curVersion, eventIds.Length, isSoftDeleted);
 			}
@@ -234,7 +234,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 				// not writing any events at all
 				var isSoftDeleted = await IsSoftDeleted(streamId, token);
 				if (expectedVersion is ExpectedVersion.SoftDeleted && !isSoftDeleted)
-					return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted);
+					return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted);
 
 				return CommitOk(streamId, expectedVersion, curVersion, eventIds.Length, isSoftDeleted);
 			}
@@ -250,8 +250,8 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 				? idempotentEvent.Record.LogPosition
 				: -1;
 			return isReplicated
-				? new(CommitDecision.Idempotent, streamId, expectedVersion, curVersion, startEventNumber, endEventNumber, isSoftDeleted: null, logPos)
-				: new(CommitDecision.IdempotentNotReady, streamId, expectedVersion, curVersion, startEventNumber, endEventNumber, isSoftDeleted: null, logPos);
+				? new(CommitDecision.Idempotent, eventIds.Length, streamId, expectedVersion, curVersion, startEventNumber, endEventNumber, isSoftDeleted: null, logPos)
+				: new(CommitDecision.IdempotentNotReady, eventIds.Length, streamId, expectedVersion, curVersion, startEventNumber, endEventNumber, isSoftDeleted: null, logPos);
 		}
 
 		// strong idempotency checks. the request specifies specific event numbers
@@ -277,14 +277,14 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 				// found an event that isn't already written
 				var first = i == 0;
 				if (!first)
-					return new(CommitDecision.CorruptedIdempotency, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
+					return new(CommitDecision.CorruptedIdempotency, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
 
 				// the first event in the write is not already written
 				if (expectedVersion is ExpectedVersion.NoStream && await IsSoftDeleted(streamId, token))
 					return CommitOk(streamId, expectedVersion, curVersion, eventIds.Length, isSoftDeleted: true);
 
 				// trying to write new events earlier than the end of the stream
-				return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
+				return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
 			}
 
 			// could not find any unwritten events
@@ -294,7 +294,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 					return CommitOk(streamId, expectedVersion, curVersion, eventIds.Length, isSoftDeleted: true);
 
 				// expected the stream to be at an earlier version than it is
-				return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
+				return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
 			}
 
 			// we are writing events and they are all written already
@@ -310,7 +310,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 				: -1;
 
 			return new(
-				isReplicated ? CommitDecision.Idempotent : CommitDecision.IdempotentNotReady, streamId,
+				isReplicated ? CommitDecision.Idempotent : CommitDecision.IdempotentNotReady, eventIds.Length, streamId,
 				expectedVersion,
 				curVersion,
 				expectedVersion + 1, eventNumber,  isSoftDeleted: null, logPos);
@@ -318,7 +318,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId> {
 
 		// writing after the end -> fail
 		if (expectedVersion > curVersion)
-			return new(CommitDecision.ConsistencyCheckFailure, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
+			return new(CommitDecision.ConsistencyCheckFailure, eventIds.Length, streamId, expectedVersion, curVersion, -1, -1, isSoftDeleted: null);
 
 		// writing exactly to the end (expectedVersion == currentVersion) -> ok
 		return CommitOk(streamId, expectedVersion, curVersion, eventIds.Length, await IsSoftDeleted(streamId, token));

--- a/src/KurrentDB.Core/Services/Storage/StorageWriterService.cs
+++ b/src/KurrentDB.Core/Services/Storage/StorageWriterService.cs
@@ -104,7 +104,6 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 	private struct WritePreparesStreamInfo {
 		public long LatestVersion { get; set; }
 		public bool IsSoftDeletedMeta { get; init; }
-		public bool HasEventsToWrite { get; init; }
 	}
 
 	private readonly ArrayPool<WritePreparesStreamInfo> _streamInfosPool =
@@ -328,7 +327,6 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 					IsSoftDeletedMeta = _systemStreams.IsMetaStream(streamId)
 										&& await _indexWriter.IsSoftDeleted(_systemStreams.OriginalStreamOf(streamId), token),
 					LatestVersion = commitChecks[streamIndex].CurrentVersion,
-					HasEventsToWrite = numEventIds > 0,
 				};
 			}
 
@@ -345,10 +343,11 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			for (int i = 0; i < commitCheckResults.Length; i++) {
 				ref readonly var checkResult = ref commitCheckResults.Span[i];
 				Debug.Assert(checkResult.Decision == CommitDecision.Ok);
-				if (isEmptyWriteToSingleStream || streamInfos[i].HasEventsToWrite) {
+				if (isEmptyWriteToSingleStream || checkResult.HasEventsToWrite) {
 					firstEventNumbers = firstEventNumbers.Add(checkResult.StartEventNumber);
 					lastEventNumbers = lastEventNumbers.Add(checkResult.EndEventNumber);
 				} else {
+					// check-only stream
 					firstEventNumbers = firstEventNumbers.Add(EventNumber.CheckOnlyFirst);
 					lastEventNumbers = lastEventNumbers.Add(EventNumber.CheckOnlyLast);
 				}
@@ -423,7 +422,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			// for backwards compatibility, an empty write (which must be to a single stream) causes undeletion, too.
 			// TODO: soft undelete in a transaction
 			for (int i = 0; i < msg.EventStreamIds.Length; i++) {
-				if (isEmptyWriteToSingleStream || streamInfos[i].HasEventsToWrite) {
+				if (isEmptyWriteToSingleStream || commitChecks[i].HasEventsToWrite) {
 					if (commitChecks[i].IsSoftDeleted is true)
 						// we are writing to a soft deleted stream. undelete it
 						await SoftUndeleteStream(commitChecks[i].EventStreamId, commitChecks[i].CurrentVersion + 1, token);
@@ -570,7 +569,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 
 				if (await _indexWriter.GetStreamLastEventNumber(streamId, token) < 0 && expectedVersion < 0) {
 					// stream has never existed 
-					commitCheck = new CommitCheckResult<TStreamId>(CommitDecision.ConsistencyCheckFailure, streamId, message.ExpectedVersion, -1, -1, -1, isSoftDeleted: false);
+					commitCheck = new CommitCheckResult<TStreamId>(CommitDecision.ConsistencyCheckFailure, 0, streamId, message.ExpectedVersion, -1, -1, -1, isSoftDeleted: false);
 
 					// send reply
 					if (VerifyCommitChecks(message.Envelope, message.CorrelationId, numStreams: 1, new(commitCheck)))
@@ -760,8 +759,18 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 		var idempotentCount = 0;
 		var consistencyCheckFailureCount = 0;
 
-		for (var streamIndex = 0; streamIndex < results.Length; streamIndex++) {
-			var checkResult = results.Span[streamIndex];
+		// number of streams the request attempts to write to
+		var hasEventsToWriteCount = 0;
+
+		foreach (ref readonly var checkResult in results.Span) {
+			if (checkResult.HasEventsToWrite)
+				hasEventsToWriteCount++;
+			else if (checkResult.Decision
+				is CommitDecision.Idempotent
+				or CommitDecision.CorruptedIdempotency
+				or CommitDecision.IdempotentNotReady)
+				throw new InvalidOperationException("Unexpected error: check-only streams cannot be idempotent");
+
 			switch (checkResult.Decision) {
 				case CommitDecision.Ok:
 					okCount++;
@@ -795,21 +804,35 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			}
 		}
 
+		// invariant: okCount + idempotentCount + consistencyCheckFailureCount == numStreams
+		// we haven't returned early, so each stream is ok or idempotent or failed.
+
 		// if everything is OK, continue with the write.
 		if (okCount == numStreams) {
 			return true;
 		}
 
-		// if everything is idempotent, reply with AlreadyCommitted.
-		if (idempotentCount == numStreams) {
+		// not everything was ok, something was idempotent or failed.
+		// if all streams with events to write are idempotent, reply AlreadyCommitted.
+		// it doesn't matter if check-only streams failed, this write is a retry of a previously
+		// successful write, and so it is successful.
+		if (hasEventsToWriteCount > 0 && idempotentCount == hasEventsToWriteCount) {
 			var firstEventNumbers = new long[numStreams];
 			var lastEventNumbers = new long[numStreams];
 			var idempotentLogPosition = long.MinValue;
 
 			for (var streamIndex = 0; streamIndex < results.Length; streamIndex++) {
-				firstEventNumbers[streamIndex] = results.Span[streamIndex].StartEventNumber;
-				lastEventNumbers[streamIndex] = results.Span[streamIndex].EndEventNumber;
-				idempotentLogPosition = Math.Max(results.Span[streamIndex].IdempotentLogPosition, idempotentLogPosition);
+				if (results.Span[streamIndex].HasEventsToWrite) {
+					firstEventNumbers[streamIndex] = results.Span[streamIndex].StartEventNumber;
+					lastEventNumbers[streamIndex] = results.Span[streamIndex].EndEventNumber;
+					idempotentLogPosition = Math.Max(results.Span[streamIndex].IdempotentLogPosition, idempotentLogPosition);
+				} else {
+					// check-only stream. we can't send the state of the stream because the
+					// idempotent reply must be the same as the original reply, and the state
+					// of the stream may have changed in the mean time.
+					firstEventNumbers[streamIndex] = EventNumber.CheckOnlyFirst;
+					lastEventNumbers[streamIndex] = EventNumber.CheckOnlyLast;
+				}
 			}
 
 			envelope.ReplyWith(new StorageMessage.AlreadyCommitted(
@@ -820,12 +843,8 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			return false;
 		}
 
-		// There is at least one consistency check failure, or there is a mixture of OK and Idempotent.
+		// For streams we are writing to there is at least one consistency check failure, or there is a mixture of OK and Idempotent.
 		// Reply with the consistency check failures and also the idempotent cases.
-		// If there were no errors, only OK and Idempotent, then potentially we could skip the idempotent parts of the write
-		// and continue with the OK parts, but this situation is unlikely to happen in practice (it could not be a simple
-		// multi stream write retry). Instead we tell the caller all the streams that they that they need to sync with
-		// to make the request successful.
 		var failures = new ConsistencyCheckFailure[consistencyCheckFailureCount + idempotentCount];
 		var idx = 0;
 		for (var streamIndex = 0; streamIndex < results.Length; streamIndex++) {


### PR DESCRIPTION
An idempotent multi-stream write retry should succeed even if a
check-only stream's expected version no longer matches. The events are
already written and the check-only stream's state may have changed
since, ultimately we resend the same response to the client as they
should have received the first time they sent the request.

Previously, a check-only stream (failing or not) caused the entire retry
to fail with WrongExpectedVersion.