### PR TITLE
[DB-2156] Populate position fields for unresolved link-to events in HTTP API

### DIFF
--- a/src/KurrentDB.Core.Tests/Services/Transport/Http/convert_to_entry.cs
+++ b/src/KurrentDB.Core.Tests/Services/Transport/Http/convert_to_entry.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Text;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Services.Transport.Http.Controllers;
+using KurrentDB.Core.TransactionLog.LogRecords;
+using KurrentDB.Transport.Http.Atom;
+using NUnit.Framework;
+using Convert = KurrentDB.Core.Services.Transport.Http.Convert;
+
+namespace KurrentDB.Core.Tests.Services.Transport.Http;
+
+[TestFixture]
+public class convert_to_entry {
+	private static readonly Uri RequestedUrl = new("http://localhost:2113/streams/test");
+
+	private static EventRecord CreateLinkEvent(long eventNumber, string targetStream, long targetEventNumber) {
+		var linkData = Encoding.UTF8.GetBytes($"{targetEventNumber}@{targetStream}");
+		return new EventRecord(
+			eventNumber, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+			"$persistentsubscription-test-group-parked", 0,
+			DateTime.UtcNow, PrepareFlags.None, "$>",
+			linkData, Encoding.UTF8.GetBytes("{\"some\":\"metadata\"}"));
+	}
+
+	private static EventRecord CreateEvent(long eventNumber, string stream) {
+		return new EventRecord(
+			eventNumber, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+			stream, 0,
+			DateTime.UtcNow, PrepareFlags.IsJson, "TestEvent",
+			Encoding.UTF8.GetBytes("{\"key\":\"value\"}"), Encoding.UTF8.GetBytes("{}"));
+	}
+
+	[Test]
+	public void unresolved_link_produces_rich_entry_with_position_fields() {
+		var link = CreateLinkEvent(5, "source-stream", 42);
+		var resolved = ResolvedEvent.ForFailedResolvedLink(link, ReadEventResult.StreamDeleted);
+
+		var entry = Convert.ToEntry(resolved, RequestedUrl, EmbedLevel.Body);
+
+		Assert.That(entry, Is.InstanceOf<RichEntryElement>());
+		var rich = (RichEntryElement)entry;
+		Assert.That(rich.PositionEventNumber, Is.EqualTo(5));
+		Assert.That(rich.PositionStreamId, Is.EqualTo("$persistentsubscription-test-group-parked"));
+	}
+
+	[Test]
+	public void unresolved_link_does_not_populate_resolved_event_fields() {
+		var link = CreateLinkEvent(5, "source-stream", 42);
+		var resolved = ResolvedEvent.ForFailedResolvedLink(link, ReadEventResult.StreamDeleted);
+
+		var entry = Convert.ToEntry(resolved, RequestedUrl, EmbedLevel.Body);
+
+		var rich = (RichEntryElement)entry;
+		Assert.That(rich.EventId, Is.EqualTo(Guid.Empty));
+		Assert.That(rich.EventType, Is.Null);
+		Assert.That(rich.Data, Is.Null);
+	}
+
+	[Test]
+	public void unresolved_link_populates_link_metadata() {
+		var link = CreateLinkEvent(5, "source-stream", 42);
+		var resolved = ResolvedEvent.ForFailedResolvedLink(link, ReadEventResult.StreamDeleted);
+
+		var entry = Convert.ToEntry(resolved, RequestedUrl, EmbedLevel.Body);
+
+		var rich = (RichEntryElement)entry;
+		Assert.That(rich.LinkMetaData, Is.EqualTo("{\"some\":\"metadata\"}"));
+		Assert.That(rich.IsLinkMetaData, Is.True);
+	}
+
+	[Test]
+	public void resolved_link_produces_rich_entry_with_all_fields() {
+		var targetEvent = CreateEvent(42, "source-stream");
+		var link = CreateLinkEvent(5, "source-stream", 42);
+		var resolved = ResolvedEvent.ForResolvedLink(targetEvent, link);
+
+		var entry = Convert.ToEntry(resolved, RequestedUrl, EmbedLevel.Body);
+
+		Assert.That(entry, Is.InstanceOf<RichEntryElement>());
+		var rich = (RichEntryElement)entry;
+		Assert.That(rich.PositionEventNumber, Is.EqualTo(5));
+		Assert.That(rich.PositionStreamId, Is.EqualTo("$persistentsubscription-test-group-parked"));
+		Assert.That(rich.EventId, Is.EqualTo(targetEvent.EventId));
+		Assert.That(rich.EventType, Is.EqualTo("TestEvent"));
+		Assert.That(rich.EventNumber, Is.EqualTo(42));
+		Assert.That(rich.StreamId, Is.EqualTo("source-stream"));
+	}
+
+	[Test]
+	public void unresolved_link_with_content_embed_does_not_produce_rich_entry() {
+		var link = CreateLinkEvent(5, "source-stream", 42);
+		var resolved = ResolvedEvent.ForFailedResolvedLink(link, ReadEventResult.StreamDeleted);
+
+		var entry = Convert.ToEntry(resolved, RequestedUrl, EmbedLevel.Content);
+
+		Assert.That(entry, Is.Not.InstanceOf<RichEntryElement>());
+	}
+}

