### PR TITLE
Add caller metadata to projection Create/Update

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -4228,6 +4228,11 @@
                     "id": 5,
                     "name": "engine_version",
                     "type": "int32"
+                  },
+                  {
+                    "id": 6,
+                    "name": "metadata",
+                    "type": "bytes"
                   }
                 ],
                 "messages": [
@@ -4300,6 +4305,11 @@
                     "id": 4,
                     "name": "no_emit_options",
                     "type": "event_store.client.Empty"
+                  },
+                  {
+                    "id": 5,
+                    "name": "metadata",
+                    "type": "bytes"
                   }
                 ]
               }

--- a/proto.lock
+++ b/proto.lock
@@ -4228,11 +4228,16 @@
                     "id": 5,
                     "name": "engine_version",
                     "type": "int32"
-                  },
+                  }
+                ],
+                "maps": [
                   {
-                    "id": 6,
-                    "name": "metadata",
-                    "type": "bytes"
+                    "key_type": "string",
+                    "field": {
+                      "id": 6,
+                      "name": "properties",
+                      "type": "google.protobuf.Value"
+                    }
                   }
                 ],
                 "messages": [
@@ -4305,11 +4310,16 @@
                     "id": 4,
                     "name": "no_emit_options",
                     "type": "event_store.client.Empty"
-                  },
+                  }
+                ],
+                "maps": [
                   {
-                    "id": 5,
-                    "name": "metadata",
-                    "type": "bytes"
+                    "key_type": "string",
+                    "field": {
+                      "id": 5,
+                      "name": "properties",
+                      "type": "google.protobuf.Value"
+                    }
                   }
                 ]
               }

--- a/src/KurrentDB.Projections.Management.Tests/Services/grpc_service/ProjectionMetadataTests.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/grpc_service/ProjectionMetadataTests.cs
@@ -63,8 +63,8 @@ public class ProjectionMetadataTests : SpecificationWithNodeAndProjectionsManage
 
 	public override Task When() => Task.CompletedTask;
 
-	// The definition write that carries the properties is the first $ProjectionUpdated event; later
-	// lifecycle writes are metadataless, so read forward and take the earliest.
+	// The definition write that carries the user properties is the first $ProjectionUpdated event;
+	// later lifecycle writes only contain synthetic properties, so read forward and take the earliest.
 	private async Task<byte[]> ReadDefinitionMetadata(string projectionName) {
 		var stream = ProjectionNamesBuilder.ProjectionsStreamPrefix + projectionName;
 		var slice = await _connection.ReadStreamEventsForwardAsync(stream, 0, 100, false, _credentials);
@@ -84,9 +84,13 @@ public class ProjectionMetadataTests : SpecificationWithNodeAndProjectionsManage
 	}
 
 	[Test]
