### PR TITLE
Fix unit errors in secondary index commit duration metric

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -73,6 +73,7 @@
     <PackageVersion Include="LruCacheNet" Version="1.2.0" />
     <PackageVersion Include="Lucene.Net" Version="4.8.0-beta00017" />
     <PackageVersion Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00017" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />

--- a/src/KurrentDB.Kontext/KurrentDB.Kontext.csproj
+++ b/src/KurrentDB.Kontext/KurrentDB.Kontext.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Catalyst.Models.English" />
     <!-- Override vulnerable transitive (pulled by Catalyst). -->
     <PackageReference Include="NuGet.CommandLine" />
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="Cloud.Unum.USearch" />
     <PackageReference Include="Eventuous.Application" />
     <PackageReference Include="Eventuous.Extensions.DependencyInjection" />

--- a/src/KurrentDB.SecondaryIndexing.Tests/Diagnostics/SecondaryIndexProgressTrackerTests.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Diagnostics/SecondaryIndexProgressTrackerTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Diagnostics.Metrics;
+using KurrentDB.SecondaryIndexing.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace KurrentDB.SecondaryIndexing.Tests.Diagnostics;
+
+public class SecondaryIndexProgressTrackerTests {
+	[Theory]
+	[InlineData(2.5)]
+	[InlineData(0.25)]
+	public void commit_duration_records_total_elapsed_time_in_seconds(double commitDurationSeconds) {
+		using var meter = new Meter("test");
+		var clock = new FakeTimeProvider();
+		var tracker = new SecondaryIndexProgressTracker(
+			"default",
+			"kurrentdb",
+			meter,
+			clock,
+			NullLogger<SecondaryIndexProgressTracker>.Instance);
+
+		List<(double Value, KeyValuePair<string, object?>[] Tags)> measurements = [];
+		using var listener = new MeterListener();
+		listener.InstrumentPublished = (instrument, l) => {
+			if (instrument.Meter == meter && instrument.Name == "kurrentdb.indexes.secondary.commit.seconds")
+				l.EnableMeasurementEvents(instrument);
+		};
+		listener.SetMeasurementEventCallback<double>(
+			(_, value, tags, _) => measurements.Add((value, tags.ToArray())));
+		listener.Start();
+
+		using (tracker.StartCommitDuration())
+			clock.Advance(TimeSpan.FromSeconds(commitDurationSeconds));
+
+		var measurement = Assert.Single(measurements);
+		Assert.Equal(commitDurationSeconds, measurement.Value, precision: 6);
+		Assert.Contains(measurement.Tags, t => t is { Key: "index", Value: "default" });
+	}
+}

--- a/src/KurrentDB.SecondaryIndexing/Diagnostics/SecondaryIndexProgressTracker.cs
+++ b/src/KurrentDB.SecondaryIndexing/Diagnostics/SecondaryIndexProgressTracker.cs
@@ -108,15 +108,15 @@ public class SecondaryIndexProgressTracker {
 		private readonly long _start = clock.GetTimestamp();
 
 		public void Dispose() {
-			var elapsed = clock.GetElapsedTime(_start).Milliseconds;
-			log.LogSecondaryIndexIndexRecordsCommitted(indexName, elapsed);
-			histogram.Record(elapsed, tag);
+			var elapsed = clock.GetElapsedTime(_start);
+			log.LogSecondaryIndexIndexRecordsCommitted(indexName, elapsed.TotalMilliseconds);
+			histogram.Record(elapsed.TotalSeconds, tag);
 		}
 
 	}
 }
 
 static partial class SecondaryIndexProgressTrackerLogMessage {
-	[LoggerMessage(LogLevel.Debug, "Secondary index {index} records committed in {duration} ms")]
-	public static partial void LogSecondaryIndexIndexRecordsCommitted(this ILogger logger, string index, int duration);
+	[LoggerMessage(LogLevel.Debug, "Secondary index {index} records committed in {duration:N1} ms")]
+	public static partial void LogSecondaryIndexIndexRecordsCommitted(this ILogger logger, string index, double duration);
 }


