### PR TITLE
[UI-1491] Expose cluster identity on `/info` endpoint

### DIFF
--- a/src/KurrentDB.Core.Tests/Http/Info/when_getting_info.cs
+++ b/src/KurrentDB.Core.Tests/Http/Info/when_getting_info.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using KurrentDB.Common.Utils;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace KurrentDB.Core.Tests.Http.Info;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_getting_info<TLogFormat, TStreamId> : HttpBehaviorSpecification<TLogFormat, TStreamId> {
+	private JObject _response;
+
+	protected override Task Given() => Task.CompletedTask;
+
+	protected override async Task When() {
+		await Get("/info", "");
+		_response = _lastResponseBody.ParseJson<JObject>();
+	}
+
+	[Test]
+	public void returns_ok() {
+		Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+	}
+
+	[Test]
+	public void response_contains_cluster_id() {
+		var clusterId = _response["clusterId"];
+		Assert.That(clusterId, Is.Not.Null, "clusterId should be present in /info response");
+		Assert.That(clusterId.Type, Is.EqualTo(JTokenType.String));
+
+		var parsed = Guid.TryParse(clusterId.Value<string>(), out var guid);
+		Assert.That(parsed, Is.True, "clusterId should be a valid GUID");
+		Assert.That(guid, Is.Not.EqualTo(Guid.Empty));
+	}
+}

