### PR TITLE
[DB-2027] Upgrade packages for CVE-2026-33116

### DIFF
--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -6,7 +6,6 @@
 		<PackageReference Include="System.ServiceModel.Http" Version="6.2.0" />
 		<!-- CVE-2023-29331 -->
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
 		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-447r-wph3-92pm -->
 		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 	</ItemGroup>


### PR DESCRIPTION
Changed: Package references for CVE-2026-33116

https://github.com/advisories/GHSA-37gx-xxp4-5rgx