### PR TITLE
[DB-2027] Improve pinned persistent subscription performance under burst load (#5576)

### DIFF
--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -387,16 +387,19 @@ public class LiveTests {
 	public void live_subscription_pushes_events_to_client() {
 		var envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromCurrent());
 		reader.Load(null);
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(1, envelope.Replies.Count);
 	}
 
@@ -405,12 +408,14 @@ public class LiveTests {
 		var envelope1 = new FakeEnvelope();
 		var envelope2 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferRoundRobin()
 				.StartFromCurrent());
 		reader.Load(null);
@@ -418,21 +423,24 @@ public class LiveTests {
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope2, 10, "foo", "bar");
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(1, _eventSource));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(1, envelope1.Replies.Count);
 		Assert.AreEqual(1, envelope2.Replies.Count);
 	}
 
 	[Test]
-	public void live_subscription_with_prefer_one_and_two_pushes_events_to_both() {
+	public void live_subscription_with_dispatch_to_single_pushes_events_to_one() {
 		var envelope1 = new FakeEnvelope();
 		var envelope2 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromCurrent());
 		reader.Load(null);
@@ -440,6 +448,7 @@ public class LiveTests {
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope2, 10, "foo", "bar");
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(1, _eventSource));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(2, envelope1.Replies.Count);
 	}
 
@@ -448,16 +457,19 @@ public class LiveTests {
 	public void subscription_with_pull_sends_data_to_client() {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 		reader.Load(null);
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 		sub.HandleReadCompleted(new[] { Helper.GetFakeEventFor(0, _eventSource) }, Helper.GetStreamPositionFor(1, _eventSource), false);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(1, envelope1.Replies.Count);
 	}
 
@@ -465,17 +477,20 @@ public class LiveTests {
 	public void subscription_with_pull_does_not_crash_if_not_ready_yet() {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 		Assert.DoesNotThrow(() => {
 			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			sub.HandleReadCompleted(new[] { Helper.GetFakeEventFor(0, _eventSource) }, Helper.GetStreamPositionFor(1, _eventSource),
 				false);
+			pushScheduler.Push(sub);
 		});
 	}
 
@@ -483,16 +498,19 @@ public class LiveTests {
 	public void subscription_with_live_data_does_not_crash_if_not_ready_yet() {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 		Assert.DoesNotThrow(() => {
 			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource));
+			pushScheduler.Push(sub);
 		});
 	}
 
@@ -502,12 +520,14 @@ public class LiveTests {
 		var envelope1 = new FakeEnvelope();
 		var envelope2 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferRoundRobin()
 				.StartFromBeginning());
 		reader.Load(null);
@@ -517,6 +537,7 @@ public class LiveTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(1, envelope1.Replies.Count);
 		Assert.AreEqual(1, envelope2.Replies.Count);
 	}
@@ -527,12 +548,14 @@ public class LiveTests {
 		var envelope1 = new FakeEnvelope();
 		var envelope2 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning());
 		reader.Load(null);
@@ -542,6 +565,7 @@ public class LiveTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(2, envelope1.Replies.Count);
 	}
 
@@ -551,6 +575,7 @@ public class LiveTests {
 		var eventsFoundSource = new TaskCompletionSource<bool>();
 		var envelope = new FakeEnvelope();
 		var checkpointReader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader(
@@ -587,6 +612,7 @@ public class LiveTests {
 				.WithCheckpointReader(checkpointReader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 
 		//load the existing checkpoint at event #0
@@ -596,6 +622,7 @@ public class LiveTests {
 
 		//Meanwhile, during this 100ms time window, a new live event #3 comes in and subscription is notified
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource));
+		pushScheduler.Push(sub);
 
 		await eventsFoundSource.Task;
 
@@ -603,6 +630,7 @@ public class LiveTests {
 
 		//a subscriber coming in a while later, should receive all 3 events
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
+		pushScheduler.Push(sub);
 
 		//all 3 events should be received by the subscriber (except event 0 - the checkpoint which is skipped)
 		Assert.AreEqual(3, envelope.Replies.Count);
@@ -615,6 +643,7 @@ public class FilteredAllTests {
 	public void live_subscription_with_stream_prefix_filter_pushes_matching_events_to_client() {
 		var envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var streamFilter = EventFilter.StreamName.Prefixes(true, "test");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", streamFilter)
@@ -622,6 +651,7 @@ public class FilteredAllTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromCurrent());
 		reader.Load(null);
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
@@ -630,6 +660,7 @@ public class FilteredAllTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(2, _eventSource, streamPrefix: "test"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource, streamPrefix: "foo"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(4, _eventSource, streamPrefix: "bar"));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(2, envelope.Replies.Count);
 	}
 
@@ -637,6 +668,7 @@ public class FilteredAllTests {
 	public void live_subscription_with_stream_regex_filter_pushes_matching_events_to_client() {
 		var envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var streamFilter = EventFilter.StreamName.Regex(true, "^te");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", streamFilter)
@@ -644,6 +676,7 @@ public class FilteredAllTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromCurrent());
 		reader.Load(null);
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
@@ -652,6 +685,7 @@ public class FilteredAllTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(2, _eventSource, streamPrefix: "team"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource, streamPrefix: "tteam"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(4, _eventSource, streamPrefix: "bar"));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(2, envelope.Replies.Count);
 	}
 
@@ -659,6 +693,7 @@ public class FilteredAllTests {
 	public void live_subscription_with_event_type_prefix_filter_pushes_matching_events_to_client() {
 		var envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.EventType.Prefixes(true, "test");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -666,6 +701,7 @@ public class FilteredAllTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromCurrent());
 		reader.Load(null);
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
@@ -674,6 +710,7 @@ public class FilteredAllTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(2, _eventSource, eventType: "test"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource, eventType: "foo"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(4, _eventSource, eventType: "bar"));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(2, envelope.Replies.Count);
 	}
 
@@ -681,6 +718,7 @@ public class FilteredAllTests {
 	public void live_subscription_with_event_type_regex_filter_pushes_matching_events_to_client() {
 		var envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.EventType.Regex(true, "^te");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -688,6 +726,7 @@ public class FilteredAllTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromCurrent());
 		reader.Load(null);
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
@@ -696,6 +735,7 @@ public class FilteredAllTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(2, _eventSource, eventType: "team"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource, eventType: "tteam"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(4, _eventSource, eventType: "bar"));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(2, envelope.Replies.Count);
 	}
 
@@ -704,6 +744,7 @@ public class FilteredAllTests {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.StreamName.Prefixes(true, "stream");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -712,6 +753,7 @@ public class FilteredAllTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -722,6 +764,7 @@ public class FilteredAllTests {
 
 		sub.HandleSkippedEvents(Helper.GetStreamPositionFor(1, _eventSource), 2);
 		sub.NotifyClockTick(DateTime.UtcNow);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(1, _eventSource), cp);
 	}
 
@@ -730,6 +773,7 @@ public class FilteredAllTests {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.StreamName.Prefixes(true, "stream");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -738,6 +782,7 @@ public class FilteredAllTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -748,6 +793,7 @@ public class FilteredAllTests {
 
 		sub.HandleSkippedEvents(Helper.GetStreamPositionFor(1, _eventSource), 6);
 
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(1, _eventSource), cp);
 	}
 
@@ -756,6 +802,7 @@ public class FilteredAllTests {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.StreamName.Prefixes(true, "stream");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -764,6 +811,7 @@ public class FilteredAllTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -776,12 +824,15 @@ public class FilteredAllTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
+
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
 		});
 
 		sub.HandleSkippedEvents(Helper.GetStreamPositionFor(2, _eventSource), 3);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(2, _eventSource), cp);
 	}
 
@@ -790,6 +841,7 @@ public class FilteredAllTests {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.StreamName.Prefixes(true, "stream");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -798,6 +850,7 @@ public class FilteredAllTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -805,11 +858,13 @@ public class FilteredAllTests {
 		var corrid = Guid.NewGuid();
 		sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
+		pushScheduler.Push(sub);
 
 		sub.HandleReadCompleted(new[] {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 
 		sub.HandleSkippedEvents(Helper.GetStreamPositionFor(2, _eventSource), 5);
 		Assert.IsNull(cp);
@@ -820,6 +875,7 @@ public class FilteredAllTests {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.StreamName.Prefixes(true, "foo");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -828,6 +884,7 @@ public class FilteredAllTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -843,6 +900,7 @@ public class FilteredAllTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(2, _eventSource, streamPrefix: "test"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource, streamPrefix: "test"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(4, _eventSource, streamPrefix: "test"));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(4, _eventSource), cp);
 	}
 
@@ -851,6 +909,7 @@ public class FilteredAllTests {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.StreamName.Prefixes(true, "foo");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -859,6 +918,7 @@ public class FilteredAllTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -872,6 +932,7 @@ public class FilteredAllTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource, streamPrefix: "test"));
 
 		sub.NotifyClockTick(DateTime.UtcNow);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(0, _eventSource), cp);
 	}
 
@@ -880,6 +941,7 @@ public class FilteredAllTests {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.StreamName.Prefixes(true, "foo");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -888,6 +950,7 @@ public class FilteredAllTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -900,6 +963,7 @@ public class FilteredAllTests {
 
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource, streamPrefix: "foo"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(1, _eventSource, streamPrefix: "foo"));
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
@@ -908,6 +972,7 @@ public class FilteredAllTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(2, _eventSource, streamPrefix: "test"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource, streamPrefix: "test"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(4, _eventSource, streamPrefix: "test"));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(4, _eventSource), cp);
 	}
 
