### PR TITLE
[v26.1][DB-2144] Workaround https://github.com/advisories/GHSA-2m69-gcr7-jv3q (#5646)

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -36,8 +36,20 @@ jobs:
       run: |
         cd src
         dotnet restore
-        dotnet list package --vulnerable --include-transitive | tee vulnerabilities.txt
-        ! cat vulnerabilities.txt | grep -q "has the following vulnerable packages"
+        dotnet list package --vulnerable --include-transitive 2>&1 | tee vulnerabilities.txt
+        # Advisories consciously accepted while awaiting an upstream fix.
+        # Keep in sync with the NuGetAuditSuppress entries in src/Directory.Build.props.
+        # GHSA-2m69-gcr7-jv3q: CVE-2025-6965, SQLitePCLRaw e_sqlite3 2.1.11 (transitive via
+        # Microsoft.Data.Sqlite); no patched bundle yet, awaiting SQLite >= 3.50.2.
+        ALLOWED_ADVISORIES='GHSA-2m69-gcr7-jv3q'
+        # Each vulnerable finding prints an advisory URL line. Fail only if a finding remains
+        # after dropping the allowlisted advisories.
+        if grep -E 'https://github\.com/advisories/' vulnerabilities.txt | grep -vF "$ALLOWED_ADVISORIES" | grep -q .; then
+          echo "::error::Unsuppressed vulnerable packages found:"
+          grep -E 'https://github\.com/advisories/' vulnerabilities.txt | grep -vF "$ALLOWED_ADVISORIES"
+          exit 1
+        fi
+        echo "No unsuppressed vulnerable packages."
   protolock:
     runs-on: ubuntu-latest
     name: ci/github/protolock

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -83,4 +83,14 @@
 		<PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
 		<Using Include="JetBrains.Annotations" />
 	</ItemGroup>
+
+	<ItemGroup Label="NuGet Audit Suppressions">
+		<!--
+		  CVE-2025-6965 (GHSA-2m69-gcr7-jv3q): SQLitePCLRaw.lib.e_sqlite3 2.1.11 bundles SQLite < 3.50.2,
+		  pulled in transitively via Microsoft.Data.Sqlite (referenced by KurrentDB.Core for the scavenge backend).
+		  No patched SQLitePCLRaw release exists yet. Remove this suppression once Microsoft.Data.Sqlite ships
+		  a bundle with SQLite >= 3.50.2.
+		-->
+		<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+	</ItemGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,6 +2,17 @@
 	<PropertyGroup>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
+
+	<!--
+	  Review reminder for the NuGet audit suppression of GHSA-2m69-gcr7-jv3q (Directory.Build.props).
+	  Past the date below, the build emits an error prompting a recheck of whether a patched
+	  Microsoft.Data.Sqlite / SQLitePCLRaw bundle (SQLite >= 3.50.2) has shipped.
+	-->
+	<Target Name="ReviewSqliteAuditSuppression" BeforeTargets="Build">
+		<Error Condition="$([System.DateTime]::UtcNow.Ticks) &gt;= $([System.DateTime]::Parse('2026-07-19').Ticks)"
+				 Code="KDBAUDIT001"
+				 Text="The NuGet audit suppression for GHSA-2m69-gcr7-jv3q has passed its review date. Check whether Microsoft.Data.Sqlite/SQLitePCLRaw now bundles SQLite &gt;= 3.50.2 and remove the NuGetAuditSuppress entry in Directory.Build.props if so." />
+	</Target>
 	<PropertyGroup Condition="'$(IsKurrentTUnit)' == 'True' Or '$(IsKurrentXUnit)' == 'True' Or '$(IsKurrentNUnit)' == 'True'">
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>


### PR DESCRIPTION
Cherry pick of #5646

There is an advisory causing a build warning (which we treat as error) but no suitable patched package as yet.

This suppresses the warning for now, and will trigger an error in a month to revisit it.

KurrentDB operation isn't affected by the advisory

The package with the advisory is SQLitePCLRaw.lib.e_sqlite3

The package we use that depends on it is Microsoft.Data.Sqlite (we use version 10.0.x)

There is no SQLitePCLRaw.lib.e_sqlite3 package with a fix that we can pin. The fix is in a package called SourceGear.sqlite3

Newer versions of Microsoft.Data.Sqlite (11.0.x) do not depend on the vulnerable package, they depend on SQLitePCLRaw.bundle_e_sqlite3 which depends on SourceGear.sqlite3

However the 11.0.x range of Microsoft.Data.Sqlite is still in preview.