### PR TITLE
[DB-2085] Fix three JintProjectionStateHandler correctness bugs

### DIFF
--- a/src/KurrentDB.Projections.JavaScript/Services/Interpreted/JintProjectionStateHandler.cs
+++ b/src/KurrentDB.Projections.JavaScript/Services/Interpreted/JintProjectionStateHandler.cs
@@ -209,25 +209,12 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 		_emitted.Clear();
 		if (_definitionBuilder.IsBiState && _state.IsArray()) {
 			var arr = _state.AsArray();
-			if (arr.TryGetValue(0, out var state)) {
-				if (state.IsString()) {
-					newState = state.AsString();
-				} else {
-					newState = ConvertToStringHandlingNulls(state);
-				}
-			} else {
-				newState = "";
-			}
-
-			if (arr.TryGetValue(1, out var sharedState)) {
-				newSharedState = ConvertToStringHandlingNulls(sharedState);
-			} else {
-				newSharedState = null;
-			}
-
-		} else if (_state.IsString()) {
-			newState = _state.AsString();
-			newSharedState = null;
+			newState = arr.TryGetValue(0, out var state)
+				? ConvertToStringHandlingNulls(state)
+				: "";
+			newSharedState = arr.TryGetValue(1, out var sharedState)
+				? ConvertToStringHandlingNulls(sharedState)
+				: null;
 		} else {
 			newState = ConvertToStringHandlingNulls(_state);
 			newSharedState = null;
@@ -731,7 +718,7 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 			} else if (_any != null) {
 				newState = _jsFunctionCaller.Call("$any", _any, state, FromObject(Engine, eventEnvelope));
 			} else {
-				newState = eventEnvelope.BodyRaw;
+				newState = eventEnvelope.IsJson ? eventEnvelope.Body : eventEnvelope.BodyRaw;
 			}
 			return newState == Undefined ? state : newState;
 		}