@@ -916,6 +981,7 @@ public class FilteredAllTests {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var eventFilter = EventFilter.StreamName.Prefixes(true, "foo");
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToAllParamsBuilder.CreateFor("groupName", eventFilter)
@@ -924,6 +990,7 @@ public class FilteredAllTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -933,6 +1000,7 @@ public class FilteredAllTests {
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 
 		sub.HandleReadCompleted(Array.Empty<ResolvedEvent>(), new PersistentSubscriptionAllStreamPosition(0, 0), true);
+		pushScheduler.Push(sub);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource, streamPrefix: "foo"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(1, _eventSource, streamPrefix: "foo"));
@@ -940,6 +1008,7 @@ public class FilteredAllTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(2, _eventSource, streamPrefix: "test"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource, streamPrefix: "test"));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(4, _eventSource, streamPrefix: "test"));
+		pushScheduler.Push(sub);
 		Assert.IsNull(cp);
 	}
 }
@@ -1091,12 +1160,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MinimumToCheckPoint(5)
@@ -1109,7 +1180,9 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0) });
+		pushScheduler.Push(sub);
 		Assert.IsNull(cp);
 	}
 
@@ -1118,12 +1191,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
@@ -1136,7 +1211,9 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0) });
+		pushScheduler.Push(sub);
 		Assert.IsNull(cp);
 	}
 
@@ -1145,12 +1222,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MaximumToCheckPoint(1));
@@ -1163,10 +1242,12 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(1, _eventSource),
 			Helper.GetFakeEventFor(2, _eventSource),
 		}, Helper.GetStreamPositionFor(3, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
 		});
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(1, _eventSource), cp);
 	}
 
@@ -1175,12 +1256,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MaximumToCheckPoint(1));
@@ -1194,10 +1277,12 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(2, _eventSource),
 			Helper.GetFakeEventFor(3, _eventSource),
 		}, Helper.GetStreamPositionFor(4, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
 		});
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(1, _eventSource), cp);
 	}
 
@@ -1206,12 +1291,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MaximumToCheckPoint(1));
@@ -1225,9 +1312,11 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(2, _eventSource),
 			Helper.GetFakeEventFor(3, _eventSource),
 		}, Helper.GetStreamPositionFor(4, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 		});
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(Helper.GetStreamPositionFor(0, _eventSource), cp);
 	}
@@ -1237,12 +1326,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MaximumToCheckPoint(1));
@@ -1256,8 +1347,10 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(2, _eventSource),
 			Helper.GetFakeEventFor(3, _eventSource),
 		}, Helper.GetStreamPositionFor(4, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0), Helper.GetEventIdFor(2) });
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(1) }, NakAction.Park, "test park");
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(2, _eventSource), cp);
 	}
 
@@ -1266,12 +1359,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MaximumToCheckPoint(1));
@@ -1285,6 +1380,7 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(2, _eventSource),
 			Helper.GetFakeEventFor(3, _eventSource),
 		}, Helper.GetStreamPositionFor(4, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(2)
 		}, NakAction.Retry, "test retry");
@@ -1293,6 +1389,7 @@ public class Checkpointing {
 			Helper.GetEventIdFor(1),
 			Helper.GetEventIdFor(3),
 		});
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(1, _eventSource), cp);
 	}
 
@@ -1301,12 +1398,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MaximumToCheckPoint(1));
@@ -1319,11 +1418,13 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(1, _eventSource),
 			Helper.GetFakeEventFor(2, _eventSource)
 		}, Helper.GetStreamPositionFor(3, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
 			Helper.GetEventIdFor(2)
 		});
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(2, _eventSource), cp);
 	}
 
@@ -1332,6 +1433,7 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
@@ -1339,6 +1441,7 @@ public class Checkpointing {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.PreferDispatchToSingle()
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -1351,11 +1454,13 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(1, _eventSource),
 			Helper.GetFakeEventFor(2, _eventSource)
 		}, Helper.GetStreamPositionFor(3, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
 		});
 		sub.NotifyClockTick(DateTime.UtcNow);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(1, _eventSource), cp);
 	}
 
@@ -1364,12 +1469,14 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.MinimumToCheckPoint(2)
@@ -1383,11 +1490,13 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(1, _eventSource),
 			Helper.GetFakeEventFor(2, _eventSource)
 		}, Helper.GetStreamPositionFor(3, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
 		});
 		sub.NotifyClockTick(DateTime.UtcNow);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(1, _eventSource), cp);
 	}
 
@@ -1395,12 +1504,14 @@ public class Checkpointing {
 	public void subscription_does_write_checkpoint_for_disconnected_clients_on_time_when_min_is_hit() {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(5));
@@ -1410,12 +1521,14 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource),
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.GetNextNOrLessMessages(2).ToArray();
 		sub.AcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
 		});
 		sub.NotifyClockTick(DateTime.UtcNow);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(Helper.GetStreamPositionFor(1, _eventSource), cp);
 	}
 
