### PR TITLE
[DB-2027][24.10] Use server-generated Node identity in Persistent Subscription Pinned strategy (#5597)

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -567,4 +567,49 @@ public class PinnedConsumerStrategyTests {
 
 		Assert.That(streamBuffer.BufferCount, Is.EqualTo(0));
 	}
+
+	// correlation id reuse is possible through the TCP client and the JVM TCP client does
+	// do this (dotnet does not). this used to cause two Nodes with the same NodeId to
+	// be listed in the PinnedConsumerState, resulting in messages being routed to
+	// a disconnected client.
+	[Test]
+	public void events_route_to_live_client_after_correlation_id_reuse() {
+		var correlationId = Guid.NewGuid();
+		var client1Envelope = new FakeEnvelope();
+		var client2Envelope = new FakeEnvelope();
+		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
+		const string subscriptionStream = "$ce-streamName";
+		var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subscriptionStream, "groupName")
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
+				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+				.StartFromCurrent());
+		reader.Load(null);
+
+		// Client 1 connects and receives an event (which assigns a bucket to its Node)
+		var conn1 = Guid.NewGuid();
+		sub.AddClient(correlationId, conn1, "conn-1", client1Envelope, 10, "foo", "bar");
+		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "stream-A", 0));
+		pushScheduler.Push(sub);
+		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
+
+		// TCP drops, then client reconnects replaying the same CorrelationId
+		sub.RemoveClientByConnectionId(conn1);
+		sub.AddClient(correlationId, Guid.NewGuid(), "conn-2", client2Envelope, 10, "foo", "bar");
+
+		// Push a new event for the same stream (same bucket). Pre-fix it was
+		// routed to client1's dead envelope; post-fix it reaches client2.
+		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "stream-A", 1));
+		pushScheduler.Push(sub);
+
+		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1),
+			"old envelope received zombie deliveries");
+		Assert.That(client2Envelope.Replies.Count, Is.GreaterThanOrEqualTo(1),
+			"new envelope did not receive the event");
+	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnablePersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnablePersistentSubscriptionConsumerStrategy.cs
@@ -40,7 +40,7 @@ public abstract class PinnablePersistentSubscriptionConsumerStrategy : IPersiste
 	}
 
 	public void ClientRemoved(PersistentSubscriptionClient client) {
-		var nodeId = client.CorrelationId;
+		var nodeId = client.InstanceId;
 
 		client.EventConfirmed -= OnEventRemoved;
 
@@ -73,7 +73,7 @@ public abstract class PinnablePersistentSubscriptionConsumerStrategy : IPersiste
 
 	private void OnEventRemoved(PersistentSubscriptionClient client, ResolvedEvent ev) {
 		var assignmentId = GetAssignmentId(ev);
-		_state.EventRemoved(client.CorrelationId, assignmentId);
+		_state.EventRemoved(client.InstanceId, assignmentId);
 	}
 
 	private uint GetAssignmentId(ResolvedEvent ev) {

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/Node.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/Node.cs
@@ -29,7 +29,7 @@ internal class Node {
 	public Node(PersistentSubscriptionClient client) {
 		Client = client;
 		ConnectionId = client.ConnectionId;
-		NodeId = client.CorrelationId;
+		NodeId = client.InstanceId;
 
 		var portSplit = client.From.IndexOf(':');
 		if (portSplit == -1) {

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/PinnedConsumerState.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/PinnedConsumerState.cs
@@ -20,6 +20,7 @@ class PinnedConsumerState {
 
 	public BucketAssignment[] Assignments { get; set; }
 
+	// NodeId must be unique within the list
 	public IList<Node> Nodes { get; set; }
 
 	public int AssignmentCount { get; set; }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClient.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClient.cs
@@ -47,6 +47,8 @@ public class PersistentSubscriptionClient {
 		}
 	}
 
+	public Guid InstanceId { get; } = Guid.NewGuid();
+
 	/// <summary>
 	/// Raised whenever an in-flight event has been confirmed. This could be because of ack, nak, timeout or disconnection.
 	/// </summary>


### PR DESCRIPTION
cherry picked from #5597

For the TCP API (not gRPC) the Pinned consumer strategy used the client-supplied CorrelationId as the internal NodeId in its Nodes list.

The EventStore.JVM TCP client (but not the dotnet TCP client) sends the same CorrelationId when reconnecting after a heartbeat timeout.

When the previous Node still had bucket assignments, this produced two bugs:

  1. Stalled subscriptions. DisconnectNode marks the Node as Disconnected but leaves it in Nodes (Clean only removes nodes with AssignmentCount == 0). On reconnect, AddNode appends a second Node with the same NodeId. Subsequent bucket reassignment goes through

         Assignments[bucketId].Node = Nodes.First(_ => _.NodeId == newNodeId);

     First matches in list order, so it returns the older, Disconnected Node. PushMessageToClient then pushes to that Node's dead envelope; events are never acked, time out, retry 10 times, and park. The subscription appears stuck with no way for the new client to receive events.

  2. InvalidOperationException on later cleanup. When the duplicate is eventually removed (via an Update's ShutdownAll or a ConnectionClosed on the live connection), DisconnectNode also looks up by FirstOrDefault(NodeId == id) and hits the already- Disconnected Node first, throwing InvalidOperationException. The throw propagates out of ShutdownAll / ConnectionClosed, leaving the old subscription half-torn-down.

An examples of the exception in 2 is:

```
System.InvalidOperationException: Operation is not valid due to the current state of the object.
  at EventStore.Core.Services.PersistentSubscription.ConsumerStrategy.PinnedState.PinnedConsumerState.DisconnectNode(Guid nodeId)
  at EventStore.Core.Services.PersistentSubscription.PersistentSubscriptionClientCollection.RemoveClientByCorrelationId(Guid correlationId, Boolean sendDropNotification)
  at EventStore.Core.Services.PersistentSubscription.PersistentSubscriptionClientCollection.ShutdownAll()
  at EventStore.Core.Services.PersistentSubscription.PersistentSubscription.Shutdown()
  at EventStore.Core.Services.PersistentSubscription.PersistentSubscriptionService`1.UpdateSubscription(String eventSource, String groupName, PersistentSubscription replaceBy)
```

The fix adds PersistentSubscriptionClient.InstanceId, a server-generated Guid set once per client instance, and uses it as the Node.NodeId instead of the client's CorrelationId. The CorrelationId is still used for response routing (it's part of the wire protocol contract); only internal bookkeeping uses InstanceId.