--- a/src/KurrentDB.Core.Tests/Services/ElectionsService/FakeEpochManager.cs
+++ b/src/KurrentDB.Core.Tests/Services/ElectionsService/FakeEpochManager.cs
@@ -25,6 +25,7 @@ internal class FakeEpochManager : IEpochManager {
 
 	public ValueTask Init(CancellationToken token) => ValueTask.CompletedTask;
 
+	public EpochRecord GetFirstEpoch() => _epochs.FirstOrDefault();
 	public EpochRecord GetLastEpoch() => _epochs.LastOrDefault();
 
 	public ValueTask<IReadOnlyList<EpochRecord>> GetLastEpochs(int maxCount, CancellationToken token) {

--- a/src/KurrentDB.Core.Tests/Services/Storage/EpochManager/when_getting_first_epoch.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/EpochManager/when_getting_first_epoch.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.LogAbstraction;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using KurrentDB.Core.Services.Storage.EpochManager;
+using KurrentDB.Core.Tests.TransactionLog;
+using KurrentDB.Core.TransactionLog.Chunks;
+using KurrentDB.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace KurrentDB.Core.Tests.Services.Storage.EpochManager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public sealed class when_getting_first_epoch_from_empty_log<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture, IDisposable {
+	private TFChunkDb _db;
+	private LogFormatAbstractor<TStreamId> _logFormat;
+	private TFChunkWriter _writer;
+	private SynchronousScheduler _mainBus;
+	private readonly Guid _instanceId = Guid.NewGuid();
+	private readonly List<Message> _published = new();
+
+	private EpochManager<TStreamId> GetManager(int cacheSize = 10) {
+		return new EpochManager<TStreamId>(_mainBus,
+			cacheSize,
+			_db.Config.EpochCheckpoint,
+			_writer,
+			initialReaderCount: 1,
+			maxReaderCount: 5,
+			new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+			_logFormat.RecordFactory,
+			_logFormat.StreamNameIndex,
+			_logFormat.EventTypeIndex,
+			_logFormat.CreatePartitionManager(
+				reader: new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+				writer: _writer),
+			_instanceId);
+	}
+
+	[OneTimeSetUp]
+	public override async Task TestFixtureSetUp() {
+		await base.TestFixtureSetUp();
+
+		var indexDirectory = GetFilePathFor("index");
+		_logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory.Create(new() {
+			IndexDirectory = indexDirectory,
+		});
+
+		_mainBus = new(nameof(when_getting_first_epoch_from_empty_log<TLogFormat, TStreamId>));
+		_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
+		_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
+		await _db.Open();
+		_writer = new TFChunkWriter(_db);
+		await _writer.Open(CancellationToken.None);
+	}
+
+	[OneTimeTearDown]
+	public override async Task TestFixtureTearDown() {
+		Dispose();
+		await base.TestFixtureTearDown();
+	}
+
+	[Test]
+	public async Task first_epoch_lifecycle() {
+		var manager = GetManager();
+		await manager.Init(CancellationToken.None);
+
+		// null before any epochs exist
+		Assert.That(manager.GetFirstEpoch(), Is.Null);
+
+		// available after writing epoch 0
+		await manager.WriteNewEpoch(0, CancellationToken.None);
+		var firstEpoch = manager.GetFirstEpoch();
+		Assert.That(firstEpoch, Is.Not.Null);
+		Assert.That(firstEpoch.EpochNumber, Is.EqualTo(0));
+		Assert.That(firstEpoch.EpochPosition, Is.EqualTo(0));
+		Assert.That(firstEpoch.PrevEpochPosition, Is.EqualTo(-1));
+
+		// still available after writing more epochs
+		for (int i = 1; i <= 20; i++)
+			await manager.WriteNewEpoch(i, CancellationToken.None);
+
+		Assert.That(manager.GetFirstEpoch().EpochId, Is.EqualTo(firstEpoch.EpochId));
+	}
+
+	public void Dispose() {
+		try {
+			_logFormat?.Dispose();
+			using var task = _writer?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+			task.Wait();
+		} catch {
+			// workaround for TearDown error
+		}
+
+		using (var task = _db?.DisposeAsync().AsTask() ?? Task.CompletedTask) {
+			task.Wait();
+		}
+	}
+}
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public sealed class when_getting_first_epoch_after_caching<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture, IDisposable {
+	private TFChunkDb _db;
+	private LogFormatAbstractor<TStreamId> _logFormat;
+	private TFChunkWriter _writer;
+	private SynchronousScheduler _mainBus;
+	private readonly Guid _instanceId = Guid.NewGuid();
+	private readonly List<Message> _published = new();
+
+	private EpochManager<TStreamId> GetManager(int cacheSize = 10) {
+		return new EpochManager<TStreamId>(_mainBus,
+			cacheSize,
+			_db.Config.EpochCheckpoint,
+			_writer,
+			initialReaderCount: 1,
+			maxReaderCount: 5,
+			new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+			_logFormat.RecordFactory,
+			_logFormat.StreamNameIndex,
+			_logFormat.EventTypeIndex,
+			_logFormat.CreatePartitionManager(
+				reader: new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+				writer: _writer),
+			_instanceId);
+	}
+
+	[OneTimeSetUp]
+	public override async Task TestFixtureSetUp() {
+		await base.TestFixtureSetUp();
+
+		var indexDirectory = GetFilePathFor("index");
+		_logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory.Create(new() {
+			IndexDirectory = indexDirectory,
+		});
+
+		_mainBus = new(nameof(when_getting_first_epoch_after_caching<TLogFormat, TStreamId>));
+		_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
+		_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
+		await _db.Open();
+		_writer = new TFChunkWriter(_db);
+		await _writer.Open(CancellationToken.None);
+	}
+
+	[OneTimeTearDown]
+	public override async Task TestFixtureTearDown() {
+		Dispose();
+		await base.TestFixtureTearDown();
+	}
+
+	[Test]
+	public async Task is_set_after_caching_epoch_zero() {
+		var manager = GetManager();
+		await manager.Init(CancellationToken.None);
+
+		var epoch0 = new EpochRecord(0, 0, Guid.NewGuid(), -1, DateTime.UtcNow, _instanceId);
+		await manager.CacheEpoch(epoch0, CancellationToken.None);
+
+		var firstEpoch = manager.GetFirstEpoch();
+		Assert.That(firstEpoch, Is.Not.Null);
+		Assert.That(firstEpoch.EpochId, Is.EqualTo(epoch0.EpochId));
+	}
+
+	public void Dispose() {
+		try {
+			_logFormat?.Dispose();
+			using var task = _writer?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+			task.Wait();
+		} catch {
+			// workaround for TearDown error
+		}
+
+		using (var task = _db?.DisposeAsync().AsTask() ?? Task.CompletedTask) {
+			task.Wait();
+		}
+	}
+}
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public sealed class when_getting_first_epoch_with_existing_epochs<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture, IDisposable {
+	private TFChunkDb _db;
+	private LogFormatAbstractor<TStreamId> _logFormat;
+	private TFChunkWriter _writer;
+	private SynchronousScheduler _mainBus;
+	private readonly Guid _instanceId = Guid.NewGuid();
+	private readonly List<Message> _published = new();
+	private List<EpochRecord> _epochs;
+
+	private EpochManager<TStreamId> GetManager(int cacheSize = 10) {
+		return new EpochManager<TStreamId>(_mainBus,
+			cacheSize,
+			_db.Config.EpochCheckpoint,
+			_writer,
+			initialReaderCount: 1,
+			maxReaderCount: 5,
+			new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+			_logFormat.RecordFactory,
+			_logFormat.StreamNameIndex,
+			_logFormat.EventTypeIndex,
+			_logFormat.CreatePartitionManager(
+				reader: new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+				writer: _writer),
+			_instanceId);
+	}
+
+	private async ValueTask<EpochRecord> WriteEpochRaw(int epochNumber, long lastPos, CancellationToken token) {
+		long pos = _writer.Position;
+		var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, _instanceId);
+		var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
+			SystemRecordSerialization.Json, epoch.AsSerialized());
+		await _writer.Write(rec, token);
+		await _writer.Flush(token);
+		return epoch;
+	}
+
+	[OneTimeSetUp]
+	public override async Task TestFixtureSetUp() {
+		await base.TestFixtureSetUp();
+
+		var indexDirectory = GetFilePathFor("index");
+		_logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory.Create(new() {
+			IndexDirectory = indexDirectory,
+		});
+
+		_mainBus = new(nameof(when_getting_first_epoch_with_existing_epochs<TLogFormat, TStreamId>));
+		_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
+		_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
+		await _db.Open();
+		_writer = new TFChunkWriter(_db);
+		await _writer.Open(CancellationToken.None);
+
+		_epochs = new List<EpochRecord>();
+		var lastPos = -1L;
+		for (int i = 0; i < 30; i++) {
+			var epoch = await WriteEpochRaw(i, lastPos, CancellationToken.None);
+			_epochs.Add(epoch);
+			lastPos = epoch.EpochPosition;
+		}
+	}
+
+	[OneTimeTearDown]
+	public override async Task TestFixtureTearDown() {
+		Dispose();
+		await base.TestFixtureTearDown();
+	}
+
+	[Test]
+	public async Task is_available_when_epoch_zero_is_in_cache() {
+		var manager = GetManager(cacheSize: 1000);
+		await manager.Init(CancellationToken.None);
+
+		var firstEpoch = manager.GetFirstEpoch();
+		Assert.That(firstEpoch, Is.Not.Null);
+		Assert.That(firstEpoch.EpochNumber, Is.EqualTo(0));
+		Assert.That(firstEpoch.EpochId, Is.EqualTo(_epochs[0].EpochId));
+	}
+
+	[Test]
+	public async Task is_available_when_epoch_zero_is_not_in_cache() {
+		var manager = GetManager(cacheSize: 5);
+		await manager.Init(CancellationToken.None);
+
+		// cache only holds 5 epochs (25-29), but epoch 0 should still be available
+		Assert.That(manager.GetLastEpoch().EpochNumber, Is.EqualTo(29));
+
+		var firstEpoch = manager.GetFirstEpoch();
+		Assert.That(firstEpoch, Is.Not.Null);
+		Assert.That(firstEpoch.EpochNumber, Is.EqualTo(0));
+		Assert.That(firstEpoch.EpochId, Is.EqualTo(_epochs[0].EpochId));
+	}
+
+	public void Dispose() {
+		try {
+			_logFormat?.Dispose();
+			using var task = _writer?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+			task.Wait();
+		} catch {
+			// workaround for TearDown error
+		}
+
+		using (var task = _db?.DisposeAsync().AsTask() ?? Task.CompletedTask) {
+			task.Wait();
+		}
+	}
+}

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -1066,7 +1066,8 @@ public class ClusterVNode<TStreamId> :
 				["userManagement"] = options.Auth.AuthenticationType == Opts.AuthenticationTypeDefault && !options.Application.Insecure,
 				["atomPub"] = options.Interface.EnableAtomPubOverHttp || options.DevMode.Dev
 			},