@@ -1424,12 +1537,14 @@ public class Checkpointing {
 		subscription_writes_correct_checkpoint_when_outstanding_messages_is_empty_and_retry_buffer_is_non_empty() {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(1));
@@ -1445,6 +1560,7 @@ public class Checkpointing {
 			Helper.GetFakeEventFor(2, _eventSource),
 			Helper.GetFakeEventFor(3, _eventSource),
 		}, Helper.GetStreamPositionFor(4, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.GetNextNOrLessMessages(3).ToArray();
 		sub.AcknowledgeMessagesProcessed(clientCorrelationId, new[] {
 			Helper.GetEventIdFor(1)
@@ -1462,6 +1578,7 @@ public class Checkpointing {
 
 		//Disconnect the client
 		Assert.IsTrue(sub.RemoveClientByConnectionId(clientConnectionId));
+		pushScheduler.Push(sub);
 
 		//this should empty the _outstandingMessages buffer and move events 2 & 3 to the retry queue
 		Assert.AreEqual(sub.OutstandingMessageCount, 0);
@@ -1478,6 +1595,7 @@ public class Checkpointing {
 		IPersistentSubscriptionStreamPosition cp = null;
 		var reader = new FakeCheckpointReader();
 		var messageParker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
@@ -1485,6 +1603,7 @@ public class Checkpointing {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => cp = i))
 				.WithMessageParker(messageParker)
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(1));
@@ -1498,6 +1617,7 @@ public class Checkpointing {
 		sub.HandleReadCompleted(new[] {
 			Helper.GetFakeEventFor(4, _eventSource)
 		}, Helper.GetStreamPositionFor(5, _eventSource), true);
+		pushScheduler.Push(sub);
 
 		//get the message and acknowledge receipt
 		sub.GetNextNOrLessMessages(1).ToArray();
@@ -1520,6 +1640,7 @@ public class Checkpointing {
 		sub.HandleParkedReadCompleted(new[] {
 			parkedEvent,
 		}, new PersistentSubscriptionSingleStreamPosition(16), true, 17);
+		pushScheduler.Push(sub);
 
 		//checkpoint should still be at 4.
 		sub.TryMarkCheckpoint(false);
@@ -1534,6 +1655,7 @@ public class Checkpointing {
 
 		//acknowledge receipt of message. the parked event is no longer in retry or outstanding message buffers
 		sub.AcknowledgeMessagesProcessed(clientCorrelationId, new[] { parkedEventId });
+		pushScheduler.Push(sub);
 
 		//checkpoint should still be at 4.
 		sub.TryMarkCheckpoint(false);
@@ -1683,12 +1805,14 @@ public class TimeoutTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.WithMessageTimeoutOf(TimeSpan.FromSeconds(3)));
@@ -1698,8 +1822,10 @@ public class TimeoutTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource),
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		sub.NotifyClockTick(DateTime.UtcNow.AddSeconds(1));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(0, envelope1.Replies.Count);
 		Assert.AreEqual(0, parker.ParkedEvents.Count);
 	}
@@ -1709,12 +1835,14 @@ public class TimeoutTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.WithMessageTimeoutOf(TimeSpan.FromSeconds(1)));
@@ -1728,8 +1856,10 @@ public class TimeoutTests {
 			Helper.BuildLinkEvent(id2, "streamName", 1,
 				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamSource", 0, 0, 0), false, 2, 2)
 		}, Helper.GetStreamPositionFor(1, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		sub.NotifyClockTick(DateTime.UtcNow.AddSeconds(3));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(2, envelope1.Replies.Count);
 		var msg1 = (ClientMessage.PersistentSubscriptionStreamEventAppeared)envelope1.Replies[0];
 		var msg2 = (ClientMessage.PersistentSubscriptionStreamEventAppeared)envelope1.Replies[1];
@@ -1768,12 +1898,14 @@ public class TimeoutTests {
 	public void messages_dont_get_retried_when_acked_on_synchronous_reads() {
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.WithMessageTimeoutOf(TimeSpan.FromSeconds(1)));
@@ -1782,12 +1914,14 @@ public class TimeoutTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource),
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		sub.GetNextNOrLessMessages(2).ToArray();
 		sub.AcknowledgeMessagesProcessed(Guid.Empty, new[] {
 			Helper.GetEventIdFor(0),
 			Helper.GetEventIdFor(1),
 		});
 		sub.NotifyClockTick(DateTime.Now.AddSeconds(3));
+		pushScheduler.Push(sub);
 		var retries = sub.GetNextNOrLessMessages(2).ToArray();
 		Assert.AreEqual(0, retries.Length);
 		Assert.AreEqual(0, parker.ParkedEvents.Count);
@@ -1798,12 +1932,14 @@ public class TimeoutTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.WithMaxRetriesOf(0)
@@ -1813,8 +1949,10 @@ public class TimeoutTests {
 		sub.HandleReadCompleted(new[] {
 			Helper.GetFakeEventFor(0, _eventSource)
 		}, Helper.GetStreamPositionFor(1, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		sub.NotifyClockTick(DateTime.UtcNow.AddSeconds(3));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(0, envelope1.Replies.Count);
 		Assert.AreEqual(1, parker.ParkedEvents.Count);
 		Assert.AreEqual(Helper.GetEventIdFor(0), parker.ParkedEvents[0].OriginalEvent.EventId);
@@ -1825,12 +1963,14 @@ public class TimeoutTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
 				.WithMaxRetriesOf(0)
@@ -1842,8 +1982,10 @@ public class TimeoutTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		sub.NotifyClockTick(DateTime.UtcNow.AddSeconds(3));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(0, envelope1.Replies.Count);
 		Assert.AreEqual(2, parker.ParkedEvents.Count);
 
@@ -1860,12 +2002,14 @@ public class TimeoutTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.WithMaxRetriesOf(0)
 				.WithMessageTimeoutOf(TimeSpan.Zero)
 				.StartFromBeginning());
@@ -1876,6 +2020,7 @@ public class TimeoutTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, envelope1.Replies.Count);
 
@@ -1890,6 +2035,7 @@ public class TimeoutTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(4, envelope1.Replies.Count);
 	}
@@ -1899,12 +2045,14 @@ public class TimeoutTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.WithMaxRetriesOf(0)
 				.PreferDispatchToSingle()
 				.StartFromBeginning()
@@ -1915,9 +2063,11 @@ public class TimeoutTests {
 			Helper.GetFakeEventFor(0, _eventSource),
 			Helper.GetFakeEventFor(1, _eventSource)
 		}, Helper.GetStreamPositionFor(2, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		// Default timeout is 30s
 		sub.NotifyClockTick(DateTime.UtcNow.AddMinutes(1));
+		pushScheduler.Push(sub);
 		Assert.AreEqual(0, envelope1.Replies.Count);
 		Assert.AreEqual(0, parker.ParkedEvents.Count);
 	}
@@ -1937,12 +2087,14 @@ public class NAKTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 		reader.Load(null);
 		var corrid = Guid.NewGuid();
@@ -1951,10 +2103,12 @@ public class NAKTests {
 		sub.HandleReadCompleted(new[] {
 			Helper.GetFakeEventFor(0, _eventSource)
 		}, Helper.GetStreamPositionFor(1, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] {
 			Helper.GetEventIdFor(0)
 		}, NakAction.Park, "a reason from client.");
+		pushScheduler.Push(sub);
 		Assert.AreEqual(0, envelope1.Replies.Count);
 		Assert.AreEqual(1, parker.ParkedEvents.Count);
 		Assert.AreEqual(Helper.GetEventIdFor(0), parker.ParkedEvents[0].OriginalEvent.EventId);
@@ -1965,12 +2119,14 @@ public class NAKTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 		reader.Load(null);
 		var corrid = Guid.NewGuid();
@@ -1978,6 +2134,7 @@ public class NAKTests {
 		sub.HandleReadCompleted(new[] {
 			Helper.GetFakeEventFor(0, _eventSource)
 		}, Helper.GetStreamPositionFor(1, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0) }, NakAction.Skip, "a reason from client.");
 		Assert.AreEqual(0, envelope1.Replies.Count);
@@ -1989,12 +2146,14 @@ public class NAKTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 		reader.Load(null);
 		var corrid = Guid.NewGuid();
@@ -2002,8 +2161,10 @@ public class NAKTests {
 		sub.HandleReadCompleted(new[] {
 			Helper.GetFakeEventFor(0, _eventSource)
 		}, Helper.GetStreamPositionFor(1, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0) }, NakAction.Unknown, "a reason from client.");
+		pushScheduler.Push(sub);
 		Assert.AreEqual(1, envelope1.Replies.Count);
 		Assert.AreEqual(0, parker.ParkedEvents.Count);
 	}
@@ -2013,12 +2174,14 @@ public class NAKTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 		reader.Load(null);
 		var corrid = Guid.NewGuid();
@@ -2026,8 +2189,10 @@ public class NAKTests {
 		sub.HandleReadCompleted(new[] {
 			Helper.GetFakeEventFor(0, _eventSource)
 		}, Helper.GetStreamPositionFor(1, _eventSource), false);
+		pushScheduler.Push(sub);
 		envelope1.Replies.Clear();
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0) }, NakAction.Retry, "a reason from client.");
+		pushScheduler.Push(sub);
 		Assert.AreEqual(1, envelope1.Replies.Count);
 		Assert.AreEqual(Helper.GetEventIdFor(0),
 			((ClientMessage.PersistentSubscriptionStreamEventAppeared)envelope1.Replies[0]).Event.Event.EventId);
@@ -2039,6 +2204,7 @@ public class NAKTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
@@ -2046,6 +2212,7 @@ public class NAKTests {
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMaxRetriesOf(10)
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning());
 		reader.Load(null);
 		var corrid = Guid.NewGuid();
@@ -2054,9 +2221,11 @@ public class NAKTests {
 		sub.HandleReadCompleted(new[] {
 			ev,
 		}, Helper.GetStreamPositionFor(1, _eventSource), false);
+		pushScheduler.Push(sub);
 
 		for (int i = 1; i < 11; i++) {
 			sub.NotAcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0) }, NakAction.Retry, "a reason from client.");
+			pushScheduler.Push(sub);
 			Assert.AreEqual(i + 1, envelope1.Replies.Count);
 		}
 
@@ -2064,6 +2233,7 @@ public class NAKTests {
 
 		//This time should be parked
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0) }, NakAction.Retry, "a reason from client.");
+		pushScheduler.Push(sub);
 		Assert.AreEqual(11, envelope1.Replies.Count);
 		Assert.That(parker.ParkedEvents, Has.Member(ev));
 	}