### PR DESCRIPTION
## Problem

`SecondaryIndexProgressTracker.CommitDuration.Dispose()` recorded commit durations incorrectly, in two ways:

```csharp
var elapsed = clock.GetElapsedTime(_start).Milliseconds;
log.LogSecondaryIndexIndexRecordsCommitted(indexName, elapsed);
histogram.Record(elapsed, tag);
```

1. **Component instead of total.** `TimeSpan.Milliseconds` is the milliseconds *component* of the elapsed time (0–999), not the total duration. A 2.5 s commit recorded as `500`; a commit of exactly 2 s recorded as `0`.
2. **Wrong unit for the histogram.** The histogram is named `{serviceName}.indexes.secondary.commit.seconds` and is created with `MetricsConfiguration.SecondsHistogramBucketConfiguration.Boundaries` (seconds-scale buckets, ~1 µs to 10 s). The recorded value was in milliseconds, so even with `TotalMilliseconds` the unit would be 1000× off and nearly every sample would land in the `+Inf` bucket, making the metric useless for percentile/SLO queries.

## Fix

`Dispose()` now captures the `TimeSpan` once and uses the correct unit for each consumer:

```csharp
var elapsed = clock.GetElapsedTime(_start);
log.LogSecondaryIndexIndexRecordsCommitted(indexName, elapsed.TotalMilliseconds);
histogram.Record(elapsed.TotalSeconds, tag);
```

- The **histogram** receives `TotalSeconds`, matching its name and bucket boundaries.
- The **debug log line** ("committed in {duration} ms") receives `TotalMilliseconds`. The `LoggerMessage` signature changed from `int` to `double`, with an `:N1` format specifier so the rendered message stays readable (same approach as `GCSuspensionMetric`'s `{Elapsed:N0}ms`).

## Also: pin MessagePack to 3.1.7 (CI was red repo-wide)

All builds — on this PR and currently on any fresh restore of `master` — fail with `NU1903: Package 'MessagePack' 3.1.4 has a known high severity vulnerability` ([GHSA-hv8m-jj95-wg3x](https://github.com/advisories/GHSA-hv8m-jj95-wg3x), LZ4 decompression `AccessViolationException`), treated as an error. The advisory was published after the Kontext merge (#5567), whose `Catalyst` dependency pulls MessagePack 3.1.4 transitively.

This PR adds a direct `MessagePack` reference pinned to the patched **3.1.7** in `KurrentDB.Kontext.csproj`, following the existing `NuGet.CommandLine` "override vulnerable transitive" pattern in that same file (`CentralPackageTransitivePinningEnabled` is `false`, so a `PackageVersion` entry alone would not pin it). Happy to split this into its own PR if preferred, but without it no CI on this branch can pass.

## Impact

- Dashboards/alerts reading `*.indexes.secondary.commit.seconds` will start seeing correct values. Any consumer that had adapted to the previous (broken) values should be rechecked, though given the truncation bug the old data was not meaningfully interpretable.
- The structured log property `duration` changes type from `int` to `double`; the message template gains a `:N1` format specifier.
- MessagePack 3.1.4 → 3.1.7 is a patch-line bump within the version range Catalyst depends on.

## Testing

- Added `SecondaryIndexProgressTrackerTests` (there was no prior coverage of the tracker): uses `FakeTimeProvider` and a `MeterListener` to assert the histogram receives the total elapsed time **in seconds** with the `index` tag. Cases: 2.5 s and 0.25 s — under the old code these recorded 500 and 250 respectively, so both fail without the fix.
- Full `KurrentDB.SecondaryIndexing.Tests` suite: **73/73 passed** (net10.0, arm64).
- Full `KurrentDB.Kontext.Tests` suite against MessagePack 3.1.7: **400/400 passed**.
- Full-solution `dotnet restore` passes with NuGet audit enabled (no `NU1903`); resolved graph confirmed at `MessagePack/3.1.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)