### PR TITLE
[DB-1971] Pass claims principal and require leader flag when writing using ISystemClient

### DIFF
--- a/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
@@ -223,7 +223,7 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 		var writer = fixture.MiniNode.Node.Db.Config.WriterCheckpoint.Read();
 		var spaceLeftInChunk = chunkSize - (int)writer % chunkSize;
 		if (spaceLeftInChunk > 10_000) {
-			await client.Writing.WriteEvents(streamA, [CreateEvent(spaceLeftInChunk * 2 / 3)]);
+			await client.Writing.WriteEvents(streamA, [CreateEvent(spaceLeftInChunk * 2 / 3)], SystemAccounts.System);
 		}
 
 		// A write that does not fit in chunk and so creates a new one

--- a/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
@@ -223,7 +223,7 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 		var writer = fixture.MiniNode.Node.Db.Config.WriterCheckpoint.Read();
 		var spaceLeftInChunk = chunkSize - (int)writer % chunkSize;
 		if (spaceLeftInChunk > 10_000) {
-			await client.Writing.WriteEvents(streamA, [CreateEvent(spaceLeftInChunk * 2 / 3)], SystemAccounts.System);
+			await client.Writing.WriteEvents(streamA, [CreateEvent(spaceLeftInChunk * 2 / 3)], requireLeader: false, SystemAccounts.System);
 		}
 
 		// A write that does not fit in chunk and so creates a new one

--- a/src/KurrentDB.Core/Bus/Extensions/PublisherManagementExtensions.cs
+++ b/src/KurrentDB.Core/Bus/Extensions/PublisherManagementExtensions.cs
@@ -98,7 +98,7 @@ public static class PublisherManagementExtensions {
 				data: metadata.ToJsonBytes())
 		};
 
-		var (position, streamRevision) = await publisher.WriteEvents(SystemStreams.MetastreamOf(stream), events, expectedRevision, cancellationToken);
+		var (position, streamRevision) = await publisher.WriteEvents(SystemStreams.MetastreamOf(stream), events, SystemAccounts.System, expectedRevision, cancellationToken);
 
 		return (metadata, streamRevision.ToInt64());
 	}

--- a/src/KurrentDB.Core/Bus/Extensions/PublisherManagementExtensions.cs
+++ b/src/KurrentDB.Core/Bus/Extensions/PublisherManagementExtensions.cs
@@ -98,7 +98,7 @@ public static class PublisherManagementExtensions {
 				data: metadata.ToJsonBytes())
 		};
 
-		var (position, streamRevision) = await publisher.WriteEvents(SystemStreams.MetastreamOf(stream), events, SystemAccounts.System, expectedRevision, cancellationToken);
+		var (position, streamRevision) = await publisher.WriteEvents(SystemStreams.MetastreamOf(stream), events, requireLeader: false, SystemAccounts.System, expectedRevision, cancellationToken);
 
 		return (metadata, streamRevision.ToInt64());
 	}

--- a/src/KurrentDB.Core/Bus/Extensions/PublisherWriteExtensions.cs
+++ b/src/KurrentDB.Core/Bus/Extensions/PublisherWriteExtensions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using KurrentDB.Common.Utils;
@@ -16,7 +17,6 @@ using KurrentDB.Core.Messages;
 using KurrentDB.Core.Messaging;
 using KurrentDB.Core.Services.Transport.Common;
 using KurrentDB.Core.Services.Transport.Enumerators;
-using KurrentDB.Core.Services.UserManagement;
 
 namespace KurrentDB.Core.ClientPublisher;
 