@@ -2073,12 +2243,14 @@ public class NAKTests {
 		var envelope1 = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
 		var parker = new FakeMessageParker();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(parker)
+				.WithPushScheduler(pushScheduler)
 				.WithMaxRetriesOf(0)
 				.WithMessageTimeoutOf(TimeSpan.Zero)
 				.StartFromBeginning());
@@ -2091,14 +2263,17 @@ public class NAKTests {
 			Helper.GetFakeEventFor(1, _eventSource),
 			Helper.GetFakeEventFor(2, _eventSource)
 		}, Helper.GetStreamPositionFor(3, _eventSource), false);
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, envelope1.Replies.Count);
 
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(0) }, NakAction.Park, "a reason from client.");
+		pushScheduler.Push(sub);
 		Assert.AreEqual(2, envelope1.Replies.Count);
 		Assert.That(parker.ParkedEvents, Has.Exactly(1).Matches<ResolvedEvent>(_ => _.Event.EventId == Helper.GetEventIdFor(0)));
 
 		sub.NotAcknowledgeMessagesProcessed(corrid, new[] { Helper.GetEventIdFor(1) }, NakAction.Park, "a reason from client.");
+		pushScheduler.Push(sub);
 		Assert.That(parker.ParkedEvents, Has.Exactly(1).Matches<ResolvedEvent>(_ => _.Event.EventId == Helper.GetEventIdFor(1)));
 		Assert.AreEqual(3, envelope1.Replies.Count);
 	}
@@ -2143,11 +2318,13 @@ public class RemoveClientTests {
 		var client2Envelope = new FakeEnvelope();
 
 		var fakeCheckpointReader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(fakeCheckpointReader)
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferRoundRobin()
 				.StartFromCurrent()
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { })));
@@ -2164,11 +2341,13 @@ public class RemoveClientTests {
 
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(1, _eventSource));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.RemoveClientByCorrelationId(client2Id, false);
+		pushScheduler.Push(sub);
 		Assert.AreEqual(1, sub.ClientCount);
 
 		// Message 2 should be retried on client 1 as it wasn't acked.
@@ -2186,11 +2365,13 @@ public class RemoveClientTests {
 		var client2Envelope = new FakeEnvelope();
 
 		var fakeCheckpointReader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(fakeCheckpointReader)
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.PreferRoundRobin()
 				.StartFromCurrent()
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { })));
@@ -2206,11 +2387,13 @@ public class RemoveClientTests {
 
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource));
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(1, _eventSource));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		Assert.IsTrue(sub.RemoveClientByConnectionId(connectionId));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, sub.ClientCount);
 