--- a/src/KurrentDB.Projections.JavaScript/Services/Interpreted/JintProjectionStateHandler.cs
+++ b/src/KurrentDB.Projections.JavaScript/Services/Interpreted/JintProjectionStateHandler.cs
@@ -210,8 +210,8 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 		if (_definitionBuilder.IsBiState && _state.IsArray()) {
 			var arr = _state.AsArray();
 			if (arr.TryGetValue(0, out var state)) {
-				if (_state.IsString()) {
-					newState = _state.AsString();
+				if (state.IsString()) {
+					newState = state.AsString();
 				} else {
 					newState = ConvertToStringHandlingNulls(state);
 				}
@@ -875,17 +875,17 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 			}
 		}
 
-		private bool EnsureBody(out JsValue objectInstance) {
+		private bool EnsureBody(out JsValue value) {
 			if (IsJson && TryGetValue("bodyRaw", out var raw) && raw is not JsUndefined) {
 				var body = raw.IsNull() ? raw : _parser.Parse(raw.AsString());
 				var pd = new PropertyDescriptor(body, false, true, false);
 				SetOwnProperty("body", pd);
 				SetOwnProperty("data", pd);
-				objectInstance = (ObjectInstance)body;
+				value = body;
 				return true;
 			}
 
-			objectInstance = Undefined;
+			value = Undefined;
 			return false;
 		}
 
@@ -1223,7 +1223,11 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 						writer.WriteBooleanValue(true);
 					break;
 				case Types.Number:
-					writer.WriteNumberValue(value.AsNumber());
+					var n = value.AsNumber();
+					if (double.IsFinite(n))
+						writer.WriteNumberValue(n);
+					else
+						writer.WriteNullValue();
 					break;
 				case Types.BigInt:
 					writer.WriteStringValue(value.ToString());

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/Serialization/when_serializing_state.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/Serialization/when_serializing_state.cs
@@ -123,6 +123,34 @@ public class when_serializing_state {
 	}
 
 	[Test]
+	public void nan_serializes_as_null() {
+		var serialized = _sut.Serialize(new JsNumber(double.NaN));
+		Assert.AreEqual("null", serialized);
+	}
+
+	[Test]
+	public void positive_infinity_serializes_as_null() {
+		var serialized = _sut.Serialize(new JsNumber(double.PositiveInfinity));
+		Assert.AreEqual("null", serialized);
+	}
+
+	[Test]
+	public void negative_infinity_serializes_as_null() {
+		var serialized = _sut.Serialize(new JsNumber(double.NegativeInfinity));
+		Assert.AreEqual("null", serialized);
+	}
+
+	[Test]
+	public void object_with_non_finite_number_property_serializes_property_as_null() {
+		var instance = new JsObject(_engine);
+		instance.Set("nan", new JsNumber(double.NaN));
+		instance.Set("inf", new JsNumber(double.PositiveInfinity));
+		instance.Set("ok", new JsNumber(1));
+		var serialized = _sut.Serialize(instance);
+		Assert.AreEqual(@"{""nan"":null,""inf"":null,""ok"":1}", serialized);
+	}
+
+	[Test]
 	public void undefined() {
 		var serialized = _sut.Serialize(JsValue.Undefined);
 		Assert.AreEqual(@"null", serialized);

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_accessing_event_body_with_non_object_data.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_accessing_event_body_with_non_object_data.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Text.Json;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+[TestFixture]
+public class when_accessing_event_body_with_non_object_data : TestFixtureWithInterpretedProjection {
+	protected override void Given() {
+		_projection = @"
+            fromAll().when({$any:
+                function(state, event) {
+                    state.body = event.body;
+                    return state;
+                }
+            });
+        ";
+		_state = @"{}";
+	}
+
+	private string ProcessWithRaw(string raw) {
+		_stateHandler.ProcessEvent(
+			"", CheckpointTag.FromPosition(0, 10, 5), "stream1", "type1", "category", Guid.NewGuid(), 0, "{}",
+			raw, out var state, out _, out _);
+		return state;
+	}
+
+	[Test, Category(_projectionType)]
+	public void raw_null_body_does_not_throw_and_yields_null() {
+		var state = ProcessWithRaw("null");
+		var doc = JsonDocument.Parse(state);
+		Assert.True(doc.RootElement.TryGetProperty("body", out var body));
+		Assert.AreEqual(JsonValueKind.Null, body.ValueKind);
+	}
+
+	[Test, Category(_projectionType)]
+	public void raw_number_body_does_not_throw_and_yields_number() {
+		var state = ProcessWithRaw("42");
+		var doc = JsonDocument.Parse(state);
+		Assert.True(doc.RootElement.TryGetProperty("body", out var body));
+		Assert.AreEqual(JsonValueKind.Number, body.ValueKind);
+		Assert.AreEqual(42, body.GetInt32());
+	}
+
+	[Test, Category(_projectionType)]
+	public void raw_string_body_does_not_throw_and_yields_string() {
+		var state = ProcessWithRaw("\"hello\"");
+		var doc = JsonDocument.Parse(state);
+		Assert.True(doc.RootElement.TryGetProperty("body", out var body));
+		Assert.AreEqual(JsonValueKind.String, body.ValueKind);
+		Assert.AreEqual("hello", body.GetString());
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_round_tripping_bi_state_js_projection_with_string_state.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_round_tripping_bi_state_js_projection_with_string_state.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.Services.Jint;
 
 [TestFixture]
-public class when_running_bi_state_js_projection_with_string_state : TestFixtureWithInterpretedProjection {
+public class when_round_tripping_bi_state_js_projection_with_string_state : TestFixtureWithInterpretedProjection {
 	protected override void Given() {
 		_projection = @"
                 options({
@@ -21,15 +21,22 @@ public class when_running_bi_state_js_projection_with_string_state : TestFixture
                     }});
             ";
 		_state = @"{}";
-		_sharedState = @"{""sharedCount"": 0}";
+		_sharedState = @"{}";
 	}
 
 	[Test, Category(_projectionType)]
-	public void state_returned_as_raw_string_not_json_encoded() {
+	public void produced_state_is_json_encoded_so_it_round_trips() {
 		_stateHandler.ProcessEvent(
 			"", CheckpointTag.FromPosition(0, 10, 5), "stream1", "type1", "category", Guid.NewGuid(), 0, "metadata",
-			@"{""a"":""b""}", out var state, out var sharedState, out var emittedEvents);
+			@"{}", out var producedState, out var producedSharedState, out _);
 
-		Assert.AreEqual("hello", state);
+		Assert.AreEqual("\"hello\"", producedState,
+			"Bi-state slot[0] string state must be JSON-encoded so Load() can parse it on restart.");
+
+		var freshHandler = CreateStateHandler();
+		Assert.DoesNotThrow(
+			() => freshHandler.Load(producedState),
+			$"Load() threw on the produced state value: <<{producedState}>>. Round-trip is broken.");
+		Assert.DoesNotThrow(() => freshHandler.LoadShared(producedSharedState));
 	}
 }

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_round_tripping_uni_state_js_projection_with_string_state.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_round_tripping_uni_state_js_projection_with_string_state.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+[TestFixture]
+public class when_round_tripping_uni_state_js_projection_with_string_state : TestFixtureWithInterpretedProjection {
+	protected override void Given() {
+		_projection = @"
+                fromAll().when({
+                    type1: function(state, event) {
+                        return ""hello"";
+                    }
+                });
+            ";
+		_state = @"{}";
+	}
+
+	[Test, Category(_projectionType)]
+	public void produced_state_is_json_encoded_so_it_round_trips() {
+		_stateHandler.ProcessEvent(
+			"", CheckpointTag.FromPosition(0, 10, 5), "stream1", "type1", "category", Guid.NewGuid(), 0, "metadata",
+			@"{}", out var producedState, out _, out _);
+
+		Assert.AreEqual("\"hello\"", producedState,
+			"String state must be JSON-encoded so Load() can parse it on restart.");
+
+		var freshHandler = CreateStateHandler();
+		Assert.DoesNotThrow(
+			() => freshHandler.Load(producedState),
+			$"Load() threw on the produced state value: <<{producedState}>>. Round-trip is broken.");
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_running_bi_state_js_projection_with_string_state.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_running_bi_state_js_projection_with_string_state.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+[TestFixture]
+public class when_running_bi_state_js_projection_with_string_state : TestFixtureWithInterpretedProjection {
+	protected override void Given() {
+		_projection = @"
+                options({
+                    biState: true,
+                });
+                fromAll().foreachStream().when({
+                    type1: function(state, event) {
+                        return [""hello"", state[1]];
+                    }});
+            ";
+		_state = @"{}";
+		_sharedState = @"{""sharedCount"": 0}";
+	}
+
+	[Test, Category(_projectionType)]
+	public void state_returned_as_raw_string_not_json_encoded() {
+		_stateHandler.ProcessEvent(
+			"", CheckpointTag.FromPosition(0, 10, 5), "stream1", "type1", "category", Guid.NewGuid(), 0, "metadata",
+			@"{""a"":""b""}", out var state, out var sharedState, out var emittedEvents);
+
+		Assert.AreEqual("hello", state);
+	}
+}


### PR DESCRIPTION
## Summary

- Projections reading `event.body` no longer fault on events with primitive JSON
  bodies (numbers, strings, booleans, `null`, as opposed to objects).
- Projections that return string state — and projections defined without explicit
  `when()` handlers — now persist and reload state correctly across restarts.
- Projection state containing `NaN` or `Infinity` is now persisted as `null`
  (matching `JSON.stringify`) instead of faulting the projection.

## Details

Fixes three correctness bugs in `JintProjectionStateHandler` (shared by V1 and V2 projection engines). Each bug faults the projection on a real-world input.

- **`EnsureBody` cast** (`JintProjectionStateHandler.cs:884`) — `(ObjectInstance)body` throws `InvalidCastException` whenever `bodyRaw` parses to a non-object: `null`, a number, a string, or a boolean. Cast removed; the `out` parameter was already typed `JsValue`. The sibling `EnsureMetadata` was already correct — this matches it.
- **`PrepareOutput` raw string output** (`JintProjectionStateHandler.cs:207-217`) — both bi-state and uni-state paths emitted JS string state raw (e.g. `hello`) instead of JSON-encoded, so `Load()`'s `JsonParser.Parse` faults on restart. Always JSON-encode via
  `ConvertToStringHandlingNulls`, restoring the V8 prelude's always-`JSON.stringify` contract.
- **`SerializePrimitive` NaN/Infinity** (`JintProjectionStateHandler.cs:1226`) — `Utf8JsonWriter.WriteNumberValue(double)` throws `ArgumentException` on non-finite doubles regardless of `SkipValidation`. Now guarded with `double.IsFinite`; non-finite values serialize as `null` to match `JSON.stringify` semantics.

Linear issue: [DB-2085](https://linear.app/kurrent/issue/DB-2085/jintprojectionstatehandler-three-correctness-bugs-body-cast-bistate)

## Test plan

TDD — each test was watched fail with the exact reported error before the fix landed.

- [x] `when_accessing_event_body_with_non_object_data` — raw `null`, raw `42`, raw `"hello"` event bodies are accessible via `event.body` without `InvalidCastException`.
- [x] `when_running_bi_state_js_projection_with_string_state` — biState returning `["foo", {…}]` produces `newState == "foo"` (raw, not JSON-quoted).
- [x] `when_serializing_state` — `JsNumber(NaN)`, `+Infinity`, `-Infinity`, and an object containing those properties all serialize as `null`.
- [x] Full Jint test suite: 8 new tests green; 5 pre-existing failures unrelated to this fix (DotNext message routing in projection-management subscription tests) confirmed present on `master` baseline before the change.