### PR TITLE
[DB-2085] Fix three JintProjectionStateHandler correctness bugs (#5610)

### DIFF
--- a/src/KurrentDB.Projections.Core.Tests/Services/Jint/Serialization/when_serializing_state.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/Jint/Serialization/when_serializing_state.cs
@@ -123,6 +123,34 @@ public class when_serializing_state {
 	}
 
 	[Test]
+	public void nan_serializes_as_null() {
+		var serialized = _sut.Serialize(new JsNumber(double.NaN));
+		Assert.AreEqual("null", serialized);
+	}
+
+	[Test]
+	public void positive_infinity_serializes_as_null() {
+		var serialized = _sut.Serialize(new JsNumber(double.PositiveInfinity));
+		Assert.AreEqual("null", serialized);
+	}
+
+	[Test]
+	public void negative_infinity_serializes_as_null() {
+		var serialized = _sut.Serialize(new JsNumber(double.NegativeInfinity));
+		Assert.AreEqual("null", serialized);
+	}
+
+	[Test]
+	public void object_with_non_finite_number_property_serializes_property_as_null() {
+		var instance = new JsObject(_engine);
+		instance.Set("nan", new JsNumber(double.NaN));
+		instance.Set("inf", new JsNumber(double.PositiveInfinity));
+		instance.Set("ok", new JsNumber(1));
+		var serialized = _sut.Serialize(instance);
+		Assert.AreEqual(@"{""nan"":null,""inf"":null,""ok"":1}", serialized);
+	}
+
+	[Test]
 	public void undefined() {
 		var serialized = _sut.Serialize(JsValue.Undefined);
 		Assert.AreEqual(@"null", serialized);

--- a/src/KurrentDB.Projections.Core.Tests/Services/Jint/when_accessing_event_body_with_non_object_data.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/Jint/when_accessing_event_body_with_non_object_data.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Text.Json;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+[TestFixture]
+public class when_accessing_event_body_with_non_object_data : TestFixtureWithInterpretedProjection {
+	protected override void Given() {
+		_projection = @"
+            fromAll().when({$any:
+                function(state, event) {
+                    state.body = event.body;
+                    return state;
+                }
+            });
+        ";
+		_state = @"{}";
+	}
+
+	private string ProcessWithRaw(string raw) {
+		_stateHandler.ProcessEvent(
+			"", CheckpointTag.FromPosition(0, 10, 5), "stream1", "type1", "category", Guid.NewGuid(), 0, "{}",
+			raw, out var state, out _, out _);
+		return state;
+	}
+
+	[Test, Category(_projectionType)]
+	public void raw_null_body_does_not_throw_and_yields_null() {
+		var state = ProcessWithRaw("null");
+		var doc = JsonDocument.Parse(state);
+		Assert.True(doc.RootElement.TryGetProperty("body", out var body));
+		Assert.AreEqual(JsonValueKind.Null, body.ValueKind);
+	}
+
+	[Test, Category(_projectionType)]
+	public void raw_number_body_does_not_throw_and_yields_number() {
+		var state = ProcessWithRaw("42");
+		var doc = JsonDocument.Parse(state);
+		Assert.True(doc.RootElement.TryGetProperty("body", out var body));
+		Assert.AreEqual(JsonValueKind.Number, body.ValueKind);
+		Assert.AreEqual(42, body.GetInt32());
+	}
+
+	[Test, Category(_projectionType)]
+	public void raw_string_body_does_not_throw_and_yields_string() {
+		var state = ProcessWithRaw("\"hello\"");
+		var doc = JsonDocument.Parse(state);
+		Assert.True(doc.RootElement.TryGetProperty("body", out var body));
+		Assert.AreEqual(JsonValueKind.String, body.ValueKind);
+		Assert.AreEqual("hello", body.GetString());
+	}
+}

--- a/src/KurrentDB.Projections.Core.Tests/Services/Jint/when_round_tripping_bi_state_js_projection_with_string_state.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/Jint/when_round_tripping_bi_state_js_projection_with_string_state.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+[TestFixture]
+public class when_round_tripping_bi_state_js_projection_with_string_state : TestFixtureWithInterpretedProjection {
+	protected override void Given() {
+		_projection = @"
+                options({
+                    biState: true,
+                });
+                fromAll().foreachStream().when({
+                    type1: function(state, event) {
+                        return [""hello"", state[1]];
+                    }});
+            ";
+		_state = @"{}";
+		_sharedState = @"{}";
+	}
+
+	[Test, Category(_projectionType)]
+	public void produced_state_is_json_encoded_so_it_round_trips() {
+		_stateHandler.ProcessEvent(
+			"", CheckpointTag.FromPosition(0, 10, 5), "stream1", "type1", "category", Guid.NewGuid(), 0, "metadata",
+			@"{}", out var producedState, out var producedSharedState, out _);
+
+		Assert.AreEqual("\"hello\"", producedState,
+			"Bi-state slot[0] string state must be JSON-encoded so Load() can parse it on restart.");
+
+		var freshHandler = CreateStateHandler();
+		Assert.DoesNotThrow(
+			() => freshHandler.Load(producedState),
+			$"Load() threw on the produced state value: <<{producedState}>>. Round-trip is broken.");
+		Assert.DoesNotThrow(() => freshHandler.LoadShared(producedSharedState));
+	}
+}

--- a/src/KurrentDB.Projections.Core.Tests/Services/Jint/when_round_tripping_uni_state_js_projection_with_string_state.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/Jint/when_round_tripping_uni_state_js_projection_with_string_state.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+[TestFixture]
+public class when_round_tripping_uni_state_js_projection_with_string_state : TestFixtureWithInterpretedProjection {
+	protected override void Given() {
+		_projection = @"
+                fromAll().when({
+                    type1: function(state, event) {
+                        return ""hello"";
+                    }
+                });
+            ";
+		_state = @"{}";
+	}
+
+	[Test, Category(_projectionType)]
+	public void produced_state_is_json_encoded_so_it_round_trips() {
+		_stateHandler.ProcessEvent(
+			"", CheckpointTag.FromPosition(0, 10, 5), "stream1", "type1", "category", Guid.NewGuid(), 0, "metadata",
+			@"{}", out var producedState, out _, out _);
+
+		Assert.AreEqual("\"hello\"", producedState,
+			"String state must be JSON-encoded so Load() can parse it on restart.");
+
+		var freshHandler = CreateStateHandler();
+		Assert.DoesNotThrow(
+			() => freshHandler.Load(producedState),
+			$"Load() threw on the produced state value: <<{producedState}>>. Round-trip is broken.");
+	}
+}

--- a/src/KurrentDB.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
+++ b/src/KurrentDB.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
@@ -209,25 +209,12 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 		_emitted.Clear();
 		if (_definitionBuilder.IsBiState && _state.IsArray()) {
 			var arr = _state.AsArray();
-			if (arr.TryGetValue(0, out var state)) {
-				if (_state.IsString()) {
-					newState = _state.AsString();
-				} else {
-					newState = ConvertToStringHandlingNulls(state);
-				}
-			} else {
-				newState = "";
-			}
-
-			if (arr.TryGetValue(1, out var sharedState)) {
-				newSharedState = ConvertToStringHandlingNulls(sharedState);
-			} else {
-				newSharedState = null;
-			}
-
-		} else if (_state.IsString()) {
-			newState = _state.AsString();
-			newSharedState = null;
+			newState = arr.TryGetValue(0, out var state)
+				? ConvertToStringHandlingNulls(state)
+				: "";
+			newSharedState = arr.TryGetValue(1, out var sharedState)
+				? ConvertToStringHandlingNulls(sharedState)
+				: null;
 		} else {
 			newState = ConvertToStringHandlingNulls(_state);
 			newSharedState = null;
@@ -731,7 +718,7 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 			} else if (_any != null) {
 				newState = _jsFunctionCaller.Call("$any", _any, state, FromObject(Engine, eventEnvelope));
 			} else {
-				newState = eventEnvelope.BodyRaw;
+				newState = eventEnvelope.IsJson ? eventEnvelope.Body : eventEnvelope.BodyRaw;
 			}
 			return newState == Undefined ? state : newState;
 		}
@@ -875,17 +862,17 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 			}
 		}
 