@@ -2309,6 +2492,7 @@ public class ParkTests {
 	public void retrying_parked_messages_without_stop_at_replays_all_parkedEvents() {
 		var messageParker = new FakeMessageParker();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 
 		List<int> loadCount = new List<int>();
 
@@ -2319,6 +2503,7 @@ public class ParkTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(messageParker)
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(1));
@@ -2346,6 +2531,7 @@ public class ParkTests {
 			new PersistentSubscriptionSingleStreamPosition(19),
 			true,
 			20);
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(19, messageParker.MarkedAsProcessed);
 		Assert.AreEqual(19, sub.OutstandingMessageCount);
@@ -2356,6 +2542,7 @@ public class ParkTests {
 	public void retrying_parked_messages_with_stop_at_replays_parkedEvents_until_that_version() {
 		var messageParker = new FakeMessageParker();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 
 		List<int> loadCount = new List<int>();
 
@@ -2365,6 +2552,7 @@ public class ParkTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
 				.WithMessageParker(messageParker)
+				.WithPushScheduler(pushScheduler)
 				.StartFromBeginning()
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(1));
@@ -2394,6 +2582,7 @@ public class ParkTests {
 			new PersistentSubscriptionSingleStreamPosition(7),
 			false,
 			stopAt);
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(7, messageParker.MarkedAsProcessed);
 
@@ -2459,6 +2648,7 @@ public class CheckpointingWithSkippedEvents {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subscriptionStream = "$ce-streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subscriptionStream, "groupName")
@@ -2466,6 +2656,7 @@ public class CheckpointingWithSkippedEvents {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => checkpoint = x))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(1)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
@@ -2480,11 +2671,13 @@ public class CheckpointingWithSkippedEvents {
 		var message_1_1 = WriteEventForStream1(); // pushed immediately
 		var message_1_2 = WriteEventForStream1(); // buffered - it's skipped by the consumer strategy as `maxInFlight` = 1
 		var message_1_3 = WriteEventForStream1(); // buffered - it's skipped by the consumer strategy as `maxInFlight` = 1
+		pushScheduler.Push(sub);
 
 		// write three messages intended for client 2
 		var message_2_1 = WriteEventForStream2(); // pushed immediately
 		var message_2_2 = WriteEventForStream2(); // pushed immediately
 		var message_2_3 = WriteEventForStream2(); // pushed immediately
+		pushScheduler.Push(sub);
 
 		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
 		Assert.That(client2Envelope.Replies.Count, Is.EqualTo(3));
@@ -2499,6 +2692,7 @@ public class CheckpointingWithSkippedEvents {
 		sub.AcknowledgeMessagesProcessed(correlationId, [
 			message_1_1,
 		]);
+		pushScheduler.Push(sub);
 
 		// checkpoint should now be at #0
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
@@ -2509,6 +2703,7 @@ public class CheckpointingWithSkippedEvents {
 			message_2_2,
 			message_2_3,
 		]);
+		pushScheduler.Push(sub);
 
 		// checkpoint should still be at #0, as message_1_2 has not been acknowledged yet
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
@@ -2517,6 +2712,7 @@ public class CheckpointingWithSkippedEvents {
 		sub.AcknowledgeMessagesProcessed(correlationId, [
 			message_1_2,
 		]);
+		pushScheduler.Push(sub);
 
 		// checkpoint should now be at #1, as message_1_3 has not been acknowledged yet
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(1), checkpoint);
@@ -2525,6 +2721,7 @@ public class CheckpointingWithSkippedEvents {
 		sub.AcknowledgeMessagesProcessed(correlationId, [
 			message_1_3,
 		]);
+		pushScheduler.Push(sub);
 
 		// checkpoint should now be at #5, as all messages have been acknowledged
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(5), checkpoint);
@@ -2553,6 +2750,7 @@ public class CheckpointingWithNoMoreCapacity {
 		IPersistentSubscriptionStreamPosition checkpoint = null;
 		var clientEnvelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subscriptionStream = "streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subscriptionStream, "groupName")
@@ -2560,6 +2758,7 @@ public class CheckpointingWithNoMoreCapacity {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => checkpoint = x))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.MinimumToCheckPoint(1)
 				.MaximumToCheckPoint(1)
 				.PreferRoundRobin()
@@ -2572,12 +2771,14 @@ public class CheckpointingWithNoMoreCapacity {
 		// push two messages. the first is sent, the second hits NoMoreCapacity (maxInFlight=1).
 		var message_1 = WriteEvent();
 		var message_2 = WriteEvent();
+		pushScheduler.Push(sub);
 
 		Assert.That(clientEnvelope.Replies.Count, Is.EqualTo(1));
 		Assert.IsNull(checkpoint);
 
 		// acknowledge message_1. this frees a slot, so message_2 is pushed to the client.
 		sub.AcknowledgeMessagesProcessed(correlationId, [message_1]);
+		pushScheduler.Push(sub);
 
 		// checkpoint should be at #0 (message_1's position), not at #1 (message_2's position).
 		// message_2 is now outstanding so the checkpoint must not advance past it.
@@ -2587,6 +2788,7 @@ public class CheckpointingWithNoMoreCapacity {
 
 		// acknowledge message_2.
 		sub.AcknowledgeMessagesProcessed(correlationId, [message_2]);
+		pushScheduler.Push(sub);
 
 		// checkpoint should now be at #1, as all messages have been acknowledged.
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(1), checkpoint);
@@ -2801,5 +3003,19 @@ class FakeCheckpointWriter : IPersistentSubscriptionCheckpointWriter {
 
 	public void BeginDelete(Action<IPersistentSubscriptionCheckpointWriter> completed) {
 		_deleteAction?.Invoke();
+	}
+}
+
+class FakePushScheduler : IPersistentSubscriptionPushScheduler {
+	bool _pushScheduled;
+
+	public void SchedulePush() {
+		_pushScheduled = true;
+	}
+
+	public void Push(KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription sub) {
+		Assert.True(_pushScheduled, "Push was not scheduled");
+		_pushScheduled = false;
+		sub.PushToClientsFromSchedule();
 	}
 }

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PinnedByCorrelationConsumerStrategyTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PinnedByCorrelationConsumerStrategyTests.cs
@@ -46,6 +46,7 @@ public class PinnedByCorrelationConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor("$ce-streamName", "groupName")
@@ -53,6 +54,7 @@ public class PinnedByCorrelationConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedByCorrelationPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 
@@ -64,6 +66,7 @@ public class PinnedByCorrelationConsumerStrategyTests {
 			Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-1", 0, metaData));
 		sub.NotifyLiveSubscriptionMessage(
 			Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-1", 1, metaData));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(0, client2Envelope.Replies.Count);
@@ -72,18 +75,21 @@ public class PinnedByCorrelationConsumerStrategyTests {
 			Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-2", 2, metaData));
 		sub.NotifyLiveSubscriptionMessage(
 			Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-2", 3, metaData));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(
 			Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-1", 4, metaData));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(3, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(
 			Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-3", 5, metaData));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(4, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
@@ -95,6 +101,7 @@ public class PinnedByCorrelationConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor("$ce-streamName", "groupName")
@@ -102,6 +109,7 @@ public class PinnedByCorrelationConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedByCorrelationPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 
@@ -114,23 +122,27 @@ public class PinnedByCorrelationConsumerStrategyTests {
 		var metaData1 = Encoding.UTF8.GetBytes(@"{ ""x"": ""x"", ""$correlationId2"": ""1234567890"", ""y"": ""y"" }");
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-1", 0, metaData1));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-1", 1, metaData1));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(0, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-2", 2, metaData1));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-2", 3, metaData1));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(4, client1Envelope.Replies.Count);
 		Assert.AreEqual(0, client2Envelope.Replies.Count);
 
 		var metaData2 = Encoding.UTF8.GetBytes(@"{ ""$correlationId2"": ""1234567891"", ""y"": ""y"" }");
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-1", 4, metaData2));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(4, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEventWithMetadata(Guid.NewGuid(), "type", "streamName-3", 5, metaData2));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(4, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -18,6 +18,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor("$ce-streamName", "groupName")
@@ -25,6 +26,7 @@ public class PinnedConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -33,22 +35,26 @@ public class PinnedConsumerStrategyTests {
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 1));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(0, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 2));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 3));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 4));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(3, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-3", 5));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(4, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
@@ -59,12 +65,14 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor("$ce-streamName", "groupName")
 				.WithEventLoader(new FakeStreamReader())
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -72,21 +80,25 @@ public class PinnedConsumerStrategyTests {
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(0, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 1));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-3", 2));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-4", 4));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
@@ -97,6 +109,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subsctiptionStream, "groupName")
@@ -104,6 +117,7 @@ public class PinnedConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -112,24 +126,28 @@ public class PinnedConsumerStrategyTests {
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0)));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(0, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0)));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 2,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-3", 0)));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 3,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-4", 0)));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
@@ -140,6 +158,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subsctiptionStream, "groupName")
@@ -147,6 +166,7 @@ public class PinnedConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -155,24 +175,28 @@ public class PinnedConsumerStrategyTests {
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(0, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 2,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-3", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 3,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-4", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
 		Assert.AreEqual(2, client2Envelope.Replies.Count);
@@ -183,6 +207,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subsctiptionStream, "groupName")
@@ -190,6 +215,7 @@ public class PinnedConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -201,11 +227,13 @@ public class PinnedConsumerStrategyTests {
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		sub.RemoveClientByCorrelationId(client2Id, false);
+		pushScheduler.Push(sub);
 
 		// Message 2 should be retried on client 1 as it wasn't acked.
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
@@ -218,6 +246,7 @@ public class PinnedConsumerStrategyTests {
 		var client2Envelope = new FakeEnvelope();
 		var client3Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subsctiptionStream, "groupName")
@@ -225,6 +254,7 @@ public class PinnedConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new ByLengthHasher()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -237,6 +267,7 @@ public class PinnedConsumerStrategyTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1111", 3));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11111", 4));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "111111", 5));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(3, client1Envelope.Replies.Count);
 		Assert.AreEqual(3, client2Envelope.Replies.Count);
