### PR TITLE
[DEV-1625] Require Unicode NFC normalization for schema names

### DIFF
--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/Validators/SchemaNameValidatorTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/Validators/SchemaNameValidatorTests.cs
@@ -3,6 +3,7 @@
 
 // ReSharper disable MethodHasAsyncOverload
 
+using System.Text;
 using FluentValidation;
 using KurrentDB.Api.Infrastructure.FluentValidation;
 using KurrentDB.Api.Streams.Validators;
@@ -33,7 +34,6 @@ public class SchemaNameValidatorTests {
         var vex = await Assert
             .That(() => SchemaNameValidator.Instance.ValidateAndThrow(value))
             .Throws<DetailedValidationException>()
-            // StringMatcher.AsWildcard recently stopped matching multiline.
             .WithMessageMatching(StringMatcher.AsRegex(".*must not be empty.*"));
 
         vex.LogValidationErrors<SchemaNameValidator>();
@@ -50,6 +50,21 @@ public class SchemaNameValidatorTests {
             .Throws<DetailedValidationException>()
             // StringMatcher.AsWildcard recently stopped matching multiline.
             .WithMessageMatching(StringMatcher.AsRegex(".*can only contain.*"));
+
+        vex.LogValidationErrors<SchemaNameValidator>();
+    }
+
+    [Test]
+    [Arguments("café")]
+    [Arguments("Ärztlicher-Bericht")]
+    public async ValueTask throws_when_value_is_not_nfc_normalized(string value) {
+        // Construct NFD form at runtime so the test input is unambiguous regardless of the source file's encoding.
+        var nfd = value.Normalize(NormalizationForm.FormD);
+
+        var vex = await Assert
+            .That(() => SchemaNameValidator.Instance.ValidateAndThrow(nfd))
+            .Throws<DetailedValidationException>()
+            .WithMessageMatching(StringMatcher.AsRegex(".*NFC.*"));
 
         vex.LogValidationErrors<SchemaNameValidator>();
     }

--- a/src/KurrentDB.Api.V2/Modules/Streams/Validators/SchemaNameValidator.cs
+++ b/src/KurrentDB.Api.V2/Modules/Streams/Validators/SchemaNameValidator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using System.Text;
 using FluentValidation;
 using KurrentDB.Api.Infrastructure.FluentValidation;
 
@@ -10,7 +11,9 @@ partial class SchemaNameValidator : ValidatorBase<SchemaNameValidator, string?> 
 	public SchemaNameValidator() =>
 		RuleFor(x => x)
 			.NotEmpty()
-            .WithMessage("{PropertyName} must not be empty.")
+            .WithMessage("{PropertyName} must not be empty")
+			.Must(s => string.IsNullOrEmpty(s) || s.IsNormalized(NormalizationForm.FormC))
+			.WithMessage("{PropertyName} must be in Unicode NFC (Normalization Form C)")
 			.Matches(RegEx())
 			.WithMessage("{PropertyName} can only contain unicode letters, digits, underscores, dashes, periods, colons, and dollar signs. Attempted Value: {PropertyValue}")
             .WithName("Schema name");

--- a/src/KurrentDB.Api.V2/Modules/Streams/Validators/SchemaNameValidator.cs
+++ b/src/KurrentDB.Api.V2/Modules/Streams/Validators/SchemaNameValidator.cs
@@ -11,12 +11,11 @@ partial class SchemaNameValidator : ValidatorBase<SchemaNameValidator, string?> 
 	public SchemaNameValidator() =>
 		RuleFor(x => x)
 			.NotEmpty()
-            .WithMessage("{PropertyName} must not be empty")
+			.WithMessage("Schema name must not be empty")
 			.Must(s => string.IsNullOrEmpty(s) || s.IsNormalized(NormalizationForm.FormC))
-			.WithMessage("{PropertyName} must be in Unicode NFC (Normalization Form C)")
+			.WithMessage("Schema name must be in Unicode NFC (Normalization Form C)")
 			.Matches(RegEx())
-			.WithMessage("{PropertyName} can only contain unicode letters, digits, underscores, dashes, periods, colons, and dollar signs. Attempted Value: {PropertyValue}")
-            .WithName("Schema name");
+			.WithMessage("Schema name can only contain unicode letters, digits, underscores, dashes, periods, colons, and dollar signs. Attempted Value: {PropertyValue}");
 
 	[System.Text.RegularExpressions.GeneratedRegex(@"^[\p{L}\p{N}_.$:-]+$")]
 	private static partial System.Text.RegularExpressions.Regex RegEx();

--- a/src/SchemaRegistry/KurrentDB.SchemaRegistry.Tests/Modules/Schemas/Validators/SchemaNameValidatorTests.cs
+++ b/src/SchemaRegistry/KurrentDB.SchemaRegistry.Tests/Modules/Schemas/Validators/SchemaNameValidatorTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text;
+using Google.Protobuf;
+using KurrentDB.Protocol.Registry.V2;
+
+namespace KurrentDB.SchemaRegistry.Tests.Modules.Schemas.Validators;
+
+public class SchemaNameValidatorTests {
+    // Construct NFC/NFD forms at runtime so the test inputs are unambiguous regardless of the source file's encoding.
+    static readonly string NfcCafe = "café".Normalize(NormalizationForm.FormC);
+    static readonly string NfdCafe = "café".Normalize(NormalizationForm.FormD);
+
+    [Test]
+    public void nfc_schema_name_is_accepted() {
+        var result = SchemaNameValidator.Instance.Validate(NfcCafe);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Test]
+    public void nfd_schema_name_is_rejected() {
+        var result = SchemaNameValidator.Instance.Validate(NfdCafe);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.ErrorMessage.Contains("NFC"));
+    }
+
+    [Test]
+    public void empty_schema_name_is_rejected() {
+        var result = SchemaNameValidator.Instance.Validate("");
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Test]
+    public void get_schema_request_rejects_nfd_schema_name() {
+        var request = new GetSchemaRequest { SchemaName = NfdCafe };
+
+        var result = GetSchemaRequestValidator.Instance.Validate(request);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == nameof(GetSchemaRequest.SchemaName));
+    }
+
+    [Test]
+    public void create_schema_request_rejects_nfd_schema_name() {
+        var request = new CreateSchemaRequest {
+            SchemaName       = NfdCafe,
+            Details          = new SchemaDetails { DataFormat = SchemaDataFormat.Json, Compatibility = CompatibilityMode.None },
+            SchemaDefinition = ByteString.CopyFromUtf8("{}")
+        };
+
+        var result = CreateSchemaRequestValidator.Instance.Validate(request);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == nameof(CreateSchemaRequest.SchemaName));
+    }
+}

