### PR TITLE
[DB-2027] [release/v24.10] Persistent subscriptions: Fix wrong checkpoint when using pinned strategy

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -13,6 +13,7 @@ using EventStore.ClientAPI.Common;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
+using EventStore.Core.Index.Hashes;
 using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
@@ -2445,6 +2446,158 @@ public class DeadlockTest<TLogFormat, TStreamId> : SpecificationWithMiniNode<TLo
 	private static IEnumerable<EventData> CreateEvent() {
 		while (true) {
 			yield return new EventData(Guid.NewGuid(), "testtype", false, new byte[0], new byte[0]);
+		}
+	}
+}
+
+public class CheckpointingWithSkippedEvents {
+	[Test]
+	public void checkpointing_works_when_events_are_skipped_by_the_consumer_strategy() {
+		var categoryVersion = 0;
+		var stream1Version = 0;
+		var stream2Version = 0;
+
+		IPersistentSubscriptionStreamPosition checkpoint = null;
+		var client1Envelope = new FakeEnvelope();
+		var client2Envelope = new FakeEnvelope();
+		var reader = new FakeCheckpointReader();
+		const string subscriptionStream = "$ce-streamName";
+		var sub = new EventStore.Core.Services.PersistentSubscription.PersistentSubscription(
+			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subscriptionStream, "groupName")
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(x => checkpoint = x))
+				.WithMessageParker(new FakeMessageParker())
+				.MinimumToCheckPoint(1)
+				.MaximumToCheckPoint(1)
+				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+				.StartFromCurrent());
+		reader.Load(null);
+
+		var correlationId = Guid.NewGuid();
+		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, maxInFlight: 1, "foo", "bar");
+		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, maxInFlight: 1000, "foo", "bar");
+
+		// write three messages intended for client 1
+		var message_1_1 = WriteEventForStream1(); // pushed immediately
+		var message_1_2 = WriteEventForStream1(); // buffered - it's skipped by the consumer strategy as `maxInFlight` = 1
+		var message_1_3 = WriteEventForStream1(); // buffered - it's skipped by the consumer strategy as `maxInFlight` = 1
+
+		// write three messages intended for client 2
+		var message_2_1 = WriteEventForStream2(); // pushed immediately
+		var message_2_2 = WriteEventForStream2(); // pushed immediately
+		var message_2_3 = WriteEventForStream2(); // pushed immediately
+
+		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
+		Assert.That(client2Envelope.Replies.Count, Is.EqualTo(3));
+		Assert.True(sub.TryGetStreamBuffer(out var streamBuffer));
+		Assert.That(streamBuffer.BufferCount, Is.EqualTo(2));
+		Assert.AreEqual(null, checkpoint);
+
+		// checkpoint should be null - no messages have been acknowledged yet
+		Assert.IsNull(checkpoint);
+
+		// acknowledge message_1_1 for client 1
+		sub.AcknowledgeMessagesProcessed(correlationId, [
+			message_1_1,
+		]);
+
+		// checkpoint should now be at #0
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
+
+		// acknowledge all the messages for client 2
+		sub.AcknowledgeMessagesProcessed(correlationId, [
+			message_2_1,
+			message_2_2,
+			message_2_3,
+		]);
+
+		// checkpoint should still be at #0, as message_1_2 has not been acknowledged yet
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
+
+		// acknowledge message_1_2.
+		sub.AcknowledgeMessagesProcessed(correlationId, [
+			message_1_2,
+		]);
+
+		// checkpoint should now be at #1, as message_1_3 has not been acknowledged yet
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(1), checkpoint);
+
+		// acknowledge message_1_3.
+		sub.AcknowledgeMessagesProcessed(correlationId, [
+			message_1_3,
+		]);
+
+		// checkpoint should now be at #5, as all messages have been acknowledged
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(5), checkpoint);
+
+		Guid WriteEventForStream1() {
+			var id = Guid.NewGuid();
+			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(id, subscriptionStream, categoryVersion++,
+				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", stream1Version++), false));
+			return id;
+		}
+
+		Guid WriteEventForStream2() {
+			var id = Guid.NewGuid();
+			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(id, subscriptionStream, categoryVersion++,
+				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", stream2Version++), false));
+			return id;
+		}
+	}
+}
+
+public class CheckpointingWithNoMoreCapacity {
+	[Test]
+	public void checkpoint_is_correct_when_message_hits_no_more_capacity_then_succeeds() {
+		var version = 0;
+
+		IPersistentSubscriptionStreamPosition checkpoint = null;
+		var clientEnvelope = new FakeEnvelope();
+		var reader = new FakeCheckpointReader();
+		const string subscriptionStream = "streamName";
+		var sub = new EventStore.Core.Services.PersistentSubscription.PersistentSubscription(
+			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subscriptionStream, "groupName")
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(x => checkpoint = x))
+				.WithMessageParker(new FakeMessageParker())
+				.MinimumToCheckPoint(1)
+				.MaximumToCheckPoint(1)
+				.PreferRoundRobin()
+				.StartFromCurrent());
+		reader.Load(null);
+
+		var correlationId = Guid.NewGuid();
+		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", clientEnvelope, maxInFlight: 1, "foo", "bar");
+
+		// push two messages. the first is sent, the second hits NoMoreCapacity (maxInFlight=1).
+		var message_1 = WriteEvent();
+		var message_2 = WriteEvent();
+
+		Assert.That(clientEnvelope.Replies.Count, Is.EqualTo(1));
+		Assert.IsNull(checkpoint);
+
+		// acknowledge message_1. this frees a slot, so message_2 is pushed to the client.
+		sub.AcknowledgeMessagesProcessed(correlationId, [message_1]);
+
+		// checkpoint should be at #0 (message_1's position), not at #1 (message_2's position).
+		// message_2 is now outstanding so the checkpoint must not advance past it.
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
+
+		Assert.That(clientEnvelope.Replies.Count, Is.EqualTo(2));
+
+		// acknowledge message_2.
+		sub.AcknowledgeMessagesProcessed(correlationId, [message_2]);
+
+		// checkpoint should now be at #1, as all messages have been acknowledged.
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(1), checkpoint);
+
+		Guid WriteEvent() {
+			var id = Guid.NewGuid();
+			sub.NotifyLiveSubscriptionMessage(
+				Helper.BuildFakeEvent(id, "type", subscriptionStream, version++));
+			return id;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -236,25 +236,32 @@ public class PersistentSubscription {
 				return;
 
 			foreach (StreamBuffer.OutstandingMessagePointer messagePointer in streamBuffer.Scan()) {
-				//optimistically assume that the message will be pushed
+				//optimistically assume that the message will leave the buffer
 				//if it is, then we will increment the next sequence number if a new one was assigned
 				//if it is not, then we will not increment the next sequence number
 				(OutstandingMessage message, bool newSequenceNumberAssigned) =
 					OutstandingMessage.ForPushedEvent(messagePointer.Message, _nextSequenceNumber, _lastKnownMessage);
 				ConsumerPushResult result =
 					_pushClients.PushMessageToClient(message);
+
+				if (newSequenceNumberAssigned && result is ConsumerPushResult.Sent or ConsumerPushResult.Skipped) {
+					_lastKnownSequenceNumber = _nextSequenceNumber++;
+					_lastKnownMessage = message.EventPosition;
+				}
+
 				if (result == ConsumerPushResult.Sent) {
 					messagePointer.MarkSent();
-
-					if (newSequenceNumberAssigned) {
-						//the message was pushed and a new sequence number was assigned
-						//so we increment the next sequence number
-						_nextSequenceNumber++;
-					}
-
 					MarkBeginProcessing(message);
 				} else if (result == ConsumerPushResult.Skipped) {
-					// The consumer strategy skipped the message so leave it in the buffer and continue.
+					if (newSequenceNumberAssigned) {
+						// New message from buffer - move it to the back of retry.
+						Debug.Assert(!messagePointer.IsRetry);
+						messagePointer.MarkSent();
+						streamBuffer.AddRetryToEnd(message);
+					} else {
+						// Otherwise it's already in retry - leave it in place.
+						Debug.Assert(messagePointer.IsRetry);
+					}
 				} else if (result == ConsumerPushResult.NoMoreCapacity) {
 					return;
 				}
@@ -303,10 +310,13 @@ public class PersistentSubscription {
 				messagePointer.MarkSent();
 				(OutstandingMessage message, bool newSequenceNumberAssigned) =
 					OutstandingMessage.ForPushedEvent(messagePointer.Message, _nextSequenceNumber, _lastKnownMessage);
+
 				if (newSequenceNumberAssigned) {
-					_nextSequenceNumber++;
+					_lastKnownSequenceNumber = _nextSequenceNumber++;
+					_lastKnownMessage = message.EventPosition;
 				}
-				MarkBeginProcessing(message); //sequence number will be incremented in this call if a new one has been assigned
+
+				MarkBeginProcessing(message);
 				yield return (messagePointer.Message.ResolvedEvent, messagePointer.Message.RetryCount);
 			}
 		}
@@ -314,10 +324,6 @@ public class PersistentSubscription {
 
 	private void MarkBeginProcessing(OutstandingMessage message) {
 		_statistics.IncrementProcessed();
-		if (message.EventSequenceNumber > _lastKnownSequenceNumber) {
-			_lastKnownSequenceNumber = message.EventSequenceNumber.Value;
-			_lastKnownMessage = _settings.EventSource.GetStreamPositionFor(message.ResolvedEvent);
-		}
 
 		StartMessage(message,
 			_settings.MessageTimeout == TimeSpan.MaxValue

--- a/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
@@ -59,6 +59,10 @@ public class StreamBuffer {
 		}
 	}
 
+	public void AddRetryToEnd(OutstandingMessage ev) {
+		_retry.AddLast(ev);
+	}
+
 	public void AddRetry(OutstandingMessage ev) {
 		//add parked messages at the end of the list
 		if (ev.IsReplayedEvent) {
@@ -125,6 +129,7 @@ public class StreamBuffer {
 
 		foreach (var list in new[] { _retry, _buffer }) // save on code duplication
 		{
+			var isRetry = ReferenceEquals(list, _retry);
 			var current = list.First;
 			if (current != null) {
 				do {
@@ -132,7 +137,7 @@ public class StreamBuffer {
 					// that current is removed from the list setting next to null.
 					var next = current.Next;
 
-					yield return new OutstandingMessagePointer(current);
+					yield return new OutstandingMessagePointer(current, isRetry);
 
 					current = next;
 				} while (current != null);
@@ -161,12 +166,14 @@ public class StreamBuffer {
 		return result;
 	}
 
-	public struct OutstandingMessagePointer {
+	public readonly struct OutstandingMessagePointer {
 		private readonly LinkedListNode<OutstandingMessage> _entry;
+		private readonly bool _isRetry;
 
-		internal OutstandingMessagePointer(LinkedListNode<OutstandingMessage> entry)
+		internal OutstandingMessagePointer(LinkedListNode<OutstandingMessage> entry, bool isRetry)
 			: this() {
 			_entry = entry;
+			_isRetry = isRetry;
 		}
 
 		public OutstandingMessage Message {
@@ -180,6 +187,9 @@ public class StreamBuffer {
 
 			_entry.List.Remove(_entry);
 		}
+
+		// intended for debug assertions only
+		public bool IsRetry => _isRetry;
 	}
 }
 


### PR DESCRIPTION
Fixed: Wrong checkpoint when using pinned strategy 

Cherry picked from #5497 / #5578

Persistent subscription consumer strategies that can skip events can produce wrong checkpoints when events are skipped. The pinned consumer strategy is currently the only strategy that can skip events.

This PR fixes the following issues:

The logic for assigning sequence numbers / previous event positions to OutstandingMessage did not take skipped events into consideration - this could result into wrongly assigned sequence numbers / previous event positions and subsequently to wrong checkpoints too. The checkpointing mechanism only considers messages in the retry list but skipped events were left in the buffer - this could also result into wrong checkpoints.

(cherry picked from commit afc9985cdd04ff8a37b4c9c474a324302dfdeeaf)