### PR TITLE
[DB-2154] Reject property values with no type set at the API boundary

### DIFF
--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/Validators/AppendRecordValidatorTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/Validators/AppendRecordValidatorTests.cs
@@ -34,6 +34,48 @@ public class AppendRecordValidatorTests {
     }
 
     [Test]
+    public async ValueTask throws_when_property_value_has_no_kind_set() {
+        var value = new AppendRecord {
+            Schema = new SchemaInfo {
+                Name   = "Valid.Name",
+                Format = SchemaFormat.Json,
+                Id     = "98EACFBF-E6B6-401F-8FE0-EDC0F161B087"
+            },
+            Data = ByteString.Empty,
+            Properties = {
+                { "key", new Value() }
+            }
+        };
+
+        var vex = await Assert
+            .That(() => AppendRecordValidator.Instance.ValidateAndThrow(value))
+            .Throws<DetailedValidationException>();
+
+        vex.LogValidationErrors<AppendRecordValidator>();
+    }
+
+    [Test]
+    public async ValueTask throws_when_nested_property_value_has_no_kind_set() {
+        var value = new AppendRecord {
+            Schema = new SchemaInfo {
+                Name   = "Valid.Name",
+                Format = SchemaFormat.Json,
+                Id     = "98EACFBF-E6B6-401F-8FE0-EDC0F161B087"
+            },
+            Data = ByteString.Empty,
+            Properties = {
+                { "key", Value.ForStruct(new Struct { Fields = { ["nested"] = new Value() } }) }
+            }
+        };
+
+        var vex = await Assert
+            .That(() => AppendRecordValidator.Instance.ValidateAndThrow(value))
+            .Throws<DetailedValidationException>();
+
+        vex.LogValidationErrors<AppendRecordValidator>();
+    }
+
+    [Test]
     [Arguments("")]
     [Arguments(" ")]
     public async ValueTask throws_when_any_property_key_is_empty(string invalidKey) {

--- a/src/KurrentDB.Api.V2/Modules/Streams/Validators/AppendRecordValidator.cs
+++ b/src/KurrentDB.Api.V2/Modules/Streams/Validators/AppendRecordValidator.cs
@@ -2,6 +2,7 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using FluentValidation;
+using Google.Protobuf.WellKnownTypes;
 using KurrentDB.Api.Infrastructure.Grpc.Validation;
 using KurrentDB.Protocol.V2.Streams;
 
@@ -34,6 +35,9 @@ class AppendRecordValidator : RequestValidator<AppendRecord> {
                 v.RuleFor(x => x.Key)
                     .NotEmpty()
                     .WithMessage("Property keys must not be empty.");
+                v.RuleFor(x => x.Value)
+                    .Must(HasKindSet)
+                    .WithMessage("Property values must have a type set.");
             });
 
         // ------------------------------------------------------------------------------
@@ -54,4 +58,12 @@ class AppendRecordValidator : RequestValidator<AppendRecord> {
         //     });
 
     }
+
+    static bool HasKindSet(Value value) =>
+        value.KindCase switch {
+            Value.KindOneofCase.StructValue => value.StructValue.Fields.Values.All(HasKindSet),
+            Value.KindOneofCase.ListValue   => value.ListValue.Values.All(HasKindSet),
+            Value.KindOneofCase.None        => false,
+            _                               => true,
+        };
 }

--- a/src/KurrentDB.Core.XUnit.Tests/Data/EventRecordPropertyMetadataTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Data/EventRecordPropertyMetadataTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Text;
+using System.Text.Json;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.TransactionLog.LogRecords;
+using Xunit;
+
+namespace KurrentDB.Core.XUnit.Tests.Data;
+
+// EventRecord.Metadata synthesis from log-record Properties (the properties -> JSON path). The empty-Value
+// case used to throw straight out of the .Metadata getter — and because that getter is read on the projection
+// core thread, an unhandled throw took the whole node down. These pin the happy path and the crash regression.
+public class EventRecordPropertyMetadataTests {
+	static EventRecord PropertyRecord(Struct properties, bool isJson) =>
+		new(
+			eventNumber: 0,
+			logPosition: 0,
+			correlationId: Guid.NewGuid(),
+			eventId: Guid.NewGuid(),
+			transactionPosition: 0,
+			transactionOffset: 0,
+			eventStreamId: "test-stream",
+			expectedVersion: 0,
+			timeStamp: DateTime.UtcNow,
+			flags: PrepareFlags.IsPropertyMetadata | (isJson ? PrepareFlags.IsJson : PrepareFlags.None),
+			eventType: "TestType",
+			data: [1, 2, 3],
+			metadata: properties.ToByteArray());
+
+	[Fact]
+	public void Synthesizes_json_metadata_from_properties() {
+		var record = PropertyRecord(new Struct {
+			Fields = {
+				["user-id"] = Value.ForString("12345"),
+				["count"] = Value.ForNumber(42),
+			}
+		}, isJson: true);
+
+		using var doc = JsonDocument.Parse(record.Metadata);
+		var root = doc.RootElement;
+
+		Assert.Equal("12345", root.GetProperty("user-id").GetString());
+		Assert.Equal("TestType", root.GetProperty("$schema.name").GetString()); // schema name = event type
+		Assert.Equal("Json", root.GetProperty("$schema.format").GetString());
+		Assert.Equal("Json", record.SchemaFormat);
+	}
+
+	// Regression: a property whose google.protobuf.Value has no kind set (an empty Value) made the JSON
+	// formatter throw "Value message must contain a value for the oneof". Reading must degrade to a visible
+	// marker rather than throw (which previously crashed projections, and so the node).
+	[Fact]
+	public void Empty_property_value_is_surfaced_instead_of_throwing() {
+		var record = PropertyRecord(new Struct {
+			Fields = {
+				["good"] = Value.ForString("ok"),
+				["bad"] = new Value(),   // no kind set in the oneof
+			}
+		}, isJson: true);
+
+		var json = Encoding.UTF8.GetString(record.Metadata.Span);   // before the fix this threw
+
+		Assert.Contains("$propertiesError", json);
+		using var _ = JsonDocument.Parse(json);   // and still emits valid JSON
+	}
+
+	[Fact]
+	public void Non_json_record_with_schema_format_reads_it() {
+		var record = PropertyRecord(new Struct {
+			Fields = {
+				["k"] = Value.ForString("v"),
+				["$schema.format"] = Value.ForString("Bytes"),
+			}
+		}, isJson: false);
+
+		var json = Encoding.UTF8.GetString(record.Metadata.Span);
+
+		Assert.Equal("Bytes", record.SchemaFormat);
+		Assert.Contains("\"k\"", json);
+	}
+}

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/ResponseConverterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/ResponseConverterTests.cs
@@ -35,7 +35,7 @@ public class ResponseConverterTests {
 		Assert.True(ResponseConverter.TryConvertReadResponse(
 			new ReadResponse.SubscriptionCaughtUp(
 				timestamp: TimeStamp,
-				allCheckpoint: new Data.TFPos(100, 50)),
+				allCheckpoint: new Core.Data.TFPos(100, 50)),
 			uuidOption: null,
 			out var actual));
 
