### PR TITLE
docs: rename "Admin UI" to "embedded UI" and fix stale onExt settings

### DIFF
--- a/docs/server/configuration/networking.md
+++ b/docs/server/configuration/networking.md
@@ -343,7 +343,7 @@ You can disable the embedded UI and the admin HTTP API by setting `DisableAdminU
 | YAML                 | `DisableAdminUi`               |
 | Environment variable | `KURRENTDB_DISABLE_ADMIN_UI`   |
 
-**Default**: `false`, the embedded UI is enabled on the HTTP interface.
+**Default**: `false`, the embedded UI and the admin HTTP API are enabled on the HTTP interface.
 
 The `stats` and `metrics` endpoints can be disabled by setting `DisableStatsOnHttp` to `true`.
 

--- a/docs/server/configuration/networking.md
+++ b/docs/server/configuration/networking.md
@@ -333,7 +333,7 @@ For the gRPC heartbeats, KurrentDB and its gRPC clients use the protocol feature
 
 ## Exposing endpoints
 
-If you need to disable some HTTP endpoints, you can change the settings below. It is possible to disable the embedded UI, stats and gossip endpoints on the HTTP interface.
+If you need to disable some HTTP endpoints, you can change the settings below. It is possible to disable the embedded UI, stats and metrics, and gossip endpoints on the HTTP interface.
 
 You can disable the embedded UI and the admin HTTP API by setting `DisableAdminUi` to `true`.
 

--- a/docs/server/configuration/networking.md
+++ b/docs/server/configuration/networking.md
@@ -333,37 +333,37 @@ For the gRPC heartbeats, KurrentDB and its gRPC clients use the protocol feature
 
 ## Exposing endpoints
 
-If you need to disable some HTTP endpoints on the external HTTP interface, you can change some settings below. It is possible to disable the Admin UI, stats and gossip port to be exposed externally.
+If you need to disable some HTTP endpoints, you can change the settings below. It is possible to disable the embedded UI, stats and gossip endpoints on the HTTP interface.
 
-You can disable the Admin UI on external HTTP by setting `AdminOnExt` setting to `false`.
+You can disable the embedded UI and the admin HTTP API by setting `DisableAdminUi` to `true`.
 
-| Format               | Syntax                    |
-|:---------------------|:--------------------------|
-| Command line         | `--admin-on-ext`          |
-| YAML                 | `AdminOnExt`              |
-| Environment variable | `KURRENTDB_ADMIN_ON_EXT`  |
+| Format               | Syntax                         |
+|:---------------------|:-------------------------------|
+| Command line         | `--disable-admin-ui`           |
+| YAML                 | `DisableAdminUi`               |
+| Environment variable | `KURRENTDB_DISABLE_ADMIN_UI`   |
 
-**Default**: `true`, Admin UI is enabled on the external HTTP.
+**Default**: `false`, the embedded UI is enabled on the HTTP interface.
 
-Exposing the `stats` endpoint externally is required for the Admin UI and can also be useful if you collect stats for an external monitoring tool.
+The `stats` and `metrics` endpoints can be disabled by setting `DisableStatsOnHttp` to `true`.
 
-| Format               | Syntax                    |
-|:---------------------|:--------------------------|
-| Command line         | `--stats-on-ext`          |
-| YAML                 | `StatsOnExt`              |
-| Environment variable | `KURRENTDB_STATS_ON_EXT`  |
+| Format               | Syntax                              |
+|:---------------------|:------------------------------------|
+| Command line         | `--disable-stats-on-http`           |
+| YAML                 | `DisableStatsOnHttp`                |
+| Environment variable | `KURRENTDB_DISABLE_STATS_ON_HTTP`   |
 
-**Default**: `true`, stats endpoint is enabled on the external HTTP.
+**Default**: `false`, the stats endpoint is enabled on the HTTP interface.
 
-You can also disable the gossip protocol in the external HTTP interface. If you do that, ensure that the internal interface is properly configured. Also, if you use [gossip with DNS](cluster.md#cluster-with-dns), ensure that the [gossip port](cluster.md#gossip-port) is set to the internal HTTP port.
+You can also disable the gossip protocol on the HTTP interface by setting `DisableGossipOnHttp` to `true`.
 
-| Format               | Syntax                     |
-|:---------------------|:---------------------------|
-| Command line         | `--gossip-on-ext`          |
-| YAML                 | `GossipOnExt`              |
-| Environment variable | `KURRENTDB_GOSSIP_ON_EXT`  |
+| Format               | Syntax                               |
+|:---------------------|:-------------------------------------|
+| Command line         | `--disable-gossip-on-http`           |
+| YAML                 | `DisableGossipOnHttp`                |
+| Environment variable | `KURRENTDB_DISABLE_GOSSIP_ON_HTTP`   |
 
-**Default**: `true`, gossip is enabled on the external HTTP.
+**Default**: `false`, gossip is enabled on the HTTP interface.
 
 ## External TCP
 

--- a/docs/server/configuration/networking.md
+++ b/docs/server/configuration/networking.md
@@ -353,7 +353,7 @@ The `stats` and `metrics` endpoints can be disabled by setting `DisableStatsOnHt
 | YAML                 | `DisableStatsOnHttp`                |
 | Environment variable | `KURRENTDB_DISABLE_STATS_ON_HTTP`   |
 
