### PR TITLE
[DB-2044] Reply NotHandled when Persistent subscriptions service is not ready

### DIFF
--- a/src/KurrentDB.Core.XUnit.Tests/Services/PersistentSubscriptions/PersistentSubscriptionServiceNotReadyTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/PersistentSubscriptions/PersistentSubscriptionServiceNotReadyTests.cs
@@ -1,0 +1,196 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Helpers;
+using KurrentDB.Core.LogV2;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Metrics;
+using KurrentDB.Core.Services;
+using KurrentDB.Core.Services.PersistentSubscription;
+using KurrentDB.Core.Services.PersistentSubscription.ConsumerStrategy;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.Fakes;
+using KurrentDB.Core.Tests.Services.Replication;
+using KurrentDB.Core.Tests.TransactionLog;
+using Xunit;
+
+namespace KurrentDB.Core.XUnit.Tests.Services.PersistentSubscriptions;
+
+public class PersistentSubscriptionServiceNotReadyTests {
+	private readonly FakePublisher _publisher = new();
+	private readonly IODispatcher _ioDispatcher;
+
+	public PersistentSubscriptionServiceNotReadyTests() {
+		var bus = new SynchronousScheduler();
+		_ioDispatcher = new IODispatcher(_publisher, bus);
+		bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+	}
+
+	private PersistentSubscriptionService<string> CreateSut() {
+		_publisher.Messages.Clear();
+		var subscriber = new SynchronousScheduler();
+		var queuedHandler = new ThreadPoolMessageScheduler("test", subscriber) {
+			Strategy = ThreadPoolMessageScheduler.SynchronizeMessagesWithUnknownAffinity(),
+		};
+		var index = new FakeReadIndex<LogFormat.V2, string>(_ => false, new LogV2SystemStreams());
+		var strategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry(_publisher, subscriber,
+			Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>());
+		return new PersistentSubscriptionService<string>(
+			queuedHandler, index, _ioDispatcher, _publisher, strategyRegistry, IPersistentSubscriptionTracker.NoOp);
+	}
+
+	private static void AssertNotHandledNotReady(FakeEnvelope envelope) {
+		var reply = Assert.Single(envelope.Replies);
+		var notHandled = Assert.IsType<ClientMessage.NotHandled>(reply);
+		Assert.Equal(ClientMessage.NotHandled.Types.NotHandledReason.NotReady, notHandled.Reason);
+	}
+
+	[Fact]
+	public async Task connect_to_stream_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+		var correlationId = Guid.NewGuid();
+
+		var message = new ClientMessage.ConnectToPersistentSubscriptionToStream(
+			Guid.NewGuid(), correlationId, envelope,
+			Guid.NewGuid(), "connection", "group", "stream",
+			10, string.Empty, null);
+
+		await ((IAsyncHandle<ClientMessage.ConnectToPersistentSubscriptionToStream>)sut)
+			.HandleAsync(message, CancellationToken.None);
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public async Task connect_to_all_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+		var correlationId = Guid.NewGuid();
+
+		var message = new ClientMessage.ConnectToPersistentSubscriptionToAll(
+			Guid.NewGuid(), correlationId, envelope,
+			Guid.NewGuid(), "connection", "group",
+			10, string.Empty, null);
+
+		await ((IAsyncHandle<ClientMessage.ConnectToPersistentSubscriptionToAll>)sut)
+			.HandleAsync(message, CancellationToken.None);
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void create_stream_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.CreatePersistentSubscriptionToStream(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"stream", "group", resolveLinkTos: false, startFrom: 0,
+			messageTimeoutMilliseconds: 10000, recordStatistics: false,
+			maxRetryCount: 5, bufferSize: 10, liveBufferSize: 10,
+			readbatchSize: 10, checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 1, maxCheckPointCount: 1,
+			maxSubscriberCount: 10, namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void create_all_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.CreatePersistentSubscriptionToAll(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"group", eventFilter: null, resolveLinkTos: false,
+			startFrom: new TFPos(0, 0),
+			messageTimeoutMilliseconds: 10000, recordStatistics: false,
+			maxRetryCount: 5, bufferSize: 10, liveBufferSize: 10,
+			readbatchSize: 10, checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 1, maxCheckPointCount: 1,
+			maxSubscriberCount: 10, namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void update_stream_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.UpdatePersistentSubscriptionToStream(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"stream", "group", resolveLinkTos: false, startFrom: 0,
+			messageTimeoutMilliseconds: 10000, recordStatistics: false,
+			maxRetryCount: 5, bufferSize: 10, liveBufferSize: 10,
+			readbatchSize: 10, checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 1, maxCheckPointCount: 1,
+			maxSubscriberCount: 10, namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void update_all_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.UpdatePersistentSubscriptionToAll(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"group", resolveLinkTos: false,
+			startFrom: new TFPos(0, 0),
+			messageTimeoutMilliseconds: 10000, recordStatistics: false,
+			maxRetryCount: 5, bufferSize: 10, liveBufferSize: 10,
+			readbatchSize: 10, checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 1, maxCheckPointCount: 1,
+			maxSubscriberCount: 10, namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void delete_stream_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.DeletePersistentSubscriptionToStream(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"stream", "group", user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void delete_all_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.DeletePersistentSubscriptionToAll(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"group", user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void read_next_messages_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.ReadNextNPersistentMessages(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"stream", "group", 10, user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+}

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -256,8 +256,6 @@ public class PersistentSubscriptionService<TStreamId> :
 			Action<string> onAccessDenied,
 			string user
 	) {
-		if (!_started)
-			return;
 		var stream = eventSource.ToString();
 		var key = BuildSubscriptionGroupKey(stream, groupName);
 		Log.Debug("Creating persistent subscription {subscriptionKey}", key);
@@ -321,6 +319,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.CreatePersistentSubscriptionToStream message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		if (string.IsNullOrEmpty(message.EventStreamId)) {
 			message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
 				message.CorrelationId,
@@ -390,6 +393,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.CreatePersistentSubscriptionToAll message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		try {
 			CreatePersistentSubscription(
 				new PersistentSubscriptionAllStreamEventSource(message.EventFilter),
@@ -467,9 +475,6 @@ public class PersistentSubscriptionService<TStreamId> :
 			Action<string> onAccessDenied,
 			string user
 	) {
-		if (!_started)
-			return;
-
 		var key = BuildSubscriptionGroupKey(stream, groupName);
 		Log.Debug("Updating persistent subscription {subscriptionKey}", key);
 
@@ -543,6 +548,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.UpdatePersistentSubscriptionToStream message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		if (string.IsNullOrEmpty(message.EventStreamId)) {
 			message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
 				message.CorrelationId,
@@ -613,6 +623,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.UpdatePersistentSubscriptionToAll message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		try {
 			UpdatePersistentSubscription(
 				SystemStreams.AllStream,
@@ -727,8 +742,6 @@ public class PersistentSubscriptionService<TStreamId> :
 			Action<string> onAccessDenied,
 			string user
 	) {
-		if (!_started)
-			return;
 		var stream = eventSource.ToString();
 		var key = BuildSubscriptionGroupKey(stream, groupName);
 		Log.Debug("Deleting persistent subscription {subscriptionKey}", key);
@@ -752,6 +765,11 @@ public class PersistentSubscriptionService<TStreamId> :
 
 
 	public void Handle(ClientMessage.DeletePersistentSubscriptionToStream message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		if (string.IsNullOrEmpty(message.EventStreamId)) {
 			message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
 				message.CorrelationId,
@@ -799,6 +817,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.DeletePersistentSubscriptionToAll message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		DeletePersistentSubscription(
 			new PersistentSubscriptionAllStreamEventSource(),
 			message.GroupName,
@@ -925,8 +948,11 @@ public class PersistentSubscriptionService<TStreamId> :
 		IEnvelope envelope,
 		string user,
 		CancellationToken token) {
-		if (!_started)
+
+		if (!_started) {
+			ReplyWithNotReady(envelope, correlationId);
 			return;
+		}
 
 		var stream = eventSource.ToString();
 		if (!_subscriptionTopics.TryGetValue(stream, out _)) {
@@ -1066,8 +1092,10 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.ReadNextNPersistentMessages message) {
-		if (!_started)
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
 			return;
+		}
 
 		if (string.IsNullOrEmpty(message.EventStreamId)) {
 			message.Envelope.ReplyWith(new ClientMessage.ReadNextNPersistentMessagesCompleted(
@@ -1388,5 +1416,12 @@ public class PersistentSubscriptionService<TStreamId> :
 
 	private TimeSpan ToMessageTimeout(int milliseconds) {
 		return milliseconds == 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(milliseconds);
+	}
+
+	private static void ReplyWithNotReady(IEnvelope envelope, Guid correlationId) {
+		envelope.ReplyWith(new ClientMessage.NotHandled(
+			correlationId,
+			ClientMessage.NotHandled.Types.NotHandledReason.NotReady,
+			(string)null));
 	}
 }

--- a/src/KurrentDB.Core/Services/Transport/Http/Configure.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Configure.cs
@@ -408,7 +408,7 @@ public static class Configure {
 		}
 	}
 
-	private static ResponseConfiguration HandleNotHandled(Uri requestedUri, ClientMessage.NotHandled notHandled) {
+	public static ResponseConfiguration HandleNotHandled(Uri requestedUri, ClientMessage.NotHandled notHandled) {
 		switch (notHandled.Reason) {
 			case ClientMessage.NotHandled.Types.NotHandledReason.NotReady:
 				return ServiceUnavailable("Server Is Not Ready");

--- a/src/KurrentDB.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -417,6 +417,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			(args, message) => http.ResponseCodec.To(message),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.ReplayMessagesReceived;
 				if (m == null)
 					throw new Exception("unexpected message " + message);
@@ -473,6 +475,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			(args, message) => http.ResponseCodec.To(message),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.CreatePersistentSubscriptionToStreamCompleted;
 				if (m == null)
 					throw new Exception("unexpected message " + message);
@@ -543,6 +547,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			(args, message) => http.ResponseCodec.To(message),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.UpdatePersistentSubscriptionToStreamCompleted;
 				if (m == null)
 					throw new Exception("unexpected message " + message);
@@ -689,6 +695,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			(args, message) => http.ResponseCodec.To(message),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.DeletePersistentSubscriptionToStreamCompleted;
 				if (m == null)
 					throw new Exception("unexpected message " + message);
@@ -847,6 +855,8 @@ public class PersistentSubscriptionController : CommunicationController {
 
 	private static ResponseConfiguration StatsConfiguration(HttpEntityManager http, Message message) {
 		int code;
+		if (message is ClientMessage.NotHandled notHandled)
+			return Configure.HandleNotHandled(http.RequestedUrl, notHandled);
 		var m = message as MonitoringMessage.GetPersistentSubscriptionStatsCompleted;
 		if (m == null)
 			throw new Exception("unexpected message " + message);
@@ -889,6 +899,8 @@ public class PersistentSubscriptionController : CommunicationController {
 				message as ClientMessage.ReadNextNPersistentMessagesCompleted, stream, groupname, count, embed),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.ReadNextNPersistentMessagesCompleted;
 				if (m == null)
 					throw new Exception("unexpected message " + message);


### PR DESCRIPTION
After a leader change, persistent subscription clients could hang indefinitely when connecting to the new leader before the service finished loading its configuration. The handlers silently returned without replying to the envelope.

Now all handlers reply with NotHandled(NotReady) when !_started, allowing gRPC clients to retry and HTTP clients to receive 503.

The ClusterVNodeController was already able to reply NotHandled for all of these messages, they all derived from ReadRequestMessage.

Thanks to @w1am for figuring out the problem here.