-			_authenticationProvider
+			_authenticationProvider,
+			epochManager
 		);
 
 		_mainBus.Subscribe<SystemMessage.StateChangeMessage>(infoController);

--- a/src/KurrentDB.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/KurrentDB.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -49,7 +49,9 @@ public class EpochManager<TStreamId> : IEpochManager {
 
 	private LinkedListNode<EpochRecord> _firstCachedEpoch;
 	private LinkedListNode<EpochRecord> _lastCachedEpoch;
+	private volatile EpochRecord _firstEpoch;
 
+	public EpochRecord GetFirstEpoch() => _firstEpoch;
 	public EpochRecord GetLastEpoch() => _lastCachedEpoch?.Value;
 
 	public int LastEpochNumber => _lastCachedEpoch?.Value.EpochNumber ?? -1;
@@ -151,10 +153,19 @@ public class EpochManager<TStreamId> : IEpochManager {
 			while (epochPos >= 0 && cnt < maxEpochCount) {
 				var epoch = await ReadEpochAt(epochPos, token);
 				_epochs.AddFirst(epoch);
-				if (epoch.EpochPosition == 0) { break; }
+				if (epoch.EpochNumber == 0) {
+					_firstEpoch = epoch;
+					break;
+				}
 
 				epochPos = epoch.PrevEpochPosition;
 				cnt += 1;
+			}
+
+			// if the cache filled before reaching epoch 0, read it directly.
+			// epoch 0 is always at log position 0 (first record written to the log).
+			if (_firstEpoch is null && _epochs.Count > 0) {
+				_firstEpoch = await ReadEpochAt(0, token);
 			}
 
 			_lastCachedEpoch = _epochs.Last;
@@ -309,6 +320,9 @@ public class EpochManager<TStreamId> : IEpochManager {
 		var epoch = await WriteEpochRecordWithRetry(epochNumber, Guid.NewGuid(),
 			_lastCachedEpoch?.Value.EpochPosition ?? -1, _instanceId, token);
 
+		if (epochNumber == 0)
+			_firstEpoch = epoch;
+
 		await AddEpochToCache(epoch, token);
 	}
 
@@ -436,6 +450,9 @@ public class EpochManager<TStreamId> : IEpochManager {
 	}
 
 	public async ValueTask CacheEpoch(EpochRecord epoch, CancellationToken token) {
+		if (epoch.EpochNumber == 0)
+			_firstEpoch = epoch;
+
 		var added = await AddEpochToCache(epoch, token);
 
 		// Check each epoch as it is added to the cache for the first time from the chaser.

--- a/src/KurrentDB.Core/Services/Storage/EpochManager/IEpochManager.cs
+++ b/src/KurrentDB.Core/Services/Storage/EpochManager/IEpochManager.cs
@@ -13,6 +13,7 @@ public interface IEpochManager {
 	int LastEpochNumber { get; }
 
 	ValueTask Init(CancellationToken token);
+	EpochRecord GetFirstEpoch();
 	EpochRecord GetLastEpoch();
 	ValueTask<IReadOnlyList<EpochRecord>> GetLastEpochs(int maxCount, CancellationToken token);
 	ValueTask<EpochRecord> GetEpochAfter(int epochNumber, bool throwIfNotFound, CancellationToken token);

--- a/src/KurrentDB.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -10,6 +10,7 @@ using KurrentDB.Common.Utils;
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.Data;
 using KurrentDB.Core.Messages;
+using KurrentDB.Core.Services.Storage.EpochManager;
 using KurrentDB.Transport.Http;
 using KurrentDB.Transport.Http.Codecs;
 using KurrentDB.Transport.Http.EntityManagement;
@@ -25,13 +26,15 @@ public class InfoController : IHttpController, IHandle<SystemMessage.StateChange
 	private readonly ClusterVNodeOptions _options;
 	private readonly IDictionary<string, bool> _features;
 	private readonly IAuthenticationProvider _authenticationProvider;
+	private readonly IEpochManager _epochManager;
 	private VNodeState _currentState;
 
 	public InfoController(ClusterVNodeOptions options, IDictionary<string, bool> features,
-		IAuthenticationProvider authenticationProvider) {
+		IAuthenticationProvider authenticationProvider, IEpochManager epochManager) {
 		_options = options;
 		_features = features;
 		_authenticationProvider = authenticationProvider;
+		_epochManager = epochManager;
 	}
 
 	public void Subscribe(IHttpService service) {
@@ -57,6 +60,7 @@ public class InfoController : IHttpController, IHandle<SystemMessage.StateChange
 					DBVersion = VersionInfo.Version,
 					ESVersion = VersionInfo.Version,
 					State = _currentState.ToString().ToLower(),
+					ClusterId = _epochManager.GetFirstEpoch()?.EpochId,
 					Features = _features,
 					Authentication = GetAuthenticationInfo()
 				}

--- a/src/KurrentDB.Core/Services/Transport/Http/Controllers/InfoControllerBuilder.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Controllers/InfoControllerBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using EventStore.Plugins.Authentication;
+using KurrentDB.Core.Services.Storage.EpochManager;
 
 namespace KurrentDB.Core.Services.Transport.Http.Controllers;
 
@@ -10,6 +11,7 @@ public class InfoControllerBuilder {
 	private ClusterVNodeOptions _options;
 	private IDictionary<string, bool> _features;
 	private IAuthenticationProvider _authenticationProvider;
+	private IEpochManager _epochManager;
 
 	public InfoControllerBuilder WithOptions(ClusterVNodeOptions options) {
 		_options = options;
@@ -27,7 +29,12 @@ public class InfoControllerBuilder {
 		return this;
 	}
 
+	public InfoControllerBuilder WithEpochManager(IEpochManager epochManager) {
+		_epochManager = epochManager;
+		return this;
+	}
+
 	public InfoController Build() {
-		return new InfoController(_options, _features, _authenticationProvider);
+		return new InfoController(_options, _features, _authenticationProvider, _epochManager);
 	}
 }


### PR DESCRIPTION
Currently, Navigator uses the server address as database identity, but this isn't ideal as when a different database starts on the same address (e.g. dev environments, reprovisioning), Navigator reuses stale credentials and cached state for what is actually a different database.

Without admin credentials, there is currently no way of knowing if a cluster you are speaking to is the same one you were speaking to previously, as `instanceId` is only for the uptime of the individual nodes, and any attempt at fingerprinting is slow and fragile.

This PR adds `clusterId` to `/info` endpoint response, which acts as a stable identifier for the database, persists across restarts, and is consistent across all nodes in a cluster.

The `clusterId` is epoch 0's `EpochId`, as it already does everything we need:

- Already shared across all nodes via replication - no additional sync mechanism needed
- Persisted in the transaction log, survives restarts
- Generated once at cluster creation
- A fresh database (wiped data dir) produces a new epoch 0, correctly treated as a different database

The main addition, other than wiring up epoch manager to the info endpoint, is adding a simple way to read epoch 0 from `EpochManager`:

`EpochManager` stores epoch 0 separately from the rolling epoch cache (which only holds the 10 most recent epochs). It's populated in three places:

- **Init** - if found during the epoch chain walk, otherwise read directly from log position 0 if the cache fills before reaching it.
- **WriteNewEpoch** - captured when the leader writes epoch 0
- **CacheEpoch** - captured when epoch 0 is received via replication

`InfoController` reads it via `GetFirstEpoch()` on each request.

### Example response

```json
{
  "dbVersion": "26.1.0-prerelease",
  "state": "leader",
  "clusterId": "8e739e5f-3f1e-412b-b42c-e032afc4b4ae",
  "features": { ... }
}
```