@@ -249,6 +280,7 @@ public class PinnedConsumerStrategyTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1111", 9));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11111", 10));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "111111", 11));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(5, client1Envelope.Replies.Count);
 		Assert.AreEqual(5, client2Envelope.Replies.Count);
@@ -260,6 +292,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subsctiptionStream, "groupName")
@@ -267,6 +300,7 @@ public class PinnedConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new ByLengthHasher()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -276,11 +310,13 @@ public class PinnedConsumerStrategyTests {
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1", 0));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11", 1));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "111", 2));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(3, client1Envelope.Replies.Count);
 
 		var conn2Id = Guid.NewGuid();
 		sub.AddClient(Guid.NewGuid(), conn2Id, "connection-2", client2Envelope, 10, "foo", "bar");
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(3, client1Envelope.Replies.Count);
 		Assert.AreEqual(0, client2Envelope.Replies.Count);
@@ -296,6 +332,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subsctiptionStream, "groupName")
@@ -303,6 +340,7 @@ public class PinnedConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -314,11 +352,13 @@ public class PinnedConsumerStrategyTests {
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.AreEqual(1, client1Envelope.Replies.Count);
 		Assert.AreEqual(1, client2Envelope.Replies.Count);
 
 		Assert.IsTrue(sub.RemoveClientByConnectionId(client2Id));
+		pushScheduler.Push(sub);
 
 		// Message 2 should be retried on client 1 as it wasn't acked.
 		Assert.AreEqual(2, client1Envelope.Replies.Count);
@@ -330,6 +370,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		PersistentSubscriptionParams settings = PersistentSubscriptionToStreamParamsBuilder
 			.CreateFor(subsctiptionStream, "groupName")
@@ -337,6 +378,7 @@ public class PinnedConsumerStrategyTests {
 			.WithCheckpointReader(reader)
 			.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 			.WithMessageParker(new FakeMessageParker())
+			.WithPushScheduler(pushScheduler)
 			.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 			.StartFromCurrent();
 		var consumerStrategy = (PinnedPersistentSubscriptionConsumerStrategy)settings.ConsumerStrategy;
@@ -353,10 +395,12 @@ public class PinnedConsumerStrategyTests {
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
 
 		Assert.IsTrue(sub.RemoveClientByConnectionId(client2Id));
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
 
 		Assert.IsTrue(sub.RemoveClientByConnectionId(client1Id));
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(0));
 	}
@@ -366,6 +410,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		PersistentSubscriptionParams settings = PersistentSubscriptionToStreamParamsBuilder
 			.CreateFor(subsctiptionStream, "groupName")
@@ -373,6 +418,7 @@ public class PinnedConsumerStrategyTests {
 			.WithCheckpointReader(reader)
 			.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 			.WithMessageParker(new FakeMessageParker())
+			.WithPushScheduler(pushScheduler)
 			.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 			.StartFromCurrent();
 		var consumerStrategy = (PinnedPersistentSubscriptionConsumerStrategy)settings.ConsumerStrategy;
@@ -389,19 +435,23 @@ public class PinnedConsumerStrategyTests {
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(23));
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(22));
 
 		Assert.IsTrue(sub.RemoveClientByConnectionId(client2Id));
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(12));
 
 		Assert.IsTrue(sub.RemoveClientByConnectionId(client1Id));
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(0));
 	}
@@ -411,6 +461,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		PersistentSubscriptionParams settings = PersistentSubscriptionToStreamParamsBuilder
 			.CreateFor(subsctiptionStream, "groupName")
@@ -418,6 +469,7 @@ public class PinnedConsumerStrategyTests {
 			.WithCheckpointReader(reader)
 			.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 			.WithMessageParker(new FakeMessageParker())
+			.WithPushScheduler(pushScheduler)
 			.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 			.StartFromCurrent();
 		var consumerStrategy = (PinnedPersistentSubscriptionConsumerStrategy)settings.ConsumerStrategy;
@@ -435,20 +487,24 @@ public class PinnedConsumerStrategyTests {
 		var message1 = Guid.NewGuid();
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(message1, subsctiptionStream, 0,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(23));
 
 		var message2 = Guid.NewGuid();
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(message2, subsctiptionStream, 1,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(22));
 
 		sub.AcknowledgeMessagesProcessed(correlationId1, new[] { message1 });
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(23));
 
 		sub.AcknowledgeMessagesProcessed(correlationId2, new[] { message2 });
+		pushScheduler.Push(sub);
 
 		Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
 	}
@@ -458,6 +514,7 @@ public class PinnedConsumerStrategyTests {
 		var client1Envelope = new FakeEnvelope();
 		var client2Envelope = new FakeEnvelope();
 		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
 		const string subsctiptionStream = "$ce-streamName";
 		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
 			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subsctiptionStream, "groupName")
@@ -465,6 +522,7 @@ public class PinnedConsumerStrategyTests {
 				.WithCheckpointReader(reader)
 				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
 				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
 				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 				.StartFromCurrent());
 		reader.Load(null);
@@ -478,12 +536,14 @@ public class PinnedConsumerStrategyTests {
 		var message1 = Guid.NewGuid();
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(message1, subsctiptionStream, 0,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
 		Assert.That(client2Envelope.Replies.Count, Is.EqualTo(0));
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
 		Assert.That(client2Envelope.Replies.Count, Is.EqualTo(0));
@@ -492,6 +552,7 @@ public class PinnedConsumerStrategyTests {
 
 		sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 2,
 			Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+		pushScheduler.Push(sub);
 
 		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
 		Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));
@@ -499,6 +560,7 @@ public class PinnedConsumerStrategyTests {
 		Assert.That(streamBuffer.BufferCount, Is.EqualTo(1));
 
 		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message1 });