--- a/src/SchemaRegistry/KurrentDB.SchemaRegistry/Modules/Schemas/SchemaRequestValidators.cs
+++ b/src/SchemaRegistry/KurrentDB.SchemaRegistry/Modules/Schemas/SchemaRequestValidators.cs
@@ -183,12 +183,11 @@ public partial class SchemaNameValidator : AbstractValidator<string> {
     public SchemaNameValidator() =>
         RuleFor(x => x)
             .NotEmpty()
-            .WithMessage("{PropertyName} must not be empty")
+            .WithMessage("Schema name must not be empty")
             .Must(s => string.IsNullOrEmpty(s) || s.IsNormalized(NormalizationForm.FormC))
-            .WithMessage("{PropertyName} must be in Unicode NFC (Normalization Form C)")
+            .WithMessage("Schema name must be in Unicode NFC (Normalization Form C)")
             .Matches(RegEx())
-            .WithMessage("{PropertyName} can only contain unicode letters, digits, underscores, dashes, periods, colons, and dollar signs. Attempted Value: {PropertyValue}")
-            .WithName("Schema name");
+            .WithMessage("Schema name can only contain unicode letters, digits, underscores, dashes, periods, colons, and dollar signs. Attempted Value: {PropertyValue}");
 
     [System.Text.RegularExpressions.GeneratedRegex(@"^[\p{L}\p{N}_.$:-]+$")]
     private static partial System.Text.RegularExpressions.Regex RegEx();

--- a/src/SchemaRegistry/KurrentDB.SchemaRegistry/Modules/Schemas/SchemaRequestValidators.cs
+++ b/src/SchemaRegistry/KurrentDB.SchemaRegistry/Modules/Schemas/SchemaRequestValidators.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using System.Text;
 using FluentValidation;
 using Google.Protobuf;
 using KurrentDB.Protocol.Registry.V2;
@@ -107,8 +108,7 @@ public class GetSchemaRequestValidator : AbstractValidator<GetSchemaRequest> {
 
     public GetSchemaRequestValidator() {
         RuleFor(x => x.SchemaName)
-            .NotEmpty()
-            .WithMessage("Schema name must not be empty");
+            .SetValidator(SchemaNameValidator.Instance);
     }
 }
 
@@ -183,8 +183,12 @@ public partial class SchemaNameValidator : AbstractValidator<string> {
     public SchemaNameValidator() =>
         RuleFor(x => x)
             .NotEmpty()
+            .WithMessage("{PropertyName} must not be empty")
+            .Must(s => string.IsNullOrEmpty(s) || s.IsNormalized(NormalizationForm.FormC))
+            .WithMessage("{PropertyName} must be in Unicode NFC (Normalization Form C)")
             .Matches(RegEx())
-            .WithMessage("Schema name must not be empty and can only contain unicode letters, digits, underscores, dashes, periods, colons, and dollar signs");
+            .WithMessage("{PropertyName} can only contain unicode letters, digits, underscores, dashes, periods, colons, and dollar signs. Attempted Value: {PropertyValue}")
+            .WithName("Schema name");
 
     [System.Text.RegularExpressions.GeneratedRegex(@"^[\p{L}\p{N}_.$:-]+$")]
     private static partial System.Text.RegularExpressions.Regex RegEx();


### PR DESCRIPTION
Now that schema names can contain Unicode, inputs in NFD form would silently split into distinct schemas: core persists and hashes raw bytes without normalizing, so "café" (precomposed e-acute) and "cafe" + combining acute become different streams.