-		private bool EnsureBody(out JsValue objectInstance) {
+		private bool EnsureBody(out JsValue value) {
 			if (IsJson && TryGetValue("bodyRaw", out var raw) && raw is not JsUndefined) {
 				var body = raw.IsNull() ? raw : _parser.Parse(raw.AsString());
 				var pd = new PropertyDescriptor(body, false, true, false);
 				SetOwnProperty("body", pd);
 				SetOwnProperty("data", pd);
-				objectInstance = (ObjectInstance)body;
+				value = body;
 				return true;
 			}
 
-			objectInstance = Undefined;
+			value = Undefined;
 			return false;
 		}
 
@@ -1223,7 +1210,11 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 						writer.WriteBooleanValue(true);
 					break;
 				case Types.Number:
-					writer.WriteNumberValue(value.AsNumber());
+					var n = value.AsNumber();
+					if (double.IsFinite(n))
+						writer.WriteNumberValue(n);
+					else
+						writer.WriteNullValue();
 					break;
 				case Types.BigInt:
 					writer.WriteStringValue(value.ToString());


### PR DESCRIPTION
cherry pick from #5610

* [DB-2085] Fix three correctness bugs in JintProjectionStateHandler

- EnsureBody: drop unsafe (ObjectInstance) cast that crashed on raw null, number, string, or boolean event bodies marked isJson:true.
- PrepareOutput biState: test the extracted slot-0 element for IsString, not the array itself, so a string state serializes raw rather than JSON-quoted.
- SerializePrimitive: guard WriteNumberValue with double.IsFinite; emit null for NaN/+Inf/-Inf to match JSON.stringify semantics instead of faulting the projection with ArgumentException.

Bugs affect both V1 and V2 projection engines (shared JS state handler).

* Always JSON-encode projection state in PrepareOutput

  1. PrepareOutput had IsString() carve-outs on both the bi-state and uni-state paths that returned raw JS strings instead of JSON-encoded ones. Raw `hello` is not valid JSON, so Load()'s JsonParser.Parse() throws on restart and the projection faults. Route both paths through ConvertToStringHandlingNulls — V8's prelude unconditionally JSON.stringify'd state.

  2. Handle() assigned BodyRaw (raw text) when no user handler matched, making _state a JS string. The IsString carve-out emitted it verbatim, so the on-disk output looked right but in-JS state.data was always undefined. V8's defaultEventHandler returned the parsed body. Use parsed Body for JSON events; BodyRaw fallback for non-JSON.

  Existing bi-state checkpoints round-trip cleanly: the typo bug
  incidentally over-encoded strings as `"\"hello\""`, which is what the
  new code also produces.

  Replace the typo-targeted regression test with two round-trip tests,
  one per code path.
