### PR TITLE
[DB-2143] Unwire transient projections

### DIFF
--- a/src/KurrentDB.Projections.Management.Tests/AssemblyLoading.cs
+++ b/src/KurrentDB.Projections.Management.Tests/AssemblyLoading.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using KurrentDB.Projections.Core.Messages;
+
+namespace KurrentDB.Projections.Core;
+
+static class AssemblyLoading {
+	/// <summary>
+	/// Force the V1 projections assembly to load before InMemoryBus's static
+	/// constructor scans AppDomain assemblies for message types. Fires when the
+	/// test runner loads this test assembly — the earliest possible point —
+	/// guaranteeing V1 message types are discoverable by the bus.
+	/// </summary>
+	[ModuleInitializer]
+	[SuppressMessage("Usage", "CA2255:The 'ModuleInitializer' attribute should not be used in libraries")]
+	internal static void EnsureV1AssemblyLoaded() {
+		RuntimeHelpers.RunClassConstructor(typeof(EventReaderSubscriptionMessage).TypeHandle);
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/ClientAPI/projectionsManager/projectionsManagerTests.cs
+++ b/src/KurrentDB.Projections.Management.Tests/ClientAPI/projectionsManager/projectionsManagerTests.cs
@@ -41,6 +41,7 @@ public class when_creating_one_time_projection<TLogFormat, TStreamId> : Specific
 
 [Category("ProjectionsManager")]
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).")]
 public class when_creating_transient_projection<TLogFormat, TStreamId> : SpecificationWithNodeAndProjectionsManager<TLogFormat, TStreamId> {
 	private string _streamName;
 	private string _projectionName;

--- a/src/KurrentDB.Projections.Management.Tests/ClientAPI/when_executing_query/with_long_from_all_query/when_getting_result.cs
+++ b/src/KurrentDB.Projections.Management.Tests/ClientAPI/when_executing_query/with_long_from_all_query/when_getting_result.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.ClientAPI.when_executing_query.with_long_from_all_query;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).")]
 public class when_getting_result<TLogFormat, TStreamId>
 	: specification_with_standard_projections_runnning<TLogFormat, TStreamId> {
 	protected override async Task Given() {

--- a/src/KurrentDB.Projections.Management.Tests/ClientAPI/when_executing_query/with_long_from_all_query/when_getting_result_and_timeout_exceeded.cs
+++ b/src/KurrentDB.Projections.Management.Tests/ClientAPI/when_executing_query/with_long_from_all_query/when_getting_result_and_timeout_exceeded.cs
@@ -10,6 +10,7 @@ using static KurrentDB.Core.Tests.AssertEx;
 namespace KurrentDB.Projections.Core.Tests.ClientAPI.when_executing_query.with_long_from_all_query;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).")]
 public class when_getting_result_and_timeout_exceeded<TLogFormat, TStreamId>
 	: specification_with_standard_projections_runnning<TLogFormat, TStreamId> {
 	protected override async Task Given() {

--- a/src/KurrentDB.Projections.Management.Tests/Integration/scenarios/when_recategorizing_chat_events_by_users.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Integration/scenarios/when_recategorizing_chat_events_by_users.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.Integration.scenarios;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).")]
 public class when_recategorizing_chat_events_by_users<TLogFormat, TStreamId> : specification_with_a_v8_query_posted<TLogFormat, TStreamId> {
 	protected override void GivenEvents() {
 	}

--- a/src/KurrentDB.Projections.Management.Tests/Integration/specification_with_a_v8_query_posted.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Integration/specification_with_a_v8_query_posted.cs
@@ -10,6 +10,7 @@ using KurrentDB.Projections.Core.Messages;
 using KurrentDB.Projections.Core.Services;
 using KurrentDB.Projections.Core.Services.Processing;
 using KurrentDB.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
 
 namespace KurrentDB.Projections.Core.Tests.Integration;
 
@@ -35,6 +36,8 @@ public abstract class specification_with_a_v8_query_posted<TLogFormat, TStreamId
 		_trackEmittedStreams = false;
 		_emitEnabled = false;
 		_startSystemProjections = GivenStartSystemProjections();
+		if (_projectionMode == ProjectionMode.Transient && !string.IsNullOrEmpty(_projectionSource))
+			Assert.Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).");
 	}
 
 	protected override Tuple<SynchronousScheduler, IPublisher, SynchronousScheduler, Guid>[] GivenProcessingQueues() {

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/Scenarios/specification_with_js_query_posted.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/Scenarios/specification_with_js_query_posted.cs
@@ -10,6 +10,7 @@ using KurrentDB.Projections.Core.Messages;
 using KurrentDB.Projections.Core.Services;
 using KurrentDB.Projections.Core.Services.Processing;
 using KurrentDB.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
 
 namespace KurrentDB.Projections.Core.Tests.Services.Jint.Scenarios;
 
@@ -36,6 +37,8 @@ public abstract class specification_with_js_query_posted<TLogFormat, TStreamId> 
 		_trackEmittedStreams = false;
 		_emitEnabled = false;
 		_startSystemProjections = GivenStartSystemProjections();
+		if (_projectionMode == ProjectionMode.Transient && !string.IsNullOrEmpty(_projectionSource))
+			Assert.Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).");
 	}
 
 	protected override Tuple<SynchronousScheduler, IPublisher, SynchronousScheduler, Guid>[] GivenProcessingQueues() {

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/Scenarios/when_recategorizing_chat_events_by_users.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/Scenarios/when_recategorizing_chat_events_by_users.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.Services.Jint.Scenarios;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).")]
 public class when_recategorizing_chat_events_by_users<TLogFormat, TStream> : specification_with_js_query_posted<TLogFormat, TStream> {
 	protected override void GivenEvents() {
 	}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/query/a_new_posted_projection.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/query/a_new_posted_projection.cs
@@ -34,6 +34,7 @@ public static class a_new_posted_projection {
 			_trackEmittedStreams = false;
 			_emitEnabled = false;
 			NoOtherStreams();
+			Assert.Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).");
 		}
 
 		protected override IEnumerable<WhenStep> When() {

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.Services.projections_manager.runas {
 	namespace when_posting_a_transient_projection {
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).")]
 		public class Authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 			private ClaimsPrincipal _testUserPrincipal;

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_an_onetime_projection.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_an_onetime_projection.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post). (Misleading file name — this fixture actually posts as Transient via the 4-arg Post shortcut.)")]
 public class when_posting_an_onetime_projection<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 	protected override void Given() {
 		NoOtherStreams();

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_the_onetime_projection_has_been_posted.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_the_onetime_projection_has_been_posted.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post). (Misleading file name — this fixture actually posts as Transient via the 4-arg Post shortcut.)")]
 public class when_the_onetime_projection_has_been_posted<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 	private string _projectionName;
 	private string _projectionQuery;

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).")]
 public class when_updating_an_onetime_projection_query_text<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 	private string _projectionName;
 	private string _newProjectionSource;

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_an_onetime_system_projection_query_text.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_an_onetime_system_projection_query_text.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[Ignore("Transient projections are deprecated — see ProjectionManager.Handle(Post).")]
 public class when_updating_an_onetime_system_projection_query_text<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 	private string _projectionName;
 	private string _newProjectionSource;

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
@@ -76,12 +76,17 @@ internal partial class ProjectionManagement {
 		return new CreateResp();
 
 		void OnMessage(Message message) {
-			if (message is not ProjectionManagementMessage.Updated) {
-				createdSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
-				return;
+			switch (message) {
+				case ProjectionManagementMessage.Updated:
+					createdSource.TrySetResult(true);
+					break;
+				case ProjectionManagementMessage.OperationFailed failed:
+					createdSource.TrySetException(OperationFailed(failed));
+					break;
+				default:
+					createdSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+					break;
 			}
-
-			createdSource.TrySetResult(true);
 		}
 	}
 }

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
@@ -10,6 +10,7 @@ using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.Messaging;
+using KurrentDB.Projections.Core.Messages;
 
 
 // ReSharper disable CheckNamespace
@@ -46,6 +47,9 @@ namespace EventStore.Projections.Core.Services.Grpc {
 
 		private static Exception ProjectionNotFound(string name) =>
 			new RpcException(new Status(StatusCode.NotFound, $"Projection '{name}' not found"));
+
+		private static Exception OperationFailed(ProjectionManagementMessage.OperationFailed message) =>
+			new RpcException(new Status(StatusCode.FailedPrecondition, message.Reason));
 
 		private static Value GetProtoValue(JsonElement element) =>
 			element.ValueKind switch {

--- a/src/KurrentDB.Projections.Management/Services/Management/ProjectionManager.cs
+++ b/src/KurrentDB.Projections.Management/Services/Management/ProjectionManager.cs
@@ -264,11 +264,10 @@ public class ProjectionManager
 			return;
 
 		if (message.Mode == ProjectionMode.Transient) {
-			var transientProjection = new PendingProjection(ProjectionQueryId, message);
-			if (!ValidateProjections(new[] { transientProjection }, message))
-				return;
-
-			PostNewTransientProjection(transientProjection, message.Envelope);
+			message.Envelope.ReplyWith(
+				new ProjectionManagementMessage.OperationFailed(
+					"Transient projections are deprecated. Use the secondary indexing query API."));
+			return;
 		} else {
 			if (_isWritePending) {
 				DelayMessage(message);

--- a/src/KurrentDB.Projections.V1.Tests/AssemblyLoading.cs
+++ b/src/KurrentDB.Projections.V1.Tests/AssemblyLoading.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using KurrentDB.Projections.Core.Messages;
+
+namespace KurrentDB.Projections.Core;
+
+static class AssemblyLoading {
+	/// <summary>
+	/// Force the V1 projections assembly to load before InMemoryBus's static
+	/// constructor scans AppDomain assemblies for message types. Fires when the
+	/// test runner loads this test assembly — the earliest possible point —
+	/// guaranteeing V1 message types are discoverable by the bus.
+	/// </summary>
+	[ModuleInitializer]
+	[SuppressMessage("Usage", "CA2255:The 'ModuleInitializer' attribute should not be used in libraries")]
+	internal static void EnsureV1AssemblyLoaded() {
+		RuntimeHelpers.RunClassConstructor(typeof(EventReaderSubscriptionMessage).TypeHandle);
+	}
+}


### PR DESCRIPTION
Transient projections (the "query" feature in the old projections engine) are deprecated in favor of the secondary-indexing query mechanism. Unplug the feature at a single chokepoint in ProjectionManager.Handle(Post) so every interface that funnels through the message bus (HTTP, gRPC, future) returns OperationFailed without needing to find each endpoint individually.

The internal machinery — PostNewTransientProjection, ManagedProjection expiry/cleanup, the Transient enum value — is left in place. This keeps the change small and easy to revert if we need to reinstate the feature.

Tests that posted transients are skipped, not deleted:
  - The query/ folder tests inherit from a_new_posted_projection.Base, which now Assert.Ignore's in Given() — covers all 6 files.
  - specification_with_a_v8_query_posted and the JS variant skip conditionally (only when the derived test actually posts a transient), so system-projection tests that reuse the base with an empty source still run.
  - Three standalone fixtures get [Ignore]: when_posting_a_transient_ projection.Authenticated and the two onetime-query-text fixtures (which post as Transient despite their names).
  - when_starting_a_managed_projection_without_follower_projections is unaffected — it constructs a ManagedProjection directly and bypasses the dispatcher.

Search "Transient projections are deprecated" to find every skip site and the chokepoint itself when reverting or moving to full removal.