-	public async Task no_properties_writes_no_metadata() {
+	public async Task no_properties_writes_only_synthetic_metadata() {
 		var metadata = await ReadDefinitionMetadata(WithoutProperties);
-		Assert.AreEqual(0, metadata.Length);
+		if (metadata.Length == 0) return;
+
+		using var json = JsonDocument.Parse(metadata);
+		foreach (var prop in json.RootElement.EnumerateObject())
+			Assert.That(prop.Name.StartsWith('$'), $"Unexpected user property: {prop.Name}");
 	}
 
 	public override Task TestFixtureTearDown() {

--- a/src/KurrentDB.Projections.Management.Tests/Services/grpc_service/ProjectionMetadataTests.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/grpc_service/ProjectionMetadataTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using EventStore.Client.Projections;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Grpc.Net.Client;
+using KurrentDB.Core.Tests;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing;
+using KurrentDB.Projections.Core.Tests.ClientAPI.projectionsManager;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.grpc_service;
+
+[TestFixture]
+public class ProjectionMetadataTests : SpecificationWithNodeAndProjectionsManager<LogFormat.V2, string> {
+	private const string WithProperties = "projection-with-properties";
+	private const string WithoutProperties = "projection-without-properties";
+
+	private EventStore.Client.Projections.Projections.ProjectionsClient _client;
+	private GrpcChannel _channel;
+
+	public override async Task Given() {
+		_channel = GrpcChannel.ForAddress(
+			new Uri($"https://{_node.HttpEndPoint}"),
+			new GrpcChannelOptions {
+				HttpHandler = _node.HttpMessageHandler,
+			});
+		_client = new EventStore.Client.Projections.Projections.ProjectionsClient(_channel);
+
+		await _client.CreateAsync(new CreateReq {
+			Options = new CreateReq.Types.Options {
+				Continuous = new CreateReq.Types.Options.Types.Continuous {
+					Name = WithProperties,
+					EmitEnabled = false,
+					TrackEmittedStreams = false,
+				},
+				Query = "fromAll().when({})",
+				Properties = {
+					{ "deploy", Value.ForString("abc123") },
+					{ "tool", Value.ForString("gaffer") },
+				},
+			},
+		}, GetCallOptions());
+
+		await _client.CreateAsync(new CreateReq {
+			Options = new CreateReq.Types.Options {
+				Continuous = new CreateReq.Types.Options.Types.Continuous {
+					Name = WithoutProperties,
+					EmitEnabled = false,
+					TrackEmittedStreams = false,
+				},
+				Query = "fromAll().when({})",
+			},
+		}, GetCallOptions());
+	}
+
+	public override Task When() => Task.CompletedTask;
+
+	// The definition write that carries the properties is the first $ProjectionUpdated event; later
+	// lifecycle writes are metadataless, so read forward and take the earliest.
+	private async Task<byte[]> ReadDefinitionMetadata(string projectionName) {
+		var stream = ProjectionNamesBuilder.ProjectionsStreamPrefix + projectionName;
+		var slice = await _connection.ReadStreamEventsForwardAsync(stream, 0, 100, false, _credentials);
+		return slice.Events
+			.Select(resolved => resolved.Event)
+			.First(e => e.EventType == ProjectionEventTypes.ProjectionUpdated)
+			.Metadata;
+	}
+
+	[Test]
+	public async Task properties_round_trip_into_the_definition_event_metadata() {
+		var metadata = await ReadDefinitionMetadata(WithProperties);
+		// Property metadata is synthesized back to JSON on read; the caller's keys round-trip at the top level.
+		using var json = JsonDocument.Parse(metadata);
+		Assert.AreEqual("abc123", json.RootElement.GetProperty("deploy").GetString());
+		Assert.AreEqual("gaffer", json.RootElement.GetProperty("tool").GetString());
+	}
+
+	[Test]
+	public async Task no_properties_writes_no_metadata() {
+		var metadata = await ReadDefinitionMetadata(WithoutProperties);
+		Assert.AreEqual(0, metadata.Length);
+	}
+
+	public override Task TestFixtureTearDown() {
+		_channel.Dispose();
+		return base.TestFixtureTearDown();
+	}
+
+	private static CallOptions GetCallOptions() {
+		var credentials = CallCredentials.FromInterceptor((_, metadata) => {
+			metadata.Add(new Metadata.Entry("authorization",
+				$"Basic {Convert.ToBase64String("admin:changeit"u8.ToArray())}"));
+			return Task.CompletedTask;
+		});
+		return new(credentials: credentials,
+			deadline: Debugger.IsAttached
+				? DateTime.UtcNow.AddDays(1)
+				: new DateTime?());
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/managed_projection/when_updating_config_after_a_metadata_post.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/managed_projection/when_updating_config_after_a_metadata_post.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.Services.TimeService;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Management;
+using KurrentDB.Projections.Core.Services.Processing;
+using KurrentDB.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projections_manager.managed_projection;
+
+// A metadata-bearing create must not leak its blob onto a later, non-metadata config write through the shared
+// CreatePersistedStateEvent chokepoint.
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_updating_config_after_a_metadata_post<TLogFormat, TStreamId> : projection_config_test_base<TLogFormat, TStreamId> {
+	private ManagedProjection _mp;
+	private readonly Guid _projectionId = Guid.NewGuid();
+	private readonly byte[] _metadata = Helper.UTF8NoBom.GetBytes("{\"deploy\":\"abc123\"}");
+
+	private ManagedProjection.PersistedState _persistedState => new ManagedProjection.PersistedState {
+		Enabled = false,
+		HandlerType = "JS",
+		Query = "fromAll().when({});",
+		Mode = ProjectionMode.Continuous,
+		CheckpointsDisabled = false,
+		Epoch = -1,
+		Version = -1,
+		RunAs = SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous),
+		EmitEnabled = false,
+		TrackEmittedStreams = true,
+		CheckpointAfterMs = 1,
+		CheckpointHandledThreshold = 2,
+		CheckpointUnhandledBytesThreshold = 3,
+		PendingEventsThreshold = 4,
+		MaxWriteBatchLength = 5,
+		MaxAllowedWritesInFlight = 6,
+		ProjectionExecutionTimeout = 11
+	};
+
+	public when_updating_config_after_a_metadata_post() {
+		AllWritesQueueUp();
+	}
+
+	protected override void Given() {
+		_timeProvider = new FakeTimeProvider();
+		_mp = CreateManagedProjection();
+
+		_mp.InitializeNew(_persistedState, null, _metadata);
+		_mp.Handle(new CoreProjectionStatusMessage.Prepared(_projectionId, new ProjectionSourceDefinition()));
+		OneWriteCompletes();
+		_mp.Handle(new CoreProjectionStatusMessage.Stopped(_projectionId, ProjectionName, false));
+
+		_mp.Handle(CreateConfig());
+		OneWriteCompletes();
+	}
+
+	[Test]
+	public void the_create_write_carried_the_metadata() {
+		CollectionAssert.AreEqual(_metadata, _streams[ProjectionStreamId].First().Metadata.ToArray());
+	}
+
+	[Test]
+	public void the_config_write_is_metadata_less() {
+		Assert.AreEqual(0, _streams[ProjectionStreamId].Last().Metadata.Length);
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_a_lifecycle_write_follows_a_metadata_post.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_a_lifecycle_write_follows_a_metadata_post.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.TestAdapters;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Management;
+using KurrentDB.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_a_lifecycle_write_follows_a_metadata_post<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+	private string _projectionName;
+	private readonly byte[] _metadata = Helper.UTF8NoBom.GetBytes("{\"deploy\":\"abc123\"}");
+
+	protected override void Given() {
+		_projectionName = "test-projection";
+		NoStream("$projections-test-projection");
+		NoStream("$projections-test-projection-result");
+		NoStream("$projections-test-projection-order");
+		AllWritesToSucceed("$projections-test-projection-order");
+		NoStream("$projections-test-projection-checkpoint");
+		AllWritesSucceed();
+	}
+
+	protected override IEnumerable<WhenStep> When() {
+		yield return new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid());
+		yield return
+			new ProjectionManagementMessage.Command.Post(
+				_bus, ProjectionMode.Continuous, _projectionName,
+				ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
+				enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+				metadata: _metadata);
+		yield return
+			new ProjectionManagementMessage.Command.Disable(
+				_bus, _projectionName, ProjectionManagementMessage.RunAs.System);
+	}
+
+	private List<ClientMessage.WriteEvents> DefinitionWrites() {
+		var stream = ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName;
+		return _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+			.Where(x => x.EventStreamId == stream && x.Events[0].EventType == ProjectionEventTypes.ProjectionUpdated)
+			.ToList();
+	}
+
+	[Test, Category("v8")]
+	public void the_post_write_carries_the_metadata() {
+		CollectionAssert.AreEqual(_metadata, DefinitionWrites().First().Events[0].Metadata);
+	}
+
+	[Test, Category("v8")]
+	public void the_lifecycle_write_does_not_re_stamp_the_metadata() {
+		var writes = DefinitionWrites();
+		Assert.Greater(writes.Count, 1, "expected the disable to produce a further definition write");
+		Assert.IsEmpty(writes.Last().Events[0].Metadata);
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_loading_a_projection_whose_definition_has_metadata.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_loading_a_projection_whose_definition_has_metadata.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KurrentDB.Common.Options;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Services.TimerService;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.Services.TimeService;
+using KurrentDB.Core.Util;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Metrics;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Management;
+using KurrentDB.Projections.Core.Services.Processing;
+using KurrentDB.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
+
+// Forward-compat keystone: the load path reads only Event.Data, never Event.Metadata, so a definition event
+// that carries caller metadata must load exactly as one without it.
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_loading_a_projection_whose_definition_has_metadata<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
+	private new ITimeProvider _timeProvider;
+	private ProjectionManager _manager;
+	private Guid _workerId;
+
+	protected override void Given() {
+		_workerId = Guid.NewGuid();
+		ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, ProjectionEventTypes.ProjectionCreated,
+			null, "projection1");
+		ExistingEvent(
+			"$projections-projection1", ProjectionEventTypes.ProjectionUpdated,
+			@"{""deploy"":""abc123""}",
+			@"{""Query"":""fromAll(); on_any(function(){});log('hello');"", ""Mode"":""3"", ""Enabled"":true, ""HandlerType"":""JS""}");
+	}
+
+	[SetUp]
+	public void setup() {
+		_timeProvider = new FakeTimeProvider();
+		var queues = new Dictionary<Guid, IPublisher> { { _workerId, _bus } };
+		_manager = new ProjectionManager(
+			_bus,
+			_bus,
+			queues,
+			_timeProvider,
+			ProjectionType.All,
+			_ioDispatcher,
+			TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+			IProjectionTracker.NoOp);
+		_bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
+		_bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
+		_bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);
+		_manager.Handle(new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid()));
+	}
+
+	[TearDown]
+	public void TearDown() {
+		_manager.Dispose();
+	}
+
+	[Test]
+	public void the_projection_loads_normally() {
+		_manager.Handle(new ProjectionManagementMessage.Command.GetStatistics(_bus, null, "projection1"));
+		var stats = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>()
+			.SingleOrDefault(v => v.Projections[0].Name == "projection1");
+		Assert.IsNotNull(stats);
+		Assert.AreEqual(ManagedProjectionState.Preparing, stats.Projections[0].LeaderStatus);
+	}
+
+	[Test]
+	public void the_definition_body_is_read_intact() {
+		_manager.Handle(
+			new ProjectionManagementMessage.Command.GetQuery(
+				_bus, "projection1", ProjectionManagementMessage.RunAs.Anonymous));
+		var query = _consumer.HandledMessages.OfType<ProjectionManagementMessage.ProjectionQuery>().Single();
+		Assert.AreEqual("projection1", query.Name);
+		StringAssert.Contains("fromAll()", query.Query);
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_with_metadata.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_with_metadata.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.TestAdapters;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Management;
+using KurrentDB.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_posting_a_projection_with_metadata<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+	private string _projectionName;
+	private readonly byte[] _metadata = Helper.UTF8NoBom.GetBytes("{\"deploy\":\"abc123\"}");
+
+	protected override void Given() {
+		_projectionName = "test-projection";
+		NoStream("$projections-test-projection");
+		NoStream("$projections-test-projection-result");
+		NoStream("$projections-test-projection-order");
+		AllWritesToSucceed("$projections-test-projection-order");
+		NoStream("$projections-test-projection-checkpoint");
+		AllWritesSucceed();
+	}
+
+	protected override IEnumerable<WhenStep> When() {
+		yield return new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid());
+		yield return
+			new ProjectionManagementMessage.Command.Post(
+				_bus, ProjectionMode.Continuous, _projectionName,
+				ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
+				enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+				metadata: _metadata);
+	}
+
+	private List<ClientMessage.WriteEvents> DefinitionWrites() {
+		var stream = ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName;
+		return _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+			.Where(x => x.EventStreamId == stream && x.Events[0].EventType == ProjectionEventTypes.ProjectionUpdated)
+			.ToList();
+	}
+
+	[Test, Category("v8")]
+	public void the_definition_event_carries_the_metadata() {
+		var writes = DefinitionWrites();
+		CollectionAssert.IsNotEmpty(writes);
+		CollectionAssert.AreEqual(_metadata, writes.First().Events[0].Metadata);
+	}
+
+	[Test, Category("v8")]
+	public void no_later_write_re_stamps_the_metadata() {
+		Assert.IsTrue(DefinitionWrites().Skip(1).All(w => w.Events[0].Metadata.Length == 0));
+	}
+
+	[Test, Category("v8")]
+	public void the_definition_event_body_is_the_unchanged_persisted_state() {
+		var state = DefinitionWrites().First().Events[0].Data.ParseJson<ManagedProjection.PersistedState>();
+		Assert.AreEqual("JS", state.HandlerType);
+		Assert.AreEqual(ProjectionMode.Continuous, state.Mode);
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_with_metadata.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_with_metadata.cs
@@ -55,6 +55,11 @@ public class when_posting_a_projection_with_metadata<TLogFormat, TStreamId> : Te
 	}
 
 	[Test, Category("v8")]
+	public void the_definition_event_metadata_is_property_metadata() {
+		Assert.IsTrue(DefinitionWrites().First().Events[0].IsPropertyMetadata);
+	}
+
+	[Test, Category("v8")]
 	public void no_later_write_re_stamps_the_metadata() {
 		Assert.IsTrue(DefinitionWrites().Skip(1).All(w => w.Events[0].Metadata.Length == 0));
 	}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_without_metadata.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_without_metadata.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.TestAdapters;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_posting_a_projection_without_metadata<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+	private string _projectionName;
+
+	protected override void Given() {
+		_projectionName = "test-projection";
+		NoStream("$projections-test-projection");
+		NoStream("$projections-test-projection-result");
+		NoStream("$projections-test-projection-order");
+		AllWritesToSucceed("$projections-test-projection-order");
+		NoStream("$projections-test-projection-checkpoint");
+		AllWritesSucceed();
+	}
+
+	protected override IEnumerable<WhenStep> When() {
+		yield return new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid());
+		yield return
+			new ProjectionManagementMessage.Command.Post(
+				_bus, ProjectionMode.Continuous, _projectionName,
+				ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
+				enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+	}
+
+	[Test, Category("v8")]
+	public void no_definition_event_carries_metadata() {
+		var stream = ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName;
+		var writes = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+			.Where(x => x.EventStreamId == stream && x.Events[0].EventType == ProjectionEventTypes.ProjectionUpdated)
+			.ToList();
+		CollectionAssert.IsNotEmpty(writes);
+		Assert.IsTrue(writes.All(w => w.Events[0].Metadata.Length == 0));
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_a_projection_with_metadata.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_a_projection_with_metadata.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.TestAdapters;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_updating_a_projection_with_metadata<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+	private string _projectionName;
+	private readonly byte[] _updateMetadata = Helper.UTF8NoBom.GetBytes("{\"deploy\":\"def456\"}");
+
+	protected override void Given() {
+		_projectionName = "test-projection";
+		NoStream("$projections-test-projection");
+		NoStream("$projections-test-projection-result");
+		NoStream("$projections-test-projection-order");
+		AllWritesToSucceed("$projections-test-projection-order");
+		NoStream("$projections-test-projection-checkpoint");
+		AllWritesSucceed();
+	}
+
+	protected override IEnumerable<WhenStep> When() {
+		yield return new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid());
+		yield return
+			new ProjectionManagementMessage.Command.Post(
+				_bus, ProjectionMode.Continuous, _projectionName,
+				ProjectionManagementMessage.RunAs.System, "JS", @"fromAll(); on_any(function(){return {};});",
+				enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+		yield return
+			new ProjectionManagementMessage.Command.UpdateQuery(
+				_bus, _projectionName, ProjectionManagementMessage.RunAs.System,
+				@"fromAll().when({a:function(){return {};}});", emitEnabled: null,
+				metadata: _updateMetadata);
+	}
+
+	[Test, Category("v8")]
+	public void the_update_definition_write_carries_the_metadata() {
+		var stream = ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName;
+		var writes = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+			.Where(x => x.EventStreamId == stream && x.Events[0].EventType == ProjectionEventTypes.ProjectionUpdated)
+			.ToList();
+		CollectionAssert.AreEqual(_updateMetadata, writes.Last().Events[0].Metadata);
+	}
+}

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
@@ -69,7 +69,7 @@ internal partial class ProjectionManagement {
 
 		_publisher.Publish(new ProjectionManagementMessage.Command.Post(envelope, projectionMode, name, runAs,
 			handlerType, options.Query, true, checkpointsEnabled, emitEnabled, trackEmittedStreams, true,
-			engineVersion, options.Metadata.IsEmpty ? null : options.Metadata.ToByteArray()));
+			engineVersion, ToMetadata(options.Properties)));
 
 		await createdSource.Task;
 

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
@@ -69,7 +69,7 @@ internal partial class ProjectionManagement {
 
 		_publisher.Publish(new ProjectionManagementMessage.Command.Post(envelope, projectionMode, name, runAs,
 			handlerType, options.Query, true, checkpointsEnabled, emitEnabled, trackEmittedStreams, true,
-			engineVersion));
+			engineVersion, options.Metadata.IsEmpty ? null : options.Metadata.ToByteArray()));
 
 		await createdSource.Task;
 

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs
@@ -39,7 +39,7 @@ internal partial class ProjectionManagement {
 		var envelope = new CallbackEnvelope(OnMessage);
 		_publisher.Publish(
 			new ProjectionManagementMessage.Command.UpdateQuery(envelope, name, runAs, query,
-				emitEnabled, options.Metadata.IsEmpty ? null : options.Metadata.ToByteArray()));
+				emitEnabled, ToMetadata(options.Properties)));
 
 		await updatedSource.Task;
 

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs
@@ -39,7 +39,7 @@ internal partial class ProjectionManagement {
 		var envelope = new CallbackEnvelope(OnMessage);
 		_publisher.Publish(
 			new ProjectionManagementMessage.Command.UpdateQuery(envelope, name, runAs, query,
-				emitEnabled));
+				emitEnabled, options.Metadata.IsEmpty ? null : options.Metadata.ToByteArray()));
 
 		await updatedSource.Task;
 

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			new RpcException(new Status(StatusCode.FailedPrecondition, message.Reason));
 
 		private static byte[] ToMetadata(IDictionary<string, Value> properties) =>
