### PR TITLE
ci: add AgentScore MCP dependency policy gate

### DIFF
--- a/.github/workflows/agentscore-policy-gate.yml
+++ b/.github/workflows/agentscore-policy-gate.yml
@@ -16,5 +16,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Thezenmonster/mcp-verdict-action@v1
         with:
-          packages: "@upstash/context7-mcp,@modelcontextprotocol/server-sequential-thinking"
           fail-on: block

--- a/.github/workflows/agentscore-policy-gate.yml
+++ b/.github/workflows/agentscore-policy-gate.yml
@@ -16,4 +16,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Thezenmonster/mcp-verdict-action@v1
         with:
+          packages: "@upstash/context7-mcp,@modelcontextprotocol/server-sequential-thinking"
           fail-on: block

--- a/.github/workflows/agentscore-policy-gate.yml
+++ b/.github/workflows/agentscore-policy-gate.yml
@@ -1,0 +1,19 @@
+name: AgentScore Policy Gate
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  mcp-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Thezenmonster/mcp-verdict-action@v1
+        with:
+          fail-on: block


### PR DESCRIPTION
## What this does

Adds a GitHub Actions workflow that checks MCP package dependencies on every PR and push to master.

The Action auto-discovers MCP packages from:
- \`package.json\` dependencies
- MCP config files (\`.mcp.json\`, \`mcp.json\`, \`.cursor/mcp.json\`)

For your repo, it will detect and scan:
- \`@upstash/context7-mcp\` (from \`.mcp.json\`)
- \`@modelcontextprotocol/server-sequential-thinking\` (from \`.mcp.json\`)

## What is NOT covered

\`serena\` is installed via \`uvx --from git+https://github.com/oraios/serena\`. This is not an npm package and cannot be scanned. The Action will log a warning:

\`\`\`
serena: git URL install (not an npm package). Not scannable by AgentScore.
\`\`\`

## How it works

- No API key needed. Authenticates via GitHub OIDC.
- First run auto-provisions the repo.
- Shows per-package trust verdicts and AI capability classification.

## To try it

Merge this PR. Push to master. The gate runs automatically.

Ref: #5575

---
Free 30-day pilot. No lock-in. Remove the workflow file anytime.