-**Default**: `false`, the stats endpoint is enabled on the HTTP interface.
+**Default**: `false`, the stats and metrics endpoints are enabled on the HTTP interface.
 
 You can also disable the gossip protocol on the HTTP interface by setting `DisableGossipOnHttp` to `true`.
 

--- a/docs/server/features/persistent-subscriptions.md
+++ b/docs/server/features/persistent-subscriptions.md
@@ -35,7 +35,7 @@ Clients must acknowledge (or not acknowledge) messages as they are handled. If m
 
 ## Parked messages
 
-Messages that have been retried too many times will often be parked in the persistent subscription's parked message stream. This stream is named `$persistentsubscription-{streamname}::{groupname}-parked`. You can easily see the number of parked events in the persistent subscription statistics or browse the parked messages in the admin UI.
+Messages that have been retried too many times will often be parked in the persistent subscription's parked message stream. This stream is named `$persistentsubscription-{streamname}::{groupname}-parked`. You can easily see the number of parked events in the persistent subscription statistics or browse the parked messages in the embedded UI.
 
 If you want to retry the parked messages, you can `Replay` the parked messages for that subscription. This will push the parked messages to subscribers before any new events on the subscription.
 

--- a/docs/server/features/projections/settings.md
+++ b/docs/server/features/projections/settings.md
@@ -21,7 +21,7 @@ By using the `System` value for this option, you can instruct the server to enab
 server starts. However, system projections will only start if the `StartStandardProjections` option is set
 to `true`. When the `RunProjections` option value is `System` (or `All`) but the `StartStandardProjections`
 option value is `false`, system projections will be enabled but not start. You can start them later manually
-via the Admin UI or via an API call.
+via the embedded UI or via an API call.
 
 Finally, you can set `RunProjections` to `All` and it will enable both system and custom projections.
 
@@ -52,7 +52,7 @@ run will be re-enabled — the setting drives state on each startup, it does not
 projection itself.
 
 When this option is `false` (the default) the five standard projections exist but stay `Stopped`. Enable them
-on demand, either from the admin UI or via the HTTP API:
+on demand, either from the embedded UI or via the HTTP API:
 
 ```bash:no-line-numbers
 curl -i -X POST "http://{host}:{http-port}/projection/$by_category/command/enable" \

--- a/docs/server/features/projections/tutorial.md
+++ b/docs/server/features/projections/tutorial.md
@@ -66,7 +66,7 @@ Below is the updated projection:
 
 @[code](@samples/http-api/xbox-one-s-counter-outputState.js)
 
-To update the projection, edit the projection definition in the Admin UI, or issue the following request:
+To update the projection, edit the projection definition in the embedded UI, or issue the following request:
 
 @[code](@samples/http-api/xbox-one-s-counter-outputState.sh)
 

--- a/docs/server/features/queries/ui.md
+++ b/docs/server/features/queries/ui.md
@@ -1,6 +1,6 @@
 # Queries UI
 
-The KurrentDB Web Admin UI provides a basic interface to write and run ad-hoc queries against your event streams. This is useful for quick analysis and exploration of your data without needing to set up a full projection.
+The KurrentDB embedded UI provides a basic interface to write and run ad-hoc queries against your event streams. This is useful for quick analysis and exploration of your data without needing to set up a full projection.
 
 ::: important
 The query feature is intended for temporary and exploratory use. For long-running or production workloads, consider using persistent projections or external tools.
@@ -12,7 +12,7 @@ When querying event data and metadata, keep in mind that the query engine proces
 
 ## Motivation
 
-Before v25.1, KurrentDB users had to rely on projections or external tools to query event data. We now want to offer a simpler way to run ad-hoc queries directly from the Web Admin UI, and using other protocols in the future.
+Before v25.1, KurrentDB users had to rely on projections or external tools to query event data. We now want to offer a simpler way to run ad-hoc queries directly from the embedded UI, and using other protocols in the future.
 
 There was already a way to run ad-hoc queries using [JavaScript projections](../projections/custom.md) using the Projections - Query screen, but that requires learning the projections API and JavaScript. The new Queries UI provides a more straightforward way to run simple queries using SQL. It is powered by the [Secondary Indexes](../indexes/secondary.md) feature.
 

--- a/docs/server/quick-start/installation.md
+++ b/docs/server/quick-start/installation.md
@@ -16,7 +16,7 @@ The installation procedure consists of the following steps:
 - Obtain SSL certificates, either signed by a publicly trusted or private certificate authority.
 - Copy the configuration files and SSL certificates to each node.
 - Start the KurrentDB service on each node.
-- Check the cluster status using the Admin UI on any node.
+- Check the cluster status using the embedded UI on any node.
 
 ### Default access
 
@@ -330,7 +330,7 @@ docker pull docker.kurrent.io/kurrent-lts/kurrentdb:latest
 ```
 :::
 