@@ -49,7 +49,7 @@ public class ResponseConverterTests {
 		Assert.True(ResponseConverter.TryConvertReadResponse(
 			new ReadResponse.SubscriptionCaughtUp(
 				timestamp: TimeStamp,
-				allCheckpoint: new Data.TFPos(100, 50)),
+				allCheckpoint: new Core.Data.TFPos(100, 50)),
 			uuidOption: null,
 			out var actual));
 

--- a/src/KurrentDB.Core/Data/EventRecord.cs
+++ b/src/KurrentDB.Core/Data/EventRecord.cs
@@ -93,6 +93,7 @@ public class EventRecord : IEquatable<EventRecord> {
 				JsonFormatter.Default.Format(new Struct {
 					Fields = {
 						[Constants.RecordProperties.SchemaNameKey] = Value.ForString(EventType),
+						[Constants.RecordProperties.SchemaFormatKey] = Value.ForString(_schemaFormat),
 						[PropertiesErrorKey] = Value.ForString($"Could not render record properties: {ex.Message}")
 					}
 				}));

--- a/src/KurrentDB.Core/Data/EventRecord.cs
+++ b/src/KurrentDB.Core/Data/EventRecord.cs
@@ -68,21 +68,35 @@ public class EventRecord : IEquatable<EventRecord> {
 
 	private const string BytesFormat = "Bytes";
 	private const string JsonFormat = "Json";
+	private const string PropertiesErrorKey = "$propertiesError";
 	static readonly Value JsonDataFormatValue = Value.ForString(JsonFormat);
 
 	void SynthesizeMetadataFromProperties() {
-		var props = Struct.Parser.ParseFrom(Properties.Span);
+		try {
+			var props = Struct.Parser.ParseFrom(Properties.Span);
 
-		props.Fields[Constants.RecordProperties.SchemaNameKey] = Value.ForString(EventType);
+			props.Fields[Constants.RecordProperties.SchemaNameKey] = Value.ForString(EventType);
 
-		if (IsJson) {
-			props.Fields[Constants.RecordProperties.SchemaFormatKey] = JsonDataFormatValue;
-			_schemaFormat = JsonFormat;
-		} else {
-			_schemaFormat = props.Fields[Constants.RecordProperties.SchemaFormatKey].StringValue;
+			if (IsJson) {
+				props.Fields[Constants.RecordProperties.SchemaFormatKey] = JsonDataFormatValue;
+				_schemaFormat = JsonFormat;
+			} else {
+				_schemaFormat = props.Fields[Constants.RecordProperties.SchemaFormatKey].StringValue;
+			}
+
+			_metadata = Encoding.UTF8.GetBytes(JsonFormatter.Default.Format(props));
+		} catch (Exception ex) {
+			// Record properties can technically hold values the JSON formatter can't represent — most notably a protobuf
+			// Value with no kind set ("Value message must contain a value for the oneof").
+			_schemaFormat ??= IsJson ? JsonFormat : BytesFormat;
+			_metadata = Encoding.UTF8.GetBytes(
+				JsonFormatter.Default.Format(new Struct {
+					Fields = {
+						[Constants.RecordProperties.SchemaNameKey] = Value.ForString(EventType),
+						[PropertiesErrorKey] = Value.ForString($"Could not render record properties: {ex.Message}")
+					}
+				}));
 		}
-
-		_metadata = Encoding.UTF8.GetBytes(JsonFormatter.Default.Format(props));
 	}
 
 	public EventRecord(long eventNumber, IPrepareLogRecord prepare, string eventStreamId, string? eventType) {


### PR DESCRIPTION
Add a lightweight validator that checks every Value in the properties map has a kind set (recursing into nested structs and lists). This prevents records that are valid protobuf but unrepresentable as JSON from being persisted. Such values invalid: 'Absence of any variant is an invalid state' https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/struct.proto and would throw when being rendered as json.

The try/catch in SynthesizeMetadataFromProperties is safety net for records already persisted.