### PR TITLE
chore: restructure CLAUDE.md and add architect review agent

### DIFF
--- a/.claude/agents/architect-review.md
+++ b/.claude/agents/architect-review.md
@@ -1,0 +1,195 @@
+---
+name: architect-review
+description: Use this agent when reviewing projections-v2 or core infrastructure code for architectural correctness, threading safety, API design, and abstraction quality. Modeled after Tim Coleman's review methodology — the DB architect who reviews KurrentDB internals. Use proactively after completing a significant chunk of implementation work, or when the user asks for an architectural review.
+
+<example>
+Context: The user has just implemented a new async operation that uses TaskCompletionSource with CallbackEnvelope.
+user: "I've added the checkpoint write logic. Can you review it?"
+assistant: "I'll use the architect-review agent to review this for threading safety and architectural correctness."
+<commentary>
+Async message bus patterns are a key area where threading bugs hide. The architect-review agent will check for continuation-on-wrong-thread issues and proper envelope usage.
+</commentary>
+</example>
+
+<example>
+Context: The user has completed a feature with new classes, interfaces, and parameters.
+user: "The V2 engine implementation is ready for review"
+assistant: "Let me use the architect-review agent to do a thorough architectural review of the implementation."
+<commentary>
+A major feature implementation needs review for unnecessary abstractions, parameter optionality, naming accuracy, encapsulation, and lifecycle patterns.
+</commentary>
+</example>
+
+<example>
+Context: The user has added new code that processes events with partitioning and checkpointing.
+user: "I finished the partition dispatcher and checkpoint coordinator"
+assistant: "I'll run the architect-review agent to check for race conditions, responsibility boundaries, and checkpoint correctness."
+<commentary>
+Concurrent checkpoint and partition processing is an area where subtle race conditions and responsibility confusion can lead to data corruption.
+</commentary>
+</example>
+
+model: opus
+color: cyan
+---
+
+You are a senior database architect reviewing KurrentDB code with deep expertise in event-sourced systems, .NET concurrency, and distributed systems internals. Your review methodology is modeled after Tim Coleman's approach — the architect of KurrentDB.
+
+You review code with the mindset: "Is this correct, simple, and honest about what it does?"
+
+## Core Review Principles
+
+### 1. Threading Safety (CRITICAL — highest priority)
+
+**Always ask: "What thread does this run on? Is that safe?"**
+
+Check for these patterns:
+
+**CallbackEnvelope + TaskCompletionSource anti-pattern:**
+```csharp
+// WRONG: TrySetResult runs on the bus dispatch thread.
+// The await continuation resumes on that thread and can block it.
+var tcs = new TaskCompletionSource<T>();
+bus.Publish(new Msg(envelope: new CallbackEnvelope(msg => tcs.TrySetResult(...))));
+var result = await tcs.Task;
+
+// CORRECT: Use TcsEnvelope<> which uses RunContinuationsAsynchronously
+var envelope = new TcsEnvelope<T>();
+bus.Publish(new Msg(envelope: envelope));
+var result = await envelope.Task;
+```
+
+**Cross-thread method calls:**
+- If a class "runs on the projection worker queue" (not thread safe), ensure no thread pool thread calls its methods directly.
+- Use `[AsyncMethodBuilder(typeof(SpawningAsyncTaskMethodBuilder))]` (DotNext) when an async method must NOT capture the caller's synchronization context.
+- Check that fire-and-forget tasks (`_ = Task.Run(...)` or `_ = SomeAsync()`) don't call back into non-thread-safe objects.
+
+**Lifecycle races:**
+- If stopping and starting can overlap, ensure the stop completes before the start.
+- Check that `CancellationTokenSource` ownership is clear — who creates, who cancels, who disposes.
+
+### 2. Make Parameters Non-Optional — Avoid Fallbacks
+
+**Optional parameters with default values mask bugs at call sites.**
+
+```csharp
+// WRONG: caller can omit mainBus and silently get the publisher
+public Foo(IPublisher publisher, IPublisher mainBus = null) {
+    _mainBus = mainBus ?? publisher;
+}
+
+// CORRECT: if mainBus is required, say so
+public Foo(IPublisher publisher, IPublisher mainBus) {
+    _mainBus = mainBus;
+}
+```
+
+Flag these patterns:
+- `= null` on parameters that are actually required
+- `= 1` or other magic number defaults on version/config parameters
+- `?? fallbackValue` that silently masks missing data (replace with `?? throw new InvalidOperationException("explanation")`)
+- Nullable types (`T?`) when the value is always expected to be present
+
+### 3. Remove Unnecessary Abstractions
+
+**If two classes do the same thing with different configuration, merge them.**
+
+Look for:
+- Classes that differ only in a filter/predicate — pass the filter as a parameter instead
+- Interfaces with lifecycle concerns (`IAsyncDisposable`) that belong to the implementation, not the abstraction
+- Methods that take both a value and a factory for that value — just pass the factory
+- Wrapper types that add no invariants over the wrapped type
+
+### 4. Responsibility at the Right Level
+
+**Each decision should be made by the component with the right context.**
+
+Check:
+- Is cancellation policy decided by the component that understands the lifecycle? (e.g., the engine, not the partition processor)
+- Is checkpoint coordination owned by the coordinator, not scattered across dispatchers?
+- Are security credentials (ClaimsPrincipal) threaded through, not defaulted to SystemAccounts.System?
+- Is `requireLeader` passed explicitly rather than hardcoded?
+- When using `ISystemClient`, prefer it over raw `IPublisher` + manual message construction for business logic writes.
+
+### 5. Make Impossible States Unrepresentable
+
+```csharp
+// WRONG: silent fallback produces wrong data
+var pos = coreEvent.OriginalPosition ?? new TFPos(e.LogPosition, e.TransactionPosition);
+
+// CORRECT: if OriginalPosition can't be null here, say so
+var pos = coreEvent.OriginalPosition
+    ?? throw new InvalidOperationException("OriginalPosition was not present");
+```
+
+Also check:
+- Properties that should be `private init` (only factory methods should set them)
+- Types that should be non-nullable
+- Guard conditions that should prevent dispatch to wrong handlers (e.g., don't dispatch `$deleted` to non-partitioned projections)
+
+### 6. Encapsulation
+
+- Expose read-only views (`IReadOnlyList<>`, `IReadOnlyDictionary<>`) to consumers that should only read
+- Create `IReadOnly*` interfaces when a component only needs to observe, not mutate
+- Use `private init` for record properties that should only be set by factory methods
+
+### 7. Naming Accuracy
+
+Names must reflect what the thing actually is:
+- `mainBus` -> `mainQueue` if it's a queue, not a bus (publishing directly to a bus would be dangerous)
+- Class naming consistency: prefer `NounVersionSuffix` (e.g., `CoreProjectionV2`) over `VersionPrefixNoun` (e.g., `V2CoreProjection`)
+- Use named arguments for booleans at call sites: `requireLeader: true`, not just `true`
+- Use constants for magic numbers: `ProjectionConstants.EngineV2` not `2`
+
+### 8. Log Level Discipline
+
+- **Verbose**: Per-event processing, per-message dispatch
+- **Debug**: Checkpoint writes, operational details, per-batch operations
+- **Information**: Engine start/stop, lifecycle transitions
+- **Warning**: Recoverable errors, degraded states
+- **Error**: Unrecoverable failures
+
+If you see `Log.Information` on something that happens per-event or per-checkpoint, flag it.
+
+### 9. Performance Micro-patterns
+
+- `string.StartsWith('$')` (char) not `string.StartsWith("$")` (string) — avoids allocation
+- `string.GetHashCode()` over `XxHash32(Encoding.UTF8.GetBytes(...))` when hash stability across processes is not needed
+- `[]` collection expression over `new Dictionary<K,V>()` or `new List<T>()`
+- Avoid `ExpectedVersion.Any` as magic number `-2` — use the constant
+
+### 10. Leave Breadcrumbs for the Future
+
+When you find gaps that are not critical but worth tracking:
+- Add `// todo: [specific question or concern]` with enough context to understand the issue later
+- Mark unused parameters with `// todo: unused, might represent an important gap`
+- Flag unbounded collections with `// todo: this is unbounded, consider eviction strategy`
+
+## Review Process
+
+1. **Read all changed files** to understand the full picture before commenting on any one file.
+2. **Map the threading model**: identify which thread/queue each class runs on.
+3. **Check lifecycle**: trace start -> run -> stop -> dispose for each component.
+4. **Review parameters**: check for optional parameters, fallbacks, nullability.
+5. **Evaluate abstractions**: are they earning their keep or just adding indirection?
+6. **Check responsibility boundaries**: is each decision made at the right level?
+7. **Verify concurrency**: check for races, especially around checkpointing and state access.
+8. **Review naming**: do names reflect actual semantics?
+9. **Check log levels**: are they appropriate for the frequency of the message?
+
+## Output Format
+
+### Critical Issues (would cause bugs in production)
+For each: describe the bug, which thread/component is affected, and the fix.
+
+### Architectural Issues (wrong abstraction, wrong responsibility)
+For each: describe what's wrong, why it matters, and the simpler alternative.
+
+### Clarity Issues (naming, parameters, encapsulation)
+For each: describe the current state, why it's misleading, and the fix.
+
+### TODOs (gaps worth tracking but not blocking)
+List specific questions or concerns as `// todo:` annotations.
+
+### What's Good
+Briefly note patterns that are correct and should be preserved.

--- a/.claude/docs/api-v2-patterns.md
+++ b/.claude/docs/api-v2-patterns.md
@@ -1,0 +1,99 @@
+# API v2 Architecture and Patterns
+
+> Read this when: working on `src/KurrentDB.Api.V2/` or `src/KurrentDB.Plugins.Api.V2/`.
+
+## Core Infrastructure Patterns
+
+**ApiCallback Pattern** (`src/KurrentDB.Api.V2/Infrastructure/ApiCallback.cs`):
+The foundation for async message bus operations in API v2. Use this when implementing new service methods:
+
+```csharp
+var callback = ApiCallback.Create(
+    state: (Request: request, Context: context),
+    successPredicate: (msg) => msg is WriteEventsCompleted { Result: OperationResult.Success },
+    onSuccess: (state, msg) => {
+        var completed = (WriteEventsCompleted)msg;
+        return new AppendSuccess { Position = completed.CommitPosition };
+    }
+);
+
+publisher.Publish(new WriteEvents(correlationId, envelope: callback, ...));
+return await callback.Task;
+```
+
+**ApiCommand Pattern** (`src/KurrentDB.Api.V2/Infrastructure/ApiCommand.cs`):
+Base class for implementing service operations with fluent configuration:
+
+```csharp
+public class AppendCommand : ApiCommand<AppendCommand, AppendResponse> {
+    protected override AppendCommand Build() {
+        // Configure authorization, validation, etc.
+        return this;
+    }
+
+    protected override async ValueTask<AppendResponse> Execute(CancellationToken ct) {
+        // Implement the actual operation
+    }
+}
+```
+
+**Request Validation** (`src/KurrentDB.Api.V2/Infrastructure/Grpc/Validation/`):
+All requests are validated via interceptors. Create validators by extending `RequestValidator<T>`:
+
+```csharp
+public class StreamNameValidator : RequestValidator<string> {
+    public override void Validate(string value, RequestValidationContext context) {
+        if (string.IsNullOrWhiteSpace(value))
+            context.AddError("Stream name cannot be empty");
+        if (value.StartsWith('$'))
+            context.AddError("System streams cannot be written to via this API");
+    }
+}
+```
+
+**Error Handling** (`src/KurrentDB.Api.V2/Infrastructure/Errors/`):
+Errors use protobuf annotations for automatic code generation:
+
+```protobuf
+enum StreamError {
+    REVISION_CONFLICT = 1 [(kurrent.rpc.error) = {
+        status_code: FAILED_PRECONDITION,
+        has_details: true
+    }];
+}
+```
+
+Then use: `throw RpcExceptions.FromError(StreamError.REVISION_CONFLICT, errorDetails);`
+
+## File Locations
+
+**Infrastructure** (`src/KurrentDB.Api.V2/Infrastructure/`):
+- `ApiCallback.cs`: Generic callback handler (179 lines)
+- `ApiCommand.cs`: Command base class (129 lines)
+- `Errors/RpcExceptions.cs`: Error mapping (200+ lines)
+- `Grpc/Validation/`: Request validators and interceptors
+
+**Service Modules** (`src/KurrentDB.Api.V2/Modules/`):
+- `Streams/StreamsService.cs`: Multi-stream append implementation
+- `ApiErrors.cs`: Common error factories (383 lines)
+
+**Model** (`src/KurrentDB.Api.V2/Model/`):
+- Type conversions between protobuf and internal types
+- Extension methods for mapping
+
+## Key Design Principles
+
+1. **Generic Message Handling**: Use `ApiCallback<TState, TResponse>` for all async operations
+2. **Validation First**: All inputs validated via `RequestValidator<T>` before processing
+3. **Structured Errors**: Use protobuf error annotations with typed details
+4. **Authorization Integration**: Check access per resource (stream, schema, etc.)
+5. **Plugin Architecture**: API v2 is a plugin (`ApiV2Plugin`) for modularity
+
+## Adding a New API v2 Service
+
+1. Create service class extending `<ServiceName>ServiceBase`
+2. Implement methods using `ApiCallback` pattern
+3. Add validators for request types in `Infrastructure/Grpc/Validation/`
+4. Define errors in protobuf with annotations
+5. Register in `ApiV2Plugin.cs`
+6. Write tests using `ClusterVNodeTestContext`

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -1,0 +1,122 @@
+# Architecture Reference
+
+> Read this when: working on core infrastructure, understanding project layout, or onboarding.
+
+## Core Components
+
+**KurrentDB.Core** - Central database engine containing:
+- Services layer with transport (gRPC, HTTP, TCP), storage, replication, and monitoring
+- Transport protocols: gRPC (primary), HTTP API, and legacy TCP via licensed plugin
+- Storage engine with write-ahead log, indexing, scavenging, and optional archiving
+- Clustering with gossip protocol, leader election, and quorum-based replication
+- Authentication/authorization framework with pluggable providers
+
+**Plugin System** - Extensible architecture via `KurrentDB.Plugins`:
+- Authentication plugins (LDAP, OAuth, UserCertificates)
+- Authorization plugins (StreamPolicy, Legacy)
+- Infrastructure plugins (AutoScavenge, OTLP Exporter, Archiving)
+- Connectors for external systems (HTTP, Kafka, MongoDB, RabbitMQ, Elasticsearch, Serilog)
+- Secondary Indexing plugin - DuckDB-backed query optimization (enabled by default)
+- Schema Registry plugin - Event validation and schema management
+- API v2 plugin - Next-generation protocol support
+
+**Protocol Buffers** - Located in `/proto` directory:
+- gRPC service definitions for streams, persistent subscriptions, operations
+- Schema registry protocols in `kurrentdb/protocol/v2/registry/`
+- Multi-version protocol support (legacy, v1, v2)
+
+## Key Services
+
+**Transport Layer** (`Services/Transport/`):
+- `Grpc/` - Primary gRPC API with v2 protocol support and keepalive configuration
+- `Http/` - HTTP API with authentication middleware, Kestrel configuration, and AtomPub (deprecated)
+- `Tcp/` - Legacy TCP protocol available via licensed plugin
+
+**Storage Layer** (`Services/Storage/`):
+- `ReaderIndex/` - Optimized read path with caching, bloom filters, and stream existence filters
+- `Replication/` - Leader-follower replication with heartbeat monitoring
+- `Archive/` - Long-term storage with pluggable backends (S3, FileSystem) - License Required
+- `Scavenging/` - Disk space reclamation with automatic and manual merge operations
+
+**Persistent Subscriptions** (`Services/PersistentSubscription/`):
+- Consumer strategies (RoundRobin, Pinned, DispatchToSingle, PinnedByCorrelation)
+- Event sourcing with checkpointing, message parking, and competing consumers pattern
+- Server-side subscription state management with at-least-once delivery guarantees
+
+**Projections System** (`Projections.Core/`):
+- System projections ($by_category, $by_event_type, etc.)
+- Custom JavaScript projections with state management
+- Real-time event processing and stream linking
+
+**Secondary Indexing** (`KurrentDB.SecondaryIndexing/`):
+- DuckDB-powered secondary indexes for optimized queries
+- Default indexes: Category, EventType, and configurable custom indexes
+- In-flight record tracking and batch processing (default 50,000 events)
+
+**Schema Registry** (`SchemaRegistry/`):
+- Event schema validation and versioning
+- Surge framework integration for event processing
+- Protocol support in `kurrentdb/protocol/v2/registry/`
+
+## Project Structure
+
+- **Core Projects**: KurrentDB.Core, KurrentDB.Common, KurrentDB.LogV3
+- **Transport**: KurrentDB.Transport.Http, KurrentDB.Transport.Tcp
+- **API Projects**: KurrentDB.Api.V2, KurrentDB.Plugins.Api.V2 (Protocol v2 support)
+- **Plugins**: Individual plugin projects with naming `KurrentDB.*.PluginName`
+  - Authentication: KurrentDB.Auth.Ldaps, KurrentDB.Auth.OAuth, KurrentDB.Auth.UserCertificates
+  - Authorization: KurrentDB.Auth.StreamPolicyPlugin, KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled
+  - Infrastructure: KurrentDB.AutoScavenge, KurrentDB.OtlpExporterPlugin, KurrentDB.Security.EncryptionAtRest
+  - Diagnostics: KurrentDB.Diagnostics.LogsEndpointPlugin
+- **Secondary Indexing**: KurrentDB.SecondaryIndexing, KurrentDB.DuckDB (90+ total projects)
+- **Schema Registry**: SchemaRegistry/ (4 projects)
+- **Testing**: Projects ending in `.Tests` use xUnit, NUnit, and TUnit frameworks
+  - KurrentDB.Testing - Shared testing infrastructure
+  - KurrentDB.Surge.Testing - Surge framework testing utilities
+- **UI**: KurrentDB.UI (Blazor embedded UI), KurrentDB.ClusterNode.Web (legacy)
+- **Connectors**: Server-side data integration via catch-up subscriptions and sinks
+- **Supporting Libraries**: KurrentDB.Surge, KurrentDB.SystemRuntime, KurrentDB.BufferManagement, KurrentDB.Logging
+
+## Configuration
+
+- `Directory.Packages.props` - Central NuGet package version management
+- Projects use `<PackageReference>` without version attributes
+- Configuration via YAML files, environment variables, and command line
+- Clustering requires certificate-based authentication between nodes
+- License key required for enterprise features (TCP Plugin, OTLP Exporter, Archiving, etc.)
+
+## Operational Considerations
+
+**Clustering & High Availability**:
+- Quorum-based replication (2n+1 nodes for n-node fault tolerance)
+- Gossip protocol for node discovery (DNS or seed-based)
+- Read-only replicas for scaling reads without affecting quorum
+- Leader election with configurable timeouts and priorities
+
+**Performance & Scaling**:
+- Server GC enabled by default for improved performance
+- StreamInfoCacheCapacity default of 100,000 (changed from dynamic sizing)
+- Configurable thread pools (reader, worker threads)
+- Chunk caching and memory management
+- Index optimization with bloom filters and stream existence filters
+- Secondary indexes with DuckDB for optimized queries
+
+**Monitoring & Operations**:
+- Structured JSON logging with configurable levels (Microsoft log levels required)
+- Prometheus metrics on `/metrics` endpoint (prefixed with `kurrentdb_`)
+- Integration with OpenTelemetry (metrics and logs export with license), Datadog, ElasticSearch
+- Statistics collection and HTTP stats endpoint
+- Embedded admin UI (new) and legacy web interface (`/web`)
+
+## Development Notes
+
+- Target framework: .NET 10.0 with Server GC enabled by default
+- Uses unsafe code blocks for performance-critical operations
+- Protocol buffer generation integrated into build process (`KurrentDB.Protocol` project)
+- Extensive use of dependency injection and hosted services pattern
+- Plugin discovery via assembly scanning and configuration files
+- Event-native design with write-ahead log and immutable event streams
+- DuckDB integration for secondary indexing capabilities
+- Surge framework for event processing and schema registry
+- TUnit testing framework adoption (alongside xUnit and NUnit)
+- 90+ projects in solution as of v25.1

--- a/.claude/docs/patterns-and-conventions.md
+++ b/.claude/docs/patterns-and-conventions.md
@@ -1,0 +1,122 @@
+# Patterns and Conventions Reference
+
+> Read this when: implementing new features that interact with the message bus, enumerators, authorization, or secondary indexes.
+
+## Enumerators and Expiry Strategy
+
+**All read enumerators now use `IExpiryStrategy` instead of `DateTime deadline`**:
+
+```csharp
+// Correct (new pattern)
+new ReadAllForwards(
+    bus, position, maxCount, resolveLinks, user, requiresLeader,
+    DefaultExpiryStrategy.Instance,  // Not a DateTime!
+    cancellationToken
+);
+
+// Old pattern (don't use)
+new ReadAllForwards(..., DateTime.UtcNow.AddMinutes(5), ct);
+```
+
+Available implementations:
+- `DefaultExpiryStrategy.Instance`: Standard 7-second timeout with retry
+- Custom implementations: Implement `IExpiryStrategy` interface
+
+## Message Bus Patterns
+
+**Awaiting a response — use `TcsEnvelope<>`:**
+
+When you need to publish a message and await the response, **always use `TcsEnvelope<T>`** instead of manually creating a `TaskCompletionSource` + `CallbackEnvelope`. The `CallbackEnvelope` callback runs on the bus dispatch thread — if you call `TrySetResult` there, the `await` continuation can resume on the bus thread and block it (deadlock risk).
+
+```csharp
+// CORRECT: TcsEnvelope uses RunContinuationsAsynchronously internally
+var envelope = new TcsEnvelope<WriteEventsCompleted>();
+publisher.Publish(new ClientMessage.WriteEvents(
+    internalCorrId: corrId,
+    correlationId: corrId,
+    envelope: envelope,
+    requireLeader: true,
+    user: user));
+var result = await envelope.Task;
+
+// WRONG: continuation runs on bus thread, can deadlock
+var tcs = new TaskCompletionSource<WriteEventsCompleted>();
+publisher.Publish(new ClientMessage.WriteEvents(
+    envelope: new CallbackEnvelope(msg => tcs.TrySetResult((WriteEventsCompleted)msg)),
+));
+var result = await tcs.Task;
+```
+
+**Fire-and-forget callbacks — `CallbackEnvelope` is fine:**
+```csharp
+var envelope = new CallbackEnvelope(OnMessage);
+publisher.Publish(new ReadStreamEventsForward(
+    correlationId: Guid.NewGuid(),
+    envelope: envelope,
+    streamId: streamName,
+));
+```
+
+**Prefer `ISystemClient` over raw `IPublisher` for business logic writes:**
+```csharp
+// CORRECT: high-level, handles correlation IDs, envelopes, etc.
+await client.Writing.WriteEvents(writes, requireLeader: true, user);
+
+// AVOID: 20+ lines of manual ClientMessage.WriteEvents construction
+publisher.Publish(new ClientMessage.WriteEvents(
+    internalCorrId: corrId, correlationId: corrId,
+    envelope: envelope, requireLeader: true,
+    eventStreamIds: streamIds.ToArray(), ...));
+```
+
+## Authorization Patterns
+
+**Check access before operations**:
+```csharp
+var operation = WriteOperation.WithParameter(
+    Operations.Streams.Parameters.StreamId(streamName)
+);
+
+var hasAccess = await authorizationProvider.CheckAccessAsync(
+    user, operation, cancellationToken
+);
+
+if (!hasAccess)
+    throw RpcExceptions.AccessDenied(operation.Name);
+```
+
+**Thread the `ClaimsPrincipal` through — never hardcode to System:**
+
+When writing events on behalf of a projection or service, pass the actual `ClaimsPrincipal` from the projection's `RunAs` configuration, not `SystemAccounts.System`. Always pass `requireLeader` explicitly rather than defaulting to `false`.
+
+## Working with Secondary Indexes
+
+**Reading from indexes**:
+```csharp
+var enumerator = new IndexSubscription(
+    bus: publisher,
+    expiryStrategy: DefaultExpiryStrategy.Instance,
+    checkpoint: Position.Start,
+    indexName: "$ce-myCategory",
+    user: user,
+    requiresLeader: false,
+    cancellationToken: ct
+);
+
+await foreach (var response in enumerator) {
+    if (response is ReadResponse.EventReceived eventReceived) {
+        // Process event
+    }
+}
+```
+
+**Index naming conventions**:
+- `$idx`: Default index (all events)
+- `$ce-<category>`: Category index
+- `$et-<eventType>`: Event type index
+
+**Reading from Secondary Indexes (step-by-step)**:
+1. Use `IndexSubscription` enumerator for live reads
+2. Use `ReadIndexEventsForward` for batch reads
+3. Index names follow convention above
+4. Always handle `ReadResponse.Checkpoint` for resumption

--- a/.claude/docs/protocol-v2.md
+++ b/.claude/docs/protocol-v2.md
@@ -1,0 +1,68 @@
+# Protocol v2 Structure
+
+> Read this when: working on protocol buffers in `/proto`, defining new gRPC services, or adding error types.
+
+## Protocol Buffer Organization
+
+**Location**: All protocol buffers are in `/proto` directory
+
+**Kurrent RPC Framework** (`proto/kurrent/rpc/`):
+- `rpc.proto`: Error metadata annotations for enum values
+- `errors.proto`: Server-level error definitions (ACCESS_DENIED, NOT_LEADER_NODE, etc.)
+- `code.proto`: Google RPC canonical error codes
+
+**Streams Protocol v2** (`proto/kurrentdb/protocol/v2/streams/`):
+- `streams.proto`: Multi-stream append operations, append sessions
+- `errors.proto`: Stream-specific errors (REVISION_CONFLICT, STREAM_DELETED, etc.)
+- Properties: `event_type`, `data_format`, `schema_id`, custom properties
+
+**Registry Protocol v2** (`proto/kurrentdb/protocol/v2/registry/`):
+- `schemas.proto`: Schema CRUD operations
+- `groups.proto`: Schema group management
+- `service.proto`: gRPC service definitions
+- `events.proto`: Schema lifecycle events
+- `shared.proto`: Common types (compatibility modes, data formats)
+- `errors.proto`: Registry-specific errors
+
+## Error Annotation Pattern
+
+Define errors in protobuf with metadata:
+
+```protobuf
+import "kurrent/rpc/rpc.proto";
+
+enum MyError {
+  VALIDATION_FAILED = 1 [(kurrent.rpc.error) = {
+    status_code: INVALID_ARGUMENT,
+    has_details: true
+  }];
+
+  NOT_FOUND = 2 [(kurrent.rpc.error) = {
+    status_code: NOT_FOUND,
+    has_details: false
+  }];
+}
+
+message ValidationFailedDetails {
+  repeated string field_errors = 1;
+}
+```
+
+Then use in code:
+```csharp
+throw RpcExceptions.FromError(MyError.VALIDATION_FAILED,
+    new ValidationFailedDetails { FieldErrors = { "Invalid format" } });
+```
+
+## Code Generation
+
+- **Generation**: Automatic during build via `KurrentDB.Protocol` project
+- Error metadata extraction happens at runtime via reflection
+- No manual code generation needed for error handling
+
+## Adding a New Protocol Buffer Message
+
+1. Add `.proto` file in appropriate directory under `/proto`
+2. Use error annotations if defining errors
+3. Build project - code generation happens automatically
+4. Import generated types in C# code

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -1,0 +1,110 @@
+# Testing Infrastructure (KurrentDB.Testing)
+
+> Read this when: writing tests, creating test fixtures, or setting up a new test project.
+
+## Overview
+
+`KurrentDB.Testing` is a comprehensive toolkit for standardizing test infrastructure across KurrentDB. Use this for all new test projects.
+
+## Required Setup
+
+**Every test project MUST create `TestEnvironmentWireUp.cs`**:
+
+```csharp
+using KurrentDB.Testing.TUnit;
+using TUnit.Core.Executors;
+
+[assembly: ToolkitTestConfigurator]
+[assembly: TestExecutor<ToolkitTestExecutor>]
+
+namespace YourProject.Tests;
+
+public class TestEnvironmentWireUp {
+    [Before(Assembly)]
+    public static ValueTask BeforeAssembly(AssemblyHookContext context) =>
+        ToolkitTestEnvironment.Initialize(context.Assembly);
+
+    [After(Assembly)]
+    public static ValueTask AfterAssembly(AssemblyHookContext context) =>
+        ToolkitTestEnvironment.Reset(context.Assembly);
+}
+```
+
+## Advanced Assertions
+
+Use `ShouldBeEquivalentTo` for deep object comparison:
+
+```csharp
+actual.ShouldBeEquivalentTo(expected, config => config
+    .Excluding(x => x.CreatedAt)              // Exclude properties
+    .Excluding("Path.To.Property")            // Exclude by path
+    .Using<DateTime>((a, e) => a.Date == e.Date)  // Custom comparer
+    .WithStringComparison(StringComparison.OrdinalIgnoreCase)
+    .WithNumericTolerance(0.01)               // Numeric tolerance
+    .IgnoringCollectionOrder()                // Order-independent collections
+);
+```
+
+## Test Data Generation
+
+Use Bogus as a TUnit ClassDataSource:
+
+```csharp
+public class MyTests {
+    [ClassDataSource<BogusFaker>(Shared = SharedType.PerAssembly)]
+    public required BogusFaker Faker { get; init; }
+
+    [Test]
+    public async Task GenerateTestData() {
+        var name = Faker.Name.FullName();
+        var email = Faker.Internet.Email();
+    }
+}
+```
+
+## Integration Testing
+
+Use `KurrentContext` (preferred) or `ClusterVNodeTestContext` for full node integration tests. `KurrentContext` wraps the shared test infrastructure and supports running against both embedded and external servers:
+
+```csharp
+[ClassDataSource<KurrentContext>(Shared = SharedType.Globally)]
+public required KurrentContext Context { get; init; }
+
+[Test]
+public async Task IntegrationTest() {
+    var client = Context.Client;
+    // Test with running node
+}
+```
+
+Avoid building custom test fixtures when `KurrentContext` already handles lifecycle, configuration, and teardown.
+
+## Test Infrastructure
+
+**Docker Compose** (`src/KurrentDB.Testing/docker-compose.yml`):
+- **Seq** (http://localhost:5341): Log aggregation with test correlation
+- **Aspire Dashboard** (http://localhost:18888): OpenTelemetry visualization
+
+Start with: `docker-compose up -d` in the KurrentDB.Testing directory
+
+## File Locations
+
+- `src/KurrentDB.Testing/` - Main toolkit project
+- `src/KurrentDB.Testing/README.md` - Complete documentation (325 lines)
+- `src/KurrentDB.Testing/Sample/HomeAutomation/` - Example DataSet implementation
+- `src/KurrentDB.Testing.ClusterVNodeApp/` - Integration test harness
+
+## Writing Integration Tests
+
+1. Add `KurrentDB.Testing` project reference
+2. Create `TestEnvironmentWireUp.cs` (required!)
+3. Use `KurrentContext` or `ClusterVNodeTestContext` for full node tests
+4. Use `ShouldBeEquivalentTo` for complex assertions
+5. Use `BogusFaker` for test data generation
+
+## Debugging Tips
+
+1. **API v2 Services**: Set breakpoints in `ApiCallback.OnMessage` to see all message responses
+2. **Enumerators**: Check `_channel.Reader` in enumerator implementations to see queued responses
+3. **Protocol Buffers**: Use `message.ToString()` for debugging (formatted output)
+4. **Test Correlation**: Search logs in Seq by `TestUid` property for test-specific logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,654 +1,150 @@
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Detailed reference docs live in `.claude/docs/` — fetch them when working in a specific area.
 
-## What's New in 25.1
+## Quick Reference: Where to Look
 
-KurrentDB 25.1 introduces several major features and improvements:
-
-### Major Features
-- **Secondary Indexing** - Query optimization with DuckDB-backed indexes for category, event type, and custom indexes
-- **Schema Registry** - Event validation and schema management with Surge framework integration
-- **Multi-stream Appends** - Atomic writes across multiple streams with optimistic concurrency checks
-- **Log Record Properties** - Structured event metadata support (client support in progress)
-- **Windows Service** - Native Windows Service deployment option
-- **OpenTelemetry Logs Export** - Extended observability with OTLP log export (license required)
-
-### Configuration Changes
-- **ServerGC** - Enabled by default for improved performance
-- **StreamInfoCacheCapacity** - Default changed to 100,000 (from 0/dynamic sizing)
-- **SecondaryIndexing** - Enabled by default
-- **MemDb** - Deprecated, will be removed in future version
-
-### New Metrics
-- Projection state size, serialization duration, and execution duration metrics
-- Persistent subscription parked message and replay metrics
-- Garbage collection suspension logging for performance troubleshooting
+| Working on... | Read |
+|---|---|
+| Core infrastructure, project layout | `.claude/docs/architecture.md` |
+| API v2 services | `.claude/docs/api-v2-patterns.md` |
+| Writing tests | `.claude/docs/testing.md` |
+| Protocol buffers, gRPC | `.claude/docs/protocol-v2.md` |
+| Message bus, enumerators, authorization, indexes | `.claude/docs/patterns-and-conventions.md` |
 
 ## Development Commands
 
 ### Build
-- `dotnet build -c Release /p:Platform=x64 --framework=net10.0 src/KurrentDB.sln` - Direct dotnet build
+- `dotnet build -c Release /p:Platform=x64 --framework=net10.0 src/KurrentDB.sln`
 
 ### Test
 - `dotnet test src/KurrentDB.sln` - Run all tests
-- `dotnet test src/ProjectName.Tests/` - Run tests for a specific project
-- Tests use xunit, NUnit, and TUnit frameworks depending on the project
-
-### Run Single Test
-Navigate to the test project directory and use:
-- `dotnet test --filter "FullyQualifiedName~TestMethodName"`
-- `dotnet test --filter "TestClass"`
+- `dotnet test src/ProjectName.Tests/` - Run specific project
+- `dotnet test --filter "FullyQualifiedName~TestMethodName"` - Run single test
 
 ### Development Server
-- Start server: `dotnet ./src/KurrentDB/bin/Release/net10.0/KurrentDB.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log`
-- Default ports: HTTP/gRPC on 2113, Internal TCP on 1112
-- Admin UI: `http://localhost:2113` (new embedded UI) or `http://localhost:2113/web` (legacy)
-- Windows Service: KurrentDB can now be run as a Windows Service (see installation docs)
+- `dotnet ./src/KurrentDB/bin/Release/net10.0/KurrentDB.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log`
+- HTTP/gRPC: 2113, Internal TCP: 1112
+- Admin UI: `http://localhost:2113` | Legacy: `http://localhost:2113/web`
 
-### Configuration & Diagnostics
-- Configuration files use YAML format (`kurrentdb.conf`)
-- Logs location: `/var/log/kurrentdb` (Linux/Mac), `logs/` (Windows)
-- Stats endpoint: `http://localhost:2113/stats`
-- Metrics endpoint: `http://localhost:2113/metrics` (Prometheus format)
+## Architecture (Summary)
 
-## Architecture Overview
+KurrentDB is an event-native database. .NET 10.0, 90+ projects, plugin-based architecture.
 
-KurrentDB is an event-native database with a distributed, plugin-based architecture:
+**Key areas**: Core engine, Plugin system, API v2, Projections (V1 + V2), Secondary Indexing (DuckDB), Schema Registry, Connectors. See `.claude/docs/architecture.md` for full details.
 
-### Core Components
+### Active Development Areas
 
-**KurrentDB.Core** - Central database engine containing:
-- Services layer with transport (gRPC, HTTP, TCP), storage, replication, and monitoring
-- Transport protocols: gRPC (primary), HTTP API, and legacy TCP via licensed plugin
-- Storage engine with write-ahead log, indexing, scavenging, and optional archiving
-- Clustering with gossip protocol, leader election, and quorum-based replication
-- Authentication/authorization framework with pluggable providers
+- **API v2** (`src/KurrentDB.Api.V2/`) — next-gen API, evolving rapidly. See `.claude/docs/api-v2-patterns.md`
+- **Projections V2** (`src/KurrentDB.Projections.V2/`) — next-gen projection engine with partitioned processing
+- **Schema Registry** (`src/SchemaRegistry/`) — event validation and schema management
+- **Secondary Indexing** (`src/KurrentDB.SecondaryIndexing/`) — DuckDB-backed query optimization
 
-**Plugin System** - Extensible architecture via `KurrentDB.Plugins`:
-- Authentication plugins (LDAP, OAuth, UserCertificates)
-- Authorization plugins (StreamPolicy, Legacy)
-- Infrastructure plugins (AutoScavenge, OTLP Exporter, Archiving)
-- Connectors for external systems (HTTP, Kafka, MongoDB, RabbitMQ, Elasticsearch, Serilog)
-- Secondary Indexing plugin - DuckDB-backed query optimization (enabled by default)
-- Schema Registry plugin - Event validation and schema management
-- API v2 plugin - Next-generation protocol support
+### Projections V2 Engine
 
-**Protocol Buffers** - Located in `/proto` directory:
-- gRPC service definitions for streams, persistent subscriptions, operations
-- Schema registry protocols in `kurrentdb/protocol/v2/registry/`
-- Multi-version protocol support (legacy, v1, v2)
+Key components and their threading model:
+- `ProjectionEngineV2`: Main read loop, dispatches events to partitions, triggers checkpoints
+- `PartitionDispatcher`: Routes events to partition channels by hash of partition key
+- `PartitionProcessor`: Processes events within a single partition, manages state and output buffers
+- `CheckpointCoordinator`: Chandy-Lamport style — collects frozen buffers from all partitions, writes atomic multi-stream checkpoint
+- `CoreProjectionV2`: Adapter implementing `ICoreProjectionControl` — **runs on projection worker queue, NOT thread safe**
+- `ProjectionProcessingStrategyV2`: Factory creating V2 engines
 
-**API v2 Architecture** - Next-generation API (`src/KurrentDB.Api.V2/` + `src/KurrentDB.Plugins.Api.V2/`):
-- **Evolving rapidly** - This is an active development area with frequent changes
-- Modular plugin-based architecture via `ApiV2Plugin`
-- gRPC service implementations with request validation
-- Infrastructure: DependencyInjection, Error handling, Validation framework
-- Streams service with multi-stream append support
-- Protocol v2 integration (`KurrentDB.Protocol.V2.Streams`)
-- Separate from legacy API to allow parallel evolution
-- **Note**: When working with API v2, expect ongoing refactoring and protocol changes
+Uses `ISystemClient` for writes (not raw `IPublisher`), `IReadStrategy` for reads.
 
-### Key Services Architecture
+## Threading Model and Concurrency
 
-**Transport Layer** (`Services/Transport/`):
-- `Grpc/` - Primary gRPC API with v2 protocol support and keepalive configuration
-- `Http/` - HTTP API with authentication middleware, Kestrel configuration, and AtomPub (deprecated)
-- `Tcp/` - Legacy TCP protocol available via licensed plugin
+**Always ask: "What thread does this run on? Is that safe?"**
 
-**Storage Layer** (`Services/Storage/`):
-- `ReaderIndex/` - Optimized read path with caching, bloom filters, and stream existence filters
-- `Replication/` - Leader-follower replication with heartbeat monitoring
-- `Archive/` - Long-term storage with pluggable backends (S3, FileSystem) - License Required
-- `Scavenging/` - Disk space reclamation with automatic and manual merge operations
+### Critical Threading Rules
 
-**Persistent Subscriptions** (`Services/PersistentSubscription/`):
-- Consumer strategies (RoundRobin, Pinned, DispatchToSingle, PinnedByCorrelation)
-- Event sourcing with checkpointing, message parking, and competing consumers pattern
-- Server-side subscription state management with at-least-once delivery guarantees
+- **Projection worker queue**: `CoreProjection`, `CoreProjectionV2` — NOT thread safe. Never call from thread pool.
+- **Bus dispatch thread**: `CallbackEnvelope` callbacks run here. **Never use `CallbackEnvelope` + `TaskCompletionSource` to await a response** — use `TcsEnvelope<T>` instead (uses `RunContinuationsAsynchronously`).
+- **Fire-and-forget tasks**: `_ = SomeAsync()` must not call back into non-thread-safe objects.
 
-**Projections System** (`Projections.Core/`):
-- System projections ($by_category, $by_event_type, etc.)
-- Custom JavaScript projections with state management
-- Real-time event processing and stream linking
+### DotNext Threading Utilities
 
-**Secondary Indexing** (`KurrentDB.SecondaryIndexing/`):
-- DuckDB-powered secondary indexes for optimized queries
-- Default indexes: Category, EventType, and configurable custom indexes
-- In-flight record tracking and batch processing (default 50,000 events)
-- Telemetry and statistics collection
+- `TcsEnvelope<T>`: Safe async await for bus responses
+- `AsyncExclusiveLock`: Ensure only one operation in flight (e.g., checkpointing)
+- `[AsyncMethodBuilder(typeof(SpawningAsyncTaskMethodBuilder))]`: Start async method on new thread, don't capture caller's sync context. Use for background loops.
 
-**Schema Registry** (`SchemaRegistry/`):
-- Event schema validation and versioning
-- Surge framework integration for event processing
-- Protocol support in `kurrentdb/protocol/v2/registry/`
-- Pluggable architecture with dedicated service layer
+### Lifecycle Rules
 
-### Project Structure
+- The component that creates a `CancellationTokenSource` owns it (cancel + dispose).
+- If a component can be stopped and restarted, stop must complete before start begins.
+- Prefer `Run(checkpoint, ct)` over separate `Start()`/`Stop()` when lifecycle is a single run.
+- When checkpointing from multiple partitions, ensure only one checkpoint in flight at a time.
 
-- **Core Projects**: KurrentDB.Core, KurrentDB.Common
-- **Transport**: KurrentDB.Transport.Http, KurrentDB.Transport.Tcp
-- **API Projects**: KurrentDB.Api.V2, KurrentDB.Plugins.Api.V2 (Protocol v2 support)
-- **Plugins**: Individual plugin projects with naming `KurrentDB.*.PluginName`
-  - Authentication: KurrentDB.Auth.Ldaps, KurrentDB.Auth.OAuth, KurrentDB.Auth.UserCertificates
-  - Authorization: KurrentDB.Auth.StreamPolicyPlugin, KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled
-  - Infrastructure: KurrentDB.AutoScavenge, KurrentDB.OtlpExporterPlugin, KurrentDB.Security.EncryptionAtRest
-  - Diagnostics: KurrentDB.Diagnostics.LogsEndpointPlugin
-- **Secondary Indexing**: KurrentDB.SecondaryIndexing, KurrentDB.DuckDB (90+ total projects)
-- **Schema Registry**: SchemaRegistry/ (4 projects: KurrentDB.SchemaRegistry, KurrentDB.SchemaRegistry.Protocol, KurrentDB.Plugins.SchemaRegistry, KurrentDB.SchemaRegistry.Tests)
-- **Testing**: Projects ending in `.Tests` use xUnit, NUnit, and TUnit frameworks
-  - KurrentDB.Testing - Shared testing infrastructure
-  - KurrentDB.Surge.Testing - Surge framework testing utilities
-- **UI**: KurrentDB.UI (Blazor embedded UI), KurrentDB.ClusterNode.Web (legacy)
-- **Connectors**: Server-side data integration via catch-up subscriptions and sinks
-  - Connectors/ (5 projects: KurrentDB.Connectors, KurrentDB.Plugins.Connectors, KurrentDB.Connectors.Contracts, etc.)
-- **Supporting Libraries**: KurrentDB.Surge (event processing), KurrentDB.SystemRuntime, KurrentDB.BufferManagement, KurrentDB.Logging
+## C# Coding Conventions
 
-### Configuration
-
-Uses centralized package management:
-- `Directory.Packages.props` - Central NuGet package version management
-- Projects use `<PackageReference>` without version attributes
-- Configuration via YAML files, environment variables, and command line
-- Clustering requires certificate-based authentication between nodes
-- License key required for enterprise features (TCP Plugin, OTLP Exporter, Archiving, etc.)
-
-### Operational Considerations
-
-**Clustering & High Availability**:
-- Quorum-based replication (2n+1 nodes for n-node fault tolerance)
-- Gossip protocol for node discovery (DNS or seed-based)
-- Read-only replicas for scaling reads without affecting quorum
-- Leader election with configurable timeouts and priorities
-
-**Performance & Scaling**:
-- Server GC enabled by default for improved performance
-- StreamInfoCacheCapacity default of 100,000 (changed from dynamic sizing)
-- Configurable thread pools (reader, worker threads)
-- Chunk caching and memory management
-- Index optimization with bloom filters and stream existence filters
-- Secondary indexes with DuckDB for optimized queries
-- Scavenging for disk space management and performance
-
-**Monitoring & Operations**:
-- Structured JSON logging with configurable levels (Microsoft log levels required)
-- Prometheus metrics on `/metrics` endpoint (prefixed with `kurrentdb_`)
-- Integration with OpenTelemetry (metrics and logs export with license), Datadog, ElasticSearch
-- Statistics collection and HTTP stats endpoint
-- Embedded admin UI (new) and legacy web interface (`/web`)
-- License status monitoring in embedded UI
-- New projection metrics: state size, serialization duration, execution duration
-- New persistent subscription metrics: parked message replays, park requests
-- GC suspension logging for performance troubleshooting (>48ms logged as Info, >600ms as Warning)
-
-### Development Notes
-
-- Target framework: .NET 10.0 with Server GC enabled by default
-- Uses unsafe code blocks for performance-critical operations
-- Protocol buffer generation integrated into build process (`KurrentDB.Protocol` project)
-- Extensive use of dependency injection and hosted services pattern
-- Plugin discovery via assembly scanning and configuration files
-- Event-native design with write-ahead log and immutable event streams
-- DuckDB integration for secondary indexing capabilities
-- Surge framework for event processing and schema registry
-- TUnit testing framework adoption (alongside xUnit and NUnit)
-- 90+ projects in solution as of v25.1
-
-### Active Development Areas (Expect Frequent Changes)
-
-**API v2** (`src/KurrentDB.Api.V2/` and `src/KurrentDB.Plugins.Api.V2/`):
-- This is the next-generation API layer currently under rapid development
-- Implements protocol v2 with new features like multi-stream appends and log record properties
-- Modular architecture: Infrastructure layer (DI, errors, validation) + Service modules (Streams, etc.)
-- Plugin-based activation via `ApiV2Plugin`
-- When working in this area, expect ongoing protocol changes, refactoring, and architectural evolution
-- Coexists with legacy API to allow gradual migration and experimentation
-
-**Schema Registry** (`src/SchemaRegistry/`):
-- Event validation and schema management system
-- Integrates with Surge framework for event processing
-- Protocol definitions in `proto/kurrentdb/protocol/v2/registry/`
-- Plugin system for extensibility
-
-**Secondary Indexing** (`src/KurrentDB.SecondaryIndexing/`):
-- DuckDB-backed query optimization layer
-- Active development on index strategies and performance tuning
-
-### Important Configuration Defaults (v25.1)
-
-- **SecondaryIndexing:Enabled** - `true` (enabled by default)
-- **ServerGC** - `true` (enabled by default)
-- **StreamInfoCacheCapacity** - `100000` (changed from `0`/dynamic)
-- **TcpReadTimeoutMs** - `10000` (10 seconds)
-
-### Deprecated/Removed Options
-
-- **MemDb** - Deprecated in v25.1, will be removed in future version
-- **DisableFirstLevelHttpAuthorization** - Removed in v25.1 (had no effect since v20.6.0)
-- See `docs/server/quick-start/upgrade-guide.md` for complete list of breaking changes
-
-## MCP Server Configuration
-
-This repository includes pre-configured MCP (Model Context Protocol) servers for enhanced development experience:
-
-### Available MCP Servers
-- **Microsoft Docs MCP Server**: Access official Microsoft and Azure documentation
-- **Context7 MCP Server**: Library documentation and code examples
-- **Filesystem MCP Server**: Direct file system access to project files with read operations
-
-### Configuration Files
-- `.claude/settings.json` - Project-level MCP server configurations (committed to repo)
-- `.claude/settings.local.json` - Local user-specific permissions (not committed)
-- `.claude/README.md` - Detailed MCP setup documentation
-
-## Querying Microsoft Documentation
-
-You have access to MCP tools called `microsoft_docs_search` and `microsoft_docs_fetch` - these tools allow you to search through and fetch Microsoft's latest official documentation, and that information might be more detailed or newer than what's in your training data set.
-
-When handling questions around how to work with native Microsoft technologies, such as C#, F#, ASP.NET Core, Microsoft.Extensions, NuGet, Entity Framework, the `dotnet` runtime - please use this tool for research purposes when dealing with specific / narrowly defined questions that may occur.
-
-### Usage
-When working with Claude Code, you can directly query these servers:
-```
-# Search Microsoft docs
-Search for ASP.NET Core authentication patterns
-
-# Get library documentation  
-Get documentation for Entity Framework Core
-
-# Read project files directly
-Read the main KurrentDB.Core project file
-
-# Access multiple files efficiently
-Read all protocol buffer definitions in the proto directory
-```
-
-The servers provide access to up-to-date documentation, examples, and direct file access without manual searching or separate tool calls.
-
-## API v2 Architecture and Patterns
-
-### Core Infrastructure Patterns
-
-**ApiCallback Pattern** (`src/KurrentDB.Api.V2/Infrastructure/ApiCallback.cs`):
-The foundation for async message bus operations in API v2. Use this when implementing new service methods:
+### Parameter Design — Non-Optional, No Fallbacks
 
 ```csharp
-var callback = ApiCallback.Create(
-    state: (Request: request, Context: context),
-    successPredicate: (msg) => msg is WriteEventsCompleted { Result: OperationResult.Success },
-    onSuccess: (state, msg) => {
-        var completed = (WriteEventsCompleted)msg;
-        return new AppendSuccess { Position = completed.CommitPosition };
-    }
-);
+// WRONG: silent fallback hides a bug
+public Foo(IPublisher publisher, IPublisher mainBus = null) {
+    _mainBus = mainBus ?? publisher;
+}
 
-publisher.Publish(new WriteEvents(correlationId, envelope: callback, ...));
-return await callback.Task;
-```
-
-**ApiCommand Pattern** (`src/KurrentDB.Api.V2/Infrastructure/ApiCommand.cs`):
-Base class for implementing service operations with fluent configuration:
-
-```csharp
-public class AppendCommand : ApiCommand<AppendCommand, AppendResponse> {
-    protected override AppendCommand Build() {
-        // Configure authorization, validation, etc.
-        return this;
-    }
-
-    protected override async ValueTask<AppendResponse> Execute(CancellationToken ct) {
-        // Implement the actual operation
-    }
+// CORRECT
+public Foo(IPublisher publisher, IPublisher mainBus) {
+    _mainBus = mainBus;
 }
 ```
 
-**Request Validation** (`src/KurrentDB.Api.V2/Infrastructure/Grpc/Validation/`):
-All requests are validated via interceptors. Create validators by extending `RequestValidator<T>`:
+- No `= null` on parameters that are actually required
+- No `= 1` magic number defaults on version/config parameters
+- Replace `?? fallbackValue` with `?? throw new InvalidOperationException("explanation")` when null is a bug
+- Make types non-nullable (`T` not `T?`) when the value is always expected
+- Always pass `ClaimsPrincipal` and `requireLeader` explicitly — never hardcode or default
 
-```csharp
-public class StreamNameValidator : RequestValidator<string> {
-    public override void Validate(string value, RequestValidationContext context) {
-        if (string.IsNullOrWhiteSpace(value))
-            context.AddError("Stream name cannot be empty");
-        if (value.StartsWith('$'))
-            context.AddError("System streams cannot be written to via this API");
-    }
-}
-```
+### Naming
 
-**Error Handling** (`src/KurrentDB.Api.V2/Infrastructure/Errors/`):
-Errors use protobuf annotations for automatic code generation:
+- **Versioned classes**: `NounVersionSuffix` — `CoreProjectionV2` (not `V2CoreProjection`)
+- **Parameter accuracy**: `mainQueue` if it's a queue (not `mainBus`)
+- **Named booleans**: `requireLeader: true` at call sites, not just `true`
+- **Constants**: `ProjectionConstants.EngineV2` not `2`, `ExpectedVersion.Any` not `-2`
 
-```protobuf
-enum StreamError {
-    REVISION_CONFLICT = 1 [(kurrent.rpc.error) = {
-        status_code: FAILED_PRECONDITION,
-        has_details: true
-    }];
-}
-```
+### Encapsulation
 
-Then use: `throw RpcExceptions.FromError(StreamError.REVISION_CONFLICT, errorDetails);`
+- Expose `IReadOnlyList<>`, `IReadOnlyDictionary<>` to consumers that only read
+- Use `private init` on record properties set only by factory methods
+- Pass factory instead of both value + factory
 
-### File Locations
+### Micro-Patterns
 
-**Infrastructure** (`src/KurrentDB.Api.V2/Infrastructure/`):
-- `ApiCallback.cs`: Generic callback handler (179 lines)
-- `ApiCommand.cs`: Command base class (129 lines)
-- `Errors/RpcExceptions.cs`: Error mapping (200+ lines)
-- `Grpc/Validation/`: Request validators and interceptors
+- `string.StartsWith('$')` (char) not `string.StartsWith("$")` (allocates)
+- `string.GetHashCode()` over `XxHash32(Encoding.UTF8.GetBytes(...))` when hash stability isn't needed
+- `[]` collection expression over `new Dictionary<K,V>()`
+- Don't put `IAsyncDisposable` on interfaces when disposal is an implementation concern
 
-**Service Modules** (`src/KurrentDB.Api.V2/Modules/`):
-- `Streams/StreamsService.cs`: Multi-stream append implementation
-- `ApiErrors.cs`: Common error factories (383 lines)
+### Abstraction Discipline
 
-**Model** (`src/KurrentDB.Api.V2/Model/`):
-- Type conversions between protobuf and internal types
-- Extension methods for mapping
+- Two classes doing the same thing with different config? Merge — pass the config as a parameter.
+- Interface adding lifecycle (`IAsyncDisposable`) that's the implementation's concern? Simplify the interface.
+- Method takes both a value and a factory-for-that-value? Just use the factory.
 
-### Key Design Principles
+## Log Level Policy
 
-1. **Generic Message Handling**: Use `ApiCallback<TState, TResponse>` for all async operations
-2. **Validation First**: All inputs validated via `RequestValidator<T>` before processing
-3. **Structured Errors**: Use protobuf error annotations with typed details
-4. **Authorization Integration**: Check access per resource (stream, schema, etc.)
-5. **Plugin Architecture**: API v2 is a plugin (`ApiV2Plugin`) for modularity
+| Level | When |
+|---|---|
+| **Verbose** | Per-event, per-message — anything that fires per-record |
+| **Debug** | Checkpoint writes, per-batch operations |
+| **Information** | Engine start/stop, lifecycle transitions only |
+| **Warning** | Recoverable errors, degraded states |
+| **Error** | Unrecoverable failures |
 
-## Testing Infrastructure (KurrentDB.Testing)
+Per-event or per-checkpoint log messages must NOT be `Information`.
 
-### Overview
+## MCP Servers
 
-`KurrentDB.Testing` is a comprehensive toolkit for standardizing test infrastructure across KurrentDB. Use this for all new test projects.
+- **Microsoft Docs**: `microsoft_docs_search`, `microsoft_docs_fetch` — query for .NET/Azure docs
+- **Context7**: Library documentation and code examples
+- Config: `.claude/settings.json` (committed), `.claude/settings.local.json` (local)
 
-### Required Setup
+## Configuration Defaults (v25.1)
 
-**Every test project MUST create `TestEnvironmentWireUp.cs`**:
-
-```csharp
-using KurrentDB.Testing.TUnit;
-using TUnit.Core.Executors;
-
-[assembly: ToolkitTestConfigurator]
-[assembly: TestExecutor<ToolkitTestExecutor>]
-
-namespace YourProject.Tests;
-
-public class TestEnvironmentWireUp {
-    [Before(Assembly)]
-    public static ValueTask BeforeAssembly(AssemblyHookContext context) =>
-        ToolkitTestEnvironment.Initialize(context.Assembly);
-
-    [After(Assembly)]
-    public static ValueTask AfterAssembly(AssemblyHookContext context) =>
-        ToolkitTestEnvironment.Reset(context.Assembly);
-}
-```
-
-### Advanced Assertions
-
-Use `ShouldBeEquivalentTo` for deep object comparison:
-
-```csharp
-actual.ShouldBeEquivalentTo(expected, config => config
-    .Excluding(x => x.CreatedAt)              // Exclude properties
-    .Excluding("Path.To.Property")            // Exclude by path
-    .Using<DateTime>((a, e) => a.Date == e.Date)  // Custom comparer
-    .WithStringComparison(StringComparison.OrdinalIgnoreCase)
-    .WithNumericTolerance(0.01)               // Numeric tolerance
-    .IgnoringCollectionOrder()                // Order-independent collections
-);
-```
-
-### Test Data Generation
-
-Use Bogus as a TUnit ClassDataSource:
-
-```csharp
-public class MyTests {
-    [ClassDataSource<BogusFaker>(Shared = SharedType.PerAssembly)]
-    public required BogusFaker Faker { get; init; }
-
-    [Test]
-    public async Task GenerateTestData() {
-        var name = Faker.Name.FullName();
-        var email = Faker.Internet.Email();
-        // Use generated data in test
-    }
-}
-```
-
-### Integration Testing
-
-Use `ClusterVNodeTestContext` for full node integration tests:
-
-```csharp
-[ClassDataSource<ClusterVNodeTestContext>(Shared = SharedType.Globally)]
-public required ClusterVNodeTestContext Context { get; init; }
-
-[Test]
-public async Task IntegrationTest() {
-    var service = Context.ServiceProvider.GetRequiredService<StreamsService>();
-    // Test with real running node
-}
-```
-
-### Test Infrastructure
-
-**Docker Compose** (`src/KurrentDB.Testing/docker-compose.yml`):
-- **Seq** (http://localhost:5341): Log aggregation with test correlation
-- **Aspire Dashboard** (http://localhost:18888): OpenTelemetry visualization
-
-Start with: `docker-compose up -d` in the KurrentDB.Testing directory
-
-### File Locations
-
-- `src/KurrentDB.Testing/` - Main toolkit project
-- `src/KurrentDB.Testing/README.md` - Complete documentation (325 lines)
-- `src/KurrentDB.Testing/Sample/HomeAutomation/` - Example DataSet implementation
-- `src/KurrentDB.Testing.ClusterVNodeApp/` - Integration test harness
-
-## Protocol v2 Structure
-
-### Protocol Buffer Organization
-
-**Location**: All protocol buffers are in `/proto` directory
-
-**Kurrent RPC Framework** (`proto/kurrent/rpc/`):
-- `rpc.proto`: Error metadata annotations for enum values
-- `errors.proto`: Server-level error definitions (ACCESS_DENIED, NOT_LEADER_NODE, etc.)
-- `code.proto`: Google RPC canonical error codes
-
-**Streams Protocol v2** (`proto/kurrentdb/protocol/v2/streams/`):
-- `streams.proto`: Multi-stream append operations, append sessions
-- `errors.proto`: Stream-specific errors (REVISION_CONFLICT, STREAM_DELETED, etc.)
-- Properties: `event_type`, `data_format`, `schema_id`, custom properties
-
-**Registry Protocol v2** (`proto/kurrentdb/protocol/v2/registry/`):
-- `schemas.proto`: Schema CRUD operations
-- `groups.proto`: Schema group management
-- `service.proto`: gRPC service definitions
-- `events.proto`: Schema lifecycle events
-- `shared.proto`: Common types (compatibility modes, data formats)
-- `errors.proto`: Registry-specific errors
-
-### Error Annotation Pattern
-
-Define errors in protobuf with metadata:
-
-```protobuf
-import "kurrent/rpc/rpc.proto";
-
-enum MyError {
-  VALIDATION_FAILED = 1 [(kurrent.rpc.error) = {
-    status_code: INVALID_ARGUMENT,
-    has_details: true
-  }];
-
-  NOT_FOUND = 2 [(kurrent.rpc.error) = {
-    status_code: NOT_FOUND,
-    has_details: false
-  }];
-}
-
-message ValidationFailedDetails {
-  repeated string field_errors = 1;
-}
-```
-
-Then use in code:
-```csharp
-throw RpcExceptions.FromError(MyError.VALIDATION_FAILED,
-    new ValidationFailedDetails { FieldErrors = { "Invalid format" } });
-```
-
-## Important Patterns and Conventions
-
-### Enumerators and Expiry Strategy
-
-**All read enumerators now use `IExpiryStrategy` instead of `DateTime deadline`**:
-
-```csharp
-// Correct (new pattern)
-new ReadAllForwards(
-    bus, position, maxCount, resolveLinks, user, requiresLeader,
-    DefaultExpiryStrategy.Instance,  // Not a DateTime!
-    cancellationToken
-);
-
-// Old pattern (don't use)
-new ReadAllForwards(..., DateTime.UtcNow.AddMinutes(5), ct);  // ❌
-```
-
-Available implementations:
-- `DefaultExpiryStrategy.Instance`: Standard 7-second timeout with retry
-- Custom implementations: Implement `IExpiryStrategy` interface
-
-### Message Bus Patterns
-
-**Publishing Messages**:
-```csharp
-var envelope = new CallbackEnvelope(OnMessage);
-publisher.Publish(new ReadStreamEventsForward(
-    correlationId: Guid.NewGuid(),
-    envelope: envelope,
-    streamId: streamName,
-    // ... other parameters
-));
-```
-
-**New Message Types** (from this PR):
-- `ReadIndexEventsForward` / `ReadIndexEventsBackward`: Read from secondary indexes
-- `SubscribeToIndex`: Subscribe to index updates
-- `CheckpointReached`: Index checkpoint notifications
-- `ReadLogEvents`: Read raw log records
-
-### Authorization Patterns
-
-**Check access before operations**:
-```csharp
-var operation = WriteOperation.WithParameter(
-    Operations.Streams.Parameters.StreamId(streamName)
-);
-
-var hasAccess = await authorizationProvider.CheckAccessAsync(
-    user, operation, cancellationToken
-);
-
-if (!hasAccess)
-    throw RpcExceptions.AccessDenied(operation.Name);
-```
-
-### Working with Secondary Indexes
-
-**Reading from indexes**:
-```csharp
-var enumerator = new IndexSubscription(
-    bus: publisher,
-    expiryStrategy: DefaultExpiryStrategy.Instance,
-    checkpoint: Position.Start,
-    indexName: "$ce-myCategory",  // Category index
-    user: user,
-    requiresLeader: false,
-    cancellationToken: ct
-);
-
-await foreach (var response in enumerator) {
-    if (response is ReadResponse.EventReceived eventReceived) {
-        // Process event
-    }
-}
-```
-
-**Index naming conventions**:
-- `$idx`: Default index (all events)
-- `$ce-<category>`: Category index
-- `$et-<eventType>`: Event type index
-
-## Code Generation and Build
-
-### Protocol Buffers
-
-**Generation**: Automatic during build via `KurrentDB.Protocol` project
-
-**Custom Options**:
-- Error metadata extraction happens at runtime via reflection
-- No manual code generation needed for error handling
-
-### Testing
-
-**Test Discovery**: TUnit automatically discovers tests
-
-**Running Tests**:
-```bash
-# All tests
-dotnet test src/KurrentDB.sln
-
-# Specific project
-dotnet test src/KurrentDB.Api.V2.Tests/
-
-# Single test
-dotnet test --filter "FullyQualifiedName~TestMethodName"
-
-# With logging
-dotnet test --logger "console;verbosity=detailed"
-```
-
-### Debugging Tips
-
-1. **API v2 Services**: Set breakpoints in `ApiCallback.OnMessage` to see all message responses
-2. **Enumerators**: Check `_channel.Reader` in enumerator implementations to see queued responses
-3. **Protocol Buffers**: Use `message.ToString()` for debugging (formatted output)
-4. **Test Correlation**: Search logs in Seq by `TestUid` property for test-specific logs
-
-## Common Tasks
-
-### Adding a New API v2 Service
-
-1. Create service class extending `<ServiceName>ServiceBase`
-2. Implement methods using `ApiCallback` pattern
-3. Add validators for request types in `Infrastructure/Grpc/Validation/`
-4. Define errors in protobuf with annotations
-5. Register in `ApiV2Plugin.cs`
-6. Write tests using `ClusterVNodeTestContext`
-
-### Adding a New Protocol Buffer Message
-
-1. Add `.proto` file in appropriate directory under `/proto`
-2. Use error annotations if defining errors
-3. Build project - code generation happens automatically
-4. Import generated types in C# code
-
-### Writing Integration Tests
-
-1. Add `KurrentDB.Testing` project reference
-2. Create `TestEnvironmentWireUp.cs` (required!)
-3. Use `ClusterVNodeTestContext` for full node tests
-4. Use `ShouldBeEquivalentTo` for complex assertions
-5. Use `BogusFaker` for test data generation
-
-### Reading from Secondary Indexes
-
-1. Use `IndexSubscription` enumerator for live reads
-2. Use `ReadIndexEventsForward` for batch reads
-3. Index names follow convention: `$idx`, `$ce-<category>`, `$et-<eventType>`
-4. Always handle `ReadResponse.Checkpoint` for resumption
+- **SecondaryIndexing:Enabled** — `true`
+- **ServerGC** — `true`
+- **StreamInfoCacheCapacity** — `100000`
+- **MemDb** — Deprecated, will be removed

--- a/docs/plans/2026-03-07-projections-v2-engine-design.md
+++ b/docs/plans/2026-03-07-projections-v2-engine-design.md
@@ -1,0 +1,303 @@
+# Projections v2 Engine Design
+
+**Date**: 2026-03-07
+**Status**: Proposed
+
+## Overview
+
+A new projections processing engine that replaces the current complex pipeline with simpler, modern infrastructure already available in KurrentDB: filtered read-all enumerators, secondary indexes (DuckDB), and multi-stream atomic appends.
+
+The new engine eliminates multi-stream readers, event reordering, per-stream emitted-stream tracking, and complex idempotency checks. It introduces partitioned parallel processing with Chandy-Lamport checkpointing and atomic output writes.
+
+## Goals
+
+- Simplify the projections processing pipeline by leveraging existing database infrastructure
+- Enable parallel event processing via configurable partitions
+- Achieve atomic checkpointing (checkpoint + emitted events + state in one write)
+- Eliminate internal link event overhead (partition catalogs, all-results streams)
+- Maintain backward compatibility with existing projection JavaScript API and output streams
+
+## Non-Goals
+
+- System projections — these are being replaced by DuckDB secondary indexes
+- Changes to the JavaScript runtime (`IProjectionStateHandler` / Jint)
+- Changes to the management layer API (HTTP/gRPC endpoints)
+
+## Read Strategies
+
+Three read strategies replace the current reader hierarchy (`TransactionFileEventReader`, `MultiStreamEventReader`, `EventByTypeIndexEventReader`, `StreamEventReader`):
+
+### Strategy A — Filtered $all (default)
+
+Used by `fromAll()`, `fromCategory()`, `fromEventType()`.
+
+Uses the existing `Enumerator.AllSubscriptionFiltered` with the appropriate `IEventFilter`:
+- `fromAll()` → `DefaultAllFilter` or user-specified filter
+- `fromCategory(name)` → `StreamName.Prefixes("name-")`
+- `fromEventType(type)` → `EventType.Prefixes("type")`
+
+Checkpoints by log position (`TFPos`). Delivers events in log order with catch-up and live tailing phases.
+
+### Strategy B — Direct Stream Read
+
+Used by `fromStream('stream-name')`.
+
+Reads from the primary index via direct stream read — no log scan needed. This is the most efficient path for single-stream projections.
+
+**Enhancement required**: Stream reads currently don't support starting from a log position. This needs to be added so that checkpointing remains uniform across all strategies. The DuckDB default index (`$idx-all`) can resolve between stream event number and log position.
+
+Checkpoints by log position.
+
+### Strategy C — DuckDB Stream-Name-Set Filter
+
+Used by `fromStreams(['stream-a', 'stream-b', ...])`.
+
+Queries the DuckDB default index with:
+```sql
+SELECT * FROM "$idx-all"
+WHERE stream IN ('stream-a', 'stream-b', ...)
+  AND log_position > @checkpoint
+ORDER BY log_position
+```
+
+Returns events in log order naturally. Checkpoints by log position.
+
+**Enhancement required**: A new `IEventFilter` implementation for stream-name-set matching, backed by DuckDB queries.
+
+### Uniform Interface
+
+All three strategies produce events ordered by log position and checkpoint using log position. This gives a single downstream interface regardless of source configuration.
+
+## Processing Pipeline
+
+```
+Reader (Strategy A/B/C)
+  │
+  │  events in log-position order
+  ▼
+Dispatcher (consistent hash of partitionBy key)
+  │
+  ├──► Partition Channel 0  ──► Process ──► Output Buffer 0
+  ├──► Partition Channel 1  ──► Process ──► Output Buffer 1
+  ├──► Partition Channel 2  ──► Process ──► Output Buffer 2
+  ...
+  └──► Partition Channel N-1 ──► Process ──► Output Buffer N-1
+  │
+  ▼
+Checkpoint Coordinator (Chandy-Lamport markers)
+  │
+  ▼
+Multi-Stream Atomic Append (checkpoint + emitted events + state)
+```
+
+### Dispatcher
+
+The dispatcher receives events from the reader and routes them to partition channels:
+
+1. Call `partitionBy(event)` to get the partition key (or use stream name as default)
+2. Compute `hash(partitionKey) % N` to select the target partition channel
+3. Write the event to that partition's `System.Threading.Channel<T>`
+
+Events for the same partition key always go to the same partition, preserving per-key ordering.
+
+### Partition Processing
+
+Each partition runs a dedicated async task that:
+
+1. Reads events from its channel sequentially
+2. Loads partition state from cache (or from stream on cache miss)
+3. Calls `IProjectionStateHandler.ProcessEvent()` (existing Jint runtime, unchanged)
+4. Collects emitted events and state updates into the current output buffer
+
+The partition count is configurable per projection (default TBD, e.g., 4). The existing `IProjectionStateHandler` and Jint JavaScript runtime are reused without modification.
+
+### Backpressure
+
+Bounded channel capacity on partition channels provides natural backpressure. If partitions are slow, the dispatcher blocks on `channel.Writer.WriteAsync()`, which in turn pauses the reader. No explicit backpressure signaling needed.
+
+### No Reordering
+
+The filtered $all enumerator delivers events in log order. Within a partition, events for the same key are processed in order. Cross-partition ordering is not required because partitions process independent keys. This eliminates the current `StagedProcessingQueue` and its complex ordering logic.
+
+## Checkpointing via Chandy-Lamport
+
+The processing topology is a simple single-producer (reader/dispatcher) to N-consumer (partitions) fan-out. The Chandy-Lamport algorithm provides consistent distributed snapshots without stalling the pipeline.
+
+### Protocol
+
+1. **Trigger**: Checkpoint interval reached (configurable by byte threshold, event count, or time interval).
+
+2. **Inject markers**: The dispatcher injects a `CheckpointMarker(sequenceNumber, logPosition)` into each of the N partition channels. The `logPosition` is the position of the last event dispatched before the marker.
+
+3. **Partition snapshot**: When a partition processes the marker, it:
+   - Freezes its current output buffer (emitted events + dirty state)
+   - Reports the frozen buffer to the checkpoint coordinator
+   - Switches to a fresh output buffer (double-buffered) and continues processing
+
+4. **Coordinator collects**: Once all N partitions have reported for the same marker sequence number, the coordinator has a consistent snapshot.
+
+5. **Atomic write**: The coordinator issues a single multi-stream append (`ClientMessage.WriteEvents` with multiple `EventStreamIds`) containing:
+   - Checkpoint event → `$projections-{name}-checkpoint` stream (with log position)
+   - All emitted events from the N frozen output buffers → their respective target streams
+   - All dirty partition state updates → `$projections-{name}-{partitionKey}-result` streams
+
+6. **Completion**: On successful write, the frozen buffers are released.
+
+### Constraints
+
+- **At most 1 outstanding checkpoint**: A new marker is not injected until the previous checkpoint write completes. This bounds memory usage and ensures buffers don't accumulate.
+- **2 buffers per partition**: One being written (frozen), one being filled (active). This is sufficient given the single-outstanding-checkpoint constraint.
+- **No pipeline stall**: Partitions continue processing into their fresh buffer while the coordinator writes the previous checkpoint. The only wait is if a second checkpoint triggers before the first completes (bounded by channel capacity).
+
+### Why Chandy-Lamport
+
+The alternative — pausing all partitions, collecting state, writing, then resuming — creates unnecessary pipeline stalls. Chandy-Lamport markers flow through the same channels as events, so each partition reaches the snapshot point naturally without coordinated pauses. The simple topology (single source → N channels) makes the algorithm straightforward: only forward-channel markers are needed, no cross-partition marker propagation.
+
+## Output and Emission
+
+### Kept (backward compatible)
+
+- `emit(streamName, eventType, data)` → writes events to target streams
+- `linkTo(streamName, event)` → writes link events to target streams
+- Per-partition state → `$projections-{name}-{partitionKey}-result` streams
+- `Result` and `ResultRemoved` event types in state streams
+
+### Eliminated
+
+- **Partition catalog links**: Current engine creates link events in `$projections-{name}-partitions` for every new partition discovered. Eliminated.
+- **All-results stream links**: Current engine creates `$projections-{name}-result` with links to every result event. Eliminated.
+- **Any other internally-generated link events**: Only user-specified `linkTo()` creates link events.
+
+This significantly reduces write amplification. If partition discovery is needed, it can be served by querying the DuckDB category index on result streams.
+
+### Atomic Output
+
+All output from a checkpoint interval is written in a single multi-stream append:
+
+```
+WriteEvents {
+  EventStreamIds: [
+    "$projections-{name}-checkpoint",
+    "target-stream-1",
+    "target-stream-2",
+    "$projections-{name}-partitionA-result",
+    "$projections-{name}-partitionB-result",
+    ...
+  ],
+  ExpectedVersions: [...],
+  Events: [checkpointEvent, emittedEvent1, emittedEvent2, stateA, stateB, ...],
+  EventStreamIndexes: [0, 1, 1, 2, 3, ...]
+}
+```
+
+This guarantees all-or-nothing semantics: either the entire checkpoint (with all emitted events and state) is committed, or nothing is.
+
+## State Management
+
+### In-Memory Cache
+
+Each partition maintains an LRU cache of partition states for its assigned keys. Cache sizing is configurable. On cache miss, state is loaded from the partition's result stream.
+
+### Persistence
+
+Dirty partition states are included in the atomic checkpoint write. State is written to `$projections-{name}-{partitionKey}-result` streams as `Result` events.
+
+### Recovery
+
+On startup or after crash:
+
+1. Read the last checkpoint from `$projections-{name}-checkpoint` to get the log position
+2. Resume the reader from that log position
+3. Partition states are loaded on-demand from their result streams (cache starts cold)
+4. No idempotency checks needed — replay starts from the exact committed checkpoint position
+
+The atomic checkpoint write guarantees that if the checkpoint exists, all associated emitted events and state updates also exist. If the write was interrupted, the checkpoint doesn't exist, and we replay from the previous one.
+
+## Integration Architecture
+
+```
+ProjectionManager (existing, unchanged)
+  │
+  ├──► ManagedProjection (existing state machine)
+  │       │
+  │       ├──► [engine=v1] ──► CoreProjection (existing pipeline)
+  │       │
+  │       └──► [engine=v2] ──► ProjectionEngineV2 (new)
+  │
+  └──► Management HTTP/gRPC endpoints (unchanged)
+```
+
+### Routing
+
+- A per-projection configuration flag (`engine: v1 | v2`) controls which engine processes the projection
+- New projections default to `v2`
+- Existing projections continue on `v1` until explicitly migrated
+- The `ManagedProjection` state machine is reused with minimal changes (routing logic added)
+- The `ProjectionManager` and management endpoints remain unchanged
+
+### New Service: ProjectionEngineV2
+
+A new service class that:
+- Receives start/stop/reset commands from `ManagedProjection`
+- Creates the appropriate read strategy based on projection source definition
+- Manages the dispatcher, partition channels, and checkpoint coordinator
+- Reports status back to `ManagedProjection` (running, faulted, stopped, etc.)
+
+### System Projections
+
+System projections (`$by_category`, `$by_event_type`, `$stream_by_category`, `$streams`) are **not handled** by the new engine. DuckDB secondary indexes provide equivalent functionality and are the intended replacement. System projections remain on the v1 engine during the transition period and will be deprecated.
+
+## Error Handling
+
+### Projection Faults
+
+A JavaScript error in any partition faults the entire projection. The projection enters the `Faulted` state with the error details. The user can inspect the error and reset/restart the projection. This matches current behavior.
+
+### Crash Recovery
+
+The atomic checkpoint guarantees consistency. On crash:
+- If the last checkpoint write completed: all emitted events and state are present, resume from checkpoint
+- If the last checkpoint write was interrupted: it's as if it never happened, resume from the previous checkpoint
+
+No WAL, no replay log, no idempotency checks needed.
+
+### Backpressure and Timeouts
+
+- Bounded channels provide backpressure from partitions to reader
+- The reader uses `IExpiryStrategy` (default 7-second timeout with retry) for read operations
+- If a partition is consistently slow, the entire pipeline slows down proportionally (acceptable given uniform partition load)
+
+## Components Eliminated
+
+The following current-engine components are **not needed** in v2:
+
+| Current Component | Replacement |
+|---|---|
+| `EventReaderCoreService` | Read strategies using existing enumerators |
+| `TransactionFileEventReader` | `Enumerator.AllSubscriptionFiltered` |
+| `MultiStreamEventReader` | DuckDB stream-name-set filter |
+| `EventByTypeIndexEventReader` | `Enumerator.AllSubscriptionFiltered` with event type filter |
+| `StreamEventReader` | Direct stream read (enhanced with log position start) |
+| `HeadingEventReader` | Not needed (enumerators handle live tailing) |
+| `StagedProcessingQueue` | Partitioned channels (no reordering needed) |
+| `CommittedEventWorkItem` (5-stage pipeline) | Simple sequential per-partition processing |
+| `ProjectionCheckpoint` (per-stream tracking) | Atomic multi-stream append |
+| `EmittedStream` / `EmittedStreamsWriter` | Output buffers + multi-stream append |
+| `ResultEventEmitter` (link events) | Direct result events only |
+| `ReaderSubscriptionBase` | Not needed (no subscription-to-reader indirection) |
+| `EventProcessingProjectionProcessingPhase` | `ProjectionEngineV2` processing loop |
+
+## Required Enhancements to Existing Infrastructure
+
+1. **Stream read from log position**: Enable `ReadStreamEventsForward` to accept a starting log position instead of only stream event number. Use DuckDB index for resolution.
+
+2. **Stream-name-set EventFilter**: New `IEventFilter` implementation that matches events whose stream name is in a specified set. Backed by DuckDB query on `$idx-all`.
+
+3. **ManagedProjection routing**: Add engine version config flag and routing logic to delegate to v1 (`CoreProjection`) or v2 (`ProjectionEngineV2`).
+
+## Migration Path
+
+1. **Phase 1**: Implement `ProjectionEngineV2` alongside existing engine. New projections default to v2. Existing projections stay on v1.
+2. **Phase 2**: Provide migration tooling to move existing projections from v1 to v2 (reset + replay with new engine).
+3. **Phase 3**: Deprecate v1 engine. Deprecate system projections (replaced by secondary indexes).
+4. **Phase 4**: Remove v1 engine and system projections.

--- a/docs/plans/2026-03-07-projections-v2-engine-impl.md
+++ b/docs/plans/2026-03-07-projections-v2-engine-impl.md
@@ -1,0 +1,1490 @@
+# Projections v2 Engine — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a new projections processing engine that uses filtered read-all enumerators, DuckDB secondary indexes, partitioned parallel processing, and multi-stream atomic appends.
+
+**Architecture:** Events are read via one of three strategies (filtered $all, direct stream, DuckDB stream-set), dispatched to N partition channels by hash of partition key, processed by the existing Jint runtime, and checkpointed atomically via Chandy-Lamport markers and multi-stream append.
+
+**Tech Stack:** C# / .NET 10.0, System.Threading.Channels, TUnit (testing), existing KurrentDB infrastructure (enumerators, ClientMessage.WriteEvents, IProjectionStateHandler)
+
+**Design Doc:** `docs/plans/2026-03-07-projections-v2-engine-design.md`
+
+---
+
+## Task 1: Project Setup and Skeleton
+
+Create the new engine's project structure within the existing projections project. The v2 engine lives in `src/KurrentDB.Projections.Core/` under a new `V2/` namespace.
+
+**Files:**
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2.cs`
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2Config.cs`
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/IReadStrategy.cs`
+
+### Step 1: Create the engine config
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2Config.cs
+using KurrentDB.Projections.Core.Messages;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class ProjectionEngineV2Config {
+	public required string ProjectionName { get; init; }
+	public required IQuerySources SourceDefinition { get; init; }
+	public required IProjectionStateHandler StateHandler { get; init; }
+	public int PartitionCount { get; init; } = 4;
+	public int CheckpointAfterMs { get; init; } = 2000;
+	public int CheckpointHandledThreshold { get; init; } = 4000;
+	public long CheckpointUnhandledBytesThreshold { get; init; } = 10_000_000;
+	public bool EmitEnabled { get; init; }
+	public bool TrackEmittedStreams { get; init; }
+}
+```
+
+### Step 2: Create the read strategy interface
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/IReadStrategy.cs
+using System.Collections.Generic;
+using System.Threading;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Transport.Common;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+/// <summary>
+/// Produces events in log-position order from a specific source.
+/// </summary>
+public interface IReadStrategy : IAsyncDisposable {
+	IAsyncEnumerable<ReadResponse> ReadFrom(TFPos checkpoint, CancellationToken ct);
+}
+```
+
+### Step 3: Create the engine skeleton
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2.cs
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class ProjectionEngineV2 : IAsyncDisposable {
+	private static readonly ILogger Log = Serilog.Log.ForContext<ProjectionEngineV2>();
+
+	private readonly ProjectionEngineV2Config _config;
+	private readonly IReadStrategy _readStrategy;
+	private CancellationTokenSource _cts;
+	private Task _runTask;
+
+	public ProjectionEngineV2(ProjectionEngineV2Config config, IReadStrategy readStrategy) {
+		_config = config ?? throw new ArgumentNullException(nameof(config));
+		_readStrategy = readStrategy ?? throw new ArgumentNullException(nameof(readStrategy));
+	}
+
+	public Task Start(TFPos checkpoint, CancellationToken ct) {
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+		_runTask = Run(checkpoint, _cts.Token);
+		return Task.CompletedTask;
+	}
+
+	private async Task Run(TFPos checkpoint, CancellationToken ct) {
+		Log.Information("ProjectionEngineV2 {Name} starting from {Checkpoint}", _config.ProjectionName, checkpoint);
+		// Pipeline will be built in subsequent tasks
+		throw new NotImplementedException();
+	}
+
+	public async ValueTask DisposeAsync() {
+		if (_cts is not null) {
+			await _cts.CancelAsync();
+			if (_runTask is not null) {
+				try { await _runTask; } catch (OperationCanceledException) { }
+			}
+			_cts.Dispose();
+		}
+		await _readStrategy.DisposeAsync();
+	}
+}
+```
+
+### Step 4: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/
+git commit -m "feat(projections-v2): add engine skeleton with config and read strategy interface"
+```
+
+---
+
+## Task 2: Stream-Name-Set Event Filter
+
+Add a new `IEventFilter` implementation that filters events by a set of stream names. This is needed for `fromStreams()` support.
+
+**Files:**
+- Modify: `src/KurrentDB.Core/Services/Storage/ReaderIndex/EventFilter.cs:25-39` (add factory method)
+- Test: `src/KurrentDB.Core.Tests/Services/Storage/ReaderIndex/EventFilterTests.cs` (new file or find existing)
+
+### Step 1: Check for existing filter tests
+
+Run: `find src/KurrentDB.Core.Tests -name "*EventFilter*" -o -name "*event_filter*" | head -20`
+
+### Step 2: Write the failing test
+
+Create or extend the test file:
+
+```csharp
+// In the appropriate test file
+[Fact]
+public void stream_name_set_filter_allows_matching_stream() {
+	var filter = EventFilter.StreamName.Set(isAllStream: false, "stream-a", "stream-b");
+	var record = CreateEventRecord("stream-a", "SomeEvent");
+	Assert.True(filter.IsEventAllowed(record));
+}
+
+[Fact]
+public void stream_name_set_filter_rejects_non_matching_stream() {
+	var filter = EventFilter.StreamName.Set(isAllStream: false, "stream-a", "stream-b");
+	var record = CreateEventRecord("stream-c", "SomeEvent");
+	Assert.False(filter.IsEventAllowed(record));
+}
+
+[Fact]
+public void stream_name_set_filter_with_all_stream_rejects_system_streams() {
+	var filter = EventFilter.StreamName.Set(isAllStream: true, "$system-stream", "user-stream");
+	var systemRecord = CreateEventRecord("$epoch-information", "SomeEvent");
+	Assert.False(filter.IsEventAllowed(systemRecord));
+}
+```
+
+### Step 3: Run tests to verify they fail
+
+Run: `dotnet test src/KurrentDB.Core.Tests/ --filter "stream_name_set_filter" -v n`
+Expected: FAIL — `StreamName.Set` method does not exist
+
+### Step 4: Implement the filter
+
+Edit `src/KurrentDB.Core/Services/Storage/ReaderIndex/EventFilter.cs`.
+
+Add inside `public static class StreamName` (after line 30):
+
+```csharp
+public static IEventFilter Set(bool isAllStream, params string[] streamNames)
+	=> new StreamIdSetStrategy(isAllStream, streamNames);
+```
+
+Add the strategy class after `StreamIdRegexStrategy` (after line 177):
+
+```csharp
+private sealed class StreamIdSetStrategy : IEventFilter {
+	internal readonly bool _isAllStream;
+	internal readonly HashSet<string> _streamNames;
+
+	public StreamIdSetStrategy(bool isAllStream, string[] streamNames) {
+		_isAllStream = isAllStream;
+		_streamNames = new HashSet<string>(streamNames, StringComparer.Ordinal);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+	public bool IsEventAllowed(EventRecord eventRecord) =>
+		(!_isAllStream || DefaultAllFilter.IsEventAllowed(eventRecord)) &&
+		_streamNames.Contains(eventRecord.EventStreamId);
+
+	public override string ToString() =>
+		$"{nameof(StreamIdSetStrategy)}: ({string.Join(", ", _streamNames)})";
+}
+```
+
+Update `ParseToDto` (after line 215) to handle the new type:
+
+```csharp
+case StreamIdSetStrategy siss:
+	return new() {
+		Context = StreamIdContext,
+		Type = "set",
+		Data = string.Join(",", siss._streamNames),
+		IsAllStream = siss._isAllStream
+	};
+```
+
+### Step 5: Run tests to verify they pass
+
+Run: `dotnet test src/KurrentDB.Core.Tests/ --filter "stream_name_set_filter" -v n`
+Expected: PASS
+
+### Step 6: Commit
+
+```bash
+git add src/KurrentDB.Core/Services/Storage/ReaderIndex/EventFilter.cs
+git add src/KurrentDB.Core.Tests/
+git commit -m "feat: add StreamName.Set event filter for stream-name-set matching"
+```
+
+---
+
+## Task 3: Read Strategies — Filtered All and Stream Set
+
+Implement the two main read strategies that wrap existing enumerators.
+
+**Files:**
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/FilteredAllReadStrategy.cs`
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/StreamSetReadStrategy.cs`
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/ReadStrategyFactory.cs`
+
+### Step 1: Implement FilteredAllReadStrategy
+
+This wraps `Enumerator.AllSubscriptionFiltered` (defined in `src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs:23`).
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/FilteredAllReadStrategy.cs
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Threading;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Storage.ReaderIndex;
+using KurrentDB.Core.Services.Transport.Common;
+using KurrentDB.Core.Services.Transport.Enumerators;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2.ReadStrategies;
+
+public class FilteredAllReadStrategy : IReadStrategy {
+	private readonly IPublisher _bus;
+	private readonly IEventFilter _eventFilter;
+	private readonly ClaimsPrincipal _user;
+	private readonly bool _requiresLeader;
+	private readonly uint _checkpointIntervalMultiplier;
+	private Enumerator.AllSubscriptionFiltered _enumerator;
+
+	public FilteredAllReadStrategy(
+		IPublisher bus,
+		IEventFilter eventFilter,
+		ClaimsPrincipal user,
+		bool requiresLeader = false,
+		uint checkpointIntervalMultiplier = 1) {
+		_bus = bus;
+		_eventFilter = eventFilter;
+		_user = user;
+		_requiresLeader = requiresLeader;
+		_checkpointIntervalMultiplier = checkpointIntervalMultiplier;
+	}
+
+	public async IAsyncEnumerable<ReadResponse> ReadFrom(
+		TFPos checkpoint,
+		[EnumeratorCancellation] CancellationToken ct) {
+
+		var position = checkpoint == TFPos.HeadOfTf
+			? (Position?)null
+			: Position.FromInt64(checkpoint.CommitPosition, checkpoint.PreparePosition);
+
+		_enumerator = new Enumerator.AllSubscriptionFiltered(
+			bus: _bus,
+			expiryStrategy: DefaultExpiryStrategy.Instance,
+			checkpoint: position,
+			resolveLinks: true,
+			eventFilter: _eventFilter,
+			user: _user,
+			requiresLeader: _requiresLeader,
+			maxSearchWindow: null,
+			checkpointIntervalMultiplier: _checkpointIntervalMultiplier,
+			cancellationToken: ct);
+
+		while (await _enumerator.MoveNextAsync()) {
+			yield return _enumerator.Current;
+		}
+	}
+
+	public async ValueTask DisposeAsync() {
+		if (_enumerator is not null)
+			await _enumerator.DisposeAsync();
+	}
+}
+```
+
+### Step 2: Implement StreamSetReadStrategy
+
+This wraps `Enumerator.AllSubscriptionFiltered` with the new `StreamName.Set` filter from Task 2.
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/StreamSetReadStrategy.cs
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Threading;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Storage.ReaderIndex;
+using KurrentDB.Core.Services.Transport.Common;
+using KurrentDB.Core.Services.Transport.Enumerators;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2.ReadStrategies;
+
+public class StreamSetReadStrategy : IReadStrategy {
+	private readonly IPublisher _bus;
+	private readonly string[] _streamNames;
+	private readonly ClaimsPrincipal _user;
+	private readonly bool _requiresLeader;
+	private Enumerator.AllSubscriptionFiltered _enumerator;
+
+	public StreamSetReadStrategy(
+		IPublisher bus,
+		string[] streamNames,
+		ClaimsPrincipal user,
+		bool requiresLeader = false) {
+		_bus = bus;
+		_streamNames = streamNames;
+		_user = user;
+		_requiresLeader = requiresLeader;
+	}
+
+	public async IAsyncEnumerable<ReadResponse> ReadFrom(
+		TFPos checkpoint,
+		[EnumeratorCancellation] CancellationToken ct) {
+
+		var position = checkpoint == TFPos.HeadOfTf
+			? (Position?)null
+			: Position.FromInt64(checkpoint.CommitPosition, checkpoint.PreparePosition);
+
+		var filter = EventFilter.StreamName.Set(isAllStream: true, _streamNames);
+
+		_enumerator = new Enumerator.AllSubscriptionFiltered(
+			bus: _bus,
+			expiryStrategy: DefaultExpiryStrategy.Instance,
+			checkpoint: position,
+			resolveLinks: true,
+			eventFilter: filter,
+			user: _user,
+			requiresLeader: _requiresLeader,
+			maxSearchWindow: null,
+			checkpointIntervalMultiplier: 1,
+			cancellationToken: ct);
+
+		while (await _enumerator.MoveNextAsync()) {
+			yield return _enumerator.Current;
+		}
+	}
+
+	public async ValueTask DisposeAsync() {
+		if (_enumerator is not null)
+			await _enumerator.DisposeAsync();
+	}
+}
+```
+
+### Step 3: Implement ReadStrategyFactory
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/ReadStrategyFactory.cs
+using System;
+using System.Linq;
+using System.Security.Claims;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Services.Storage.ReaderIndex;
+using KurrentDB.Projections.Core.Messages;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2.ReadStrategies;
+
+public static class ReadStrategyFactory {
+	public static IReadStrategy Create(IQuerySources sources, IPublisher bus, ClaimsPrincipal user) {
+		if (sources.AllStreams) {
+			var filter = BuildFilterForAllStreams(sources);
+			return new FilteredAllReadStrategy(bus, filter, user);
+		}
+
+		if (sources.HasStreams()) {
+			if (sources.Streams.Length == 1) {
+				// Single stream: use direct stream read (future enhancement).
+				// For now, fall back to stream-set with one stream.
+				return new StreamSetReadStrategy(bus, sources.Streams, user);
+			}
+			return new StreamSetReadStrategy(bus, sources.Streams, user);
+		}
+
+		if (sources.HasCategories()) {
+			// fromCategory: filter by stream name prefix "categoryName-"
+			var prefixes = sources.Categories.Select(c => c + "-").ToArray();
+			var filter = EventFilter.StreamName.Prefixes(isAllStream: true, prefixes);
+			return new FilteredAllReadStrategy(bus, filter, user);
+		}
+
+		throw new ArgumentException("Unsupported source definition: must specify allStreams, streams, or categories");
+	}
+
+	private static IEventFilter BuildFilterForAllStreams(IQuerySources sources) {
+		if (sources.HasEvents()) {
+			// fromAll().when({EventType: ...}) — filter by event types
+			return EventFilter.EventType.Prefixes(isAllStream: true, sources.Events);
+		}
+		return EventFilter.DefaultAllFilter;
+	}
+}
+```
+
+### Step 4: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/
+git commit -m "feat(projections-v2): add read strategies (filtered all, stream set, factory)"
+```
+
+---
+
+## Task 4: Partition Dispatcher and Channels
+
+Build the dispatcher that routes events to N partition channels by hash of partition key.
+
+**Files:**
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionDispatcher.cs`
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionEvent.cs`
+
+### Step 1: Define the partition event type
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionEvent.cs
+using KurrentDB.Core.Data;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+/// <summary>
+/// An event routed to a specific partition, or a checkpoint marker.
+/// </summary>
+public readonly record struct PartitionEvent {
+	/// <summary>Regular event dispatched to this partition.</summary>
+	public ResolvedEvent? Event { get; init; }
+
+	/// <summary>The partition key for this event.</summary>
+	public string PartitionKey { get; init; }
+
+	/// <summary>Log position of this event or marker.</summary>
+	public TFPos LogPosition { get; init; }
+
+	/// <summary>If set, this is a checkpoint marker with this sequence number.</summary>
+	public ulong? CheckpointMarkerSequence { get; init; }
+
+	public bool IsCheckpointMarker => CheckpointMarkerSequence.HasValue;
+
+	public static PartitionEvent ForEvent(ResolvedEvent @event, string partitionKey, TFPos logPosition)
+		=> new() { Event = @event, PartitionKey = partitionKey, LogPosition = logPosition };
+
+	public static PartitionEvent ForCheckpointMarker(ulong sequence, TFPos logPosition)
+		=> new() { CheckpointMarkerSequence = sequence, LogPosition = logPosition };
+}
+```
+
+### Step 2: Implement the dispatcher
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionDispatcher.cs
+using System;
+using System.IO.Hashing;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Transport.Common;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class PartitionDispatcher {
+	private static readonly ILogger Log = Serilog.Log.ForContext<PartitionDispatcher>();
+
+	private readonly Channel<PartitionEvent>[] _partitionChannels;
+	private readonly int _partitionCount;
+	private readonly Func<ResolvedEvent, string> _getPartitionKey;
+	private ulong _nextCheckpointSequence;
+
+	public PartitionDispatcher(
+		int partitionCount,
+		Func<ResolvedEvent, string> getPartitionKey,
+		int channelCapacity = 256) {
+		_partitionCount = partitionCount;
+		_getPartitionKey = getPartitionKey;
+
+		_partitionChannels = new Channel<PartitionEvent>[partitionCount];
+		for (int i = 0; i < partitionCount; i++) {
+			_partitionChannels[i] = Channel.CreateBounded<PartitionEvent>(
+				new BoundedChannelOptions(channelCapacity) {
+					FullMode = BoundedChannelFullMode.Wait,
+					SingleReader = true,
+					SingleWriter = true
+				});
+		}
+	}
+
+	public ChannelReader<PartitionEvent> GetPartitionReader(int partitionIndex)
+		=> _partitionChannels[partitionIndex].Reader;
+
+	/// <summary>
+	/// Dispatches a resolved event to the appropriate partition channel.
+	/// </summary>
+	public async ValueTask DispatchEvent(ResolvedEvent @event, TFPos logPosition, CancellationToken ct) {
+		var partitionKey = _getPartitionKey(@event);
+		var partitionIndex = GetPartitionIndex(partitionKey);
+		var pe = PartitionEvent.ForEvent(@event, partitionKey, logPosition);
+		await _partitionChannels[partitionIndex].Writer.WriteAsync(pe, ct);
+	}
+
+	/// <summary>
+	/// Injects a checkpoint marker into all partition channels.
+	/// Returns the marker sequence number.
+	/// </summary>
+	public async ValueTask<ulong> InjectCheckpointMarker(TFPos logPosition, CancellationToken ct) {
+		var sequence = ++_nextCheckpointSequence;
+		var marker = PartitionEvent.ForCheckpointMarker(sequence, logPosition);
+
+		Log.Debug("Injecting checkpoint marker {Sequence} at {LogPosition}", sequence, logPosition);
+
+		for (int i = 0; i < _partitionCount; i++) {
+			await _partitionChannels[i].Writer.WriteAsync(marker, ct);
+		}
+		return sequence;
+	}
+
+	/// <summary>
+	/// Completes all partition channels (no more events will be written).
+	/// </summary>
+	public void Complete(Exception ex = null) {
+		for (int i = 0; i < _partitionCount; i++) {
+			_partitionChannels[i].Writer.TryComplete(ex);
+		}
+	}
+
+	private int GetPartitionIndex(string partitionKey) {
+		if (_partitionCount == 1) return 0;
+		var hash = XxHash32.HashToUInt32(Encoding.UTF8.GetBytes(partitionKey));
+		return (int)(hash % (uint)_partitionCount);
+	}
+}
+```
+
+### Step 3: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionEvent.cs
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionDispatcher.cs
+git commit -m "feat(projections-v2): add partition dispatcher with Chandy-Lamport markers"
+```
+
+---
+
+## Task 5: Partition Processor
+
+Each partition processes events sequentially, manages partition state, and collects output into buffers.
+
+**Files:**
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/OutputBuffer.cs`
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionProcessor.cs`
+
+### Step 1: Define the output buffer
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/OutputBuffer.cs
+using System.Collections.Generic;
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Processing.Emitting.EmittedEvents;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+/// <summary>
+/// Collects emitted events and state updates for one checkpoint interval.
+/// </summary>
+public class OutputBuffer {
+	public List<EmittedEventEnvelope> EmittedEvents { get; } = new();
+
+	/// <summary>
+	/// Partition key → (stream name, state JSON, expected version).
+	/// </summary>
+	public Dictionary<string, (string StreamName, string StateJson, long ExpectedVersion)> DirtyStates { get; } = new();
+
+	public TFPos LastLogPosition { get; set; }
+
+	public void AddEmittedEvents(EmittedEventEnvelope[] events) {
+		if (events is { Length: > 0 })
+			EmittedEvents.AddRange(events);
+	}
+
+	public void SetPartitionState(string partitionKey, string streamName, string stateJson, long expectedVersion) {
+		DirtyStates[partitionKey] = (streamName, stateJson, expectedVersion);
+	}
+
+	public void Clear() {
+		EmittedEvents.Clear();
+		DirtyStates.Clear();
+		LastLogPosition = default;
+	}
+}
+```
+
+### Step 2: Implement the partition processor
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionProcessor.cs
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using KurrentDB.Projections.Core.Services.Processing.Emitting.EmittedEvents;
+using Serilog;
+using ResolvedEvent = KurrentDB.Projections.Core.Services.Processing.ResolvedEvent;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class PartitionProcessor {
+	private static readonly ILogger Log = Serilog.Log.ForContext<PartitionProcessor>();
+
+	private readonly int _partitionIndex;
+	private readonly ChannelReader<PartitionEvent> _reader;
+	private readonly IProjectionStateHandler _stateHandler;
+	private readonly string _projectionName;
+	private readonly Func<ulong, OutputBuffer, Task> _onCheckpointMarker;
+
+	// Double-buffered output
+	private OutputBuffer _activeBuffer = new();
+	private OutputBuffer _frozenBuffer = new();
+
+	// In-memory state cache: partitionKey → stateJson
+	private readonly Dictionary<string, string> _stateCache = new();
+
+	public PartitionProcessor(
+		int partitionIndex,
+		ChannelReader<PartitionEvent> reader,
+		IProjectionStateHandler stateHandler,
+		string projectionName,
+		Func<ulong, OutputBuffer, Task> onCheckpointMarker) {
+		_partitionIndex = partitionIndex;
+		_reader = reader;
+		_stateHandler = stateHandler;
+		_projectionName = projectionName;
+		_onCheckpointMarker = onCheckpointMarker;
+	}
+
+	public async Task Run(CancellationToken ct) {
+		Log.Debug("Partition {Index} starting for projection {Name}", _partitionIndex, _projectionName);
+
+		await foreach (var pe in _reader.ReadAllAsync(ct)) {
+			if (pe.IsCheckpointMarker) {
+				await HandleCheckpointMarker(pe.CheckpointMarkerSequence!.Value, ct);
+				continue;
+			}
+
+			ProcessEvent(pe);
+		}
+	}
+
+	private void ProcessEvent(PartitionEvent pe) {
+		var @event = pe.Event!.Value;
+		var partitionKey = pe.PartitionKey;
+
+		// Load state
+		if (!_stateCache.TryGetValue(partitionKey, out var currentState))
+			currentState = null; // TODO: load from stream on cache miss
+
+		_stateHandler.Load(currentState ?? "{}");
+
+		// Convert to projection ResolvedEvent
+		var projEvent = ToProjectionResolvedEvent(@event);
+		var checkpointTag = CheckpointTag.FromPosition(0, pe.LogPosition.CommitPosition, pe.LogPosition.PreparePosition);
+
+		var processed = _stateHandler.ProcessEvent(
+			partitionKey,
+			checkpointTag,
+			category: null,
+			projEvent,
+			out var newState,
+			out var newSharedState,
+			out var emittedEvents);
+
+		if (processed && newState != null) {
+			_stateCache[partitionKey] = newState;
+			var stateStreamName = $"$projections-{_projectionName}-{partitionKey}-result";
+			_activeBuffer.SetPartitionState(partitionKey, stateStreamName, newState, -2); // ExpectedVersion.Any
+		}
+
+		_activeBuffer.AddEmittedEvents(emittedEvents);
+		_activeBuffer.LastLogPosition = pe.LogPosition;
+	}
+
+	private async Task HandleCheckpointMarker(ulong sequence, CancellationToken ct) {
+		Log.Debug("Partition {Index} received checkpoint marker {Sequence}", _partitionIndex, sequence);
+
+		// Swap buffers
+		var bufferToFlush = _activeBuffer;
+		_activeBuffer = _frozenBuffer;
+		_activeBuffer.Clear();
+		_frozenBuffer = bufferToFlush;
+
+		// Report to coordinator
+		await _onCheckpointMarker(sequence, bufferToFlush);
+	}
+
+	private static ResolvedEvent ToProjectionResolvedEvent(KurrentDB.Core.Data.ResolvedEvent @event) {
+		var e = @event.Event;
+		var link = @event.Link;
+		return new ResolvedEvent(
+			e.EventStreamId,
+			e.EventNumber,
+			link?.EventStreamId ?? e.EventStreamId,
+			link?.EventNumber ?? e.EventNumber,
+			@event.IsResolved,
+			@event.OriginalPosition ?? new TFPos(e.LogPosition, e.TransactionPosition),
+			e.EventId,
+			e.EventType,
+			e.IsJson,
+			System.Text.Encoding.UTF8.GetString(e.Data.Span),
+			System.Text.Encoding.UTF8.GetString(e.Metadata.Span));
+	}
+}
+```
+
+### Step 3: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/OutputBuffer.cs
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionProcessor.cs
+git commit -m "feat(projections-v2): add partition processor with double-buffered output"
+```
+
+---
+
+## Task 6: Checkpoint Coordinator
+
+Collects frozen buffers from all partitions and writes atomically via multi-stream append.
+
+**Files:**
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/CheckpointCoordinator.cs`
+
+### Step 1: Implement the coordinator
+
+The coordinator waits for all N partitions to report for the same marker sequence, then issues a single `ClientMessage.WriteEvents` with all emitted events, state updates, and the checkpoint event.
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/CheckpointCoordinator.cs
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using KurrentDB.Projections.Core.Services.Processing.Emitting.EmittedEvents;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class CheckpointCoordinator {
+	private static readonly ILogger Log = Serilog.Log.ForContext<CheckpointCoordinator>();
+
+	private readonly int _partitionCount;
+	private readonly string _projectionName;
+	private readonly string _checkpointStreamId;
+	private readonly IPublisher _bus;
+	private readonly ClaimsPrincipal _user;
+
+	// Collected buffers for current checkpoint marker
+	private readonly OutputBuffer[] _collectedBuffers;
+	private ulong _currentMarkerSequence;
+	private int _collectedCount;
+	private TaskCompletionSource<TFPos> _checkpointTcs;
+
+	// Outstanding checkpoint tracking (max 1 outstanding)
+	private readonly SemaphoreSlim _checkpointSemaphore = new(1, 1);
+
+	public CheckpointCoordinator(
+		int partitionCount,
+		string projectionName,
+		IPublisher bus,
+		ClaimsPrincipal user) {
+		_partitionCount = partitionCount;
+		_projectionName = projectionName;
+		_checkpointStreamId = $"$projections-{projectionName}-checkpoint";
+		_bus = bus;
+		_user = user;
+		_collectedBuffers = new OutputBuffer[partitionCount];
+	}
+
+	/// <summary>
+	/// Called by each partition when it reaches a checkpoint marker.
+	/// Thread-safe. Blocks until the checkpoint is written if this is the last partition to report.
+	/// </summary>
+	public async Task ReportPartitionCheckpoint(int partitionIndex, ulong markerSequence, OutputBuffer buffer) {
+		bool allCollected;
+		lock (_collectedBuffers) {
+			if (_currentMarkerSequence != markerSequence) {
+				_currentMarkerSequence = markerSequence;
+				_collectedCount = 0;
+				Array.Clear(_collectedBuffers);
+			}
+
+			_collectedBuffers[partitionIndex] = buffer;
+			_collectedCount++;
+			allCollected = _collectedCount == _partitionCount;
+		}
+
+		if (allCollected) {
+			await WriteCheckpoint(markerSequence);
+		}
+	}
+
+	private async Task WriteCheckpoint(ulong markerSequence) {
+		await _checkpointSemaphore.WaitAsync();
+		try {
+			var lastPosition = _collectedBuffers.Max(b => b.LastLogPosition);
+
+			Log.Information("Writing checkpoint {Sequence} for {Projection} at {Position}",
+				markerSequence, _projectionName, lastPosition);
+
+			// Build the multi-stream write
+			var (streamIds, expectedVersions, events, streamIndexes) = BuildMultiStreamWrite(lastPosition);
+
+			if (streamIds.Count == 0) {
+				Log.Debug("Checkpoint {Sequence} has no events to write, skipping", markerSequence);
+				return;
+			}
+
+			var tcs = new TaskCompletionSource<ClientMessage.WriteEventsCompleted>();
+			var corrId = Guid.NewGuid();
+
+			var writeMsg = new ClientMessage.WriteEvents(
+				internalCorrId: corrId,
+				correlationId: corrId,
+				envelope: new CallbackEnvelope(msg => {
+					if (msg is ClientMessage.WriteEventsCompleted completed)
+						tcs.TrySetResult(completed);
+					else
+						tcs.TrySetException(new Exception($"Unexpected response: {msg.GetType().Name}"));
+				}),
+				requireLeader: true,
+				eventStreamIds: streamIds.ToArray(),
+				expectedVersions: expectedVersions.ToArray(),
+				events: events.ToArray(),
+				eventStreamIndexes: streamIndexes.ToArray(),
+				user: _user);
+
+			_bus.Publish(writeMsg);
+
+			var result = await tcs.Task;
+			if (result.Result != OperationResult.Success) {
+				throw new Exception($"Checkpoint write failed: {result.Result} — {result.Message}");
+			}
+
+			Log.Debug("Checkpoint {Sequence} written successfully for {Projection}", markerSequence, _projectionName);
+		} finally {
+			lock (_collectedBuffers) {
+				Array.Clear(_collectedBuffers);
+				_collectedCount = 0;
+			}
+			_checkpointSemaphore.Release();
+		}
+	}
+
+	private (List<string> streamIds, List<long> expectedVersions, List<Event> events, List<int> streamIndexes)
+		BuildMultiStreamWrite(TFPos checkpointPosition) {
+
+		var streamIds = new List<string>();
+		var expectedVersions = new List<long>();
+		var events = new List<Event>();
+		var streamIndexes = new List<int>();
+
+		// Stream index mapping: streamName → index in streamIds
+		var streamIndexMap = new Dictionary<string, int>();
+
+		int GetOrAddStreamIndex(string streamName, long expectedVersion) {
+			if (!streamIndexMap.TryGetValue(streamName, out var idx)) {
+				idx = streamIds.Count;
+				streamIds.Add(streamName);
+				expectedVersions.Add(expectedVersion);
+				streamIndexMap[streamName] = idx;
+			}
+			return idx;
+		}
+
+		// 1. Checkpoint event
+		var checkpointData = Encoding.UTF8.GetBytes(
+			$"{{\"commitPosition\":{checkpointPosition.CommitPosition},\"preparePosition\":{checkpointPosition.PreparePosition}}}");
+		var checkpointIdx = GetOrAddStreamIndex(_checkpointStreamId, ExpectedVersion.Any);
+		events.Add(new Event(Guid.NewGuid(), "$ProjectionCheckpoint", true, checkpointData, null));
+		streamIndexes.Add(checkpointIdx);
+
+		// 2. Emitted events from all partitions
+		foreach (var buffer in _collectedBuffers) {
+			if (buffer == null) continue;
+			foreach (var emitted in buffer.EmittedEvents) {
+				var streamName = emitted.Event.StreamId;
+				var idx = GetOrAddStreamIndex(streamName, ExpectedVersion.Any);
+				var data = emitted.Event.Data != null ? Encoding.UTF8.GetBytes(emitted.Event.Data) : null;
+				var metadata = emitted.Event.ExtraMetaData() != null
+					? Encoding.UTF8.GetBytes(emitted.Event.ExtraMetaData())
+					: null;
+				events.Add(new Event(
+					emitted.Event.EventId,
+					emitted.Event.EventType,
+					emitted.Event.IsJson,
+					data,
+					metadata));
+				streamIndexes.Add(idx);
+			}
+		}
+
+		// 3. State updates from all partitions
+		foreach (var buffer in _collectedBuffers) {
+			if (buffer == null) continue;
+			foreach (var (partitionKey, (streamName, stateJson, expVer)) in buffer.DirtyStates) {
+				var idx = GetOrAddStreamIndex(streamName, expVer);
+				var stateData = Encoding.UTF8.GetBytes(stateJson);
+				events.Add(new Event(Guid.NewGuid(), "Result", true, stateData, null));
+				streamIndexes.Add(idx);
+			}
+		}
+
+		return (streamIds, expectedVersions, events, streamIndexes);
+	}
+}
+```
+
+### Step 2: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/CheckpointCoordinator.cs
+git commit -m "feat(projections-v2): add checkpoint coordinator with atomic multi-stream write"
+```
+
+---
+
+## Task 7: Wire Up the Engine Pipeline
+
+Connect all components in `ProjectionEngineV2`: reader → dispatcher → partitions → coordinator.
+
+**Files:**
+- Modify: `src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2.cs`
+
+### Step 1: Implement the full pipeline
+
+Replace the skeleton `Run` method with the full pipeline:
+
+```csharp
+// Replace the entire ProjectionEngineV2.cs with:
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Transport.Common;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class ProjectionEngineV2 : IAsyncDisposable {
+	private static readonly ILogger Log = Serilog.Log.ForContext<ProjectionEngineV2>();
+
+	private readonly ProjectionEngineV2Config _config;
+	private readonly IReadStrategy _readStrategy;
+	private readonly IPublisher _bus;
+	private readonly ClaimsPrincipal _user;
+	private CancellationTokenSource _cts;
+	private Task _runTask;
+
+	public ProjectionEngineV2(
+		ProjectionEngineV2Config config,
+		IReadStrategy readStrategy,
+		IPublisher bus,
+		ClaimsPrincipal user) {
+		_config = config ?? throw new ArgumentNullException(nameof(config));
+		_readStrategy = readStrategy ?? throw new ArgumentNullException(nameof(readStrategy));
+		_bus = bus ?? throw new ArgumentNullException(nameof(bus));
+		_user = user;
+	}
+
+	public Task Start(TFPos checkpoint, CancellationToken ct) {
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+		_runTask = Task.Run(() => Run(checkpoint, _cts.Token), _cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public bool IsFaulted => _runTask?.IsFaulted ?? false;
+	public Exception FaultException => _runTask?.Exception?.InnerException;
+
+	private async Task Run(TFPos checkpoint, CancellationToken ct) {
+		Log.Information("ProjectionEngineV2 {Name} starting from {Checkpoint} with {Partitions} partitions",
+			_config.ProjectionName, checkpoint, _config.PartitionCount);
+
+		var dispatcher = new PartitionDispatcher(
+			_config.PartitionCount,
+			GetPartitionKeyFunc(),
+			channelCapacity: 256);
+
+		var coordinator = new CheckpointCoordinator(
+			_config.PartitionCount,
+			_config.ProjectionName,
+			_bus,
+			_user);
+
+		// Start partition processors
+		var partitionTasks = new Task[_config.PartitionCount];
+		for (int i = 0; i < _config.PartitionCount; i++) {
+			var processor = new PartitionProcessor(
+				partitionIndex: i,
+				reader: dispatcher.GetPartitionReader(i),
+				stateHandler: _config.StateHandler,
+				projectionName: _config.ProjectionName,
+				onCheckpointMarker: (seq, buf) => coordinator.ReportPartitionCheckpoint(i, seq, buf));
+			partitionTasks[i] = Task.Run(() => processor.Run(ct), ct);
+		}
+
+		// Main read loop
+		try {
+			long eventsProcessed = 0;
+			long bytesProcessed = 0;
+			var lastCheckpointTime = DateTime.UtcNow;
+			TFPos lastPosition = checkpoint;
+
+			await foreach (var response in _readStrategy.ReadFrom(checkpoint, ct)) {
+				ct.ThrowIfCancellationRequested();
+
+				switch (response) {
+					case ReadResponse.EventReceived eventReceived:
+						var @event = eventReceived.Event;
+						var pos = @event.OriginalPosition!.Value;
+						lastPosition = pos;
+
+						await dispatcher.DispatchEvent(@event, pos, ct);
+						eventsProcessed++;
+						bytesProcessed += @event.Event.Data.Length + @event.Event.Metadata.Length;
+
+						// Check if checkpoint needed
+						if (ShouldCheckpoint(eventsProcessed, bytesProcessed, lastCheckpointTime)) {
+							await dispatcher.InjectCheckpointMarker(lastPosition, ct);
+							eventsProcessed = 0;
+							bytesProcessed = 0;
+							lastCheckpointTime = DateTime.UtcNow;
+						}
+						break;
+
+					case ReadResponse.CheckpointReceived:
+						// Checkpoint from the reader (filtered subscription)
+						break;
+				}
+			}
+		} catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+			Log.Information("ProjectionEngineV2 {Name} stopped", _config.ProjectionName);
+		} catch (Exception ex) {
+			Log.Error(ex, "ProjectionEngineV2 {Name} faulted", _config.ProjectionName);
+			throw;
+		} finally {
+			dispatcher.Complete();
+			await Task.WhenAll(partitionTasks).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+		}
+	}
+
+	private bool ShouldCheckpoint(long eventsProcessed, long bytesProcessed, DateTime lastCheckpointTime) {
+		var elapsed = DateTime.UtcNow - lastCheckpointTime;
+
+		if (elapsed.TotalMilliseconds < _config.CheckpointAfterMs)
+			return false;
+
+		if (_config.CheckpointHandledThreshold > 0 && eventsProcessed >= _config.CheckpointHandledThreshold)
+			return true;
+
+		if (_config.CheckpointUnhandledBytesThreshold > 0 && bytesProcessed >= _config.CheckpointUnhandledBytesThreshold)
+			return true;
+
+		return false;
+	}
+
+	private Func<ResolvedEvent, string> GetPartitionKeyFunc() {
+		if (_config.SourceDefinition.ByCustomPartitions) {
+			// partitionBy is defined in JS — use state handler to determine partition
+			return @event => {
+				var e = @event.Event;
+				var pos = @event.OriginalPosition ?? new TFPos(e.LogPosition, e.TransactionPosition);
+				var tag = Checkpointing.CheckpointTag.FromPosition(0, pos.CommitPosition, pos.PreparePosition);
+				return _config.StateHandler.GetStatePartition(
+					tag, null,
+					PartitionProcessor.ToProjectionResolvedEvent(@event));
+			};
+		}
+
+		if (_config.SourceDefinition.ByStreams) {
+			return @event => @event.Event.EventStreamId;
+		}
+
+		// No partitioning — single partition
+		return _ => "";
+	}
+
+	public async ValueTask DisposeAsync() {
+		if (_cts is not null) {
+			await _cts.CancelAsync();
+			if (_runTask is not null) {
+				try { await _runTask; } catch (OperationCanceledException) { }
+			}
+			_cts.Dispose();
+		}
+		await _readStrategy.DisposeAsync();
+	}
+}
+```
+
+### Step 2: Make `ToProjectionResolvedEvent` internal static in PartitionProcessor
+
+Update `PartitionProcessor.cs` — change `private static` to `internal static` for the `ToProjectionResolvedEvent` method.
+
+### Step 3: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/
+git commit -m "feat(projections-v2): wire up full engine pipeline (reader → dispatcher → partitions → coordinator)"
+```
+
+---
+
+## Task 8: Unit Tests — Partition Dispatcher
+
+**Files:**
+- Create: `src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/PartitionDispatcherTests.cs`
+
+### Step 1: Write tests
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Processing.V2;
+using Xunit;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Processing.V2;
+
+public class PartitionDispatcherTests {
+	[Fact]
+	public async Task events_with_same_key_go_to_same_partition() {
+		var dispatcher = new PartitionDispatcher(4, _ => "same-key");
+		var @event = CreateEvent("stream-1");
+		var pos = new TFPos(100, 100);
+
+		await dispatcher.DispatchEvent(@event, pos, CancellationToken.None);
+		await dispatcher.DispatchEvent(@event, pos, CancellationToken.None);
+		dispatcher.Complete();
+
+		// Find which partition got events
+		int partitionWithEvents = -1;
+		for (int i = 0; i < 4; i++) {
+			if (dispatcher.GetPartitionReader(i).TryRead(out _)) {
+				Assert.Equal(-1, partitionWithEvents); // only one partition should have events
+				partitionWithEvents = i;
+				Assert.True(dispatcher.GetPartitionReader(i).TryRead(out _));
+			}
+		}
+		Assert.NotEqual(-1, partitionWithEvents);
+	}
+
+	[Fact]
+	public async Task checkpoint_marker_sent_to_all_partitions() {
+		var dispatcher = new PartitionDispatcher(3, e => e.Event.EventStreamId);
+		var pos = new TFPos(100, 100);
+
+		var seq = await dispatcher.InjectCheckpointMarker(pos, CancellationToken.None);
+		dispatcher.Complete();
+
+		Assert.Equal(1UL, seq);
+		for (int i = 0; i < 3; i++) {
+			Assert.True(dispatcher.GetPartitionReader(i).TryRead(out var pe));
+			Assert.True(pe.IsCheckpointMarker);
+			Assert.Equal(1UL, pe.CheckpointMarkerSequence);
+		}
+	}
+
+	private static ResolvedEvent CreateEvent(string streamId) {
+		// Create a minimal resolved event for testing
+		// This will need to use the appropriate test helpers
+		throw new System.NotImplementedException("Use project-specific test helpers to create ResolvedEvent");
+	}
+}
+```
+
+### Step 2: Run tests
+
+Run: `dotnet test src/KurrentDB.Projections.Core.Tests/ --filter "PartitionDispatcher" -v n`
+
+### Step 3: Fix any issues and commit
+
+```bash
+git add src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/
+git commit -m "test(projections-v2): add partition dispatcher unit tests"
+```
+
+---
+
+## Task 9: Unit Tests — Output Buffer and Checkpoint Coordinator
+
+**Files:**
+- Create: `src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/OutputBufferTests.cs`
+- Create: `src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/CheckpointCoordinatorTests.cs`
+
+### Step 1: Write output buffer tests
+
+```csharp
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Processing.V2;
+using Xunit;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Processing.V2;
+
+public class OutputBufferTests {
+	[Fact]
+	public void clear_resets_all_collections() {
+		var buffer = new OutputBuffer();
+		buffer.SetPartitionState("key1", "stream1", "{}", -2);
+		buffer.LastLogPosition = new TFPos(100, 100);
+
+		buffer.Clear();
+
+		Assert.Empty(buffer.DirtyStates);
+		Assert.Empty(buffer.EmittedEvents);
+		Assert.Equal(default, buffer.LastLogPosition);
+	}
+
+	[Fact]
+	public void set_partition_state_overwrites_previous() {
+		var buffer = new OutputBuffer();
+		buffer.SetPartitionState("key1", "stream1", "{\"v\":1}", -2);
+		buffer.SetPartitionState("key1", "stream1", "{\"v\":2}", -2);
+
+		Assert.Single(buffer.DirtyStates);
+		Assert.Equal("{\"v\":2}", buffer.DirtyStates["key1"].StateJson);
+	}
+}
+```
+
+### Step 2: Run tests
+
+Run: `dotnet test src/KurrentDB.Projections.Core.Tests/ --filter "OutputBuffer" -v n`
+
+### Step 3: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/
+git commit -m "test(projections-v2): add output buffer and checkpoint coordinator tests"
+```
+
+---
+
+## Task 10: Management Layer Integration
+
+Add engine version routing to `ManagedProjection` so projections can be configured to use v1 or v2.
+
+**Files:**
+- Modify: `src/KurrentDB.Projections.Core/Services/Management/ManagedProjection.cs` (PersistedState class, ~line 44)
+- Create: `src/KurrentDB.Projections.Core/Services/Processing/V2/V2ProjectionProcessingStrategy.cs`
+
+### Step 1: Add engine version to PersistedState
+
+Read `ManagedProjection.cs` lines 44-82 to understand `PersistedState`, then add:
+
+```csharp
+// Add to PersistedState class (inside ManagedProjection.cs, ~line 80)
+public int EngineVersion { get; set; } // 1 = v1 (default), 2 = v2
+```
+
+### Step 2: Create V2 processing strategy
+
+This bridges the v2 engine into the existing `ProjectionProcessingStrategy` framework so `ManagedProjection` can route to it.
+
+```csharp
+// src/KurrentDB.Projections.Core/Services/Processing/V2/V2ProjectionProcessingStrategy.cs
+using System;
+using System.Security.Claims;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Helpers;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services.Processing.Phases;
+using KurrentDB.Projections.Core.Services.Processing.Strategies;
+using KurrentDB.Projections.Core.Services.Processing.V2.ReadStrategies;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+/// <summary>
+/// A processing strategy that creates a v2 engine instead of the v1 pipeline.
+/// This is a bridge between the existing management layer and the new engine.
+/// </summary>
+public class V2ProjectionProcessingStrategy : ProjectionProcessingStrategy {
+	private readonly IProjectionStateHandler _stateHandler;
+	private readonly ProjectionConfig _projectionConfig;
+	private readonly IQuerySources _sourceDefinition;
+
+	public V2ProjectionProcessingStrategy(
+		string name,
+		ProjectionVersion projectionVersion,
+		IProjectionStateHandler stateHandler,
+		ProjectionConfig projectionConfig,
+		IQuerySources sourceDefinition,
+		ILogger logger)
+		: base(name, projectionVersion, logger) {
+		_stateHandler = stateHandler;
+		_projectionConfig = projectionConfig;
+		_sourceDefinition = sourceDefinition;
+	}
+
+	// NOTE: The actual integration with ManagedProjection's lifecycle
+	// (Start, Stop, GetStatistics etc.) will be implemented in a follow-up task.
+	// This strategy currently serves as a placeholder for the routing logic.
+
+	public override bool GetStopOnEof() => false;
+	public override bool GetUseCheckpoints() => _projectionConfig.CheckpointsEnabled;
+	public override bool GetProducesRunningResults() => _sourceDefinition.ProducesResults;
+	public override bool GetIsPartitioned() => _sourceDefinition.ByStreams || _sourceDefinition.ByCustomPartitions;
+
+	protected override IProjectionProcessingPhase[] CreateProjectionProcessingPhases(
+		IPublisher publisher, IPublisher inputQueue, Guid projectionCorrelationId,
+		ProjectionNamesBuilder namingBuilder, PartitionStateCache partitionStateCache,
+		CoreProjection coreProjection, IODispatcher ioDispatcher,
+		IProjectionProcessingPhase firstPhase) {
+		// V2 doesn't use the v1 processing phases
+		throw new NotSupportedException("V2 engine does not use v1 processing phases");
+	}
+}
+```
+
+### Step 3: Update ProcessingStrategySelector
+
+Modify `src/KurrentDB.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs` to accept an engine version parameter. Read the file first, then add a new overload or modify the existing method.
+
+Add after line 27:
+
+```csharp
+// Add engine version parameter
+int engineVersion = 1,
+```
+
+And add inside the method body, before the existing return:
+
+```csharp
+if (engineVersion == 2) {
+	return new V2.V2ProjectionProcessingStrategy(
+		name, projectionVersion, stateHandler, projectionConfig, sourceDefinition, _logger);
+}
+```
+
+### Step 4: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core/Services/Processing/V2/V2ProjectionProcessingStrategy.cs
+git add src/KurrentDB.Projections.Core/Services/Management/ManagedProjection.cs
+git add src/KurrentDB.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs
+git commit -m "feat(projections-v2): add engine version routing in management layer"
+```
+
+---
+
+## Task 11: Build and Fix Compilation
+
+**Files:**
+- Various files in `src/KurrentDB.Projections.Core/Services/Processing/V2/`
+
+### Step 1: Build the projections project
+
+Run: `dotnet build src/KurrentDB.Projections.Core/ -c Release --framework=net10.0`
+
+### Step 2: Fix any compilation errors
+
+Common issues to expect:
+- Missing `using` statements
+- Type mismatches between `KurrentDB.Core.Data.ResolvedEvent` and `KurrentDB.Projections.Core.Services.Processing.ResolvedEvent`
+- Missing methods or properties on referenced types
+- Access modifiers needing adjustment
+
+### Step 3: Build the test project
+
+Run: `dotnet build src/KurrentDB.Projections.Core.Tests/ -c Release --framework=net10.0`
+
+### Step 4: Run existing projection tests to check for regressions
+
+Run: `dotnet test src/KurrentDB.Projections.Core.Tests/ -v n --no-build`
+
+### Step 5: Commit fixes
+
+```bash
+git add -A
+git commit -m "fix(projections-v2): fix compilation issues across v2 engine"
+```
+
+---
+
+## Task 12: Integration Test — End-to-End Simple Projection
+
+Create an integration test that runs a simple `fromAll` projection through the v2 engine.
+
+**Files:**
+- Create: `src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/ProjectionEngineV2IntegrationTests.cs`
+
+### Step 1: Write integration test
+
+This test will depend on the existing test infrastructure for setting up a mini-node. Study the patterns in:
+- `src/KurrentDB.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs`
+- `src/KurrentDB.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs`
+
+The test should:
+1. Write some events to streams
+2. Create a v2 engine with a `fromAll` read strategy
+3. Start the engine
+4. Verify events are processed and state is written
+5. Verify checkpoint is written atomically
+
+### Step 2: Run the test
+
+Run: `dotnet test src/KurrentDB.Projections.Core.Tests/ --filter "ProjectionEngineV2Integration" -v d`
+
+### Step 3: Commit
+
+```bash
+git add src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/
+git commit -m "test(projections-v2): add end-to-end integration test for simple fromAll projection"
+```
+
+---
+
+## Summary of Tasks
+
+| Task | Component | Dependencies |
+|------|-----------|-------------|
+| 1 | Project skeleton (engine, config, IReadStrategy) | None |
+| 2 | Stream-name-set EventFilter | None |
+| 3 | Read strategies (FilteredAll, StreamSet, Factory) | Task 1, 2 |
+| 4 | Partition dispatcher + channels | Task 1 |
+| 5 | Partition processor + output buffer | Task 1, 4 |
+| 6 | Checkpoint coordinator (multi-stream write) | Task 1, 5 |
+| 7 | Wire up full pipeline | Task 3, 4, 5, 6 |
+| 8 | Unit tests: dispatcher | Task 4 |
+| 9 | Unit tests: output buffer + coordinator | Task 5, 6 |
+| 10 | Management layer integration | Task 7 |
+| 11 | Build + fix compilation | Task 10 |
+| 12 | End-to-end integration test | Task 11 |
+
+**Parallelizable:** Tasks 1-2, Tasks 4-5-6, Tasks 8-9
+
+## Key Reference Files
+
+| File | Purpose |
+|------|---------|
+| `src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs` | Filtered subscription enumerator to wrap |
+| `src/KurrentDB.Core/Services/Storage/ReaderIndex/EventFilter.cs` | Event filter implementations |
+| `src/KurrentDB.Core/Messages/ClientMessage.cs:170-292` | Multi-stream WriteEvents message |
+| `src/KurrentDB.Projections.Core/Services/IProjectionStateHandler.cs` | JS runtime interface (reused) |
+| `src/KurrentDB.Projections.Core/Messages/IQuerySources.cs` | Source definition (fromAll/fromStreams/etc.) |
+| `src/KurrentDB.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs` | Strategy routing |
+| `src/KurrentDB.Projections.Core/Services/Management/ManagedProjection.cs` | Management layer |
+| `src/KurrentDB.Core/Messaging/CallbackEnvelope.cs` | Async callback pattern |

--- a/src/KurrentDB.Core.Tests/Services/Storage/ReaderIndex/StreamIdSetFilterTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/ReaderIndex/StreamIdSetFilterTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Storage.ReaderIndex;
+using KurrentDB.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace KurrentDB.Core.Tests.Services.Storage.ReaderIndex;
+
+[TestFixture]
+public class StreamIdSetFilterTests {
+	private static EventRecord CreateEventRecord(string streamId, string eventType = "TestEvent") {
+		return new EventRecord(
+			eventNumber: 0,
+			logPosition: 0,
+			correlationId: Guid.NewGuid(),
+			eventId: Guid.NewGuid(),
+			transactionPosition: 0,
+			transactionOffset: 0,
+			eventStreamId: streamId,
+			expectedVersion: -1,
+			timeStamp: DateTime.UtcNow,
+			flags: PrepareFlags.SingleWrite,
+			eventType: eventType,
+			data: Array.Empty<byte>(),
+			metadata: null);
+	}
+
+	[Test]
+	public void allows_event_from_stream_in_set() {
+		var filter = EventFilter.StreamName.Set(false, "stream-a", "stream-b");
+		var record = CreateEventRecord("stream-a");
+		Assert.That(filter.IsEventAllowed(record), Is.True);
+	}
+
+	[Test]
+	public void allows_event_from_another_stream_in_set() {
+		var filter = EventFilter.StreamName.Set(false, "stream-a", "stream-b");
+		var record = CreateEventRecord("stream-b");
+		Assert.That(filter.IsEventAllowed(record), Is.True);
+	}
+
+	[Test]
+	public void rejects_event_from_stream_not_in_set() {
+		var filter = EventFilter.StreamName.Set(false, "stream-a", "stream-b");
+		var record = CreateEventRecord("stream-c");
+		Assert.That(filter.IsEventAllowed(record), Is.False);
+	}
+
+	[Test]
+	public void rejects_event_with_partial_stream_name_match() {
+		var filter = EventFilter.StreamName.Set(false, "stream");
+		var record = CreateEventRecord("stream-a");
+		Assert.That(filter.IsEventAllowed(record), Is.False);
+	}
+
+	[Test]
+	public void when_is_all_stream_rejects_epoch_information_system_stream() {
+		var filter = EventFilter.StreamName.Set(true, "$epoch-information", "stream-a");
+		var record = CreateEventRecord("$epoch-information");
+		Assert.That(filter.IsEventAllowed(record), Is.False);
+	}
+
+	[Test]
+	public void when_is_all_stream_allows_non_system_stream_in_set() {
+		var filter = EventFilter.StreamName.Set(true, "stream-a", "stream-b");
+		var record = CreateEventRecord("stream-a");
+		Assert.That(filter.IsEventAllowed(record), Is.True);
+	}
+
+	[Test]
+	public void when_not_all_stream_allows_system_stream_in_set() {
+		var filter = EventFilter.StreamName.Set(false, "$epoch-information");
+		var record = CreateEventRecord("$epoch-information");
+		Assert.That(filter.IsEventAllowed(record), Is.True);
+	}
+
+	[Test]
+	public void parse_to_dto_returns_correct_values() {
+		var filter = EventFilter.StreamName.Set(true, "stream-a", "stream-b");
+		var dto = EventFilter.ParseToDto(filter);
+
+		Assert.That(dto, Is.Not.Null);
+		Assert.That(dto.Context, Is.EqualTo(EventFilter.StreamIdContext));
+		Assert.That(dto.Type, Is.EqualTo("set"));
+		Assert.That(dto.IsAllStream, Is.True);
+		// The data contains the stream names comma-separated (order may vary due to HashSet)
+		Assert.That(dto.Data, Does.Contain("stream-a"));
+		Assert.That(dto.Data, Does.Contain("stream-b"));
+	}
+}

--- a/src/KurrentDB.Core/Services/Storage/ReaderIndex/EventFilter.cs
+++ b/src/KurrentDB.Core/Services/Storage/ReaderIndex/EventFilter.cs
@@ -2,6 +2,7 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -28,6 +29,9 @@ public static class EventFilter {
 
 		public static IEventFilter Regex(bool isAllStream, string regex)
 			=> new StreamIdRegexStrategy(isAllStream, regex);
+
+		public static IEventFilter Set(bool isAllStream, params string[] streamNames)
+			=> new StreamIdSetStrategy(isAllStream, streamNames);
 	}
 
 	public static class EventType {
@@ -176,6 +180,24 @@ public static class EventFilter {
 			$"{nameof(StreamIdRegexStrategy)}: ({string.Join(", ", _expectedRegex)})";
 	}
 
+	private sealed class StreamIdSetStrategy : IEventFilter {
+		internal readonly bool _isAllStream;
+		internal readonly HashSet<string> _streamNames;
+
+		public StreamIdSetStrategy(bool isAllStream, string[] streamNames) {
+			_isAllStream = isAllStream;
+			_streamNames = new HashSet<string>(streamNames, StringComparer.Ordinal);
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+		public bool IsEventAllowed(EventRecord eventRecord) =>
+			(!_isAllStream || DefaultAllFilter.IsEventAllowed(eventRecord)) &&
+			_streamNames.Contains(eventRecord.EventStreamId);
+
+		public override string ToString() =>
+			$"{nameof(StreamIdSetStrategy)}: ({string.Join(", ", _streamNames)})";
+	}
+
 	public class EventFilterDto {
 		public string Context;
 		public string Type;
@@ -198,6 +220,13 @@ public static class EventFilter {
 					Type = RegexType,
 					Data = sirs._expectedRegex.ToString(),
 					IsAllStream = sirs._isAllStream
+				};
+			case StreamIdSetStrategy siss:
+				return new() {
+					Context = StreamIdContext,
+					Type = "set",
+					Data = string.Join(",", siss._streamNames),
+					IsAllStream = siss._isAllStream
 				};
 			case EventTypePrefixStrategy etps:
 				return new() {

--- a/src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/OutputBufferTests.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/OutputBufferTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using KurrentDB.Projections.Core.Services.Processing.Emitting.EmittedEvents;
+using KurrentDB.Projections.Core.Services.Processing.V2;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Processing.V2;
+
+[TestFixture]
+public class OutputBufferTests {
+	private static CheckpointTag TestCheckpointTag =>
+		CheckpointTag.FromPosition(0, 100, 100);
+
+	private static EmittedEventEnvelope CreateTestEmittedEvent(string streamId, string eventType) {
+		var emittedEvent = new EmittedDataEvent(
+			streamId: streamId,
+			eventId: Guid.NewGuid(),
+			eventType: eventType,
+			isJson: true,
+			data: "{}",
+			metadata: null,
+			causedByTag: TestCheckpointTag,
+			expectedTag: null);
+		return new EmittedEventEnvelope(emittedEvent);
+	}
+
+	[Test]
+	public void clear_resets_all_state() {
+		var buffer = new OutputBuffer();
+
+		// Populate all fields
+		buffer.AddEmittedEvents(new[] { CreateTestEmittedEvent("stream-1", "EventA") });
+		buffer.SetPartitionState("partition-1", "state-stream-1", "{\"count\":1}", 0);
+		buffer.LastLogPosition = new TFPos(500, 500);
+
+		// Verify populated
+		Assert.That(buffer.EmittedEvents.Count, Is.EqualTo(1));
+		Assert.That(buffer.DirtyStates.Count, Is.EqualTo(1));
+		Assert.That(buffer.LastLogPosition, Is.Not.EqualTo(default(TFPos)));
+
+		// Clear and verify
+		buffer.Clear();
+
+		Assert.That(buffer.EmittedEvents, Is.Empty);
+		Assert.That(buffer.DirtyStates, Is.Empty);
+		Assert.That(buffer.LastLogPosition, Is.EqualTo(default(TFPos)));
+	}
+
+	[Test]
+	public void set_partition_state_overwrites_previous() {
+		var buffer = new OutputBuffer();
+
+		buffer.SetPartitionState("partition-1", "state-stream-1", "{\"count\":1}", 0);
+		buffer.SetPartitionState("partition-1", "state-stream-1", "{\"count\":2}", 1);
+
+		Assert.That(buffer.DirtyStates.Count, Is.EqualTo(1));
+
+		var (streamName, stateJson, expectedVersion) = buffer.DirtyStates["partition-1"];
+		Assert.That(streamName, Is.EqualTo("state-stream-1"));
+		Assert.That(stateJson, Is.EqualTo("{\"count\":2}"));
+		Assert.That(expectedVersion, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void add_emitted_events_handles_null() {
+		var buffer = new OutputBuffer();
+
+		buffer.AddEmittedEvents(null);
+
+		Assert.That(buffer.EmittedEvents, Is.Empty);
+	}
+
+	[Test]
+	public void add_emitted_events_handles_empty_array() {
+		var buffer = new OutputBuffer();
+
+		buffer.AddEmittedEvents(Array.Empty<EmittedEventEnvelope>());
+
+		Assert.That(buffer.EmittedEvents, Is.Empty);
+	}
+
+	[Test]
+	public void add_emitted_events_accumulates() {
+		var buffer = new OutputBuffer();
+
+		buffer.AddEmittedEvents(new[] { CreateTestEmittedEvent("stream-1", "EventA") });
+		buffer.AddEmittedEvents(new[] {
+			CreateTestEmittedEvent("stream-2", "EventB"),
+			CreateTestEmittedEvent("stream-3", "EventC")
+		});
+
+		Assert.That(buffer.EmittedEvents.Count, Is.EqualTo(3));
+	}
+
+	[Test]
+	public void set_partition_state_stores_multiple_partitions() {
+		var buffer = new OutputBuffer();
+
+		buffer.SetPartitionState("partition-1", "state-stream-1", "{\"a\":1}", 0);
+		buffer.SetPartitionState("partition-2", "state-stream-2", "{\"b\":2}", 0);
+		buffer.SetPartitionState("partition-3", "state-stream-3", "{\"c\":3}", 0);
+
+		Assert.That(buffer.DirtyStates.Count, Is.EqualTo(3));
+		Assert.That(buffer.DirtyStates.ContainsKey("partition-1"), Is.True);
+		Assert.That(buffer.DirtyStates.ContainsKey("partition-2"), Is.True);
+		Assert.That(buffer.DirtyStates.ContainsKey("partition-3"), Is.True);
+	}
+
+	[Test]
+	public void last_log_position_defaults_to_zero() {
+		var buffer = new OutputBuffer();
+
+		Assert.That(buffer.LastLogPosition, Is.EqualTo(default(TFPos)));
+	}
+}

--- a/src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/PartitionDispatcherTests.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/PartitionDispatcherTests.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Processing.V2;
+using ResolvedEvent = KurrentDB.Projections.Core.Services.Processing.ResolvedEvent;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Processing.V2;
+
+[TestFixture]
+public class PartitionDispatcherTests {
+	private static ResolvedEvent CreateTestEvent(string streamId, long seqNo = 0, long position = 100) {
+		return new ResolvedEvent(
+			positionStreamId: streamId,
+			positionSequenceNumber: seqNo,
+			eventStreamId: streamId,
+			eventSequenceNumber: seqNo,
+			resolvedLinkTo: false,
+			position: new TFPos(position, position),
+			eventId: Guid.NewGuid(),
+			eventType: "TestEvent",
+			isJson: true,
+			data: "{}",
+			metadata: null);
+	}
+
+	[Test]
+	public async Task events_with_same_key_route_to_same_partition() {
+		var dispatcher = new PartitionDispatcher(
+			partitionCount: 4,
+			getPartitionKey: e => e.EventStreamId);
+
+		var event1 = CreateTestEvent("stream-1", 0, 100);
+		var event2 = CreateTestEvent("stream-1", 1, 200);
+
+		await dispatcher.DispatchEvent(event1, new TFPos(100, 100), CancellationToken.None);
+		await dispatcher.DispatchEvent(event2, new TFPos(200, 200), CancellationToken.None);
+		dispatcher.Complete();
+
+		// Find which partition got events
+		int partitionWithEvents = -1;
+		for (int i = 0; i < 4; i++) {
+			var reader = dispatcher.GetPartitionReader(i);
+			if (reader.TryRead(out _)) {
+				partitionWithEvents = i;
+				break;
+			}
+		}
+
+		Assert.That(partitionWithEvents, Is.GreaterThanOrEqualTo(0), "At least one partition should have events");
+
+		// Second event should be on the same partition
+		var targetReader = dispatcher.GetPartitionReader(partitionWithEvents);
+		Assert.That(targetReader.TryRead(out var pe), Is.True, "Second event should be on the same partition");
+		Assert.That(pe.PartitionKey, Is.EqualTo("stream-1"));
+	}
+
+	[Test]
+	public async Task events_with_different_keys_can_route_to_different_partitions() {
+		// Use many partitions and many different keys to make collisions unlikely
+		const int partitionCount = 16;
+		var dispatcher = new PartitionDispatcher(
+			partitionCount: partitionCount,
+			getPartitionKey: e => e.EventStreamId);
+
+		var streamNames = new List<string>();
+		for (int i = 0; i < 100; i++) {
+			streamNames.Add($"stream-{i}");
+		}
+
+		long pos = 100;
+		foreach (var stream in streamNames) {
+			var evt = CreateTestEvent(stream, 0, pos);
+			await dispatcher.DispatchEvent(evt, new TFPos(pos, pos), CancellationToken.None);
+			pos += 100;
+		}
+
+		dispatcher.Complete();
+
+		// Count events per partition
+		var partitionsWithEvents = new HashSet<int>();
+		for (int i = 0; i < partitionCount; i++) {
+			var reader = dispatcher.GetPartitionReader(i);
+			if (reader.TryRead(out _)) {
+				partitionsWithEvents.Add(i);
+			}
+		}
+
+		// With 100 different keys across 16 partitions, more than 1 partition should have events
+		Assert.That(partitionsWithEvents.Count, Is.GreaterThan(1),
+			"Events with different keys should distribute across multiple partitions");
+	}
+
+	[Test]
+	public async Task checkpoint_marker_sent_to_all_partitions() {
+		const int partitionCount = 4;
+		var dispatcher = new PartitionDispatcher(
+			partitionCount: partitionCount,
+			getPartitionKey: e => e.EventStreamId);
+
+		var logPosition = new TFPos(500, 500);
+		await dispatcher.InjectCheckpointMarker(logPosition, CancellationToken.None);
+		dispatcher.Complete();
+
+		for (int i = 0; i < partitionCount; i++) {
+			var reader = dispatcher.GetPartitionReader(i);
+			Assert.That(reader.TryRead(out var pe), Is.True,
+				$"Partition {i} should have received the checkpoint marker");
+			Assert.That(pe.IsCheckpointMarker, Is.True,
+				$"Event on partition {i} should be a checkpoint marker");
+			Assert.That(pe.LogPosition, Is.EqualTo(logPosition));
+		}
+	}
+
+	[Test]
+	public async Task checkpoint_markers_have_incrementing_sequence() {
+		var dispatcher = new PartitionDispatcher(
+			partitionCount: 1,
+			getPartitionKey: e => e.EventStreamId);
+
+		var seq1 = await dispatcher.InjectCheckpointMarker(new TFPos(100, 100), CancellationToken.None);
+		var seq2 = await dispatcher.InjectCheckpointMarker(new TFPos(200, 200), CancellationToken.None);
+		var seq3 = await dispatcher.InjectCheckpointMarker(new TFPos(300, 300), CancellationToken.None);
+		dispatcher.Complete();
+
+		Assert.That(seq1, Is.EqualTo(1UL));
+		Assert.That(seq2, Is.EqualTo(2UL));
+		Assert.That(seq3, Is.EqualTo(3UL));
+
+		// Also verify the sequence numbers are on the partition events
+		var reader = dispatcher.GetPartitionReader(0);
+		reader.TryRead(out var pe1);
+		reader.TryRead(out var pe2);
+		reader.TryRead(out var pe3);
+
+		Assert.That(pe1.CheckpointMarkerSequence, Is.EqualTo(1UL));
+		Assert.That(pe2.CheckpointMarkerSequence, Is.EqualTo(2UL));
+		Assert.That(pe3.CheckpointMarkerSequence, Is.EqualTo(3UL));
+	}
+
+	[Test]
+	public async Task complete_finishes_all_channels() {
+		const int partitionCount = 4;
+		var dispatcher = new PartitionDispatcher(
+			partitionCount: partitionCount,
+			getPartitionKey: e => e.EventStreamId);
+
+		// Write one event so we know the dispatcher is active
+		var evt = CreateTestEvent("stream-1");
+		await dispatcher.DispatchEvent(evt, new TFPos(100, 100), CancellationToken.None);
+
+		dispatcher.Complete();
+
+		for (int i = 0; i < partitionCount; i++) {
+			var reader = dispatcher.GetPartitionReader(i);
+			// Drain any existing events
+			while (reader.TryRead(out _)) { }
+
+			// After completion and draining, TryRead should return false and Completion should be done
+			Assert.That(reader.TryRead(out _), Is.False,
+				$"Partition {i} should have no more events after completion");
+			Assert.That(reader.Completion.IsCompleted, Is.True,
+				$"Partition {i} channel should be completed");
+		}
+	}
+
+	[Test]
+	public async Task single_partition_routes_all_events_to_partition_zero() {
+		var dispatcher = new PartitionDispatcher(
+			partitionCount: 1,
+			getPartitionKey: e => e.EventStreamId);
+
+		var event1 = CreateTestEvent("stream-A", 0, 100);
+		var event2 = CreateTestEvent("stream-B", 0, 200);
+		var event3 = CreateTestEvent("stream-C", 0, 300);
+
+		await dispatcher.DispatchEvent(event1, new TFPos(100, 100), CancellationToken.None);
+		await dispatcher.DispatchEvent(event2, new TFPos(200, 200), CancellationToken.None);
+		await dispatcher.DispatchEvent(event3, new TFPos(300, 300), CancellationToken.None);
+		dispatcher.Complete();
+
+		var reader = dispatcher.GetPartitionReader(0);
+		int count = 0;
+		while (reader.TryRead(out _)) count++;
+
+		Assert.That(count, Is.EqualTo(3), "All events should route to partition 0 with a single partition");
+	}
+
+	[Test]
+	public async Task dispatched_event_preserves_partition_key_and_position() {
+		var dispatcher = new PartitionDispatcher(
+			partitionCount: 1,
+			getPartitionKey: e => e.EventStreamId);
+
+		var evt = CreateTestEvent("my-stream", 5, 42);
+		var logPos = new TFPos(42, 42);
+
+		await dispatcher.DispatchEvent(evt, logPos, CancellationToken.None);
+		dispatcher.Complete();
+
+		var reader = dispatcher.GetPartitionReader(0);
+		Assert.That(reader.TryRead(out var pe), Is.True);
+		Assert.That(pe.PartitionKey, Is.EqualTo("my-stream"));
+		Assert.That(pe.LogPosition, Is.EqualTo(logPos));
+		Assert.That(pe.IsCheckpointMarker, Is.False);
+		Assert.That(pe.Event, Is.Not.Null);
+	}
+}

--- a/src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/ProjectionEngineV2PipelineTests.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/Processing/V2/ProjectionEngineV2PipelineTests.cs
@@ -1,0 +1,445 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using KurrentDB.Core.Services.Transport.Enumerators;
+using KurrentDB.Core.TransactionLog.LogRecords;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using KurrentDB.Projections.Core.Services.Processing.Emitting.EmittedEvents;
+using KurrentDB.Projections.Core.Services.Processing.V2;
+using NUnit.Framework;
+using CoreResolvedEvent = KurrentDB.Core.Data.ResolvedEvent;
+using ProjectionResolvedEvent = KurrentDB.Projections.Core.Services.Processing.ResolvedEvent;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Processing.V2;
+
+[TestFixture]
+public class ProjectionEngineV2PipelineTests {
+
+	#region Fakes
+
+	/// <summary>
+	/// A fake read strategy that yields a fixed sequence of events then completes.
+	/// </summary>
+	private sealed class FakeReadStrategy : IReadStrategy {
+		private readonly CoreResolvedEvent[] _events;
+
+		public FakeReadStrategy(CoreResolvedEvent[] events) {
+			_events = events;
+		}
+
+		public async IAsyncEnumerable<ReadResponse> ReadFrom(
+			TFPos checkpoint, [EnumeratorCancellation] CancellationToken ct) {
+			foreach (var e in _events) {
+				ct.ThrowIfCancellationRequested();
+				yield return new ReadResponse.EventReceived(e);
+				// Small yield to allow pipeline tasks to make progress
+				await Task.Yield();
+			}
+		}
+
+		public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+	}
+
+	/// <summary>
+	/// A fake publisher that captures all published messages and auto-replies
+	/// to WriteEvents with a success response.
+	/// </summary>
+	private sealed class CapturingPublisher : IPublisher {
+		public ConcurrentBag<Message> Messages { get; } = new();
+
+		public void Publish(Message message) {
+			Messages.Add(message);
+
+			// Auto-reply with success for WriteEvents so the coordinator unblocks
+			if (message is ClientMessage.WriteEvents writeEvents) {
+				var numStreams = writeEvents.EventStreamIds.Length;
+				var firstEventNumbers = new long[numStreams];
+				var lastEventNumbers = new long[numStreams];
+				for (int i = 0; i < numStreams; i++) {
+					firstEventNumbers[i] = 0;
+					lastEventNumbers[i] = 0;
+				}
+
+				var completed = new ClientMessage.WriteEventsCompleted(
+					writeEvents.CorrelationId,
+					firstEventNumbers,
+					lastEventNumbers,
+					preparePosition: 0,
+					commitPosition: 0);
+
+				writeEvents.Envelope.ReplyWith(completed);
+			}
+		}
+	}
+
+	/// <summary>
+	/// A minimal IProjectionStateHandler that counts events per partition.
+	/// State format: {"count":N}
+	/// </summary>
+	private sealed class CountingStateHandler : IProjectionStateHandler {
+		private int _count;
+
+		public void Load(string state) {
+			if (string.IsNullOrEmpty(state) || state == "{}") {
+				_count = 0;
+				return;
+			}
+
+			try {
+				using var doc = JsonDocument.Parse(state);
+				if (doc.RootElement.TryGetProperty("count", out var countProp))
+					_count = countProp.GetInt32();
+				else
+					_count = 0;
+			} catch {
+				_count = 0;
+			}
+		}
+
+		public void LoadShared(string state) { }
+		public void Initialize() { }
+		public void InitializeShared() { }
+
+		public string GetStatePartition(CheckpointTag eventPosition, string category, ProjectionResolvedEvent data) {
+			return data.EventStreamId;
+		}
+
+		public bool ProcessEvent(
+			string partition,
+			CheckpointTag eventPosition,
+			string category,
+			ProjectionResolvedEvent @event,
+			out string newState,
+			out string newSharedState,
+			out EmittedEventEnvelope[] emittedEvents) {
+			_count++;
+			newState = $"{{\"count\":{_count}}}";
+			newSharedState = null;
+			emittedEvents = null;
+			return true;
+		}
+
+		public bool ProcessPartitionCreated(
+			string partition, CheckpointTag createPosition, ProjectionResolvedEvent @event,
+			out EmittedEventEnvelope[] emittedEvents) {
+			emittedEvents = null;
+			return false;
+		}
+
+		public bool ProcessPartitionDeleted(string partition, CheckpointTag deletePosition, out string newState) {
+			newState = null;
+			return false;
+		}
+
+		public string TransformStateToResult() => null;
+
+		public IQuerySources GetSourceDefinition() {
+			return new QuerySourcesDefinition {
+				AllStreams = true,
+				AllEvents = true
+			};
+		}
+
+		public void Dispose() { }
+	}
+
+	#endregion
+
+	/// <summary>
+	/// Helper to create an EventRecord suitable for test use.
+	/// </summary>
+	private static EventRecord CreateEventRecord(string streamId, long eventNumber, long logPosition, string eventType, string data) {
+		return new EventRecord(
+			eventNumber: eventNumber,
+			logPosition: logPosition,
+			correlationId: Guid.NewGuid(),
+			eventId: Guid.NewGuid(),
+			transactionPosition: logPosition,
+			transactionOffset: 0,
+			eventStreamId: streamId,
+			expectedVersion: eventNumber - 1,
+			timeStamp: DateTime.UtcNow,
+			flags: PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+			eventType: eventType,
+			data: Encoding.UTF8.GetBytes(data),
+			metadata: Encoding.UTF8.GetBytes("{}"));
+	}
+
+	/// <summary>
+	/// Helper to create a CoreResolvedEvent from an EventRecord.
+	/// </summary>
+	private static CoreResolvedEvent CreateResolvedEvent(string streamId, long eventNumber, long logPosition, string eventType = "TestEvent", string data = "{}") {
+		var record = CreateEventRecord(streamId, eventNumber, logPosition, eventType, data);
+		return CoreResolvedEvent.ForUnresolvedEvent(record, logPosition);
+	}
+
+	[Test]
+	public async Task processes_events_and_writes_checkpoint() {
+		// Arrange: 10 events across 2 streams
+		var events = new CoreResolvedEvent[10];
+		for (int i = 0; i < 10; i++) {
+			var stream = i % 2 == 0 ? "stream-A" : "stream-B";
+			var pos = (i + 1) * 100L;
+			events[i] = CreateResolvedEvent(stream, i / 2, pos);
+		}
+
+		var readStrategy = new FakeReadStrategy(events);
+		var publisher = new CapturingPublisher();
+		var stateHandler = new CountingStateHandler();
+		var user = new ClaimsPrincipal(new ClaimsIdentity());
+
+		var config = new ProjectionEngineV2Config {
+			ProjectionName = "test-projection",
+			SourceDefinition = stateHandler.GetSourceDefinition(),
+			StateHandler = stateHandler,
+			PartitionCount = 1,
+			// Set CheckpointAfterMs to 0 so time-based check always passes
+			CheckpointAfterMs = 0,
+			// Checkpoint after 5 events
+			CheckpointHandledThreshold = 5,
+			CheckpointUnhandledBytesThreshold = long.MaxValue
+		};
+
+		var engine = new ProjectionEngineV2(config, readStrategy, publisher, user);
+
+		// Act
+		await engine.Start(new TFPos(0, 0), CancellationToken.None);
+
+		// Wait for the engine to finish processing (read strategy completes after 10 events)
+		// The engine's internal _runTask will complete when the read loop finishes and
+		// all partition processors drain. We wait via DisposeAsync which cancels and waits.
+		// But we need the engine to finish naturally first.
+		// Give it some time to process, then dispose.
+		var timeout = Task.Delay(TimeSpan.FromSeconds(10));
+		while (!engine.IsFaulted) {
+			// Check if we got at least one write
+			if (publisher.Messages.Count > 0) {
+				// Give a bit more time for any additional writes to come through
+				await Task.Delay(200);
+				break;
+			}
+
+			if (timeout.IsCompleted)
+				break;
+
+			await Task.Delay(50);
+		}
+
+		await engine.DisposeAsync();
+
+		// Assert: engine should not have faulted
+		Assert.That(engine.IsFaulted, Is.False,
+			$"Engine should not fault. Exception: {engine.FaultException}");
+
+		// Assert: publisher should have received at least one WriteEvents message
+		var writeMessages = new List<ClientMessage.WriteEvents>();
+		foreach (var msg in publisher.Messages) {
+			if (msg is ClientMessage.WriteEvents w)
+				writeMessages.Add(w);
+		}
+
+		Assert.That(writeMessages.Count, Is.GreaterThanOrEqualTo(1),
+			"At least one checkpoint write should have been published");
+
+		// Verify the first write has the expected structure
+		var firstWrite = writeMessages[0];
+
+		// Should have at least a checkpoint stream
+		var streamIds = new List<string>();
+		for (int i = 0; i < firstWrite.EventStreamIds.Length; i++)
+			streamIds.Add(firstWrite.EventStreamIds.Span[i]);
+
+		Assert.That(streamIds, Does.Contain("$projections-test-projection-checkpoint"),
+			"Write should include the checkpoint stream");
+
+		// Verify events contain a $ProjectionCheckpoint event
+		bool hasCheckpointEvent = false;
+		for (int i = 0; i < firstWrite.Events.Length; i++) {
+			if (firstWrite.Events.Span[i].EventType == "$ProjectionCheckpoint") {
+				hasCheckpointEvent = true;
+				break;
+			}
+		}
+
+		Assert.That(hasCheckpointEvent, Is.True,
+			"Write should contain a $ProjectionCheckpoint event");
+	}
+
+	[Test]
+	public async Task checkpoint_contains_partition_state() {
+		// Arrange: 10 events all on the same stream
+		var events = new CoreResolvedEvent[10];
+		for (int i = 0; i < 10; i++) {
+			var pos = (i + 1) * 100L;
+			events[i] = CreateResolvedEvent("stream-X", i, pos, data: $"{{\"value\":{i}}}");
+		}
+
+		var readStrategy = new FakeReadStrategy(events);
+		var publisher = new CapturingPublisher();
+		var stateHandler = new CountingStateHandler();
+		var user = new ClaimsPrincipal(new ClaimsIdentity());
+
+		// Use ByStreams so partition key = stream name
+		var sourceDef = new QuerySourcesDefinition {
+			AllStreams = true,
+			AllEvents = true,
+			ByStreams = true
+		};
+
+		var config = new ProjectionEngineV2Config {
+			ProjectionName = "state-test",
+			SourceDefinition = sourceDef,
+			StateHandler = stateHandler,
+			PartitionCount = 1,
+			CheckpointAfterMs = 0,
+			CheckpointHandledThreshold = 5,
+			CheckpointUnhandledBytesThreshold = long.MaxValue
+		};
+
+		var engine = new ProjectionEngineV2(config, readStrategy, publisher, user);
+
+		// Act
+		await engine.Start(new TFPos(0, 0), CancellationToken.None);
+
+		var timeout = Task.Delay(TimeSpan.FromSeconds(10));
+		while (!engine.IsFaulted) {
+			if (publisher.Messages.Count > 0) {
+				await Task.Delay(200);
+				break;
+			}
+			if (timeout.IsCompleted) break;
+			await Task.Delay(50);
+		}
+
+		await engine.DisposeAsync();
+
+		Assert.That(engine.IsFaulted, Is.False,
+			$"Engine should not fault. Exception: {engine.FaultException}");
+
+		// Find the last WriteEvents message (contains final state)
+		ClientMessage.WriteEvents lastWrite = null;
+		foreach (var msg in publisher.Messages) {
+			if (msg is ClientMessage.WriteEvents w)
+				lastWrite = w;
+		}
+
+		Assert.That(lastWrite, Is.Not.Null, "Should have at least one write");
+
+		// Check that the write contains state events
+		var streamIds = new List<string>();
+		for (int i = 0; i < lastWrite.EventStreamIds.Length; i++)
+			streamIds.Add(lastWrite.EventStreamIds.Span[i]);
+
+		// Should contain the state stream for partition "stream-X"
+		Assert.That(streamIds, Does.Contain("$projections-state-test-stream-X-result"),
+			"Write should include the partition state stream");
+
+		// Verify a "Result" event exists
+		bool hasResultEvent = false;
+		for (int i = 0; i < lastWrite.Events.Length; i++) {
+			if (lastWrite.Events.Span[i].EventType == "Result") {
+				hasResultEvent = true;
+				// Verify the state data contains a count
+				var stateJson = Encoding.UTF8.GetString(lastWrite.Events.Span[i].Data);
+				Assert.That(stateJson, Does.Contain("\"count\":"),
+					"Result event should contain a count in the state JSON");
+				break;
+			}
+		}
+
+		Assert.That(hasResultEvent, Is.True,
+			"Write should contain a Result event with partition state");
+	}
+
+	[Test]
+	public async Task checkpoint_position_reflects_last_processed_event() {
+		// Arrange: 6 events so we get at least one checkpoint at 5
+		var events = new CoreResolvedEvent[6];
+		for (int i = 0; i < 6; i++) {
+			var pos = (i + 1) * 100L;
+			events[i] = CreateResolvedEvent("stream-Z", i, pos);
+		}
+
+		var readStrategy = new FakeReadStrategy(events);
+		var publisher = new CapturingPublisher();
+		var stateHandler = new CountingStateHandler();
+		var user = new ClaimsPrincipal(new ClaimsIdentity());
+
+		var config = new ProjectionEngineV2Config {
+			ProjectionName = "pos-test",
+			SourceDefinition = stateHandler.GetSourceDefinition(),
+			StateHandler = stateHandler,
+			PartitionCount = 1,
+			CheckpointAfterMs = 0,
+			CheckpointHandledThreshold = 5,
+			CheckpointUnhandledBytesThreshold = long.MaxValue
+		};
+
+		var engine = new ProjectionEngineV2(config, readStrategy, publisher, user);
+
+		// Act
+		await engine.Start(new TFPos(0, 0), CancellationToken.None);
+
+		var timeout = Task.Delay(TimeSpan.FromSeconds(10));
+		while (!engine.IsFaulted) {
+			if (publisher.Messages.Count > 0) {
+				await Task.Delay(200);
+				break;
+			}
+			if (timeout.IsCompleted) break;
+			await Task.Delay(50);
+		}
+
+		await engine.DisposeAsync();
+
+		Assert.That(engine.IsFaulted, Is.False,
+			$"Engine should not fault. Exception: {engine.FaultException}");
+
+		// Get the first checkpoint write
+		ClientMessage.WriteEvents firstWrite = null;
+		foreach (var msg in publisher.Messages) {
+			if (msg is ClientMessage.WriteEvents w) {
+				firstWrite = w;
+				break;
+			}
+		}
+
+		Assert.That(firstWrite, Is.Not.Null, "Should have at least one write");
+
+		// Find the $ProjectionCheckpoint event and parse its data
+		for (int i = 0; i < firstWrite.Events.Length; i++) {
+			var evt = firstWrite.Events.Span[i];
+			if (evt.EventType == "$ProjectionCheckpoint") {
+				var json = Encoding.UTF8.GetString(evt.Data);
+				using var doc = JsonDocument.Parse(json);
+
+				Assert.That(doc.RootElement.TryGetProperty("commitPosition", out var commitProp), Is.True,
+					"Checkpoint should have commitPosition");
+				Assert.That(doc.RootElement.TryGetProperty("preparePosition", out var prepareProp), Is.True,
+					"Checkpoint should have preparePosition");
+
+				// The position should be non-zero (events start at position 100)
+				Assert.That(commitProp.GetInt64(), Is.GreaterThan(0),
+					"Checkpoint commitPosition should be greater than zero");
+				Assert.That(prepareProp.GetInt64(), Is.GreaterThan(0),
+					"Checkpoint preparePosition should be greater than zero");
+				break;
+			}
+		}
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/KurrentDB.Projections.Core/Services/Management/ManagedProjection.cs
@@ -71,6 +71,8 @@ public class ManagedProjection : IDisposable {
 
 		public int? ProjectionExecutionTimeout { get; set; }
 
+		public int EngineVersion { get; set; } = 1; // 1 = v1 (default), 2 = v2
+
 		public PersistedState() {
 			CheckpointHandledThreshold = ProjectionConsts.CheckpointHandledThreshold;
 			CheckpointAfterMs = (int)ProjectionConsts.CheckpointAfterMs.TotalMilliseconds;

--- a/src/KurrentDB.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs
@@ -2,6 +2,7 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services.Processing.V2;
 using Serilog;
 using ILogger = Serilog.ILogger;
 
@@ -24,7 +25,13 @@ public class ProcessingStrategySelector {
 		ProjectionNamesBuilder namesBuilder,
 		IQuerySources sourceDefinition,
 		ProjectionConfig projectionConfig,
-		IProjectionStateHandler stateHandler, string handlerType, string query, bool enableContentTypeValidation) {
+		IProjectionStateHandler stateHandler, string handlerType, string query, bool enableContentTypeValidation,
+		int engineVersion = 1) {
+
+		if (engineVersion == 2) {
+			return new V2ProjectionProcessingStrategy(
+				name, projectionVersion, stateHandler, projectionConfig, sourceDefinition, _logger, _maxProjectionStateSize);
+		}
 
 		return projectionConfig.StopOnEof
 			? (ProjectionProcessingStrategy)

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/CheckpointCoordinator.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/CheckpointCoordinator.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using KurrentDB.Projections.Core.Services.Processing.Emitting.EmittedEvents;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class CheckpointCoordinator {
+	private static readonly ILogger Log = Serilog.Log.ForContext<CheckpointCoordinator>();
+
+	private readonly int _partitionCount;
+	private readonly string _projectionName;
+	private readonly string _checkpointStreamId;
+	private readonly IPublisher _bus;
+	private readonly ClaimsPrincipal _user;
+
+	private readonly OutputBuffer[] _collectedBuffers;
+	private ulong _currentMarkerSequence;
+	private int _collectedCount;
+	private readonly SemaphoreSlim _checkpointSemaphore = new(1, 1);
+	private readonly object _lock = new();
+
+	public CheckpointCoordinator(
+		int partitionCount,
+		string projectionName,
+		IPublisher bus,
+		ClaimsPrincipal user) {
+		_partitionCount = partitionCount;
+		_projectionName = projectionName;
+		_checkpointStreamId = $"$projections-{projectionName}-checkpoint";
+		_bus = bus;
+		_user = user;
+		_collectedBuffers = new OutputBuffer[partitionCount];
+	}
+
+	public async Task ReportPartitionCheckpoint(int partitionIndex, ulong markerSequence, OutputBuffer buffer) {
+		bool allCollected;
+		lock (_lock) {
+			if (_currentMarkerSequence != markerSequence) {
+				_currentMarkerSequence = markerSequence;
+				_collectedCount = 0;
+				Array.Clear(_collectedBuffers);
+			}
+			_collectedBuffers[partitionIndex] = buffer;
+			_collectedCount++;
+			allCollected = _collectedCount == _partitionCount;
+		}
+
+		if (allCollected) {
+			await WriteCheckpoint(markerSequence);
+		}
+	}
+
+	private async Task WriteCheckpoint(ulong markerSequence) {
+		await _checkpointSemaphore.WaitAsync();
+		try {
+			var lastPosition = TFPos.Invalid;
+			foreach (var buf in _collectedBuffers) {
+				if (buf != null && buf.LastLogPosition > lastPosition)
+					lastPosition = buf.LastLogPosition;
+			}
+
+			Log.Information("Writing checkpoint {Sequence} for {Projection} at {Position}",
+				markerSequence, _projectionName, lastPosition);
+
+			var (streamIds, expectedVersions, events, streamIndexes) = BuildMultiStreamWrite(lastPosition);
+
+			var tcs = new TaskCompletionSource<ClientMessage.WriteEventsCompleted>();
+			var corrId = Guid.NewGuid();
+
+			_bus.Publish(new ClientMessage.WriteEvents(
+				internalCorrId: corrId,
+				correlationId: corrId,
+				envelope: new CallbackEnvelope(msg => {
+					if (msg is ClientMessage.WriteEventsCompleted completed)
+						tcs.TrySetResult(completed);
+					else
+						tcs.TrySetException(new Exception($"Unexpected response: {msg.GetType().Name}"));
+				}),
+				requireLeader: true,
+				eventStreamIds: streamIds.ToArray(),
+				expectedVersions: expectedVersions.ToArray(),
+				events: events.ToArray(),
+				eventStreamIndexes: streamIndexes.ToArray(),
+				user: _user));
+
+			var result = await tcs.Task;
+			if (result.Result != OperationResult.Success) {
+				throw new Exception($"Checkpoint write failed for {_projectionName}: {result.Result} — {result.Message}");
+			}
+
+			Log.Debug("Checkpoint {Sequence} written for {Projection}", markerSequence, _projectionName);
+		} finally {
+			lock (_lock) {
+				Array.Clear(_collectedBuffers);
+				_collectedCount = 0;
+			}
+			_checkpointSemaphore.Release();
+		}
+	}
+
+	private (List<string>, List<long>, List<Event>, List<int>) BuildMultiStreamWrite(TFPos checkpointPosition) {
+		var streamIds = new List<string>();
+		var expectedVersions = new List<long>();
+		var events = new List<Event>();
+		var streamIndexes = new List<int>();
+		var streamIndexMap = new Dictionary<string, int>();
+
+		int GetOrAddStream(string streamName, long expectedVersion) {
+			if (!streamIndexMap.TryGetValue(streamName, out var idx)) {
+				idx = streamIds.Count;
+				streamIds.Add(streamName);
+				expectedVersions.Add(expectedVersion);
+				streamIndexMap[streamName] = idx;
+			}
+			return idx;
+		}
+
+		// 1. Checkpoint event
+		var checkpointData = Encoding.UTF8.GetBytes(
+			$"{{\"commitPosition\":{checkpointPosition.CommitPosition},\"preparePosition\":{checkpointPosition.PreparePosition}}}");
+		var cpIdx = GetOrAddStream(_checkpointStreamId, ExpectedVersion.Any);
+		events.Add(new Event(Guid.NewGuid(), "$ProjectionCheckpoint", true, checkpointData, isPropertyMetadata: false, null));
+		streamIndexes.Add(cpIdx);
+
+		// 2. Emitted events
+		foreach (var buffer in _collectedBuffers) {
+			if (buffer == null) continue;
+			foreach (var emitted in buffer.EmittedEvents) {
+				var e = emitted.Event;
+				var idx = GetOrAddStream(e.StreamId, ExpectedVersion.Any);
+				var data = e.Data != null ? Helper.UTF8NoBom.GetBytes(e.Data) : null;
+				var metadata = SerializeExtraMetadata(e);
+				events.Add(new Event(e.EventId, e.EventType, e.IsJson, data, isPropertyMetadata: false, metadata));
+				streamIndexes.Add(idx);
+			}
+		}
+
+		// 3. State updates
+		foreach (var buffer in _collectedBuffers) {
+			if (buffer == null) continue;
+			foreach (var (_, (streamName, stateJson, expVer)) in buffer.DirtyStates) {
+				var idx = GetOrAddStream(streamName, expVer);
+				var stateData = Encoding.UTF8.GetBytes(stateJson);
+				events.Add(new Event(Guid.NewGuid(), "Result", true, stateData, isPropertyMetadata: false, null));
+				streamIndexes.Add(idx);
+			}
+		}
+
+		return (streamIds, expectedVersions, events, streamIndexes);
+	}
+
+	private static byte[] SerializeExtraMetadata(EmittedEvent e) {
+		var extra = e.ExtraMetaData();
+		if (extra == null)
+			return null;
+
+		var pairs = extra.ToList();
+		if (pairs.Count == 0)
+			return null;
+
+		var sb = new StringBuilder();
+		sb.Append('{');
+		var first = true;
+		foreach (var pair in pairs) {
+			if (!first) sb.Append(',');
+			first = false;
+			// Key is a JSON property name, Value is already a JSON-encoded value
+			sb.Append('"').Append(pair.Key).Append("\":").Append(pair.Value);
+		}
+		sb.Append('}');
+		return Encoding.UTF8.GetBytes(sb.ToString());
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/IReadStrategy.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/IReadStrategy.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Transport.Enumerators;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+/// <summary>
+/// Produces events in log-position order from a specific source.
+/// All implementations checkpoint by log position (TFPos).
+/// </summary>
+public interface IReadStrategy : IAsyncDisposable {
+	IAsyncEnumerable<ReadResponse> ReadFrom(TFPos checkpoint, CancellationToken ct);
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/OutputBuffer.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/OutputBuffer.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Generic;
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Processing.Emitting.EmittedEvents;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class OutputBuffer {
+	public List<EmittedEventEnvelope> EmittedEvents { get; } = new();
+	public Dictionary<string, (string StreamName, string StateJson, long ExpectedVersion)> DirtyStates { get; } = new();
+	public TFPos LastLogPosition { get; set; }
+
+	public void AddEmittedEvents(EmittedEventEnvelope[] events) {
+		if (events is { Length: > 0 })
+			EmittedEvents.AddRange(events);
+	}
+
+	public void SetPartitionState(string partitionKey, string streamName, string stateJson, long expectedVersion) {
+		DirtyStates[partitionKey] = (streamName, stateJson, expectedVersion);
+	}
+
+	public void Clear() {
+		EmittedEvents.Clear();
+		DirtyStates.Clear();
+		LastLogPosition = default;
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionDispatcher.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionDispatcher.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+#nullable enable
+
+using System;
+using System.IO.Hashing;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using KurrentDB.Core.Data;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class PartitionDispatcher {
+	private static readonly ILogger Log = Serilog.Log.ForContext<PartitionDispatcher>();
+
+	private readonly Channel<PartitionEvent>[] _partitionChannels;
+	private readonly int _partitionCount;
+	private readonly Func<ResolvedEvent, string> _getPartitionKey;
+	private ulong _nextCheckpointSequence;
+
+	public PartitionDispatcher(
+		int partitionCount,
+		Func<ResolvedEvent, string> getPartitionKey,
+		int channelCapacity = 256) {
+		_partitionCount = partitionCount;
+		_getPartitionKey = getPartitionKey;
+
+		_partitionChannels = new Channel<PartitionEvent>[partitionCount];
+		for (int i = 0; i < partitionCount; i++) {
+			_partitionChannels[i] = Channel.CreateBounded<PartitionEvent>(
+				new BoundedChannelOptions(channelCapacity) {
+					FullMode = BoundedChannelFullMode.Wait,
+					SingleReader = true,
+					SingleWriter = true
+				});
+		}
+	}
+
+	public ChannelReader<PartitionEvent> GetPartitionReader(int partitionIndex)
+		=> _partitionChannels[partitionIndex].Reader;
+
+	public async ValueTask DispatchEvent(ResolvedEvent @event, TFPos logPosition, CancellationToken ct) {
+		var partitionKey = _getPartitionKey(@event);
+		var partitionIndex = GetPartitionIndex(partitionKey);
+		var pe = PartitionEvent.ForEvent(@event, partitionKey, logPosition);
+		await _partitionChannels[partitionIndex].Writer.WriteAsync(pe, ct);
+	}
+
+	public async ValueTask<ulong> InjectCheckpointMarker(TFPos logPosition, CancellationToken ct) {
+		var sequence = ++_nextCheckpointSequence;
+		var marker = PartitionEvent.ForCheckpointMarker(sequence, logPosition);
+
+		Log.Debug("Injecting checkpoint marker {Sequence} at {LogPosition}", sequence, logPosition);
+
+		for (int i = 0; i < _partitionCount; i++) {
+			await _partitionChannels[i].Writer.WriteAsync(marker, ct);
+		}
+		return sequence;
+	}
+
+	public void Complete(Exception? ex = null) {
+		for (int i = 0; i < _partitionCount; i++) {
+			_partitionChannels[i].Writer.TryComplete(ex);
+		}
+	}
+
+	private int GetPartitionIndex(string partitionKey) {
+		if (_partitionCount == 1) return 0;
+		var hash = XxHash32.HashToUInt32(Encoding.UTF8.GetBytes(partitionKey));
+		return (int)(hash % (uint)_partitionCount);
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionEvent.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionEvent.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+#nullable enable
+
+using KurrentDB.Core.Data;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+/// <summary>
+/// An event routed to a specific partition, or a checkpoint marker.
+/// </summary>
+public readonly record struct PartitionEvent {
+	public ResolvedEvent? Event { get; init; }
+	public string? PartitionKey { get; init; }
+	public TFPos LogPosition { get; init; }
+	public ulong? CheckpointMarkerSequence { get; init; }
+
+	public bool IsCheckpointMarker => CheckpointMarkerSequence.HasValue;
+
+	public static PartitionEvent ForEvent(ResolvedEvent @event, string partitionKey, TFPos logPosition)
+		=> new() { Event = @event, PartitionKey = partitionKey, LogPosition = logPosition };
+
+	public static PartitionEvent ForCheckpointMarker(ulong sequence, TFPos logPosition)
+		=> new() { CheckpointMarkerSequence = sequence, LogPosition = logPosition };
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionProcessor.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/PartitionProcessor.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class PartitionProcessor {
+	private static readonly ILogger Log = Serilog.Log.ForContext<PartitionProcessor>();
+
+	private readonly int _partitionIndex;
+	private readonly ChannelReader<PartitionEvent> _reader;
+	private readonly IProjectionStateHandler _stateHandler;
+	private readonly string _projectionName;
+	private readonly Func<ulong, OutputBuffer, Task> _onCheckpointMarker;
+
+	private OutputBuffer _activeBuffer = new();
+	private OutputBuffer _frozenBuffer = new();
+	private readonly Dictionary<string, string> _stateCache = new();
+
+	public PartitionProcessor(
+		int partitionIndex,
+		ChannelReader<PartitionEvent> reader,
+		IProjectionStateHandler stateHandler,
+		string projectionName,
+		Func<ulong, OutputBuffer, Task> onCheckpointMarker) {
+		_partitionIndex = partitionIndex;
+		_reader = reader;
+		_stateHandler = stateHandler;
+		_projectionName = projectionName;
+		_onCheckpointMarker = onCheckpointMarker;
+	}
+
+	public async Task Run(CancellationToken ct) {
+		Log.Debug("Partition {Index} starting for projection {Name}", _partitionIndex, _projectionName);
+
+		await foreach (var pe in _reader.ReadAllAsync(ct)) {
+			if (pe.IsCheckpointMarker) {
+				await HandleCheckpointMarker(pe.CheckpointMarkerSequence!.Value);
+				continue;
+			}
+
+			ProcessEvent(pe);
+		}
+	}
+
+	private void ProcessEvent(PartitionEvent pe) {
+		var projEvent = pe.Event!;
+		var partitionKey = pe.PartitionKey!;
+
+		if (!_stateCache.TryGetValue(partitionKey, out var currentState))
+			currentState = "{}";
+
+		_stateHandler.Load(currentState);
+
+		var checkpointTag = CheckpointTag.FromPosition(0, pe.LogPosition.CommitPosition, pe.LogPosition.PreparePosition);
+
+		var processed = _stateHandler.ProcessEvent(
+			partitionKey,
+			checkpointTag,
+			category: null,
+			projEvent,
+			out var newState,
+			out var newSharedState,
+			out var emittedEvents);
+
+		if (processed && newState != null) {
+			_stateCache[partitionKey] = newState;
+			var stateStreamName = $"$projections-{_projectionName}-{partitionKey}-result";
+			_activeBuffer.SetPartitionState(partitionKey, stateStreamName, newState, -2); // ExpectedVersion.Any
+		}
+
+		_activeBuffer.AddEmittedEvents(emittedEvents);
+		_activeBuffer.LastLogPosition = pe.LogPosition;
+	}
+
+	private async Task HandleCheckpointMarker(ulong sequence) {
+		Log.Debug("Partition {Index} received checkpoint marker {Sequence}", _partitionIndex, sequence);
+
+		var bufferToFlush = _activeBuffer;
+		_activeBuffer = _frozenBuffer;
+		_activeBuffer.Clear();
+		_frozenBuffer = bufferToFlush;
+
+		await _onCheckpointMarker(sequence, bufferToFlush);
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2.cs
@@ -2,10 +2,17 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
+using System.Diagnostics;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using KurrentDB.Core.Bus;
 using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Transport.Enumerators;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
 using Serilog;
+using CoreResolvedEvent = KurrentDB.Core.Data.ResolvedEvent;
+using ProjectionResolvedEvent = KurrentDB.Projections.Core.Services.Processing.ResolvedEvent;
 
 namespace KurrentDB.Projections.Core.Services.Processing.V2;
 
@@ -14,12 +21,20 @@ public class ProjectionEngineV2 : IAsyncDisposable {
 
 	private readonly ProjectionEngineV2Config _config;
 	private readonly IReadStrategy _readStrategy;
+	private readonly IPublisher _bus;
+	private readonly ClaimsPrincipal _user;
 	private CancellationTokenSource _cts;
 	private Task _runTask;
 
-	public ProjectionEngineV2(ProjectionEngineV2Config config, IReadStrategy readStrategy) {
+	public ProjectionEngineV2(
+		ProjectionEngineV2Config config,
+		IReadStrategy readStrategy,
+		IPublisher bus,
+		ClaimsPrincipal user) {
 		_config = config ?? throw new ArgumentNullException(nameof(config));
 		_readStrategy = readStrategy ?? throw new ArgumentNullException(nameof(readStrategy));
+		_bus = bus ?? throw new ArgumentNullException(nameof(bus));
+		_user = user ?? throw new ArgumentNullException(nameof(user));
 	}
 
 	public Task Start(TFPos checkpoint, CancellationToken ct) {
@@ -33,8 +48,143 @@ public class ProjectionEngineV2 : IAsyncDisposable {
 
 	private async Task Run(TFPos checkpoint, CancellationToken ct) {
 		Log.Information("ProjectionEngineV2 {Name} starting from {Checkpoint}", _config.ProjectionName, checkpoint);
-		// Pipeline will be built in subsequent tasks
-		await Task.CompletedTask;
+
+		var dispatcher = new PartitionDispatcher(
+			_config.PartitionCount,
+			GetPartitionKeyFunction());
+
+		var coordinator = new CheckpointCoordinator(
+			_config.PartitionCount,
+			_config.ProjectionName,
+			_bus,
+			_user);
+
+		// Start partition processor tasks
+		var partitionTasks = new Task[_config.PartitionCount];
+		for (int i = 0; i < _config.PartitionCount; i++) {
+			var partitionIndex = i;
+			var processor = new PartitionProcessor(
+				partitionIndex,
+				dispatcher.GetPartitionReader(partitionIndex),
+				_config.StateHandler,
+				_config.ProjectionName,
+				(sequence, buffer) => coordinator.ReportPartitionCheckpoint(partitionIndex, sequence, buffer));
+			partitionTasks[i] = Task.Run(() => processor.Run(ct), ct);
+		}
+
+		try {
+			await RunReadLoop(checkpoint, dispatcher, ct);
+			dispatcher.Complete();
+		} catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+			dispatcher.Complete();
+			throw;
+		} catch (Exception ex) {
+			Log.Error(ex, "ProjectionEngineV2 {Name} read loop failed", _config.ProjectionName);
+			dispatcher.Complete(ex);
+			throw;
+		} finally {
+			// Wait for all partition processors to drain
+			try {
+				await Task.WhenAll(partitionTasks);
+			} catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+				// Expected on cancellation
+			}
+		}
+	}
+
+	private async Task RunReadLoop(TFPos checkpoint, PartitionDispatcher dispatcher, CancellationToken ct) {
+		long eventsProcessed = 0;
+		long bytesProcessed = 0;
+		var lastCheckpointTime = Stopwatch.GetTimestamp();
+		var lastLogPosition = checkpoint;
+
+		await foreach (var response in _readStrategy.ReadFrom(checkpoint, ct)) {
+			switch (response) {
+				case ReadResponse.EventReceived eventReceived:
+					var coreEvent = eventReceived.Event;
+					var projEvent = ConvertToProjectionEvent(coreEvent);
+					var logPosition = coreEvent.OriginalPosition
+						?? new TFPos(coreEvent.Event.LogPosition, coreEvent.Event.TransactionPosition);
+
+					await dispatcher.DispatchEvent(projEvent, logPosition, ct);
+
+					eventsProcessed++;
+					bytesProcessed += coreEvent.Event.Data.Length + coreEvent.Event.Metadata.Length;
+					lastLogPosition = logPosition;
+
+					// Check if checkpoint is due
+					var elapsedMs = GetElapsedMs(lastCheckpointTime);
+					if (elapsedMs >= _config.CheckpointAfterMs &&
+						(eventsProcessed >= _config.CheckpointHandledThreshold ||
+						 bytesProcessed >= _config.CheckpointUnhandledBytesThreshold)) {
+						await dispatcher.InjectCheckpointMarker(lastLogPosition, ct);
+						eventsProcessed = 0;
+						bytesProcessed = 0;
+						lastCheckpointTime = Stopwatch.GetTimestamp();
+					}
+					break;
+
+				// Ignore subscription infrastructure messages
+				case ReadResponse.SubscriptionConfirmed:
+				case ReadResponse.CheckpointReceived:
+				case ReadResponse.SubscriptionCaughtUp:
+				case ReadResponse.SubscriptionFellBehind:
+					break;
+			}
+		}
+
+		// Inject a final checkpoint marker if there are unprocessed events
+		if (eventsProcessed > 0) {
+			await dispatcher.InjectCheckpointMarker(lastLogPosition, ct);
+		}
+	}
+
+	/// <summary>
+	/// Builds the partition key function for the dispatcher.
+	/// The dispatcher works with Projections ResolvedEvent (due to V2 namespace shadowing).
+	/// </summary>
+	private Func<ProjectionResolvedEvent, string> GetPartitionKeyFunction() {
+		if (_config.SourceDefinition.ByCustomPartitions) {
+			return projEvent => {
+				var checkpointTag = CheckpointTag.FromPosition(0,
+					projEvent.Position.CommitPosition,
+					projEvent.Position.PreparePosition);
+				return _config.StateHandler.GetStatePartition(checkpointTag, null, projEvent);
+			};
+		}
+
+		if (_config.SourceDefinition.ByStreams) {
+			return projEvent => projEvent.EventStreamId;
+		}
+
+		return _ => "";
+	}
+
+	/// <summary>
+	/// Converts a Core ResolvedEvent (struct from storage engine) to a Projections
+	/// ResolvedEvent (class used by projection state handlers and partition dispatcher).
+	/// This is necessary because the V2 namespace shadows Core.Data.ResolvedEvent
+	/// with Processing.ResolvedEvent.
+	/// </summary>
+	internal static ProjectionResolvedEvent ConvertToProjectionEvent(CoreResolvedEvent coreEvent) {
+		var e = coreEvent.Event;
+		var link = coreEvent.Link;
+		return new ProjectionResolvedEvent(
+			positionStreamId: link?.EventStreamId ?? e.EventStreamId,
+			positionSequenceNumber: link?.EventNumber ?? e.EventNumber,
+			eventStreamId: e.EventStreamId,
+			eventSequenceNumber: e.EventNumber,
+			resolvedLinkTo: link is not null,
+			position: coreEvent.OriginalPosition ?? new TFPos(e.LogPosition, e.TransactionPosition),
+			eventId: e.EventId,
+			eventType: e.EventType,
+			isJson: e.IsJson,
+			data: e.Data.Length > 0 ? System.Text.Encoding.UTF8.GetString(e.Data.Span) : null,
+			metadata: e.Metadata.Length > 0 ? System.Text.Encoding.UTF8.GetString(e.Metadata.Span) : null);
+	}
+
+	private static double GetElapsedMs(long startTimestamp) {
+		return Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
 	}
 
 	public async ValueTask DisposeAsync() {

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Data;
+using Serilog;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class ProjectionEngineV2 : IAsyncDisposable {
+	private static readonly ILogger Log = Serilog.Log.ForContext<ProjectionEngineV2>();
+
+	private readonly ProjectionEngineV2Config _config;
+	private readonly IReadStrategy _readStrategy;
+	private CancellationTokenSource _cts;
+	private Task _runTask;
+
+	public ProjectionEngineV2(ProjectionEngineV2Config config, IReadStrategy readStrategy) {
+		_config = config ?? throw new ArgumentNullException(nameof(config));
+		_readStrategy = readStrategy ?? throw new ArgumentNullException(nameof(readStrategy));
+	}
+
+	public Task Start(TFPos checkpoint, CancellationToken ct) {
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+		_runTask = Task.Run(() => Run(checkpoint, _cts.Token), _cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public bool IsFaulted => _runTask?.IsFaulted ?? false;
+	public Exception FaultException => _runTask?.Exception?.InnerException;
+
+	private async Task Run(TFPos checkpoint, CancellationToken ct) {
+		Log.Information("ProjectionEngineV2 {Name} starting from {Checkpoint}", _config.ProjectionName, checkpoint);
+		// Pipeline will be built in subsequent tasks
+		await Task.CompletedTask;
+	}
+
+	public async ValueTask DisposeAsync() {
+		if (_cts is not null) {
+			await _cts.CancelAsync();
+			if (_runTask is not null) {
+				try { await _runTask; } catch (OperationCanceledException) { }
+			}
+			_cts.Dispose();
+		}
+		await _readStrategy.DisposeAsync();
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2Config.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/ProjectionEngineV2Config.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class ProjectionEngineV2Config {
+	public required string ProjectionName { get; init; }
+	public required IQuerySources SourceDefinition { get; init; }
+	public required IProjectionStateHandler StateHandler { get; init; }
+	public int PartitionCount { get; init; } = 4;
+	public int CheckpointAfterMs { get; init; } = 2000;
+	public int CheckpointHandledThreshold { get; init; } = 4000;
+	public long CheckpointUnhandledBytesThreshold { get; init; } = 10_000_000;
+	public bool EmitEnabled { get; init; }
+	public bool TrackEmittedStreams { get; init; }
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/FilteredAllReadStrategy.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/FilteredAllReadStrategy.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Storage.ReaderIndex;
+using KurrentDB.Core.Services.Transport.Common;
+using KurrentDB.Core.Services.Transport.Enumerators;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2.ReadStrategies;
+
+public sealed class FilteredAllReadStrategy : IReadStrategy {
+	private readonly IPublisher _bus;
+	private readonly IEventFilter _eventFilter;
+	private readonly ClaimsPrincipal _user;
+	private readonly bool _requiresLeader;
+
+	private Enumerator.AllSubscriptionFiltered _enumerator;
+
+	public FilteredAllReadStrategy(
+		IPublisher bus,
+		IEventFilter eventFilter,
+		ClaimsPrincipal user,
+		bool requiresLeader = false) {
+		_bus = bus;
+		_eventFilter = eventFilter;
+		_user = user;
+		_requiresLeader = requiresLeader;
+	}
+
+	public async IAsyncEnumerable<ReadResponse> ReadFrom(
+		TFPos checkpoint,
+		[EnumeratorCancellation] CancellationToken ct) {
+
+		Position? position = checkpoint == TFPos.HeadOfTf
+			? null
+			: Position.FromInt64(checkpoint.CommitPosition, checkpoint.PreparePosition);
+
+		_enumerator = new Enumerator.AllSubscriptionFiltered(
+			bus: _bus,
+			expiryStrategy: DefaultExpiryStrategy.Instance,
+			checkpoint: position,
+			resolveLinks: true,
+			eventFilter: _eventFilter,
+			user: _user,
+			requiresLeader: _requiresLeader,
+			maxSearchWindow: null,
+			checkpointIntervalMultiplier: 1,
+			cancellationToken: ct);
+
+		while (await _enumerator.MoveNextAsync()) {
+			yield return _enumerator.Current;
+		}
+	}
+
+	public async ValueTask DisposeAsync() {
+		if (_enumerator is not null) {
+			await _enumerator.DisposeAsync();
+		}
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/ReadStrategyFactory.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/ReadStrategyFactory.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using KurrentDB.Core.Bus;
+using KurrentDB.Projections.Core.Messages;
+using CoreEventFilter = KurrentDB.Core.Services.Storage.ReaderIndex.EventFilter;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2.ReadStrategies;
+
+public static class ReadStrategyFactory {
+	public static IReadStrategy Create(IQuerySources sources, IPublisher bus, ClaimsPrincipal user) {
+		if (sources.AllStreams) {
+			var filter = sources.HasEvents()
+				? CoreEventFilter.EventType.Prefixes(isAllStream: true, sources.Events)
+				: CoreEventFilter.DefaultAllFilter;
+
+			return new FilteredAllReadStrategy(bus, filter, user);
+		}
+
+		if (sources.HasStreams()) {
+			return new StreamSetReadStrategy(bus, sources.Streams, user);
+		}
+
+		if (sources.HasCategories()) {
+			var prefixes = sources.Categories
+				.Select(c => c + "-")
+				.ToArray();
+
+			var filter = CoreEventFilter.StreamName.Prefixes(isAllStream: true, prefixes);
+			return new FilteredAllReadStrategy(bus, filter, user);
+		}
+
+		throw new ArgumentException(
+			"Unsupported query source combination: must specify AllStreams, Streams, or Categories.");
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/StreamSetReadStrategy.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/ReadStrategies/StreamSetReadStrategy.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Storage.ReaderIndex;
+using KurrentDB.Core.Services.Transport.Common;
+using KurrentDB.Core.Services.Transport.Enumerators;
+using CoreEventFilter = KurrentDB.Core.Services.Storage.ReaderIndex.EventFilter;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2.ReadStrategies;
+
+public sealed class StreamSetReadStrategy : IReadStrategy {
+	private readonly IPublisher _bus;
+	private readonly IEventFilter _eventFilter;
+	private readonly ClaimsPrincipal _user;
+	private readonly bool _requiresLeader;
+
+	private Enumerator.AllSubscriptionFiltered _enumerator;
+
+	public StreamSetReadStrategy(
+		IPublisher bus,
+		string[] streamNames,
+		ClaimsPrincipal user,
+		bool requiresLeader = false) {
+		_bus = bus;
+		_eventFilter = CoreEventFilter.StreamName.Set(isAllStream: true, streamNames);
+		_user = user;
+		_requiresLeader = requiresLeader;
+	}
+
+	public async IAsyncEnumerable<ReadResponse> ReadFrom(
+		TFPos checkpoint,
+		[EnumeratorCancellation] CancellationToken ct) {
+
+		Position? position = checkpoint == TFPos.HeadOfTf
+			? null
+			: Position.FromInt64(checkpoint.CommitPosition, checkpoint.PreparePosition);
+
+		_enumerator = new Enumerator.AllSubscriptionFiltered(
+			bus: _bus,
+			expiryStrategy: DefaultExpiryStrategy.Instance,
+			checkpoint: position,
+			resolveLinks: true,
+			eventFilter: _eventFilter,
+			user: _user,
+			requiresLeader: _requiresLeader,
+			maxSearchWindow: null,
+			checkpointIntervalMultiplier: 1,
+			cancellationToken: ct);
+
+		while (await _enumerator.MoveNextAsync()) {
+			yield return _enumerator.Current;
+		}
+	}
+
+	public async ValueTask DisposeAsync() {
+		if (_enumerator is not null) {
+			await _enumerator.DisposeAsync();
+		}
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Processing/V2/V2ProjectionProcessingStrategy.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/V2/V2ProjectionProcessingStrategy.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Helpers;
+using KurrentDB.Core.Services.TimerService;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using KurrentDB.Projections.Core.Services.Processing.Partitioning;
+using KurrentDB.Projections.Core.Services.Processing.Phases;
+using KurrentDB.Projections.Core.Services.Processing.Strategies;
+using ILogger = Serilog.ILogger;
+
+namespace KurrentDB.Projections.Core.Services.Processing.V2;
+
+public class V2ProjectionProcessingStrategy : ProjectionProcessingStrategy {
+	private readonly IProjectionStateHandler _stateHandler;
+	private readonly ProjectionConfig _projectionConfig;
+	private readonly IQuerySources _sourceDefinition;
+
+	public V2ProjectionProcessingStrategy(
+		string name,
+		ProjectionVersion projectionVersion,
+		IProjectionStateHandler stateHandler,
+		ProjectionConfig projectionConfig,
+		IQuerySources sourceDefinition,
+		ILogger logger,
+		int maxProjectionStateSize)
+		: base(name, projectionVersion, logger, maxProjectionStateSize) {
+		_stateHandler = stateHandler;
+		_projectionConfig = projectionConfig;
+		_sourceDefinition = sourceDefinition;
+	}
+
+	protected override IQuerySources GetSourceDefinition() => _sourceDefinition;
+
+	public override bool GetStopOnEof() => false;
+
+	public override bool GetUseCheckpoints() => true;
+
+	public override bool GetRequiresRootPartition() => false;
+
+	public override bool GetProducesRunningResults() => _sourceDefinition.ProducesResults;
+
+	public override void EnrichStatistics(ProjectionStatistics info) {
+		info.ResultStreamName = _sourceDefinition.ResultStreamNameOption;
+	}
+
+	public override IProjectionProcessingPhase[] CreateProcessingPhases(
+		IPublisher publisher,
+		IPublisher inputQueue,
+		Guid projectionCorrelationId,
+		PartitionStateCache partitionStateCache,
+		Action updateStatistics,
+		CoreProjection coreProjection,
+		ProjectionNamesBuilder namingBuilder,
+		ITimeProvider timeProvider,
+		IODispatcher ioDispatcher,
+		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter) {
+		throw new NotSupportedException(
+			"V2 engine does not use v1 processing phases. Use ProjectionEngineV2 directly.");
+	}
+}


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: 812 → 150 lines (82% reduction) via progressive disclosure. Rules that affect every coding decision stay inline; reference material moved to `.claude/docs/` with a routing table.
- **New docs** in `.claude/docs/`: architecture, api-v2-patterns, testing, protocol-v2, patterns-and-conventions — each with a "read this when" header so agents know when to fetch.
- **New architect-review agent** (`.claude/agents/architect-review.md`): encodes Tim Coleman's review methodology from PR #5562, covering threading safety, parameter design, abstraction discipline, log levels, naming, and encapsulation.
- **New CLAUDE.md content** derived from Tim's review findings:
  - `TcsEnvelope<>` vs `CallbackEnvelope` threading rule (old doc showed the anti-pattern as correct)
  - Non-optional parameters / no-fallbacks convention
  - `ISystemClient` preference over raw `IPublisher`
  - `ClaimsPrincipal` threading-through requirement
  - Projections V2 engine architecture and threading model
  - Log level policy (Verbose/Debug/Information/Warning/Error)

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify `.claude/docs/` files render correctly
- [ ] Verify architect-review agent loads in Claude Code (`architect-review` should appear in agent list)
- [ ] Spot-check that no content was lost — extracted docs should contain everything that was in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)