+		pushScheduler.Push(sub);
 
 		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(2));
 		Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -1213,6 +1213,7 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<MonitoringMessage.GetStreamPersistentSubscriptionStats>(perSubscrQueue);
 		_mainBus.Subscribe<MonitoringMessage.GetPersistentSubscriptionStats>(perSubscrQueue);
 		_mainBus.Subscribe<SubscriptionMessage.PersistentSubscriptionTimerTick>(perSubscrQueue);
+		_mainBus.Subscribe<SubscriptionMessage.PersistentSubscriptionPushToClients>(perSubscrQueue);
 		_mainBus.Subscribe<SubscriptionMessage.PersistentSubscriptionsRestart>(perSubscrQueue);
 
 		//TODO CC can have multiple threads working on subscription if partition
@@ -1244,6 +1245,7 @@ public class ClusterVNode<TStreamId> :
 		perSubscrBus.Subscribe<MonitoringMessage.GetPersistentSubscriptionStats>(persistentSubscription);
 		perSubscrBus.Subscribe<TelemetryMessage.Request>(persistentSubscription);
 		perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionTimerTick>(persistentSubscription);
+		perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionPushToClients>(persistentSubscription);
 		perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionsRestart>(persistentSubscription);
 
 		// STORAGE SCAVENGER

--- a/src/KurrentDB.Core/Messages/SubscriptionMessage.cs
+++ b/src/KurrentDB.Core/Messages/SubscriptionMessage.cs
@@ -52,6 +52,15 @@ public static partial class SubscriptionMessage {
 	}
 
 	[DerivedMessage(CoreMessage.Subscription)]
+	public partial class PersistentSubscriptionPushToClients : Message {
+		public string SubscriptionId { get; }
+
+		public PersistentSubscriptionPushToClients(string subscriptionId) {
+			SubscriptionId = subscriptionId;
+		}
+	}
+
+	[DerivedMessage(CoreMessage.Subscription)]
 	public partial class PersistentSubscriptionsRestart : Message {
 		public IEnvelope ReplyEnvelope { get; }
 

--- a/src/KurrentDB.Core/Services/PersistentSubscription/IPersistentSubscriptionPushScheduler.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/IPersistentSubscriptionPushScheduler.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace KurrentDB.Core.Services.PersistentSubscription;
+
+public interface IPersistentSubscriptionPushScheduler {
+	static IPersistentSubscriptionPushScheduler NoOp { get; } = new NoOp();
+	void SchedulePush();
+}
+
+file class NoOp : IPersistentSubscriptionPushScheduler {
+	public void SchedulePush() {
+	}
+}

--- a/src/KurrentDB.Core/Services/PersistentSubscription/OutstandingMessage.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/OutstandingMessage.cs
@@ -7,7 +7,7 @@ using KurrentDB.Core.Data;
 
 namespace KurrentDB.Core.Services.PersistentSubscription;
 
-public struct OutstandingMessage {
+public readonly struct OutstandingMessage {
 	public readonly ResolvedEvent ResolvedEvent;
 	public readonly int RetryCount;
 	public readonly Guid EventId;

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using KurrentDB.Common.Utils;
 using KurrentDB.Core.Data;
@@ -45,12 +46,16 @@ public class PersistentSubscription {
 	private bool _skipFirstEvent;
 	private DateTime _lastCheckPointTime = DateTime.MinValue;
 	private readonly PersistentSubscriptionParams _settings;
+	// the next sequence number that we will assign when an event leaves the _buffer
 	private long _nextSequenceNumber;
 	private long _lastCheckpointedSequenceNumber;
+	// _nextSequenceNumber - 1
 	private long _lastKnownSequenceNumber;
+	// the position of the message that has the _lastKnownSequenceNumber
 	private IPersistentSubscriptionStreamPosition _lastKnownMessage;
 	private readonly object _lock = new object();
 	private bool _faulted;
+	private bool _pushScheduled;
 
 	public bool HasClients {
 		get { return _pushClients.Count > 0; }
@@ -226,11 +231,27 @@ public class PersistentSubscription {
 
 			_nextEventToPullFrom = newPosition;
 			TryReadingNewBatch();
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 		}
 	}
 
-	private void TryPushingMessagesToClients() {
+	private void SchedulePushToClients() {
+		Debug.Assert(Monitor.IsEntered(_lock));
+		if (_pushScheduled)
+			return;
+
+		_pushScheduled = true;
+		_settings.PushScheduler.SchedulePush();
+	}
+
+	public void PushToClientsFromSchedule() {
+		lock (_lock) {
+			_pushScheduled = false;
+			PushToClients();
+		}
+	}
+
+	private void PushToClients() {
 		lock (_lock) {
 			if (!TryGetStreamBuffer(out var streamBuffer))
 				return;
@@ -297,7 +318,7 @@ public class PersistentSubscription {
 					_nextEventToPullFrom = _settings.EventSource.GetStreamPositionFor(resolvedEvent);
 			}
 
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 		}
 	}
 
@@ -322,6 +343,7 @@ public class PersistentSubscription {
 		}
 	}
 
+	// called when a message is Pushed
 	private void MarkBeginProcessing(OutstandingMessage message) {
 		_statistics.IncrementProcessed();
 
@@ -345,7 +367,7 @@ public class PersistentSubscription {
 				return;
 			}
 
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 		}
 	}
 
@@ -355,6 +377,9 @@ public class PersistentSubscription {
 		}
 	}
 
+	// For when we filtered out a new event at source.
+	// Not related to when a client skips an event (NakAction.Skip)
+	// Not related to when a consumer is too busy (ConsumerPushResult.Skipped)
 	public void HandleSkippedEvents(IPersistentSubscriptionStreamPosition position, long skippedCount) {
 		_lastKnownMessage = position;
 		_nextSequenceNumber += skippedCount;
@@ -375,7 +400,7 @@ public class PersistentSubscription {
 				RetryMessage(m);
 			}
 
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 			return true;
 		}
 	}
@@ -388,7 +413,7 @@ public class PersistentSubscription {
 				RetryMessage(m);
 			}
 
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 		}
 	}
 
@@ -457,7 +482,7 @@ public class PersistentSubscription {
 			RemoveProcessingMessages(processedEventIds);
 			TryMarkCheckpoint(false);
 			TryReadingNewBatch();
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 		}
 	}
 
@@ -473,7 +498,7 @@ public class PersistentSubscription {
 			RemoveProcessingMessages(processedEventIds);
 			TryMarkCheckpoint(false);
 			TryReadingNewBatch();
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 		}
 	}
 
@@ -527,7 +552,7 @@ public class PersistentSubscription {
 			lock (_lock) {
 				_outstandingMessages.Remove(e.OriginalEvent.EventId);
 				_pushClients.RemoveProcessingMessages(e.OriginalEvent.EventId);
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 			}
 		});
 	}
@@ -595,7 +620,7 @@ public class PersistentSubscription {
 				streamBuffer.AddRetry(OutstandingMessage.ForParkedEvent(ev));
 			}
 
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 
 			var newStreamPosition = newPosition as PersistentSubscriptionSingleStreamPosition;
 			Ensure.NotNull(newStreamPosition, "newStreamPosition");
