### PR TITLE
[DB-2027][24.10] Reply NotHandled when Persistent subscriptions service is not ready (#5596)

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/PersistentSubscriptions/PersistentSubscriptionServiceNotReadyTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/PersistentSubscriptions/PersistentSubscriptionServiceNotReadyTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
+// Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.LogV2;
+using EventStore.Core.Messages;
+using EventStore.Core.Metrics;
+using EventStore.Core.Services;
+using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using EventStore.Core.Tests.TransactionLog;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.PersistentSubscriptions;
+
+public class PersistentSubscriptionServiceNotReadyTests {
+	private readonly FakePublisher _publisher = new();
+	private readonly IODispatcher _ioDispatcher;
+
+	public PersistentSubscriptionServiceNotReadyTests() {
+		var bus = new SynchronousScheduler();
+		_ioDispatcher = new IODispatcher(_publisher, bus);
+		bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+	}
+
+	private PersistentSubscriptionService<string> CreateSut() {
+		_publisher.Messages.Clear();
+		var subscriber = new SynchronousScheduler();
+		var queuedHandler = new QueuedHandlerThreadPool(subscriber, "test", new QueueStatsManager(), new QueueTrackers());
+		var index = new FakeReadIndex<LogFormat.V2, string>(_ => false, new LogV2SystemStreams());
+		var strategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry(_publisher, subscriber,
+			Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>());
+		return new PersistentSubscriptionService<string>(
+			queuedHandler, index, _ioDispatcher, _publisher, strategyRegistry, IPersistentSubscriptionTracker.NoOp);
+	}
+
+	private static void AssertNotHandledNotReady(FakeEnvelope envelope) {
+		var reply = Assert.Single(envelope.Replies);
+		var notHandled = Assert.IsType<ClientMessage.NotHandled>(reply);
+		Assert.Equal(ClientMessage.NotHandled.Types.NotHandledReason.NotReady, notHandled.Reason);
+	}
+
+	[Fact]
+	public async Task connect_to_stream_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+		var correlationId = Guid.NewGuid();
+
+		var message = new ClientMessage.ConnectToPersistentSubscriptionToStream(
+			Guid.NewGuid(), correlationId, envelope,
+			Guid.NewGuid(), "connection", "group", "stream",
+			10, string.Empty, null);
+
+		await ((IAsyncHandle<ClientMessage.ConnectToPersistentSubscriptionToStream>)sut)
+			.HandleAsync(message, CancellationToken.None);
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public async Task connect_to_all_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+		var correlationId = Guid.NewGuid();
+
+		var message = new ClientMessage.ConnectToPersistentSubscriptionToAll(
+			Guid.NewGuid(), correlationId, envelope,
+			Guid.NewGuid(), "connection", "group",
+			10, string.Empty, null);
+
+		await ((IAsyncHandle<ClientMessage.ConnectToPersistentSubscriptionToAll>)sut)
+			.HandleAsync(message, CancellationToken.None);
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void create_stream_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.CreatePersistentSubscriptionToStream(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"stream", "group", resolveLinkTos: false, startFrom: 0,
+			messageTimeoutMilliseconds: 10000, recordStatistics: false,
+			maxRetryCount: 5, bufferSize: 10, liveBufferSize: 10,
+			readbatchSize: 10, checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 1, maxCheckPointCount: 1,
+			maxSubscriberCount: 10, namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void create_all_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.CreatePersistentSubscriptionToAll(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"group", eventFilter: null, resolveLinkTos: false,
+			startFrom: new TFPos(0, 0),
+			messageTimeoutMilliseconds: 10000, recordStatistics: false,
+			maxRetryCount: 5, bufferSize: 10, liveBufferSize: 10,
+			readbatchSize: 10, checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 1, maxCheckPointCount: 1,
+			maxSubscriberCount: 10, namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void update_stream_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.UpdatePersistentSubscriptionToStream(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"stream", "group", resolveLinkTos: false, startFrom: 0,
+			messageTimeoutMilliseconds: 10000, recordStatistics: false,
+			maxRetryCount: 5, bufferSize: 10, liveBufferSize: 10,
+			readbatchSize: 10, checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 1, maxCheckPointCount: 1,
+			maxSubscriberCount: 10, namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void update_all_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.UpdatePersistentSubscriptionToAll(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"group", resolveLinkTos: false,
+			startFrom: new TFPos(0, 0),
+			messageTimeoutMilliseconds: 10000, recordStatistics: false,
+			maxRetryCount: 5, bufferSize: 10, liveBufferSize: 10,
+			readbatchSize: 10, checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 1, maxCheckPointCount: 1,
+			maxSubscriberCount: 10, namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void delete_stream_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.DeletePersistentSubscriptionToStream(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"stream", "group", user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void delete_all_subscription_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.DeletePersistentSubscriptionToAll(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"group", user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+
+	[Fact]
+	public void read_next_messages_replies_not_handled_when_not_started() {
+		var sut = CreateSut();
+		var envelope = new FakeEnvelope();
+
+		sut.Handle(new ClientMessage.ReadNextNPersistentMessages(
+			Guid.NewGuid(), Guid.NewGuid(), envelope,
+			"stream", "group", 10, user: null));
+
+		AssertNotHandledNotReady(envelope);
+	}
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -254,8 +254,6 @@ public class PersistentSubscriptionService<TStreamId> :
 			Action<string> onAccessDenied,
 			string user
 	) {
-		if (!_started)
-			return;
 		var stream = eventSource.ToString();
 		var key = BuildSubscriptionGroupKey(stream, groupName);
 		Log.Debug("Creating persistent subscription {subscriptionKey}", key);
@@ -319,6 +317,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.CreatePersistentSubscriptionToStream message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		if (string.IsNullOrEmpty(message.EventStreamId)) {
 			message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
 				message.CorrelationId,
@@ -395,6 +398,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.CreatePersistentSubscriptionToAll message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		try {
 			CreatePersistentSubscription(
 				new PersistentSubscriptionAllStreamEventSource(message.EventFilter),
@@ -476,9 +484,6 @@ public class PersistentSubscriptionService<TStreamId> :
 			Action<string> onAccessDenied,
 			string user
 	) {
-		if (!_started)
-			return;
-
 		var key = BuildSubscriptionGroupKey(stream, groupName);
 		Log.Debug("Updating persistent subscription {subscriptionKey}", key);
 
@@ -552,6 +557,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.UpdatePersistentSubscriptionToStream message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		if (string.IsNullOrEmpty(message.EventStreamId)) {
 			message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
 				message.CorrelationId,
@@ -629,6 +639,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.UpdatePersistentSubscriptionToAll message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		try {
 			UpdatePersistentSubscription(
 				SystemStreams.AllStream,
@@ -747,8 +762,6 @@ public class PersistentSubscriptionService<TStreamId> :
 			Action<string> onAccessDenied,
 			string user
 	) {
-		if (!_started)
-			return;
 		var stream = eventSource.ToString();
 		var key = BuildSubscriptionGroupKey(stream, groupName);
 		Log.Debug("Deleting persistent subscription {subscriptionKey}", key);
@@ -772,6 +785,11 @@ public class PersistentSubscriptionService<TStreamId> :
 
 
 	public void Handle(ClientMessage.DeletePersistentSubscriptionToStream message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		if (string.IsNullOrEmpty(message.EventStreamId)) {
 			message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
 				message.CorrelationId,
@@ -825,6 +843,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.DeletePersistentSubscriptionToAll message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		DeletePersistentSubscription(
 			new PersistentSubscriptionAllStreamEventSource(),
 			message.GroupName,
@@ -951,8 +974,11 @@ public class PersistentSubscriptionService<TStreamId> :
 		Guid correlationId,
 		IEnvelope envelope,
 		string user) {
-		if (!_started)
+
+		if (!_started) {
+			ReplyWithNotReady(envelope, correlationId);
 			return;
+		}
 
 		var stream = eventSource.ToString();
 		List<PersistentSubscription> subscribers;
@@ -1091,8 +1117,10 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.ReadNextNPersistentMessages message) {
-		if (!_started)
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
 			return;
+		}
 
 		if (string.IsNullOrEmpty(message.EventStreamId)) {
 			message.Envelope.ReplyWith(new ClientMessage.ReadNextNPersistentMessagesCompleted(
@@ -1413,5 +1441,12 @@ public class PersistentSubscriptionService<TStreamId> :
 
 	private TimeSpan ToMessageTimeout(int milliseconds) {
 		return milliseconds == 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(milliseconds);
+	}
+
+	private static void ReplyWithNotReady(IEnvelope envelope, Guid correlationId) {
+		envelope.ReplyWith(new ClientMessage.NotHandled(
+			correlationId,
+			ClientMessage.NotHandled.Types.NotHandledReason.NotReady,
+			(string)null));
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -439,7 +439,7 @@ public static class Configure {
 		return InternalServerError();
 	}
 
-	private static ResponseConfiguration HandleNotHandled(Uri requestedUri, ClientMessage.NotHandled notHandled) {
+	public static ResponseConfiguration HandleNotHandled(Uri requestedUri, ClientMessage.NotHandled notHandled) {
 		switch (notHandled.Reason) {
 			case ClientMessage.NotHandled.Types.NotHandledReason.NotReady:
 				return ServiceUnavailable("Server Is Not Ready");

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -407,6 +407,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			(args, message) => http.ResponseCodec.To(message),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.ReplayMessagesReceived;
 				if (m == null)
 					throw new Exception("unexpected message " + message);
@@ -463,6 +465,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			(args, message) => http.ResponseCodec.To(message),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.CreatePersistentSubscriptionToStreamCompleted;
 				if (m == null)
 					throw new Exception("unexpected message " + message);
@@ -537,6 +541,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			(args, message) => http.ResponseCodec.To(message),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.UpdatePersistentSubscriptionToStreamCompleted;
 				if (m == null)
 					throw new Exception("unexpected message " + message);
@@ -683,6 +689,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			(args, message) => http.ResponseCodec.To(message),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.DeletePersistentSubscriptionToStreamCompleted;
 				if (m == null)
 					throw new Exception("unexpected message " + message);
@@ -841,6 +849,8 @@ public class PersistentSubscriptionController : CommunicationController {
 
 	private static ResponseConfiguration StatsConfiguration(HttpEntityManager http, Message message) {
 		int code;
+		if (message is ClientMessage.NotHandled notHandled)
+			return Configure.HandleNotHandled(http.RequestedUrl, notHandled);
 		var m = message as MonitoringMessage.GetPersistentSubscriptionStatsCompleted;
 		if (m == null)
 			throw new Exception("unexpected message " + message);
@@ -883,6 +893,8 @@ public class PersistentSubscriptionController : CommunicationController {
 				message as ClientMessage.ReadNextNPersistentMessagesCompleted, stream, groupname, count, embed),
 			(args, message) => {
 				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
 				var m = message as ClientMessage.ReadNextNPersistentMessagesCompleted;
 				if (m == null)
 					throw new Exception("unexpected message " + message);


### PR DESCRIPTION
fixed: Persistant subscription stall-on-reconnect condition after leader change

cherry picked from #5596

After a leader change, persistent subscription clients could hang indefinitely when connecting to the new leader before the service finished loading its configuration. The handlers silently returned without replying to the envelope.

Now all handlers reply with NotHandled(NotReady) when !_started, allowing gRPC clients to retry and HTTP clients to receive 503.

The ClusterVNodeController was already able to reply NotHandled for all of these messages, they all derived from ReadRequestMessage.

Thanks to William Chong <william-chong@outlook.com> for figuring out the problem here.

Co-authored-by: Timothy Coleman <timothy.coleman@gmail.com>
(cherry picked from commit 2844c3f3a86c12ae1f187222928268ef8032b02d)

Conflicts (related to rebrand and tests only):
	src/EventStore.Core.XUnit.Tests/Services/PersistentSubscriptions/PersistentSubscriptionServiceNotReadyTests.cs
	src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
	src/KurrentDB.Core/Services/Transport/Http/Configure.cs