-			properties.Count == 0 ? null : new Struct { Fields = { properties } }.ToByteArray();
+			properties.Count == 0 ? [] : new Struct { Fields = { properties } }.ToByteArray();
 
 		private static Value GetProtoValue(JsonElement element) =>
 			element.ValueKind switch {

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
@@ -2,10 +2,12 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using EventStore.Core.Services.Transport.Grpc;
 using EventStore.Plugins.Authorization;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using KurrentDB.Core.Bus;
@@ -50,6 +52,9 @@ namespace EventStore.Projections.Core.Services.Grpc {
 
 		private static Exception OperationFailed(ProjectionManagementMessage.OperationFailed message) =>
 			new RpcException(new Status(StatusCode.FailedPrecondition, message.Reason));
+
+		private static byte[] ToMetadata(IDictionary<string, Value> properties) =>
+			properties.Count == 0 ? null : new Struct { Fields = { properties } }.ToByteArray();
 
 		private static Value GetProtoValue(JsonElement element) =>
 			element.ValueKind switch {

--- a/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
+++ b/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
@@ -721,12 +721,11 @@ public class ManagedProjection : IDisposable {
 
 	private ClientMessage.WriteEvents CreatePersistedStateEvent(Guid correlationId, PersistedState persistedState,
 		string eventStreamId) {
-		var hasMetadata = _pendingMetadata is not null;
 		var metadata = _pendingMetadata ?? [];
 		_pendingMetadata = null;
 		return ClientMessage.WriteEvents.ForSingleEvent(correlationId, correlationId, _writeDispatcher.Envelope, true, eventStreamId, ExpectedVersion.Any,
 			new Event(Guid.NewGuid(), ProjectionEventTypes.ProjectionUpdated, true, persistedState.ToJsonBytes(),
-				isPropertyMetadata: hasMetadata, metadata),
+				isPropertyMetadata: true, metadata),
 			SystemAccounts.System);
 	}
 

--- a/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
+++ b/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
@@ -126,6 +126,7 @@ public class ManagedProjection : IDisposable {
 	internal bool Prepared;
 	internal bool Created;
 	private bool _pendingWritePersistedState;
+	private byte[] _pendingMetadata;
 	private readonly TimeSpan _projectionsQueryExpiry;
 
 	private ManagedProjectionStateBase _stateHandler;
@@ -493,6 +494,7 @@ public class ManagedProjection : IDisposable {
 
 		UpdateProjectionVersion();
 		_pendingWritePersistedState = true;
+		_pendingMetadata = null;
 		WritePersistedState(CreatePersistedStateEvent(Guid.NewGuid(), PersistedProjectionState,
 			ProjectionNamesBuilder.ProjectionsStreamPrefix + _name));
 
@@ -604,8 +606,9 @@ public class ManagedProjection : IDisposable {
 			   _lastAccessed.Add(_projectionsQueryExpiry) < _timeProvider.UtcNow && _persistedStateLoaded;
 	}
 
-	public void InitializeNew(PersistedState persistedState, IEnvelope replyEnvelope) {
+	public void InitializeNew(PersistedState persistedState, IEnvelope replyEnvelope, byte[] metadata = null) {
 		LoadPersistedState(persistedState);
+		_pendingMetadata = metadata;
 		UpdateProjectionVersion();
 		_pendingWritePersistedState = true;
 		SetLastReplyEnvelope(replyEnvelope);
@@ -718,8 +721,11 @@ public class ManagedProjection : IDisposable {
 
 	private ClientMessage.WriteEvents CreatePersistedStateEvent(Guid correlationId, PersistedState persistedState,
 		string eventStreamId) {
+		var metadata = _pendingMetadata ?? [];
+		_pendingMetadata = null;
 		return ClientMessage.WriteEvents.ForSingleEvent(correlationId, correlationId, _writeDispatcher.Envelope, true, eventStreamId, ExpectedVersion.Any,
-			new Event(Guid.NewGuid(), ProjectionEventTypes.ProjectionUpdated, true, persistedState.ToJsonBytes()),
+			new Event(Guid.NewGuid(), ProjectionEventTypes.ProjectionUpdated, true, persistedState.ToJsonBytes(),
+				isPropertyMetadata: false, metadata),
 			SystemAccounts.System);
 	}
 
@@ -949,6 +955,7 @@ public class ManagedProjection : IDisposable {
 		_logger.Error("The '{projection}' projection faulted due to '{e}'", _name, reason);
 		SetState(ManagedProjectionState.Faulted);
 		_faultedReason = reason;
+		_pendingMetadata = null;
 	}
 
 	private ProjectionConfig CreateDefaultProjectionConfiguration() {
@@ -1003,6 +1010,7 @@ public class ManagedProjection : IDisposable {
 	private void UpdateQuery(ProjectionManagementMessage.Command.UpdateQuery message) {
 		PersistedProjectionState.Query = message.Query;
 		PersistedProjectionState.EmitEnabled = message.EmitEnabled ?? PersistedProjectionState.EmitEnabled;
+		_pendingMetadata = message.Metadata;
 		_pendingWritePersistedState = true;
 		if (_state == ManagedProjectionState.Completed) {
 			Reset();

--- a/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
+++ b/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
@@ -721,11 +721,12 @@ public class ManagedProjection : IDisposable {
 
 	private ClientMessage.WriteEvents CreatePersistedStateEvent(Guid correlationId, PersistedState persistedState,
 		string eventStreamId) {
+		var hasMetadata = _pendingMetadata is not null;
 		var metadata = _pendingMetadata ?? [];
 		_pendingMetadata = null;
 		return ClientMessage.WriteEvents.ForSingleEvent(correlationId, correlationId, _writeDispatcher.Envelope, true, eventStreamId, ExpectedVersion.Any,
 			new Event(Guid.NewGuid(), ProjectionEventTypes.ProjectionUpdated, true, persistedState.ToJsonBytes(),
-				isPropertyMetadata: false, metadata),
+				isPropertyMetadata: hasMetadata, metadata),
 			SystemAccounts.System);
 	}
 

--- a/src/KurrentDB.Projections.Management/Services/Management/ProjectionManager.cs
+++ b/src/KurrentDB.Projections.Management/Services/Management/ProjectionManager.cs
@@ -1155,6 +1155,7 @@ public class ProjectionManager
 		private readonly IEnvelope _replyEnvelope;
 		private readonly string _name;
 		private readonly int _engineVersion;
+		private readonly byte[] _metadata;
 
 		public NewProjectionInitializer(
 			long projectionId,
@@ -1169,7 +1170,8 @@ public class ProjectionManager
 			bool trackEmittedStreams,
 			ProjectionManagementMessage.RunAs runAs,
 			IEnvelope replyEnvelope,
-			int engineVersion = ProjectionConstants.EngineV1) {
+			int engineVersion = ProjectionConstants.EngineV1,
+			byte[] metadata = null) {
 			if (projectionMode >= ProjectionMode.Continuous && !checkpointsEnabled)
 				throw new InvalidOperationException("Continuous mode requires checkpoints");
 
@@ -1189,6 +1191,7 @@ public class ProjectionManager
 			_replyEnvelope = replyEnvelope;
 			_name = name;
 			_engineVersion = engineVersion;
+			_metadata = metadata;
 		}
 
 		public void CreateAndInitializeNewProjection(
@@ -1220,7 +1223,8 @@ public class ProjectionManager
 					ProjectionExecutionTimeout = null,
 					EngineVersion = _engineVersion
 				},
-				_replyEnvelope);
+				_replyEnvelope,
+				_metadata);
 		}
 	}
 
@@ -1276,11 +1280,12 @@ public class ProjectionManager
 		public bool TrackEmittedStreams { get; }
 		public long ProjectionId { get; }
 		public int EngineVersion { get; }
+		public byte[] Metadata { get; }
 
 		public PendingProjection(
 			long projectionId, ProjectionMode mode, SerializedRunAs runAs, string name, string handlerType, string query,
 			bool enabled, bool checkpointsEnabled, bool emitEnabled, bool enableRunAs,
-			bool trackEmittedStreams, int engineVersion = ProjectionConstants.EngineV1) {
+			bool trackEmittedStreams, int engineVersion = ProjectionConstants.EngineV1, byte[] metadata = null) {
 			ProjectionId = projectionId;
 			Mode = mode;
 			RunAs = runAs;
@@ -1293,6 +1298,7 @@ public class ProjectionManager
 			EnableRunAs = enableRunAs;
 			TrackEmittedStreams = trackEmittedStreams;
 			EngineVersion = engineVersion;
+			Metadata = metadata;
 		}
 
 		public PendingProjection(long projectionId, ProjectionManagementMessage.Command.PostBatch.ProjectionPost projection)
@@ -1304,7 +1310,7 @@ public class ProjectionManager
 			: this(projectionId, projection.Mode, projection.RunAs, projection.Name, projection.HandlerType,
 				projection.Query, projection.Enabled, projection.CheckpointsEnabled,
 				projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams,
-				projection.EngineVersion) { }
+				projection.EngineVersion, projection.Metadata) { }
 
 		public NewProjectionInitializer CreateInitializer(IEnvelope replyEnvelope) {
 			return new NewProjectionInitializer(
@@ -1320,7 +1326,8 @@ public class ProjectionManager
 				TrackEmittedStreams,
 				RunAs,
 				replyEnvelope,
-				EngineVersion);
+				EngineVersion,
+				Metadata);
 		}
 	}
 

--- a/src/KurrentDB.Projections.Shared/Messages/ProjectionManagementMessage.cs
+++ b/src/KurrentDB.Projections.Shared/Messages/ProjectionManagementMessage.cs
@@ -83,11 +83,12 @@ public static partial class ProjectionManagementMessage {
 			private readonly bool _enableRunAs;
 			private readonly bool _trackEmittedStreams;
 			private readonly int _engineVersion;
+			private readonly byte[] _metadata;
 
 			public Post(
 				IEnvelope envelope, ProjectionMode mode, string name, RunAs runAs, string handlerType, string query,
 				bool enabled, bool checkpointsEnabled, bool emitEnabled, bool trackEmittedStreams,
-				bool enableRunAs = false, int engineVersion = ProjectionConstants.EngineV1)
+				bool enableRunAs = false, int engineVersion = ProjectionConstants.EngineV1, byte[] metadata = null)
 				: base(envelope, runAs) {
 				_name = name;
 				_handlerType = handlerType;
@@ -99,6 +100,7 @@ public static partial class ProjectionManagementMessage {
 				_trackEmittedStreams = trackEmittedStreams;
 				_enableRunAs = enableRunAs;
 				_engineVersion = engineVersion;
+				_metadata = metadata;
 			}
 
 			public Post(
@@ -171,6 +173,10 @@ public static partial class ProjectionManagementMessage {
 			public int EngineVersion {
 				get { return _engineVersion; }
 			}
+
+			public byte[] Metadata {
+				get { return _metadata; }
+			}
 		}
 
 		[DerivedMessage(ProjectionMessage.Management)]
@@ -220,13 +226,15 @@ public static partial class ProjectionManagementMessage {
 			private readonly string _name;
 			private readonly string _query;
 			private readonly bool? _emitEnabled;
+			private readonly byte[] _metadata;
 
 			public UpdateQuery(
-				IEnvelope envelope, string name, RunAs runAs, string query, bool? emitEnabled)
+				IEnvelope envelope, string name, RunAs runAs, string query, bool? emitEnabled, byte[] metadata = null)
 				: base(envelope, runAs) {
 				_name = name;
 				_query = query;
 				_emitEnabled = emitEnabled;
+				_metadata = metadata;
 			}
 
 			public string Query {
@@ -239,6 +247,10 @@ public static partial class ProjectionManagementMessage {
 
 			public bool? EmitEnabled {
 				get { return _emitEnabled; }
+			}
+
+			public byte[] Metadata {
+				get { return _metadata; }
 			}
 		}
 

--- a/src/Protos/Grpc/projections.proto
+++ b/src/Protos/Grpc/projections.proto
@@ -29,7 +29,7 @@ message CreateReq {
 		}
 		string query = 4;
 		int32 engine_version = 5; // 0 or 1 = v1 (default), 2 = v2
-		bytes metadata = 6;
+		map<string, google.protobuf.Value> properties = 6;
 
 		message Transient {
 			string name = 1;
@@ -55,7 +55,7 @@ message UpdateReq {
 			bool emit_enabled = 3;
 			event_store.client.Empty no_emit_options = 4;
 		}
-		bytes metadata = 5;
+		map<string, google.protobuf.Value> properties = 5;
 	}
 }
 

--- a/src/Protos/Grpc/projections.proto
+++ b/src/Protos/Grpc/projections.proto
@@ -29,6 +29,7 @@ message CreateReq {
 		}
 		string query = 4;
 		int32 engine_version = 5; // 0 or 1 = v1 (default), 2 = v2
+		bytes metadata = 6;
 
 		message Transient {
 			string name = 1;
@@ -54,6 +55,7 @@ message UpdateReq {
 			bool emit_enabled = 3;
 			event_store.client.Empty no_emit_options = 4;
 		}
+		bytes metadata = 5;
 	}
 }
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Attach caller metadata to projection Create/Update definition events
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

The projections engine now attaches a caller-supplied metadata blob to the event metadata of the `$ProjectionUpdated` definition event written to `$projections-{name}`. This gives deployment tooling a per-deploy ledger (content hash, actor, operation) bound to the exact projection version, without affecting the engine: the load path reads only the event data, so the blob round-trips untouched and old servers ignore it.

- Proto: optional bytes metadata on CreateReq.Options and UpdateReq.Options
- gRPC Create/Update thread the field into the Post/UpdateQuery commands
- ManagedProjection stashes the blob and stamps it on the next definition write via the metadata-carrying Event ctor, then consumes and clears it so it is written at most once
- Fault and UpdateConfig clear the pending blob so an abandoned create or a non-metadata write never inherits it, keeping metadata strictly per-deploy
- Absent metadata writes an empty slot exactly as before (no regression)
- Tests cover create/update carrying metadata, the no-metadata regression, lifecycle and config writes staying metadataless, and loading a definition event with metadata

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add optional caller metadata to projection Create/Update gRPC requests.
• Propagate metadata through management commands to be stamped on the next definition write.
• Add tests ensuring metadata is written once and never leaks to lifecycle/config writes.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["gRPC ProjectionManagement"] --> B["Mgmt Commands"] --> C["ProjectionManager"] --> D["ManagedProjection"] --> E[("$projections-{name}")]
  T["Management Tests"] --> B
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Embed metadata in the persisted state JSON body</b></summary>

- ➕ Visible to all readers without special handling of event metadata
- ➕ Survives any event rehydration that drops metadata
- ➖ Changes the projection definition schema and risks compatibility/validation issues
- ➖ Would affect engine load/semantics unless carefully ignored everywhere

</details>

<details>
<summary><b>2. Write a separate audit/ledger event (new event type or separate stream)</b></summary>

- ➕ Clear separation between engine definition and deployment/audit info
- ➕ Can retain multiple deploy records without overloading definition writes
- ➖ More moving parts: extra writes and new read paths if consumers need correlation
- ➖ Harder to guarantee a 1:1 binding to the exact definition version without additional linking

</details>

<details>
<summary><b>3. Introduce a new definition event type (e.g., $ProjectionUpdatedWithMetadata)</b></summary>

- ➕ Explicit signaling of presence/meaning of metadata
- ➕ Avoids overloading event metadata semantics
- ➖ Higher compatibility burden: readers/writers need to understand multiple types
- ➖ Migration/backfill complexity for mixed histories

</details>

**Recommendation:** Keep the PR’s approach (store caller blob in event metadata on $ProjectionUpdated) because it binds deploy info to the exact definition write while preserving forward compatibility: the load path reads only Event.Data, and older servers will ignore metadata. The one-shot stamping + explicit clearing on Fault/UpdateConfig addresses the main risk (metadata leakage across unrelated definition writes).

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (6)</summary>

<blockquote>
<details>
<summary><strong>ProjectionManagement.Create.cs</strong> <code>Thread CreateReq metadata into Post command</code> <code>+1/-1</code></summary>

<br/>

>Thread CreateReq metadata into Post command
>
><pre>
>• Reads the optional metadata bytes from CreateReq.Options and forwards it to ProjectionManagementMessage.Command.Post. Uses null when empty to preserve existing behavior.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-d99e64c5faa36d04796ff7b484a3a7fa0d46c2ade20e1a83f5ed19797bc1c992'>src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ProjectionManagement.Update.cs</strong> <code>Thread UpdateReq metadata into UpdateQuery command</code> <code>+1/-1</code></summary>

<br/>

>Thread UpdateReq metadata into UpdateQuery command
>
><pre>
>• Reads the optional metadata bytes from UpdateReq.Options and forwards it to ProjectionManagementMessage.Command.UpdateQuery. Treats empty metadata as null.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-ee236515ad97a6f3b8407fff7b14b227bf7c74356a7102dad3bf86e030301044'>src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ManagedProjection.cs</strong> <code>Stamp caller metadata on next $ProjectionUpdated write (one-shot)</code> <code>+10/-2</code></summary>

<br/>

>Stamp caller metadata on next $ProjectionUpdated write (one-shot)
>
><pre>
>• Adds a pending-metadata field that is set on InitializeNew and UpdateQuery, then consumed when creating the persisted state event so it is written at most once. Clears pending metadata on Fault and UpdateConfig to prevent leakage into unrelated writes.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-c367d21a7df458556e329416e48ffaba4d4f42b3aaa85cdfa53e71537c7f9c8b'>src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ProjectionManager.cs</strong> <code>Carry metadata through projection creation pipeline</code> <code>+12/-5</code></summary>

<br/>

>Carry metadata through projection creation pipeline
>
><pre>
>• Extends PendingProjection and NewProjectionInitializer to store optional metadata from Post/PostBatch and pass it into ManagedProjection.InitializeNew. Ensures metadata provided at creation time reaches the first definition write.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-087fd21424168d352d0e6ab6e41dc43b8926ffe5dd8134b48a923909165765e0'>src/KurrentDB.Projections.Management/Services/Management/ProjectionManager.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ProjectionManagementMessage.cs</strong> <code>Add metadata field to Post and UpdateQuery commands</code> <code>+14/-2</code></summary>

<br/>

>Add metadata field to Post and UpdateQuery commands
>
><pre>
>• Extends ProjectionManagementMessage.Command.Post and .UpdateQuery to accept and expose an optional byte[] Metadata payload. This is the internal message contract used by gRPC and manager/projection components.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-e3bb5e8c91479d10cd0f8488b7dcfd901e327f1455f6ee7ddcc014fe8e2ac335'>src/KurrentDB.Projections.Shared/Messages/ProjectionManagementMessage.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>projections.proto</strong> <code>Add optional metadata bytes to CreateReq/UpdateReq options</code> <code>+2/-0</code></summary>

<br/>

>Add optional metadata bytes to CreateReq/UpdateReq options
>
><pre>
>• Adds a bytes metadata field to CreateReq.Options and UpdateReq.Options, enabling callers to attach an opaque deployment blob to create/update operations.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-29cd297d0ee818494e9dd3dc956f9a2076b4a0e216dce36593201a5c4714d6c4'>src/Protos/Grpc/projections.proto</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (6)</summary>

<blockquote>
<details>
<summary><strong>when_updating_config_after_a_metadata_post.cs</strong> <code>Add regression test for metadata not leaking into config writes</code> <code>+72/-0</code></summary>

<br/>

>Add regression test for metadata not leaking into config writes
>
><pre>
>• Introduces a ManagedProjection-level test ensuring a metadata-bearing create stamps metadata on the create definition write only. Verifies a subsequent UpdateConfig write has empty event metadata.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-3c495d94ec522bdbc852c2c2b5ddbe16aeafd77748d1fd1597e323982bccc02f'>src/KurrentDB.Projections.Management.Tests/Services/projections_manager/managed_projection/when_updating_config_after_a_metadata_post.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>when_a_lifecycle_write_follows_a_metadata_post.cs</strong> <code>Test lifecycle writes remain metadata-less after metadata post</code> <code>+64/-0</code></summary>

<br/>

>Test lifecycle writes remain metadata-less after metadata post
>
><pre>
>• Adds a subsystem test that posts a projection with metadata and then disables it. Asserts the initial definition write carries metadata and subsequent lifecycle-triggered definition writes do not.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-25bc8c365068630d8171eadc634397a33f7bab4723d9ffcb7863465d7d9947e5'>src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_a_lifecycle_write_follows_a_metadata_post.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>when_loading_a_projection_whose_definition_has_metadata.cs</strong> <code>Test forward-compatible loading of definition events with metadata</code> <code>+84/-0</code></summary>

<br/>

>Test forward-compatible loading of definition events with metadata
>
><pre>
>• Creates existing events where the $ProjectionUpdated event has populated Event.Metadata. Verifies the projection loads normally and query retrieval reads the definition body intact (metadata ignored).
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-c0edd223d20da38ada11d61defa04b486b2ae9c97db5cfdd2404ab069c818905'>src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_loading_a_projection_whose_definition_has_metadata.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>when_posting_a_projection_with_metadata.cs</strong> <code>Test posting a projection stamps metadata once on definition write</code> <code>+68/-0</code></summary>

<br/>

>Test posting a projection stamps metadata once on definition write
>
><pre>
>• Adds a test that posts a projection with metadata and asserts the first $ProjectionUpdated write contains the metadata bytes. Also verifies no later writes re-stamp metadata and the persisted state body is unchanged.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-a96a15eafbdb1bc89ed326cfecb619068bd9038d66cd408a2ef95825b28116b7'>src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_with_metadata.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>when_posting_a_projection_without_metadata.cs</strong> <code>Test no-metadata create preserves empty metadata behavior</code> <code>+48/-0</code></summary>

<br/>

>Test no-metadata create preserves empty metadata behavior
>
><pre>
>• Adds a regression test ensuring that when metadata is absent, all $ProjectionUpdated writes have empty metadata (same behavior as before).
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-6ba8d7865a496493ad8022bbb1676bd9238263ab15e6187359859ec181e9e1c8'>src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_without_metadata.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>when_updating_a_projection_with_metadata.cs</strong> <code>Test UpdateQuery stamps metadata on the update definition write</code> <code>+54/-0</code></summary>

<br/>

>Test UpdateQuery stamps metadata on the update definition write
>
><pre>
>• Adds a test that posts a projection, then updates the query with metadata. Verifies the last $ProjectionUpdated definition write carries the update metadata bytes.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5638/files#diff-b0f9182259b938453e8e6e0cb43c34e718130d7a0bda490a5500fb8c03213a47'>src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_a_projection_with_metadata.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>