### PR TITLE
Reject oversized projection definition writes instead of hanging

### DIFF
--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_with_oversized_metadata.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_with_oversized_metadata.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.TestAdapters;
+using KurrentDB.Core.TransactionLog.Chunks;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Management;
+using KurrentDB.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_posting_a_projection_with_oversized_metadata<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+	private string _projectionName;
+	private readonly byte[] _oversizedMetadata = new byte[TFConsts.EffectiveMaxLogRecordSize];
+
+	protected override void Given() {
+		_projectionName = "test-projection";
+		NoStream("$projections-test-projection");
+		NoStream("$projections-test-projection-result");
+		NoStream("$projections-test-projection-order");
+		AllWritesToSucceed("$projections-test-projection-order");
+		NoStream("$projections-test-projection-checkpoint");
+		AllWritesSucceed();
+	}
+
+	protected override IEnumerable<WhenStep> When() {
+		yield return new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid());
+		yield return
+			new ProjectionManagementMessage.Command.Post(
+				_bus, ProjectionMode.Continuous, _projectionName,
+				ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
+				enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+				metadata: _oversizedMetadata);
+	}
+
+	[Test, Category("v8")]
+	public void the_operation_fails_as_record_too_large() {
+		var failure = _consumer.HandledMessages.OfType<ProjectionManagementMessage.RecordTooLarge>().Single();
+		StringAssert.Contains("exceeds the maximum", failure.Reason);
+	}
+
+	[Test, Category("v8")]
+	public void no_definition_event_is_written() {
+		var stream = ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName;
+		Assert.IsEmpty(_consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+			.Where(x => x.EventStreamId == stream && x.Events[0].EventType == ProjectionEventTypes.ProjectionUpdated)
+			.ToList());
+	}
+
+	[Test, Category("v8")]
+	public void the_projection_is_faulted() {
+		_manager.Handle(new ProjectionManagementMessage.Command.GetStatistics(_bus, null, _projectionName));
+		Assert.AreEqual(
+			ManagedProjectionState.Faulted,
+			_consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>().Last().Projections.Single()
+				.LeaderStatus);
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_a_projection_with_oversized_metadata.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_a_projection_with_oversized_metadata.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.TestAdapters;
+using KurrentDB.Core.TransactionLog.Chunks;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Services;
+using KurrentDB.Projections.Core.Services.Management;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projections_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_updating_a_projection_with_oversized_metadata<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+	private string _projectionName;
+	private readonly byte[] _oversizedMetadata = new byte[TFConsts.EffectiveMaxLogRecordSize];
+
+	protected override void Given() {
+		_projectionName = "test-projection";
+		NoStream("$projections-test-projection");
+		NoStream("$projections-test-projection-result");
+		NoStream("$projections-test-projection-order");
+		AllWritesToSucceed("$projections-test-projection-order");
+		NoStream("$projections-test-projection-checkpoint");
+		AllWritesSucceed();
+	}
+
+	protected override IEnumerable<WhenStep> When() {
+		yield return new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid());
+		yield return
+			new ProjectionManagementMessage.Command.Post(
+				_bus, ProjectionMode.Continuous, _projectionName,
+				ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
+				enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+		yield return
+			new ProjectionManagementMessage.Command.UpdateQuery(
+				_bus, _projectionName, ProjectionManagementMessage.RunAs.System,
+				@"fromAll().when({$any:function(s,e){return s;}});", emitEnabled: null,
+				metadata: _oversizedMetadata);
+	}
+
+	[Test, Category("v8")]
+	public void the_update_fails_as_record_too_large() {
+		var failure = _consumer.HandledMessages.OfType<ProjectionManagementMessage.RecordTooLarge>().Single();
+		StringAssert.Contains("exceeds the maximum", failure.Reason);
+	}
+
+	[Test, Category("v8")]
+	public void the_oversized_record_is_never_written() {
+		Assert.IsFalse(_consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+			.Any(x => x.Events[0].Metadata.Length >= TFConsts.EffectiveMaxLogRecordSize));
+	}
+
+	[Test, Category("v8")]
+	public void the_projection_is_faulted() {
+		_manager.Handle(new ProjectionManagementMessage.Command.GetStatistics(_bus, null, _projectionName));
+		Assert.AreEqual(
+			ManagedProjectionState.Faulted,
+			_consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>().Last().Projections.Single()
+				.LeaderStatus);
+	}
+}

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
@@ -80,11 +80,8 @@ internal partial class ProjectionManagement {
 				case ProjectionManagementMessage.Updated:
 					createdSource.TrySetResult(true);
 					break;
-				case ProjectionManagementMessage.RecordTooLarge tooLarge:
-					createdSource.TrySetException(RecordTooLarge(tooLarge.Reason));
-					break;
 				case ProjectionManagementMessage.OperationFailed failed:
-					createdSource.TrySetException(OperationFailed(failed.Reason));
+					createdSource.TrySetException(MapFailure(failed));
 					break;
 				default:
 					createdSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs
@@ -80,8 +80,11 @@ internal partial class ProjectionManagement {
 				case ProjectionManagementMessage.Updated:
 					createdSource.TrySetResult(true);
 					break;
+				case ProjectionManagementMessage.RecordTooLarge tooLarge:
+					createdSource.TrySetException(RecordTooLarge(tooLarge.Reason));
+					break;
 				case ProjectionManagementMessage.OperationFailed failed:
-					createdSource.TrySetException(OperationFailed(failed));
+					createdSource.TrySetException(OperationFailed(failed.Reason));
 					break;
 				default:
 					createdSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Delete.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Delete.cs
@@ -46,6 +46,9 @@ internal partial class ProjectionManagement {
 				case ProjectionManagementMessage.NotFound:
 					deletedSource.TrySetException(ProjectionNotFound(name));
 					break;
+				case ProjectionManagementMessage.OperationFailed failed:
+					deletedSource.TrySetException(MapFailure(failed));
+					break;
 				default:
 					deletedSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
 					break;

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Disable.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Disable.cs
@@ -45,6 +45,9 @@ internal partial class ProjectionManagement {
 				case ProjectionManagementMessage.NotFound:
 					disableSource.TrySetException(ProjectionNotFound(name));
 					break;
+				case ProjectionManagementMessage.OperationFailed failed:
+					disableSource.TrySetException(MapFailure(failed));
+					break;
 				default:
 					disableSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
 					break;

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Enable.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Enable.cs
@@ -43,6 +43,9 @@ internal partial class ProjectionManagement {
 				case ProjectionManagementMessage.NotFound:
 					enableSource.TrySetException(ProjectionNotFound(name));
 					break;
+				case ProjectionManagementMessage.OperationFailed failed:
+					enableSource.TrySetException(MapFailure(failed));
+					break;
 				default:
 					enableSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
 					break;

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Reset.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Reset.cs
@@ -43,6 +43,9 @@ internal partial class ProjectionManagement {
 				case ProjectionManagementMessage.NotFound:
 					resetSource.TrySetException(ProjectionNotFound(name));
 					break;
+				case ProjectionManagementMessage.OperationFailed failed:
+					resetSource.TrySetException(MapFailure(failed));
+					break;
 				default:
 					resetSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
 					break;

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs
@@ -53,11 +53,8 @@ internal partial class ProjectionManagement {
 				case ProjectionManagementMessage.NotFound:
 					updatedSource.TrySetException(ProjectionNotFound(name));
 					break;
-				case ProjectionManagementMessage.RecordTooLarge tooLarge:
-					updatedSource.TrySetException(RecordTooLarge(tooLarge.Reason));
-					break;
 				case ProjectionManagementMessage.OperationFailed failed:
-					updatedSource.TrySetException(OperationFailed(failed.Reason));
+					updatedSource.TrySetException(MapFailure(failed));
 					break;
 				default:
 					updatedSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs
@@ -53,6 +53,12 @@ internal partial class ProjectionManagement {
 				case ProjectionManagementMessage.NotFound:
 					updatedSource.TrySetException(ProjectionNotFound(name));
 					break;
+				case ProjectionManagementMessage.RecordTooLarge tooLarge:
+					updatedSource.TrySetException(RecordTooLarge(tooLarge.Reason));
+					break;
+				case ProjectionManagementMessage.OperationFailed failed:
+					updatedSource.TrySetException(OperationFailed(failed.Reason));
+					break;
 				default:
 					updatedSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
 					break;

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
@@ -50,14 +50,16 @@ namespace EventStore.Projections.Core.Services.Grpc {
 		private static Exception ProjectionNotFound(string name) =>
 			new RpcException(new Status(StatusCode.NotFound, $"Projection '{name}' not found"));
 
-		private static Exception OperationFailed(ProjectionManagementMessage.OperationFailed message) =>
-			new RpcException(new Status(StatusCode.FailedPrecondition, message.Reason));
-
-		private static Exception OperationFailed(string reason) =>
-			new RpcException(new Status(StatusCode.FailedPrecondition, reason));
-
-		private static Exception RecordTooLarge(string reason) =>
-			new RpcException(new Status(StatusCode.InvalidArgument, reason));
+		// Maps a projection-management failure reply to a gRPC status. RecordTooLarge mirrors the streams append
+		// API (InvalidArgument); Conflict/NotAuthorized keep their distinct semantics; anything else is a generic
+		// FailedPrecondition.
+		private static Exception MapFailure(ProjectionManagementMessage.OperationFailed failed) =>
+			failed switch {
+				ProjectionManagementMessage.RecordTooLarge => new RpcException(new Status(StatusCode.InvalidArgument, failed.Reason)),
+				ProjectionManagementMessage.Conflict => new RpcException(new Status(StatusCode.AlreadyExists, failed.Reason)),
+				ProjectionManagementMessage.NotAuthorized => new RpcException(new Status(StatusCode.PermissionDenied, failed.Reason)),
+				_ => new RpcException(new Status(StatusCode.FailedPrecondition, failed.Reason)),
+			};
 
 		private static byte[] ToMetadata(IDictionary<string, Value> properties) =>
 			properties.Count == 0 ? [] : new Struct { Fields = { properties } }.ToByteArray();

--- a/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
+++ b/src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs
@@ -53,6 +53,12 @@ namespace EventStore.Projections.Core.Services.Grpc {
 		private static Exception OperationFailed(ProjectionManagementMessage.OperationFailed message) =>
 			new RpcException(new Status(StatusCode.FailedPrecondition, message.Reason));
 
+		private static Exception OperationFailed(string reason) =>
+			new RpcException(new Status(StatusCode.FailedPrecondition, reason));
+
+		private static Exception RecordTooLarge(string reason) =>
+			new RpcException(new Status(StatusCode.InvalidArgument, reason));
+
 		private static byte[] ToMetadata(IDictionary<string, Value> properties) =>
 			properties.Count == 0 ? [] : new Struct { Fields = { properties } }.ToByteArray();
 

--- a/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
+++ b/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
@@ -14,6 +14,7 @@ using KurrentDB.Core.Messages;
 using KurrentDB.Core.Messaging;
 using KurrentDB.Core.Services.TimerService;
 using KurrentDB.Core.Services.UserManagement;
+using KurrentDB.Core.TransactionLog.Chunks;
 using KurrentDB.Projections.Core.Common;
 using KurrentDB.Projections.Core.Messages;
 using KurrentDB.Projections.Core.Services.Management.ManagedProjectionStates;
@@ -495,8 +496,12 @@ public class ManagedProjection : IDisposable {
 		UpdateProjectionVersion();
 		_pendingWritePersistedState = true;
 		_pendingMetadata = null;
-		WritePersistedState(CreatePersistedStateEvent(Guid.NewGuid(), PersistedProjectionState,
-			ProjectionNamesBuilder.ProjectionsStreamPrefix + _name));
+		var persistedStateEvent = BuildPersistedStateEvent(out var recordSize);
+		if (persistedStateEvent == null) {
+			FailPersistedStateWrite(recordSize, message.Envelope);
+			return;
+		}
+		WritePersistedState(persistedStateEvent);
 
 		message.Envelope.ReplyWith(new ProjectionManagementMessage.Updated(message.Name));
 	}
@@ -708,25 +713,52 @@ public class ManagedProjection : IDisposable {
 	}
 
 	internal void WriteStartOrLoadStopped() {
-		if (_pendingWritePersistedState)
-			WritePersistedState(CreatePersistedStateEvent(Guid.NewGuid(), PersistedProjectionState,
-				ProjectionNamesBuilder.ProjectionsStreamPrefix + _name));
-		else
+		if (!_pendingWritePersistedState) {
 			StartOrLoadStopped();
+			return;
+		}
+
+		var persistedStateEvent = BuildPersistedStateEvent(out var recordSize);
+		if (persistedStateEvent == null) {
+			FailPersistedStateWrite(recordSize, _lastReplyEnvelope);
+			_lastReplyEnvelope = null;
+			return;
+		}
+
+		WritePersistedState(persistedStateEvent);
 	}
 
 	internal void StartCompleted() {
 		Reply();
 	}
 
-	private ClientMessage.WriteEvents CreatePersistedStateEvent(Guid correlationId, PersistedState persistedState,
-		string eventStreamId) {
+	// Builds the $ProjectionUpdated definition event, or returns null (with the offending size) when the record
+	// would exceed the maximum log record size. Consumes the pending caller metadata on a successful build.
+	private ClientMessage.WriteEvents BuildPersistedStateEvent(out int recordSize) {
+		var data = PersistedProjectionState.ToJsonBytes();
+		var hasMetadata = _pendingMetadata is not null;
 		var metadata = _pendingMetadata ?? [];
+		recordSize = Event.SizeOnDisk(ProjectionEventTypes.ProjectionUpdated, data, metadata);
+		if (recordSize > TFConsts.EffectiveMaxLogRecordSize)
+			return null;
+
 		_pendingMetadata = null;
-		return ClientMessage.WriteEvents.ForSingleEvent(correlationId, correlationId, _writeDispatcher.Envelope, true, eventStreamId, ExpectedVersion.Any,
-			new Event(Guid.NewGuid(), ProjectionEventTypes.ProjectionUpdated, true, persistedState.ToJsonBytes(),
-				isPropertyMetadata: true, metadata),
+		var correlationId = Guid.NewGuid();
+		return ClientMessage.WriteEvents.ForSingleEvent(correlationId, correlationId, _writeDispatcher.Envelope, true,
+			ProjectionNamesBuilder.ProjectionsStreamPrefix + _name, ExpectedVersion.Any,
+			new Event(Guid.NewGuid(), ProjectionEventTypes.ProjectionUpdated, true, data,
+				isPropertyMetadata: hasMetadata, metadata),
 			SystemAccounts.System);
+	}
+
+	private void FailPersistedStateWrite(int recordSize, IEnvelope replyEnvelope) {
+		_pendingWritePersistedState = false;
+		_pendingMetadata = null;
+		var reason =
+			$"Projection '{_name}' definition record size ({recordSize} bytes) exceeds the maximum of {TFConsts.EffectiveMaxLogRecordSize} bytes.";
+		if (_state != ManagedProjectionState.Faulted)
+			Fault(reason);
+		replyEnvelope?.ReplyWith(new ProjectionManagementMessage.RecordTooLarge(reason));
 	}
 
 	private void WritePersistedState(ClientMessage.WriteEvents persistedStateEvent) {

--- a/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
+++ b/src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs
@@ -744,8 +744,8 @@ public class ManagedProjection : IDisposable {
 
 		_pendingMetadata = null;
 		var correlationId = Guid.NewGuid();
-		return ClientMessage.WriteEvents.ForSingleEvent(correlationId, correlationId, _writeDispatcher.Envelope, true,
-			ProjectionNamesBuilder.ProjectionsStreamPrefix + _name, ExpectedVersion.Any,
+		return ClientMessage.WriteEvents.ForSingleEvent(correlationId, correlationId, _writeDispatcher.Envelope,
+			requireLeader: true, ProjectionNamesBuilder.ProjectionsStreamPrefix + _name, ExpectedVersion.Any,
 			new Event(Guid.NewGuid(), ProjectionEventTypes.ProjectionUpdated, true, data,
 				isPropertyMetadata: hasMetadata, metadata),
 			SystemAccounts.System);

--- a/src/KurrentDB.Projections.Shared/Messages/ProjectionManagementMessage.cs
+++ b/src/KurrentDB.Projections.Shared/Messages/ProjectionManagementMessage.cs
@@ -521,6 +521,13 @@ public static partial class ProjectionManagementMessage {
 		}
 	}
 
+	[DerivedMessage(ProjectionMessage.Management)]
+	public partial class RecordTooLarge : OperationFailed {
+		public RecordTooLarge(string reason)
+			: base(reason) {
+		}
+	}
+
 	public sealed class RunAs {
 		private readonly ClaimsPrincipal _runAs;
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Reject oversized projection definition writes instead of hanging
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

A projection definition event that exceeds the maximum log record size previously threw in the Event constructor on the projections management queue, where the exception was logged and swallowed (Release) or faulted the queue (Debug). Either way no reply was sent, so the Create/Update gRPC call hung until its deadline.

ManagedProjection now sizes the $ProjectionUpdated record (definition body plus caller metadata) before writing; if it exceeds the limit the projection is faulted and the caller receives a RecordTooLarge reply instead of a swallowed throw. This covers every definition write (create, update, config), so it hardens the existing projections API, not just the new metadata field.

- ManagedProjection: size check at the single write build point; fault and reply RecordTooLarge when the record is too big. Guards against a redundant second fault when an already-faulted projection re-enters the write path.
- New ProjectionManagementMessage.RecordTooLarge (an OperationFailed subtype) so the size failure is distinguishable from generic failures.
- gRPC Create/Update: map RecordTooLarge to InvalidArgument (matching the streams append API for oversized records) and generic OperationFailed to FailedPrecondition, instead of the previous opaque Unknown.
- Tests: posting and updating a projection with oversized metadata fail as RecordTooLarge, write no oversized record, and leave the projection faulted

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Fixes a hang in Create/Update gRPC calls when a projection definition event exceeds the max log
  record size — previously the exception was swallowed and no reply was sent.
• <b><i>ManagedProjection</i></b> now pre-checks record size via <b><i>BuildPersistedStateEvent</i></b> before writing; if
  oversized, it faults the projection and replies with <b><i>RecordTooLarge</i></b> instead of silently failing.
• Adds <b><i>ProjectionManagementMessage.RecordTooLarge</i></b> (subtype of <b><i>OperationFailed</i></b>) to distinguish
  size failures from generic errors.
• Maps <b><i>RecordTooLarge</i></b> → gRPC <b><i>InvalidArgument</i></b> and generic <b><i>OperationFailed</i></b> →
  <b><i>FailedPrecondition</i></b>, replacing the previous opaque <b><i>Unknown</i></b> status.
• Adds integration tests for both post and update paths with oversized metadata, asserting no write
  occurs and the projection is left faulted.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
    A(["gRPC Create/Update"]) --> B["ManagedProjection"]
    B --> C{"BuildPersistedStateEvent"}
    C -- "size OK" --> D[("Write $ProjectionUpdated")]
    C -- "size exceeded" --> E["FailPersistedStateWrite"]
    E --> F["Fault Projection"]
    E --> G["RecordTooLarge reply"]
    G --> A
    A -- "RecordTooLarge" --> H["gRPC InvalidArgument"]
    A -- "OperationFailed" --> I["gRPC FailedPrecondition"]

    subgraph Legend
        direction LR
        _svc(["gRPC Service"]) ~~~ _proc["Processing Logic"] ~~~ _db[("Storage")]
    end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The PR&#x27;s approach is optimal: a single pre-write size check at the one place where the definition event is constructed (`BuildPersistedStateEvent`) is the minimal, correct fix. Alternatives such as catching the exception at the Event constructor level or validating at the gRPC boundary were implicitly considered — the former is where the original bug lived (swallowed exception), and the latter would require duplicating the serialization logic. Centralising the check in `ManagedProjection` keeps the guard close to the write and covers all callers (create, update, config) without repetition.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>ProjectionManagementMessage.cs</strong> <code>Add RecordTooLarge message subtype to ProjectionManagementMessage</code> <code>+7/-0</code></summary>

<br/>

>Add RecordTooLarge message subtype to ProjectionManagementMessage
>
><pre>
>• Introduces &#x27;RecordTooLarge&#x27; as a new &#x27;OperationFailed&#x27; subtype decorated with &#x27;[DerivedMessage]&#x27;. This allows callers to distinguish an oversized-record failure from other generic operation failures.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5639/files#diff-e3bb5e8c91479d10cd0f8488b7dcfd901e327f1455f6ee7ddcc014fe8e2ac335'>src/KurrentDB.Projections.Shared/Messages/ProjectionManagementMessage.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ProjectionManagement.cs</strong> <code>Add OperationFailed and RecordTooLarge gRPC exception helpers</code> <code>+6/-0</code></summary>

<br/>

>Add OperationFailed and RecordTooLarge gRPC exception helpers
>
><pre>
>• Adds two static factory methods: &#x27;OperationFailed&#x27; (maps to &#x27;FailedPrecondition&#x27;) and &#x27;RecordTooLarge&#x27; (maps to &#x27;InvalidArgument&#x27;), consistent with the streams append API convention for oversized records.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5639/files#diff-4fd1a10f72548566eb294f68a84f9b3fd749ccaf19bdbe3d7c3eab974bc51873'>src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.cs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>ManagedProjection.cs</strong> <code>Pre-check record size before writing projection definition; fault and reply on overflow</code> <code>+41/-10</code></summary>

<br/>

>Pre-check record size before writing projection definition; fault and reply on overflow
>
><pre>
>• Replaces &#x27;CreatePersistedStateEvent&#x27; with &#x27;BuildPersistedStateEvent&#x27;, which computes the on-disk size of the &#x27;$ProjectionUpdated&#x27; event before constructing it. If the size exceeds &#x27;TFConsts.EffectiveMaxLogRecordSize&#x27;, it returns null and &#x27;FailPersistedStateWrite&#x27; faults the projection and sends a &#x27;RecordTooLarge&#x27; reply to the caller. A guard prevents double-faulting an already-faulted projection.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5639/files#diff-c367d21a7df458556e329416e48ffaba4d4f42b3aaa85cdfa53e71537c7f9c8b'>src/KurrentDB.Projections.Management/Services/Management/ManagedProjection.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ProjectionManagement.Create.cs</strong> <code>Handle RecordTooLarge and OperationFailed in Create gRPC handler</code> <code>+13/-5</code></summary>

<br/>

>Handle RecordTooLarge and OperationFailed in Create gRPC handler
>
><pre>
>• Refactors the &#x27;OnMessage&#x27; callback from an if/else to a switch, adding explicit cases for &#x27;RecordTooLarge&#x27; (→ &#x27;InvalidArgument&#x27;) and &#x27;OperationFailed&#x27; (→ &#x27;FailedPrecondition&#x27;). Previously, any non-&#x27;Updated&#x27; message resulted in an opaque &#x27;Unknown&#x27; gRPC error.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5639/files#diff-d99e64c5faa36d04796ff7b484a3a7fa0d46c2ade20e1a83f5ed19797bc1c992'>src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Create.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ProjectionManagement.Update.cs</strong> <code>Handle RecordTooLarge and OperationFailed in Update gRPC handler</code> <code>+6/-0</code></summary>

<br/>

>Handle RecordTooLarge and OperationFailed in Update gRPC handler
>
><pre>
>• Adds &#x27;RecordTooLarge&#x27; and &#x27;OperationFailed&#x27; cases to the Update &#x27;OnMessage&#x27; switch, mapping them to &#x27;InvalidArgument&#x27; and &#x27;FailedPrecondition&#x27; respectively, mirroring the Create handler fix.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5639/files#diff-ee236515ad97a6f3b8407fff7b14b227bf7c74356a7102dad3bf86e030301044'>src/KurrentDB.Projections.Management/Services/Grpc/ProjectionManagement.Update.cs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>when_posting_a_projection_with_oversized_metadata.cs</strong> <code>Add tests for posting a projection with oversized metadata</code> <code>+65/-0</code></summary>

<br/>

>Add tests for posting a projection with oversized metadata
>
><pre>
>• New test fixture verifying that posting a projection with metadata exceeding &#x27;EffectiveMaxLogRecordSize&#x27; results in a &#x27;RecordTooLarge&#x27; reply, no &#x27;$ProjectionUpdated&#x27; write, and the projection left in &#x27;Faulted&#x27; state.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5639/files#diff-997815e989a902e179b1d41dc338a2494099c345e53982c2de37bc7a33b044e0'>src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_posting_a_projection_with_oversized_metadata.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>when_updating_a_projection_with_oversized_metadata.cs</strong> <code>Add tests for updating a projection with oversized metadata</code> <code>+66/-0</code></summary>

<br/>

>Add tests for updating a projection with oversized metadata
>
><pre>
>• New test fixture verifying that updating a projection with oversized metadata results in a &#x27;RecordTooLarge&#x27; reply, no oversized write event, and the projection left in &#x27;Faulted&#x27; state.
></pre>
>
><a href='https://github.com/kurrent-io/KurrentDB/pull/5639/files#diff-2921ffbd0b70bfac90eb5607984e478fe142c395d258a154960be3f12099e5c6'>src/KurrentDB.Projections.Management.Tests/Services/projections_manager/when_updating_a_projection_with_oversized_metadata.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>