@@ -665,7 +690,7 @@ public class PersistentSubscription {
 				}
 			}
 
-			TryPushingMessagesToClients();
+			SchedulePushToClients();
 			TryMarkCheckpoint(true);
 			if ((_state & (PersistentSubscriptionState.Behind |
 				 PersistentSubscriptionState.OutstandingPageRequest)) ==

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -27,7 +27,8 @@ public class PersistentSubscriptionParams {
 	private readonly IPersistentSubscriptionStreamReader _streamReader;
 	private readonly IPersistentSubscriptionCheckpointReader _checkpointReader;
 	private readonly IPersistentSubscriptionCheckpointWriter _checkpointWriter;
-	private IPersistentSubscriptionMessageParker _messageParker;
+	private readonly IPersistentSubscriptionPushScheduler _pushScheduler;
+	private readonly IPersistentSubscriptionMessageParker _messageParker;
 
 	public PersistentSubscriptionParams(bool resolveLinkTos, string subscriptionId,
 		IPersistentSubscriptionEventSource eventSource,
@@ -41,6 +42,7 @@ public class PersistentSubscriptionParams {
 		IPersistentSubscriptionStreamReader streamReader,
 		IPersistentSubscriptionCheckpointReader checkpointReader,
 		IPersistentSubscriptionCheckpointWriter checkpointWriter,
+		IPersistentSubscriptionPushScheduler pushScheduler,
 		IPersistentSubscriptionMessageParker messageParker) {
 		_resolveLinkTos = resolveLinkTos;
 		_subscriptionId = subscriptionId;
@@ -61,6 +63,7 @@ public class PersistentSubscriptionParams {
 		_streamReader = streamReader;
 		_checkpointReader = checkpointReader;
 		_checkpointWriter = checkpointWriter;
+		_pushScheduler = pushScheduler ?? throw new ArgumentNullException(nameof(pushScheduler));
 		_messageParker = messageParker;
 	}
 
@@ -103,6 +106,8 @@ public class PersistentSubscriptionParams {
 	public IPersistentSubscriptionCheckpointWriter CheckpointWriter {
 		get { return _checkpointWriter; }
 	}
+
+	public IPersistentSubscriptionPushScheduler PushScheduler => _pushScheduler;
 
 	public IPersistentSubscriptionMessageParker MessageParker {
 		get { return _messageParker; }

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
@@ -25,6 +25,7 @@ public abstract class PersistentSubscriptionParamsBuilder {
 	private IPersistentSubscriptionStreamReader _streamReader;
 	private IPersistentSubscriptionCheckpointReader _checkpointReader;
 	private IPersistentSubscriptionCheckpointWriter _checkpointWriter;
+	private IPersistentSubscriptionPushScheduler _pushScheduler = IPersistentSubscriptionPushScheduler.NoOp;
 	private IPersistentSubscriptionMessageParker _messageParker;
 	private TimeSpan _checkPointAfter;
 	private int _minCheckPointCount;
@@ -70,6 +71,11 @@ public abstract class PersistentSubscriptionParamsBuilder {
 	/// <returns></returns>
 	public PersistentSubscriptionParamsBuilder WithEventSource(IPersistentSubscriptionEventSource eventSource) {
 		_eventSource = eventSource;
+		return this;
+	}
+
+	public PersistentSubscriptionParamsBuilder WithPushScheduler(IPersistentSubscriptionPushScheduler pushScheduler) {
+		_pushScheduler = pushScheduler;
 		return this;
 	}
 
@@ -314,6 +320,7 @@ public abstract class PersistentSubscriptionParamsBuilder {
 			builder._streamReader,
 			builder._checkpointReader,
 			builder._checkpointWriter,
+			builder._pushScheduler,
 			builder._messageParker);
 	}
 }

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionPushScheduler.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionPushScheduler.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+
+namespace KurrentDB.Core.Services.PersistentSubscription;
+
+public class PersistentSubscriptionPushScheduler(string subscriptionId, IPublisher bus) : IPersistentSubscriptionPushScheduler {
+	private readonly Message _msg = new SubscriptionMessage.PersistentSubscriptionPushToClients(subscriptionId);
+
+	public void SchedulePush() {
+		bus.Publish(_msg);
+	}
+}

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -35,6 +35,7 @@ public class PersistentSubscriptionService<TStreamId> :
 	IHandle<SystemMessage.BecomeLeader>,
 	IHandle<SubscriptionMessage.PersistentSubscriptionsRestart>,
 	IHandle<SubscriptionMessage.PersistentSubscriptionTimerTick>,
+	IHandle<SubscriptionMessage.PersistentSubscriptionPushToClients>,
 	IHandle<ClientMessage.ReplayParkedMessages>,
 	IHandle<ClientMessage.ReplayParkedMessage>,
 	IHandle<SystemMessage.StateChangeMessage>,
@@ -509,6 +510,7 @@ public class PersistentSubscriptionService<TStreamId> :
 				_streamReader,
 				_checkpointReader,
 				new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
+				new PersistentSubscriptionPushScheduler(key, _bus),
 				new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
 
 		var updateEntry = new PersistentSubscriptionEntry {
@@ -708,6 +710,7 @@ public class PersistentSubscriptionService<TStreamId> :
 				_streamReader,
 				_checkpointReader,
 				new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
+				new PersistentSubscriptionPushScheduler(key, _bus),
 				new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
 
 		UpdateSubscription(stream, groupName, subscription);
@@ -1361,6 +1364,12 @@ public class PersistentSubscriptionService<TStreamId> :
 			_bus.Publish(TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
 				_bus,
 				new SubscriptionMessage.PersistentSubscriptionTimerTick(_timerTickCorrelationId)));
+		}
+	}
+
+	public void Handle(SubscriptionMessage.PersistentSubscriptionPushToClients message) {
+		if (_subscriptionsById.TryGetValue(message.SubscriptionId, out var subscription)) {
+			subscription.PushToClientsFromSchedule();
 		}
 	}
 

--- a/src/KurrentDB.Core/TransactionLog/Scavenging/ScavengeState.cs
+++ b/src/KurrentDB.Core/TransactionLog/Scavenging/ScavengeState.cs
@@ -129,7 +129,7 @@ public class ScavengeState<TStreamId> : IScavengeState<TStreamId> {
 		_checkpointStorage.TryGetValue(Unit.Instance, out checkpoint);
 
 	public IEnumerable<TStreamId> AllCollisions() {
-		return _collisionDetector.AllCollisions();
+		return _collisionDetector?.AllCollisions() ?? [];
 	}
 
 	public bool TryGetOriginalStreamData(


### PR DESCRIPTION
When events arrive in a burst, each NotifyLiveSubscriptionMessage call was scanning the entire buffer to push events to clients. Client acks are queued behind the event flood in the same FIFO queue, so clients appear full and every scan is fruitless. With N events, this results in O(N²) total work.

Instead of pushing synchronously on event arrival, we now schedule a push message on the PS queue. This lets events accumulate in the buffer cheaply, gives acks a chance to interleave, and batches the buffer scan.

All PushToClients call sites use the deferred path for consistency, since the buffer scan cost applies equally to acks, nacks, timeouts, and client changes.

(cherry picked from commit b64783241afbd30bd5125efccb0566aeca4664fa)