-The following command will start the KurrentDB node using the default HTTP port, without security. You can then connect to it using one of the clients and the `kurrentdb://localhost:2113?tls=false` connection string. You can also access the Admin UI by opening http://localhost:2113 in your browser.
+The following command will start the KurrentDB node using the default HTTP port, without security. You can then connect to it using one of the clients and the `kurrentdb://localhost:2113?tls=false` connection string. You can also access the embedded UI by opening http://localhost:2113 in your browser.
 
 ::: tabs
 @tab kurrent-latest
@@ -348,7 +348,7 @@ docker run --name kurrentdb-node -it -p 2113:2113 \
 :::
 
 Then, you'd be able to connect to KurrentDB with gRPC clients. Also, the Stream Browser will work
-in the Admin UI.
+in the embedded UI.
 
 In order to sustainably keep the data, we also recommend mapping the database and index volumes.
 
@@ -370,7 +370,7 @@ Run the instance:
 docker compose up
 ```
 
-The command above would run KurrentDB as a single node without SSL. You also get AtomPub protocol enabled, so you can get the stream browser to work in the Admin UI.
+The command above would run KurrentDB as a single node without SSL. You also get AtomPub protocol enabled, so you can get the stream browser to work in the embedded UI.
 
 #### Secure cluster
 
@@ -401,7 +401,7 @@ docker compose up
 ```
 
 Watching the log messages, you will see that after some time, the elections process completes. Then you're able to connect to each
-node using the Admin UI. Nodes should be accessible on the loopback address (`127.0.0.1` or `localhost`) over
+node using the embedded UI. Nodes should be accessible on the loopback address (`127.0.0.1` or `localhost`) over
 HTTP, using ports specified below:
 
 | Node  | HTTP port |

--- a/docs/server/security/user-authentication.md
+++ b/docs/server/security/user-authentication.md
@@ -35,7 +35,7 @@ An `$ops` user can do everything that an `$admin` can do except manage users and
 New users can be created through the following means:
 
 - The [HTTP API](../http-api/security.md#creating-users)
-- The [Admin UI](../features/admin-ui.md#users)
+- The [embedded UI](../features/admin-ui.md#users)
 <!-- TODO A [gRPC client]() -->
 
 Users are created with a username, password, and optional set of groups or roles. These roles are used for [authorization](./user-authorization.md#roles).

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -551,10 +551,10 @@ public partial record ClusterVNodeOptions {
 		[Description("The maximum number of pending connection operations allowed before a connection is closed.")]
 		public int ConnectionQueueSizeThreshold { get; init; } = 50_000;
 
-		[Description("Disables the admin ui on the HTTP endpoint.")]
+		[Description("Disables the admin HTTP API and the embedded UI.")]
 		public bool DisableAdminUi { get; init; } = false;
 
-		[Description("Disables statistics requests on the HTTP endpoint.")]
+		[Description("Disables statistics and metrics requests on the HTTP endpoint.")]
 		public bool DisableStatsOnHttp { get; init; } = false;
 
 		[Description("Disables gossip requests on the HTTP endpoint.")]


### PR DESCRIPTION
Update user-facing docs to call the server's built-in UI the "embedded UI" instead of "Admin UI" / "Web Admin UI".

Also rewrite the networking "Exposing endpoints" section, which still documented the AdminOnExt/StatsOnExt/GossipOnExt settings. These were renamed (and their polarity flipped) in 3ca4aca13:
- AdminOnExt  -> DisableAdminUi
- StatsOnExt  -> DisableStatsOnHttp
- GossipOnExt -> DisableGossipOnHttp

Default flipped from true (enabled) to false (not disabled) in each case.