--- a/src/KurrentDB.Core/Services/Transport/Http/Convert.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Convert.cs
@@ -272,22 +272,24 @@ public static class Convert {
 		var evnt = eventLinkPair.Event;
 		var link = eventLinkPair.Link;
 		EntryElement entry;
-		if (embedContent > EmbedLevel.Content && evnt != null) {
+		if (embedContent > EmbedLevel.Content && (evnt != null || link != null)) {
 			var richEntry = new RichEntryElement();
 			entry = richEntry;
 
-			richEntry.EventId = evnt.EventId;
-			richEntry.EventType = evnt.EventType;
-			richEntry.EventNumber = evnt.EventNumber;
-			richEntry.StreamId = evnt.EventStreamId;
 			richEntry.PositionEventNumber = eventLinkPair.OriginalEvent.EventNumber;
 			richEntry.PositionStreamId = eventLinkPair.OriginalEvent.EventStreamId;
-			richEntry.IsJson = (evnt.Flags & PrepareFlags.IsJson) != 0;
-			richEntry.IsRedacted = (evnt.Flags & PrepareFlags.IsRedacted) != 0;
 
-			var data = evnt.Data.Span;
+			if (evnt != null) {
+				richEntry.EventId = evnt.EventId;
+				richEntry.EventType = evnt.EventType;
+				richEntry.EventNumber = evnt.EventNumber;
+				richEntry.StreamId = evnt.EventStreamId;
+				richEntry.IsJson = (evnt.Flags & PrepareFlags.IsJson) != 0;
+				richEntry.IsRedacted = (evnt.Flags & PrepareFlags.IsRedacted) != 0;
+			}
 
-			if (embedContent >= EmbedLevel.Body && eventLinkPair.Event != null) {
+			if (embedContent >= EmbedLevel.Body && evnt != null) {
+				var data = evnt.Data.Span;
 				if (richEntry.IsJson) {
 					if (embedContent >= EmbedLevel.PrettyBody) {
 						try {
@@ -327,20 +329,18 @@ public static class Convert {
 					} catch {
 						// ignore - we tried
 					}
+				}
+			}
 
-					var lnk = eventLinkPair.Link;
-					if (lnk != null) {
-						try {
-							richEntry.LinkMetaData = Helper.UTF8NoBom.GetString(lnk.Metadata.Span);
-							richEntry.IsLinkMetaData = richEntry.LinkMetaData.IsNotEmptyString();
-							// next step may fail, so we have already assigned body
-							if (embedContent >= EmbedLevel.PrettyBody) {
-								richEntry.LinkMetaData = FormatJson(richEntry.LinkMetaData);
-							}
-						} catch {
-							// ignore - we tried
-						}
+			if (embedContent >= EmbedLevel.Body && link != null) {
+				try {
+					richEntry.LinkMetaData = Helper.UTF8NoBom.GetString(link.Metadata.Span);
+					richEntry.IsLinkMetaData = richEntry.LinkMetaData.IsNotEmptyString();
+					if (embedContent >= EmbedLevel.PrettyBody) {
+						richEntry.LinkMetaData = FormatJson(richEntry.LinkMetaData);
 					}
+				} catch {
+					// ignore - we tried
 				}
 			}
 		} else {


### PR DESCRIPTION
When link-to events could not be resolved (e.g. source stream truncated by $maxCount), Convert.ToEntry skipped creating a RichEntryElement entirely. This meant positionEventNumber was missing from the JSON response, which caused the legacy AngularJS UI's ng-repeat track-by to fail on duplicate undefined keys, hiding all parked messages.

Now a RichEntryElement is always created when embed level requires it, with position and link metadata populated from the link event regardless of whether the target resolved.