### PR TITLE
[DEV-1700] Update Surge and Connectors packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="Kurrent.Connectors.RabbitMQ" Version="1.1.1-alpha.1.70" />
     <PackageVersion Include="Kurrent.Connectors.Pulsar" Version="1.1.1-alpha.1.70" />
     <PackageVersion Include="Kurrent.Connectors.Sql" Version="1.1.1-alpha.1.70" />
-		<PackageVersion Include="Kurrent.Connectors.Webhook" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Connectors.Webhook" Version="1.1.1-alpha.1.70" />
     <PackageVersion Include="Kurrent.Surge" Version="1.1.1-alpha.1.70" />
     <PackageVersion Include="Kurrent.Surge.Core" Version="1.1.1-alpha.1.70" />
     <PackageVersion Include="Kurrent.Surge.DataProtection" Version="1.1.1-alpha.1.70" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -47,18 +47,18 @@
     <PackageVersion Include="IgnoresAccessChecksToGenerator" Version="0.8.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageVersion Include="Jint" Version="4.0.3" />
-    <PackageVersion Include="Kurrent.Connectors.Elasticsearch" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Connectors.Http" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Connectors.Kafka" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Connectors.MongoDB" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Connectors.RabbitMQ" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Connectors.Pulsar" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Connectors.Sql" Version="1.1.1-alpha.1.69" />
-		<PackageVersion Include="Kurrent.Connectors.Webhook" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Surge" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Surge.Core" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Surge.DataProtection" Version="1.1.1-alpha.1.69" />
-    <PackageVersion Include="Kurrent.Surge.DuckDB" Version="1.1.1-alpha.1.69" />
+    <PackageVersion Include="Kurrent.Connectors.Elasticsearch" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Connectors.Http" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Connectors.Kafka" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Connectors.MongoDB" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Connectors.RabbitMQ" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Connectors.Pulsar" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Connectors.Sql" Version="1.1.1-alpha.1.70" />
+		<PackageVersion Include="Kurrent.Connectors.Webhook" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Surge" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Surge.Core" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Surge.DataProtection" Version="1.1.1-alpha.1.70" />
+    <PackageVersion Include="Kurrent.Surge.DuckDB" Version="1.1.1-alpha.1.70" />
     <PackageVersion Include="Kurrent.Quack" Version="0.0.0-alpha.176" />
     <PackageVersion Include="Kurrent.Quack.Arrow" Version="0.0.0-alpha.176" />
     <PackageVersion Include="KurrentDB.Client" Version="1.0.0" />


### PR DESCRIPTION
Bumps Kurrent.Surge and Kurrent.Connectors packages from 1.1.1-alpha.1.69 to 1.1.1-alpha.1.70 to address vulnerable package Snappier [GHSA-pggp-6c3x-2xmx](https://github.com/advisories/GHSA-pggp-6c3x-2xmx)