@@ -29,6 +29,7 @@ public static class PublisherWriteExtensions {
 		this IPublisher publisher,
 		string stream,
 		Event[] events,
+		ClaimsPrincipal principal,
 		long expectedRevision = ExpectedVersion.Any,
 		CancellationToken cancellationToken = default
 	) {
@@ -37,6 +38,7 @@ public static class PublisherWriteExtensions {
 			expectedRevisions: new(expectedRevision),
 			events: new(events),
 			eventStreamIndexes: default,
+			principal: principal,
 			cancellationToken: cancellationToken);
 
 		return new(result.Position, result.StreamRevisions.Single);
@@ -48,6 +50,7 @@ public static class PublisherWriteExtensions {
 		LowAllocReadOnlyMemory<long> expectedRevisions,
 		LowAllocReadOnlyMemory<Event> events,
 		LowAllocReadOnlyMemory<int> eventStreamIndexes,
+		ClaimsPrincipal principal,
 		CancellationToken cancellationToken = default
 	) {
 		var cid = Guid.NewGuid();
@@ -64,7 +67,7 @@ public static class PublisherWriteExtensions {
 				expectedVersions: expectedRevisions,
 				events: events,
 				eventStreamIndexes: eventStreamIndexes,
-				user: SystemAccounts.System,
+				user: principal,
 				cancellationToken: cancellationToken
 			);
 

--- a/src/KurrentDB.Core/Bus/Extensions/PublisherWriteExtensions.cs
+++ b/src/KurrentDB.Core/Bus/Extensions/PublisherWriteExtensions.cs
@@ -29,6 +29,7 @@ public static class PublisherWriteExtensions {
 		this IPublisher publisher,
 		string stream,
 		Event[] events,
+		bool requireLeader,
 		ClaimsPrincipal principal,
 		long expectedRevision = ExpectedVersion.Any,
 		CancellationToken cancellationToken = default
@@ -38,6 +39,7 @@ public static class PublisherWriteExtensions {
 			expectedRevisions: new(expectedRevision),
 			events: new(events),
 			eventStreamIndexes: default,
+			requireLeader: requireLeader,
 			principal: principal,
 			cancellationToken: cancellationToken);
 
@@ -50,6 +52,7 @@ public static class PublisherWriteExtensions {
 		LowAllocReadOnlyMemory<long> expectedRevisions,
 		LowAllocReadOnlyMemory<Event> events,
 		LowAllocReadOnlyMemory<int> eventStreamIndexes,
+		bool requireLeader,
 		ClaimsPrincipal principal,
 		CancellationToken cancellationToken = default
 	) {
@@ -62,7 +65,7 @@ public static class PublisherWriteExtensions {
 				internalCorrId: cid,
 				correlationId: cid,
 				envelope: operation,
-				requireLeader: false,
+				requireLeader: requireLeader,
 				eventStreamIds: streams,
 				expectedVersions: expectedRevisions,
 				events: events,

--- a/src/KurrentDB.Core/Bus/Extensions/SystemClient.cs
+++ b/src/KurrentDB.Core/Bus/Extensions/SystemClient.cs
@@ -74,8 +74,12 @@ public interface IReadOperations {
 
 public record struct StreamWrite(string Stream, long ExpectedRevision, LowAllocReadOnlyMemory<Event> Events);
 
+// note: if requireLeader is false we might forward the write to the leader,
+// but the credentials will only be preserved if the principal is SystemAccounts.System or contains a
+// DelegatedClaimsIdentity (such as when received via an API). see ClientWriteTcpDispatcher.CreateWriteRequestPackage.
 public interface IWriteOperations {
 	Task<WriteEventsResult> WriteEvents(string stream, Event[] events,
+		bool requireLeader,
 		ClaimsPrincipal principal,
 		long expectedRevision = -2,
 		CancellationToken cancellationToken = default);
@@ -84,10 +88,12 @@ public interface IWriteOperations {
 		LowAllocReadOnlyMemory<long> expectedRevisions,
 		LowAllocReadOnlyMemory<Event> events,
 		LowAllocReadOnlyMemory<int> eventStreamIndexes,
+		bool requireLeader,
 		ClaimsPrincipal principal,
 		CancellationToken cancellationToken = default);
 	Task<WriteEventsMultiResult> WriteEvents(
 		LowAllocReadOnlyMemory<StreamWrite> writes,
+		bool requireLeader,
 		ClaimsPrincipal principal,
 		CancellationToken cancellationToken = default);
 }
@@ -162,22 +168,25 @@ public class SystemClient : ISystemClient {
 
 	public record WriteOperations(IPublisher Publisher, ILogger Logger) : IWriteOperations {
 		public Task<WriteEventsResult> WriteEvents(string stream, Event[] events,
+			bool requireLeader,
 			ClaimsPrincipal principal,
 			long expectedRevision = -2,
 			CancellationToken cancellationToken = default) =>
-			Publisher.WriteEvents(stream, events, principal, expectedRevision, cancellationToken);
+			Publisher.WriteEvents(stream, events, requireLeader, principal, expectedRevision, cancellationToken);
 
 		public Task<WriteEventsMultiResult> WriteEvents(
 			LowAllocReadOnlyMemory<string> streams,
 			LowAllocReadOnlyMemory<long> expectedRevisions,
 			LowAllocReadOnlyMemory<Event> events,
 			LowAllocReadOnlyMemory<int> eventStreamIndexes,
+			bool requireLeader,
 			ClaimsPrincipal principal,
 			CancellationToken cancellationToken = default) =>
-			Publisher.WriteEvents(streams, expectedRevisions, events, eventStreamIndexes, principal, cancellationToken);
+			Publisher.WriteEvents(streams, expectedRevisions, events, eventStreamIndexes, requireLeader, principal, cancellationToken);
 
 		public Task<WriteEventsMultiResult> WriteEvents(
 			LowAllocReadOnlyMemory<StreamWrite> writes,
+			bool requireLeader,
 			ClaimsPrincipal principal,
 			CancellationToken cancellationToken = default) {
 
@@ -210,6 +219,7 @@ public class SystemClient : ISystemClient {
 				expectedRevisions: expectedRevisions.Build(),
 				events: events.Build(),
 				eventStreamIndexes: eventStreamIndexes.Build(),
+				requireLeader,
 				principal,
 				cancellationToken);
 		}

--- a/src/KurrentDB.Core/Bus/Extensions/SystemClient.cs
+++ b/src/KurrentDB.Core/Bus/Extensions/SystemClient.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -74,15 +75,20 @@ public interface IReadOperations {
 public record struct StreamWrite(string Stream, long ExpectedRevision, LowAllocReadOnlyMemory<Event> Events);
 
 public interface IWriteOperations {
-	Task<WriteEventsResult> WriteEvents(string stream, Event[] events, long expectedRevision = -2, CancellationToken cancellationToken = default);
+	Task<WriteEventsResult> WriteEvents(string stream, Event[] events,
+		ClaimsPrincipal principal,
+		long expectedRevision = -2,
+		CancellationToken cancellationToken = default);
 	Task<WriteEventsMultiResult> WriteEvents(
 		LowAllocReadOnlyMemory<string> streams,
 		LowAllocReadOnlyMemory<long> expectedRevisions,
 		LowAllocReadOnlyMemory<Event> events,
 		LowAllocReadOnlyMemory<int> eventStreamIndexes,
+		ClaimsPrincipal principal,
 		CancellationToken cancellationToken = default);
 	Task<WriteEventsMultiResult> WriteEvents(
 		LowAllocReadOnlyMemory<StreamWrite> writes,
+		ClaimsPrincipal principal,
 		CancellationToken cancellationToken = default);
 }
 
@@ -155,19 +161,24 @@ public class SystemClient : ISystemClient {
 	#region . Write .
 
 	public record WriteOperations(IPublisher Publisher, ILogger Logger) : IWriteOperations {
-		public Task<WriteEventsResult> WriteEvents(string stream, Event[] events, long expectedRevision = -2, CancellationToken cancellationToken = default) =>
-			Publisher.WriteEvents(stream, events, expectedRevision, cancellationToken);
+		public Task<WriteEventsResult> WriteEvents(string stream, Event[] events,
+			ClaimsPrincipal principal,
+			long expectedRevision = -2,
+			CancellationToken cancellationToken = default) =>
+			Publisher.WriteEvents(stream, events, principal, expectedRevision, cancellationToken);
 
 		public Task<WriteEventsMultiResult> WriteEvents(
 			LowAllocReadOnlyMemory<string> streams,
 			LowAllocReadOnlyMemory<long> expectedRevisions,
 			LowAllocReadOnlyMemory<Event> events,
 			LowAllocReadOnlyMemory<int> eventStreamIndexes,
+			ClaimsPrincipal principal,
 			CancellationToken cancellationToken = default) =>
-			Publisher.WriteEvents(streams, expectedRevisions, events, eventStreamIndexes, cancellationToken);
+			Publisher.WriteEvents(streams, expectedRevisions, events, eventStreamIndexes, principal, cancellationToken);
 
 		public Task<WriteEventsMultiResult> WriteEvents(
 			LowAllocReadOnlyMemory<StreamWrite> writes,
+			ClaimsPrincipal principal,
 			CancellationToken cancellationToken = default) {
 
 			var streamIndexes = new Dictionary<string, int>();
@@ -199,6 +210,7 @@ public class SystemClient : ISystemClient {
 				expectedRevisions: expectedRevisions.Build(),
 				events: events.Build(),
 				eventStreamIndexes: eventStreamIndexes.Build(),
+				principal,
 				cancellationToken);
 		}
 	}

--- a/src/KurrentDB.SecondaryIndexing.LoadTesting/Environments/InMemory/PublisherBasedMessageBatchAppender.cs
+++ b/src/KurrentDB.SecondaryIndexing.LoadTesting/Environments/InMemory/PublisherBasedMessageBatchAppender.cs
@@ -11,7 +11,7 @@ namespace KurrentDB.SecondaryIndexing.LoadTesting.Environments.InMemory;
 
 public class PublisherBasedMessageBatchAppender(IPublisher publisher) : IMessageBatchAppender {
 	public async ValueTask Append(TestMessageBatch batch) {
-		await publisher.WriteEvents(batch.StreamName, batch.Messages.Select(m => m.ToEventData()).ToArray(), SystemAccounts.System);
+		await publisher.WriteEvents(batch.StreamName, batch.Messages.Select(m => m.ToEventData()).ToArray(), requireLeader: false, SystemAccounts.System);
 	}
 
 	public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/src/KurrentDB.SecondaryIndexing.LoadTesting/Environments/InMemory/PublisherBasedMessageBatchAppender.cs
+++ b/src/KurrentDB.SecondaryIndexing.LoadTesting/Environments/InMemory/PublisherBasedMessageBatchAppender.cs
@@ -3,6 +3,7 @@
 
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.ClientPublisher;
+using KurrentDB.Core.Services.UserManagement;
 using KurrentDB.SecondaryIndexing.LoadTesting.Appenders;
 using KurrentDB.SecondaryIndexing.Tests.Generators;
 
@@ -10,7 +11,7 @@ namespace KurrentDB.SecondaryIndexing.LoadTesting.Environments.InMemory;
 
 public class PublisherBasedMessageBatchAppender(IPublisher publisher) : IMessageBatchAppender {
 	public async ValueTask Append(TestMessageBatch batch) {
-		await publisher.WriteEvents(batch.StreamName, batch.Messages.Select(m => m.ToEventData()).ToArray());
+		await publisher.WriteEvents(batch.StreamName, batch.Messages.Select(m => m.ToEventData()).ToArray(), SystemAccounts.System);
 	}
 
 	public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/src/KurrentDB.SecondaryIndexing.Tests/Fixtures/SecondaryIndexingFixture.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Fixtures/SecondaryIndexingFixture.cs
@@ -120,7 +120,7 @@ public abstract class SecondaryIndexingFixture : ClusterVNodeFixture {
 	}
 
 	public Task<WriteEventsResult> AppendToStream(string stream, params Event[] events) =>
-		Publisher.WriteEvents(stream, events, SystemAccounts.System);
+		Publisher.WriteEvents(stream, events, requireLeader: false, SystemAccounts.System);
 
 
 	public Task<WriteEventsResult> DeleteStream(string stream) =>

--- a/src/KurrentDB.SecondaryIndexing.Tests/Fixtures/SecondaryIndexingFixture.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Fixtures/SecondaryIndexingFixture.cs
@@ -8,6 +8,7 @@ using KurrentDB.Core.ClientPublisher;
 using KurrentDB.Core.Configuration.Sources;
 using KurrentDB.Core.Data;
 using KurrentDB.Core.Services.Transport.Enumerators;
+using KurrentDB.Core.Services.UserManagement;
 using KurrentDB.Core.Tests;
 using KurrentDB.Surge.Testing;
 using Position = KurrentDB.Core.Services.Transport.Common.Position;
@@ -119,7 +120,7 @@ public abstract class SecondaryIndexingFixture : ClusterVNodeFixture {
 	}
 
 	public Task<WriteEventsResult> AppendToStream(string stream, params Event[] events) =>
-		Publisher.WriteEvents(stream, events);
+		Publisher.WriteEvents(stream, events, SystemAccounts.System);
 
 
 	public Task<WriteEventsResult> DeleteStream(string stream) =>

--- a/src/KurrentDB.SecondaryIndexing/Indexes/User/Management/UserIndexEventStore.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/User/Management/UserIndexEventStore.cs
@@ -9,6 +9,7 @@ using Kurrent.Surge.Schema.Serializers;
 using KurrentDB.Common.Utils;
 using KurrentDB.Core;
 using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.UserManagement;
 
 namespace KurrentDB.SecondaryIndexing.Indexes.User.Management;
 
@@ -83,7 +84,7 @@ public class UserIndexEventStore : IEventStore {
 		}
 
 		// write all the events transactionally
-		var (position, streamRevisions) = await _client.Writing.WriteEvents(writes.Build(), cancellationToken);
+		var (position, streamRevisions) = await _client.Writing.WriteEvents(writes.Build(), SystemAccounts.System, cancellationToken);
 
 		var originalStreamIndex = 0;
 		return new AppendEventsResult(

--- a/src/KurrentDB.SecondaryIndexing/Indexes/User/Management/UserIndexEventStore.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/User/Management/UserIndexEventStore.cs
@@ -84,7 +84,7 @@ public class UserIndexEventStore : IEventStore {
 		}
 
 		// write all the events transactionally
-		var (position, streamRevisions) = await _client.Writing.WriteEvents(writes.Build(), SystemAccounts.System, cancellationToken);
+		var (position, streamRevisions) = await _client.Writing.WriteEvents(writes.Build(), requireLeader: false, SystemAccounts.System, cancellationToken);
 
 		var originalStreamIndex = 0;
 		return new AppendEventsResult(

--- a/src/KurrentDB.Surge/Producers/SystemProducer.cs
+++ b/src/KurrentDB.Surge/Producers/SystemProducer.cs
@@ -148,7 +148,7 @@ public class SystemProducer : IProducer {
 
             static async ValueTask<ProduceResult> WriteEvents(ISystemClient client, ProduceRequest request, Event[] events, long expectedRevision, CancellationToken cancellationToken) {
                 try {
-                    var (position, streamRevision) = await client.Writing.WriteEvents(request.Stream, events, SystemAccounts.System, expectedRevision, cancellationToken);
+                    var (position, streamRevision) = await client.Writing.WriteEvents(request.Stream, events, requireLeader: false, SystemAccounts.System, expectedRevision, cancellationToken);
 
                     var recordPosition = RecordPosition.ForStream(
                         StreamId.From(request.Stream),

--- a/src/KurrentDB.Surge/Producers/SystemProducer.cs
+++ b/src/KurrentDB.Surge/Producers/SystemProducer.cs
@@ -10,6 +10,7 @@ using Kurrent.Surge.Producers.LifecycleEvents;
 using Kurrent.Surge.Schema.Serializers;
 using KurrentDB.Core;
 using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.UserManagement;
 using Polly;
 
 namespace KurrentDB.Surge.Producers;
@@ -147,7 +148,7 @@ public class SystemProducer : IProducer {
 
             static async ValueTask<ProduceResult> WriteEvents(ISystemClient client, ProduceRequest request, Event[] events, long expectedRevision, CancellationToken cancellationToken) {
                 try {
-                    var (position, streamRevision) = await client.Writing.WriteEvents(request.Stream, events, expectedRevision, cancellationToken);
+                    var (position, streamRevision) = await client.Writing.WriteEvents(request.Stream, events, SystemAccounts.System, expectedRevision, cancellationToken);
 
                     var recordPosition = RecordPosition.ForStream(
                         StreamId.From(request.Stream),


### PR DESCRIPTION
Allows these to be more flexible, V2 projections will use them.

Note that if requireLeader is false we might forward the write to the leader, but the credentials will only be preserved if the principal is SystemAccounts.System or contains a DelegatedClaimsIdentity (such as when received via an API). see ClientWriteTcpDispatcher.CreateWriteRequestPackage.