### PR TITLE
[DB-2158] Add API & UI for truncating persistent subscription parked messages

### DIFF
--- a/docs/server/diagnostics/metrics.md
+++ b/docs/server/diagnostics/metrics.md
@@ -282,6 +282,7 @@ Persistent subscription metrics track the statistics for the persistent subscrip
 | `kurrentdb_persistent_sub_checkpointed_event_number`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`             | [Gauge](#common-types)   | Last checkpointed event number (streams other than `$all)`     |
 | `kurrentdb_persistent_sub_checkpointed_event_commit_position`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`    | [Gauge](#common-types)   | Last checkpointed event's commit position (`$all` stream only) |
 | `kurrentdb_persistent_sub_parked_message_replays`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`                | [Gauge](#common-types)   | Number of replays requested                                    |
+| `kurrentdb_persistent_sub_parked_message_truncations`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`            | [Gauge](#common-types)   | Number of truncations requested                                |
 | `kurrentdb_persistent_sub_park_message_requests`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>,reason=<REASON>}` | [Gauge](#common-types)   | Number of messages that have been parked. Reason can be `client-nak` or `max-retries` |
 
 Example configuration:

--- a/proto.lock
+++ b/proto.lock
@@ -4069,6 +4069,51 @@
             "name": "ReplayParkedResp"
           },
           {
+            "name": "TruncateParkedReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "group_name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "stream_identifier",
+                    "type": "event_store.client.StreamIdentifier"
+                  },
+                  {
+                    "id": 3,
+                    "name": "all",
+                    "type": "event_store.client.Empty"
+                  },
+                  {
+                    "id": 4,
+                    "name": "stop_at",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 5,
+                    "name": "no_limit",
+                    "type": "event_store.client.Empty"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "TruncateParkedResp"
+          },
+          {
             "name": "ListReq",
             "fields": [
               {
@@ -4157,6 +4202,11 @@
                 "name": "ReplayParked",
                 "in_type": "ReplayParkedReq",
                 "out_type": "ReplayParkedResp"
+              },
+              {
+                "name": "TruncateParked",
+                "in_type": "TruncateParkedReq",
+                "out_type": "TruncateParkedResp"
               },
               {
                 "name": "List",

--- a/src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory.cs
+++ b/src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory.cs
@@ -70,6 +70,7 @@ public class LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory :
 		policy.AddMatchAnyAssertion(Operations.Subscriptions.Delete, Grant.Allow, OperationsOrAdmins);
 		policy.Add(Operations.Subscriptions.ProcessMessages, subscriptionAccess);
 		policy.AddMatchAnyAssertion(Operations.Subscriptions.ReplayParked, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Subscriptions.TruncateParked, Grant.Allow, OperationsOrAdmins);
 
 		policy.Add(Operations.Streams.Read, streamAssertion);
 		policy.Add(Operations.Streams.Write, streamAssertion);

--- a/src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/RequireStreamReadAssertion.cs
+++ b/src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/RequireStreamReadAssertion.cs
@@ -23,6 +23,7 @@ public class RequireStreamReadAssertion : IAssertion {
 	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
 		EvaluationContext context) {
 		if (operation == Operations.Subscriptions.ProcessMessages ||
+			operation == Operations.Subscriptions.TruncateParked ||
 			operation == Operations.Subscriptions.ReplayParked) {
 			var stream = FindStreamId(operation.Parameters.Span);
 			return _streamAssertion.Evaluate(cp,

--- a/src/KurrentDB.Components.Tests/PersistentSubscriptionsServiceAuthorizationTests.cs
+++ b/src/KurrentDB.Components.Tests/PersistentSubscriptionsServiceAuthorizationTests.cs
@@ -78,6 +78,6 @@ public class PersistentSubscriptionsServiceAuthorizationTests {
 		AssertRequiresAccessTo(Operations.Subscriptions.ReplayParked, s => s.ReplayParkedAsync(SomeUser, "stream", "group", CancellationToken.None));
 
 	[Fact]
-	public Task TruncateParked_requires_replay() =>
-		AssertRequiresAccessTo(Operations.Subscriptions.ReplayParked, s => s.TruncateParkedAsync(SomeUser, "stream", "group", CancellationToken.None));
+	public Task TruncateParked_requires_truncate() =>
+		AssertRequiresAccessTo(Operations.Subscriptions.TruncateParked, s => s.TruncateParkedAsync(SomeUser, "stream", "group", CancellationToken.None));
 }

--- a/src/KurrentDB.Components.Tests/PersistentSubscriptionsServiceAuthorizationTests.cs
+++ b/src/KurrentDB.Components.Tests/PersistentSubscriptionsServiceAuthorizationTests.cs
@@ -76,4 +76,8 @@ public class PersistentSubscriptionsServiceAuthorizationTests {
 	[Fact]
 	public Task ReplayParked_requires_replay() =>
 		AssertRequiresAccessTo(Operations.Subscriptions.ReplayParked, s => s.ReplayParkedAsync(SomeUser, "stream", "group", CancellationToken.None));
+
+	[Fact]
+	public Task TruncateParked_requires_replay() =>
+		AssertRequiresAccessTo(Operations.Subscriptions.ReplayParked, s => s.TruncateParkedAsync(SomeUser, "stream", "group", CancellationToken.None));
 }

--- a/src/KurrentDB.Core.Testing.NUnit/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/KurrentDB.Core.Testing.NUnit/Helpers/TestFixtureWithExistingEvents.cs
@@ -284,6 +284,16 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 		ProcessRead(message);
 	}
 
+	private long GetTruncateBefore(string streamId) {
+		var metaStreamId = SystemStreams.MetastreamOf(streamId);
+		if (_streams.TryGetValue(metaStreamId, out var metaEvents) && metaEvents is { Count: > 0 }) {
+			var lastMeta = metaEvents[^1];
+			var metadata = Helper.EatException(() => StreamMetadata.FromJsonBytes(lastMeta.Data), StreamMetadata.Empty);
+			return metadata.TruncateBefore ?? 0;
+		}
+		return 0;
+	}
+
 	private void ProcessRead(ClientMessage.ReadStreamEventsBackward message) {
 		List<EventRecord> list;
 		if (_deletedStreams.Contains(message.EventStreamId)) {
@@ -295,10 +305,12 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 		} else if (_streams.TryGetValue(message.EventStreamId, out list) || _noOtherStreams) {
 			if (list != null && list.Count > 0 && (list.Last().EventNumber >= message.FromEventNumber)
 				|| (message.FromEventNumber == -1)) {
+				var tb = GetTruncateBefore(message.EventStreamId);
 				ResolvedEvent[] records =
 					list.Safe()
 						.Reverse()
 						.SkipWhile(v => message.FromEventNumber != -1 && v.EventNumber > message.FromEventNumber)
+						.Where(v => v.EventNumber >= tb)
 						.Take(message.MaxCount)
 						.Select(v => BuildEvent(v, message.ResolveLinkTos))
 						.ToArray();
@@ -328,6 +340,14 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 
 				throw new NotImplementedException();
 			}
+		} else {
+			message.Envelope.ReplyWith(
+				new ClientMessage.ReadStreamEventsBackwardCompleted(
+					message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount,
+					ReadStreamResult.NoStream, new ResolvedEvent[0], null, false, "", nextEventNumber: -1,
+					lastEventNumber: -1,
+					isEndOfStream: true,
+					tfLastCommitPosition: _fakePosition));
 		}
 	}
 
@@ -349,9 +369,11 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 					EventNumber.DeletedStream, true, _fakePosition));
 		} else if (_streams.TryGetValue(message.EventStreamId, out list) || _noOtherStreams) {
 			if (list != null && list.Count > 0 && message.FromEventNumber >= 0) {
+				var tb = GetTruncateBefore(message.EventStreamId);
+				var effectiveFrom = Math.Max(message.FromEventNumber, tb);
 				ResolvedEvent[] records =
 					list.Safe()
-						.SkipWhile(v => v.EventNumber < message.FromEventNumber)
+						.SkipWhile(v => v.EventNumber < effectiveFrom)
 						.Take(message.MaxCount)
 						.Select(v => BuildEvent(v, message.ResolveLinkTos))
 						.ToArray();
@@ -394,6 +416,14 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 													lastCommitPosition: _lastPosition));
 				*/
 			}
+		} else {
+			message.Envelope.ReplyWith(
+				new ClientMessage.ReadStreamEventsForwardCompleted(
+					message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount,
+					ReadStreamResult.NoStream, new ResolvedEvent[0], null, false, "", nextEventNumber: -1,
+					lastEventNumber: -1,
+					isEndOfStream: true,
+					tfLastCommitPosition: _fakePosition));
 		}
 	}
 

--- a/src/KurrentDB.Core.Testing.NUnit/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/KurrentDB.Core.Testing.NUnit/Helpers/TestFixtureWithExistingEvents.cs
@@ -340,14 +340,6 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 
 				throw new NotImplementedException();
 			}
-		} else {
-			message.Envelope.ReplyWith(
-				new ClientMessage.ReadStreamEventsBackwardCompleted(
-					message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount,
-					ReadStreamResult.NoStream, new ResolvedEvent[0], null, false, "", nextEventNumber: -1,
-					lastEventNumber: -1,
-					isEndOfStream: true,
-					tfLastCommitPosition: _fakePosition));
 		}
 	}
 
@@ -416,14 +408,6 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 													lastCommitPosition: _lastPosition));
 				*/
 			}
-		} else {
-			message.Envelope.ReplyWith(
-				new ClientMessage.ReadStreamEventsForwardCompleted(
-					message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount,
-					ReadStreamResult.NoStream, new ResolvedEvent[0], null, false, "", nextEventNumber: -1,
-					lastEventNumber: -1,
-					isEndOfStream: true,
-					tfLastCommitPosition: _fakePosition));
 		}
 	}
 

--- a/src/KurrentDB.Core.Tests/Authorization/LegacyPolicyVerification.cs
+++ b/src/KurrentDB.Core.Tests/Authorization/LegacyPolicyVerification.cs
@@ -401,6 +401,8 @@ public class LegacyPolicyVerification {
 			yield return CreateOperation(Operations.Node.Information.ReadLogs);
 			yield return (new Operation(Operations.Subscriptions.ReplayParked).WithParameter(Operations.Subscriptions.Parameters.StreamId(_streamWithCustomPermissions)), _streamWithCustomPermissions, null);
 			yield return (new Operation(Operations.Subscriptions.ReplayParked).WithParameter(Operations.Subscriptions.Parameters.StreamId(_streamWithDefaultPermissions)), _streamWithDefaultPermissions, null);
+			yield return (new Operation(Operations.Subscriptions.TruncateParked).WithParameter(Operations.Subscriptions.Parameters.StreamId(_streamWithCustomPermissions)), _streamWithCustomPermissions, null);
+			yield return (new Operation(Operations.Subscriptions.TruncateParked).WithParameter(Operations.Subscriptions.Parameters.StreamId(_streamWithDefaultPermissions)), _streamWithDefaultPermissions, null);
 
 			yield return CreateOperation(Operations.Projections.UpdateConfiguration);
 

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
@@ -300,6 +300,36 @@ public class PersistentSubscriptionMessageParkerTests {
 	}
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class given_parked_messages_truncated_then_truncated_to_an_earlier_point<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
+		private PersistentSubscriptionMessageParker _messageParker;
+		private string _streamId = Guid.NewGuid().ToString();
+		private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+		protected override void Given() {
+			base.Given();
+			AllWritesSucceed();
+			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+			for (var i = 0; i < 10; i++)
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, $"{i}@foo");
+			NoOtherStreams();
+		}
+
+		[Test]
+		public async Task truncating_to_an_earlier_point_does_not_resurrect_messages() {
+			// truncate all 10 parked messages
+			_messageParker.BeginMarkParkedMessagesReprocessed(10, () => {
+				Assert.Zero(_messageParker.ParkedMessageCount);
+				// truncating again to an earlier point must not bring messages back: the truncate-before is monotonic
+				_messageParker.BeginMarkParkedMessagesReprocessed(5, () => {
+					Assert.Zero(_messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+			});
+			await _done.Task.WithTimeout();
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	public class given_messages_are_parked_and_then_replayed<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
 		private PersistentSubscriptionMessageParker _messageParker;
 		private string _streamId = Guid.NewGuid().ToString();

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
@@ -161,6 +161,83 @@ public class PersistentSubscriptionMessageParkerTests {
 	}
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class given_parked_messages_with_tb_partway<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
+		private PersistentSubscriptionMessageParker _messageParker;
+		private string _streamId = Guid.NewGuid().ToString();
+		private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+		protected override void Given() {
+			base.Given();
+			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "0@foo");
+			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "1@foo");
+			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "2@foo");
+			ExistingStreamMetadata(_messageParker.ParkedStreamId,
+				new StreamMetadata(truncateBefore: 2).ToJsonString());
+		}
+
+		[Test]
+		public async Task should_have_one_parked_message() {
+			_messageParker.BeginLoadStats(() => {
+				Assert.AreEqual(1, _messageParker.ParkedMessageCount);
+				_done.TrySetResult(true);
+			});
+			await _done.Task.WithTimeout();
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class given_parked_messages_with_tb_past_all_events<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
+		private PersistentSubscriptionMessageParker _messageParker;
+		private string _streamId = Guid.NewGuid().ToString();
+		private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+		protected override void Given() {
+			base.Given();
+			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "0@foo");
+			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "1@foo");
+			ExistingStreamMetadata(_messageParker.ParkedStreamId,
+				new StreamMetadata(truncateBefore: 2).ToJsonString());
+		}
+
+		[Test]
+		public async Task should_have_no_parked_messages() {
+			_messageParker.BeginLoadStats(() => {
+				Assert.Zero(_messageParker.ParkedMessageCount);
+				Assert.Null(_messageParker.GetOldestParkedMessage);
+				_done.TrySetResult(true);
+			});
+			await _done.Task.WithTimeout();
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class given_no_parked_messages_with_tb<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
+		private PersistentSubscriptionMessageParker _messageParker;
+		private string _streamId = Guid.NewGuid().ToString();
+		private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+		protected override void Given() {
+			base.Given();
+			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+			ExistingStreamMetadata(_messageParker.ParkedStreamId,
+				new StreamMetadata(truncateBefore: 5).ToJsonString());
+			NoOtherStreams();
+		}
+
+		[Test]
+		public async Task should_have_no_parked_messages() {
+			_messageParker.BeginLoadStats(() => {
+				Assert.Zero(_messageParker.ParkedMessageCount);
+				Assert.Null(_messageParker.GetOldestParkedMessage);
+				_done.TrySetResult(true);
+			});
+			await _done.Task.WithTimeout();
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	public class given_parked_messages_and_all_are_truncated<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
 		private PersistentSubscriptionMessageParker _messageParker;
 		private string _streamId = Guid.NewGuid().ToString();
@@ -243,7 +320,7 @@ public class PersistentSubscriptionMessageParkerTests {
 		[Test]
 		public async Task should_have_no_parked_messages() {
 			await _parked.Task;
-			_messageParker.BeginMarkParkedMessagesReprocessed(2, null, true, () => {
+			_messageParker.BeginMarkParkedMessagesReprocessed(2, () => {
 				Assert.Zero(_messageParker.ParkedMessageCount);
 				Assert.AreEqual(0, _messageParker.ParkedDueToClientNak);
 				Assert.AreEqual(2, _messageParker.ParkedDueToMaxRetries);
@@ -270,7 +347,7 @@ public class PersistentSubscriptionMessageParkerTests {
 			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
 			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.ClientNak, (_, __) => {
 				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", ParkReason.ClientNak, (_, __) => {
-					_messageParker.BeginMarkParkedMessagesReprocessed(2, null, true, () => {
+					_messageParker.BeginMarkParkedMessagesReprocessed(2, () => {
 						_replayParked.SetResult(true);
 					});
 				});
@@ -299,8 +376,8 @@ public class PersistentSubscriptionMessageParkerTests {
 		private string _streamId = Guid.NewGuid().ToString();
 		private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
 
-		private TaskCompletionSource<bool> _timerMessageReceived = new TaskCompletionSource<bool>();
-		private IODispatcherDelayedMessage _timerMessage;
+		private List<TaskCompletionSource<bool>> _timerMessageReceivedSignals = new();
+		private List<IODispatcherDelayedMessage> _timerMessages = new();
 
 		protected override void Given() {
 			base.Given();
@@ -309,10 +386,12 @@ public class PersistentSubscriptionMessageParkerTests {
 
 			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
 
+			_timerMessageReceivedSignals.Add(new TaskCompletionSource<bool>());
 			_bus.Subscribe(new AdHocHandler<TimerMessage.Schedule>(
 				msg => {
-					_timerMessage = msg.ReplyMessage as IODispatcherDelayedMessage;
-					_timerMessageReceived.TrySetResult(true);
+					_timerMessages.Add(msg.ReplyMessage as IODispatcherDelayedMessage);
+					_timerMessageReceivedSignals[^1].TrySetResult(true);
+					_timerMessageReceivedSignals.Add(new TaskCompletionSource<bool>());
 				}));
 		}
 
@@ -323,8 +402,10 @@ public class PersistentSubscriptionMessageParkerTests {
 				_done.TrySetResult(true);
 			});
 
-			await _timerMessageReceived.Task.WithTimeout();
-			_ioDispatcher.Handle(_timerMessage);
+			for (var i = 0; !_done.Task.IsCompleted; i++) {
+				await _timerMessageReceivedSignals[i].Task.WithTimeout();
+				_ioDispatcher.Handle(_timerMessages[i]);
+			}
 
 			await _done.Task.WithTimeout();
 		}

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
@@ -119,6 +119,7 @@ public class PersistentSubscriptionMessageParkerTests {
 			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "7@foo");
 			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "8@foo");
 			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "9@foo");
+			NoOtherStreams();
 		}
 
 		[Test]
@@ -147,6 +148,7 @@ public class PersistentSubscriptionMessageParkerTests {
 			_eventRecords.Add(ExistingEventTimeStamp(_messageParker.ParkedStreamId, "$>", LinkMetadata, "7@foo"));
 			_eventRecords.Add(ExistingEventTimeStamp(_messageParker.ParkedStreamId, "$>", LinkMetadata, "8@foo"));
 			_eventRecords.Add(ExistingEventTimeStamp(_messageParker.ParkedStreamId, "$>", LinkMetadata, "9@foo"));
+			NoOtherStreams();
 		}
 
 		[Test]
@@ -257,6 +259,7 @@ public class PersistentSubscriptionMessageParkerTests {
 			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "8@foo");
 			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "9@foo");
 			DeletedStream(_messageParker.ParkedStreamId);
+			NoOtherStreams();
 		}
 
 		[Test]
@@ -427,6 +430,7 @@ public class PersistentSubscriptionMessageParkerTests {
 
 			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
 			ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "0@foo");
+			NoOtherStreams();
 
 			// Disable the forward reader so it times out
 			_bus.Unsubscribe(_ioDispatcher.ForwardReader);

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -2644,6 +2644,65 @@ public class ParkTests {
 
 		Assert.AreEqual(10, messageParker.MarkedAsProcessed);
 	}
+
+	[Test]
+	public void truncating_parked_messages_while_replaying_is_rejected() {
+		var messageParker = new FakeMessageParker();
+		var reader = new FakeCheckpointReader();
+
+		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
+			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
+				.WithEventLoader(new FakeStreamReader()) // no-op reader: the replay never completes, so it stays in progress
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
+				.WithMessageParker(messageParker)
+				.StartFromBeginning()
+				.MinimumToCheckPoint(1)
+				.MaximumToCheckPoint(1));
+		reader.Load(null);
+
+		var parkedEvents = Enumerable.Range(0, 5)
+			.Select(v => Helper.BuildFakeEvent(Guid.NewGuid(), "type", "$persistentsubscription-streamName::groupName-parked", v, v, v)).ToArray();
+		foreach (var parkedEvent in parkedEvents) {
+			messageParker.BeginParkMessage(parkedEvent, "parked", ParkReason.None, (ev, res) => { });
+		}
+
+		// start a replay; with the no-op stream reader it stays in progress
+		sub.RetryParkedMessages(null);
+
+		// a truncate issued while the replay is in progress is rejected and doesn't touch the truncate-before
+		Assert.AreEqual(ParkedMessageOperationResult.AlreadyInProgress, sub.TruncateParkedMessages(null));
+		Assert.AreEqual(0, messageParker.MarkedAsProcessed);
+	}
+
+	[Test]
+	public void replaying_parked_messages_while_replaying_is_rejected() {
+		var messageParker = new FakeMessageParker();
+		var reader = new FakeCheckpointReader();
+
+		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
+			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
+				.WithEventLoader(new FakeStreamReader()) // no-op reader: the replay never completes, so it stays in progress
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
+				.WithMessageParker(messageParker)
+				.StartFromBeginning()
+				.MinimumToCheckPoint(1)
+				.MaximumToCheckPoint(1));
+		reader.Load(null);
+
+		var parkedEvents = Enumerable.Range(0, 5)
+			.Select(v => Helper.BuildFakeEvent(Guid.NewGuid(), "type", "$persistentsubscription-streamName::groupName-parked", v, v, v)).ToArray();
+		foreach (var parkedEvent in parkedEvents) {
+			messageParker.BeginParkMessage(parkedEvent, "parked", ParkReason.None, (ev, res) => { });
+		}
+
+		// the first replay stays in progress (no-op stream reader)
+		Assert.AreEqual(ParkedMessageOperationResult.Started, sub.RetryParkedMessages(null));
+
+		// a second replay issued while the first is in progress is rejected
+		Assert.AreEqual(ParkedMessageOperationResult.AlreadyInProgress, sub.RetryParkedMessages(null));
+	}
 }
 
 [Ignore("very long test")]

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -2590,7 +2590,7 @@ public class ParkTests {
 	}
 
 	[Test]
-	public void truncating_parked_messages_truncates_all_and_updates_count() {
+	public void truncating_parked_messages_truncates_all() {
 		var messageParker = new FakeMessageParker();
 		var reader = new FakeCheckpointReader();
 

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -3021,8 +3021,9 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker {
 	public void NotifyTruncate() {
 	}
 
-	public void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? dateTime, bool updateOldestParkedMessage) {
+	public void BeginMarkParkedMessagesReprocessed(long sequence, Action completed) {
 		MarkedAsProcessed = sequence;
+		completed?.Invoke();
 	}
 
 	public void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed) {

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -3015,6 +3015,12 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker {
 			completed(_lastParkedEventNumber);
 	}
 
+	public void NotifyReplay() {
+	}
+
+	public void NotifyTruncate() {
+	}
+
 	public void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? dateTime, bool updateOldestParkedMessage) {
 		MarkedAsProcessed = sequence;
 	}
@@ -3039,6 +3045,7 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker {
 	public long ParkedDueToClientNak { get; }
 	public long ParkedDueToMaxRetries { get; }
 	public long ParkedMessageReplays { get; }
+	public long ParkedMessageTruncations { get; }
 }
 
 

--- a/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -2588,6 +2588,62 @@ public class ParkTests {
 		Assert.AreEqual(7, sub.OutstandingMessageCount);
 
 	}
+
+	[Test]
+	public void truncating_parked_messages_truncates_all_and_updates_count() {
+		var messageParker = new FakeMessageParker();
+		var reader = new FakeCheckpointReader();
+
+		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
+			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
+				.WithMessageParker(messageParker)
+				.StartFromBeginning()
+				.MinimumToCheckPoint(1)
+				.MaximumToCheckPoint(1));
+		reader.Load(null);
+
+		var parkedEvents = Enumerable.Range(0, 19)
+			.Select(v => Helper.BuildFakeEvent(Guid.NewGuid(), "type", "$persistentsubscription-streamName::groupName-parked", v, v, v)).ToArray();
+		foreach (var parkedEvent in parkedEvents) {
+			messageParker.BeginParkMessage(parkedEvent, "parked", ParkReason.None, (ev, res) => { });
+		}
+
+		Assert.AreEqual(19, messageParker.ParkedMessageCount);
+
+		sub.TruncateParkedMessages(null);
+
+		Assert.AreEqual(19, messageParker.MarkedAsProcessed);
+	}
+
+	[Test]
+	public void truncating_parked_messages_with_stop_at_truncates_up_to_stop_at() {
+		var messageParker = new FakeMessageParker();
+		var reader = new FakeCheckpointReader();
+
+		var sub = new KurrentDB.Core.Services.PersistentSubscription.PersistentSubscription(
+			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
+				.WithMessageParker(messageParker)
+				.StartFromBeginning()
+				.MinimumToCheckPoint(1)
+				.MaximumToCheckPoint(1));
+		reader.Load(null);
+
+		var parkedEvents = Enumerable.Range(0, 19)
+			.Select(v => Helper.BuildFakeEvent(Guid.NewGuid(), "type", "$persistentsubscription-streamName::groupName-parked", v, v, v)).ToArray();
+		foreach (var parkedEvent in parkedEvents) {
+			messageParker.BeginParkMessage(parkedEvent, "parked", ParkReason.None, (ev, res) => { });
+		}
+
+		sub.TruncateParkedMessages(10);
+
+		Assert.AreEqual(10, messageParker.MarkedAsProcessed);
+	}
 }
 
 [Ignore("very long test")]

--- a/src/KurrentDB.Core.Tests/swagger.yaml
+++ b/src/KurrentDB.Core.Tests/swagger.yaml
@@ -1241,6 +1241,43 @@ paths:
           description: Not found
       security:
         - basicAuth: []
+  "/subscriptions/{stream}/{subscription}/truncateParked":
+    post:
+      tags:
+        - Subscriptions
+      summary: Truncate parked messages in a stream
+      description: >-
+        Truncate previously parked messages in a stream by setting the
+        truncate-before metadata on the parked message stream.
+      operationId: Truncate parked messages
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - name: stopAt
+          in: query
+          description: The stream event number to stop at.
+          required: false
+          type: long
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
   /subscriptions/restart:
     post:
       description: Restart the subscription subsystem on a node.

--- a/src/KurrentDB.Core.XUnit.Tests/Authorization/FallbackStreamAccessPolicyVerification.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Authorization/FallbackStreamAccessPolicyVerification.cs
@@ -52,6 +52,7 @@ public class FallbackStreamAccessPolicyVerification {
 		Operations.Subscriptions.Restart,
 		Operations.Subscriptions.Delete,
 		Operations.Subscriptions.ReplayParked,
+		Operations.Subscriptions.TruncateParked,
 		Operations.Users.CurrentUser,
 		Operations.Users.Enable,
 		Operations.Users.Read,

--- a/src/KurrentDB.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
@@ -40,6 +40,7 @@ public class PersistentSubscriptionMetricsTests {
 			ParkedDueToClientNak = 2001,
 			ParkedDueToMaxRetries = 2002,
 			ParkedMessageReplays = 2003,
+			ParkedMessageTruncations = 2007,
 			ParkedMessageCount = 1003,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -75,6 +76,7 @@ public class PersistentSubscriptionMetricsTests {
 			ParkedDueToClientNak = 2004,
 			ParkedDueToMaxRetries = 2005,
 			ParkedMessageReplays = 2006,
+			ParkedMessageTruncations = 2008,
 			ParkedMessageCount = 1004,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -152,6 +154,14 @@ public class PersistentSubscriptionMetricsTests {
 		Assert.Collection(measurements,
 			AssertMeasurement("test", "testGroup", 2003),
 			AssertMeasurement("$all", "testGroup", 2006));
+	}
+
+	[Fact]
+	public void ObserveParkedMessageTruncations() {
+		var measurements = _sut.ObserveParkedMessageTruncations();
+		Assert.Collection(measurements,
+			AssertMeasurement("test", "testGroup", 2007),
+			AssertMeasurement("$all", "testGroup", 2008));
 	}
 
 	[Fact]

--- a/src/KurrentDB.Core/Authorization/AuthorizationPolicies/LegacyPolicySelectorFactory.cs
+++ b/src/KurrentDB.Core/Authorization/AuthorizationPolicies/LegacyPolicySelectorFactory.cs
@@ -111,6 +111,7 @@ public class LegacyPolicySelectorFactory : IPolicySelectorFactory {
 		policy.AddMatchAnyAssertion(Operations.Subscriptions.Restart, Grant.Allow, OperationsOrAdmins);
 		policy.Add(Operations.Subscriptions.ProcessMessages, subscriptionAccess);
 		policy.AddMatchAnyAssertion(Operations.Subscriptions.ReplayParked, Grant.Allow, OperationsOrAdmins);
+		policy.AddMatchAnyAssertion(Operations.Subscriptions.TruncateParked, Grant.Allow, OperationsOrAdmins);
 
 		IAssertion streamAssertion = _allowAnonymousStreamAccess
 			? legacyStreamAssertion

--- a/src/KurrentDB.Core/Authorization/RequireStreamReadAssertion.cs
+++ b/src/KurrentDB.Core/Authorization/RequireStreamReadAssertion.cs
@@ -23,6 +23,7 @@ public class RequireStreamReadAssertion : IAssertion {
 	public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
 		EvaluationContext context) {
 		if (operation == Operations.Subscriptions.ProcessMessages ||
+			operation == Operations.Subscriptions.TruncateParked ||
 			operation == Operations.Subscriptions.ReplayParked) {
 			var stream = FindStreamId(operation.Parameters.Span);
 			return _streamAssertion.Evaluate(cp,

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -1228,6 +1228,7 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<ClientMessage.PersistentSubscriptionNackEvents>(perSubscrQueue);
 		_mainBus.Subscribe<ClientMessage.ReplayParkedMessages>(perSubscrQueue);
 		_mainBus.Subscribe<ClientMessage.ReplayParkedMessage>(perSubscrQueue);
+		_mainBus.Subscribe<ClientMessage.TruncateParkedMessages>(perSubscrQueue);
 		_mainBus.Subscribe<ClientMessage.ReadNextNPersistentMessages>(perSubscrQueue);
 		_mainBus.Subscribe<StorageMessage.EventCommitted>(perSubscrQueue);
 		_mainBus.Subscribe<TelemetryMessage.Request>(perSubscrQueue);
@@ -1261,6 +1262,7 @@ public class ClusterVNode<TStreamId> :
 		perSubscrBus.Subscribe<ClientMessage.DeletePersistentSubscriptionToAll>(persistentSubscription);
 		perSubscrBus.Subscribe<ClientMessage.ReplayParkedMessages>(persistentSubscription);
 		perSubscrBus.Subscribe<ClientMessage.ReplayParkedMessage>(persistentSubscription);
+		perSubscrBus.Subscribe<ClientMessage.TruncateParkedMessages>(persistentSubscription);
 		perSubscrBus.Subscribe<ClientMessage.ReadNextNPersistentMessages>(persistentSubscription);
 		perSubscrBus.Subscribe<MonitoringMessage.GetAllPersistentSubscriptionStats>(persistentSubscription);
 		perSubscrBus.Subscribe<MonitoringMessage.GetStreamPersistentSubscriptionStats>(persistentSubscription);

--- a/src/KurrentDB.Core/Helpers/IODispatcher.cs
+++ b/src/KurrentDB.Core/Helpers/IODispatcher.cs
@@ -301,7 +301,8 @@ public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<
 		ClaimsPrincipal principal,
 		Action<ClientMessage.ReadStreamEventsBackwardCompleted> action,
 		Action timeoutAction,
-		Guid corrId) {
+		Guid corrId,
+		TimeSpan? timeout = null) {
 
 		var handler = new ReadStreamEventsBackwardHandlers.Tracking(
 			corrId,
@@ -323,10 +324,11 @@ public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<
 				false,
 				null,
 				principal,
-				replyOnExpired: false),
+				replyOnExpired: false,
+				expires: timeout is { } t ? DateTime.UtcNow.Add(t) : null),
 			handler);
 
-		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), BackwardReader, corrId);
+		Delay(timeout ?? TimeSpan.FromMilliseconds(ReadTimeoutMs), BackwardReader, corrId);
 		return corrId;
 	}
 
@@ -396,7 +398,8 @@ public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<
 		ClaimsPrincipal principal,
 		Action<ClientMessage.ReadStreamEventsForwardCompleted> action,
 		Action timeoutAction,
-		Guid corrId) {
+		Guid corrId,
+		TimeSpan? timeout = null) {
 		_requestTracker.AddPendingRead(corrId);
 
 		ForwardReader.Publish(
@@ -411,7 +414,8 @@ public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<
 				false,
 				null,
 				principal,
-				replyOnExpired: false),
+				replyOnExpired: false,
+				expires: timeout is { } t ? DateTime.UtcNow.Add(t) : null),
 			res => {
 				if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
 					action(res);
@@ -422,7 +426,7 @@ public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<
 					timeoutAction();
 				}
 			});
-		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), ForwardReader, corrId);
+		Delay(timeout ?? TimeSpan.FromMilliseconds(ReadTimeoutMs), ForwardReader, corrId);
 		return corrId;
 	}
 

--- a/src/KurrentDB.Core/Messages/ClientMessage.cs
+++ b/src/KurrentDB.Core/Messages/ClientMessage.cs
@@ -1632,6 +1632,41 @@ public static partial class ClientMessage {
 		}
 	}
 
+	[DerivedMessage(CoreMessage.Client)]
+	public partial class TruncateParkedMessages : ReadRequestMessage {
+		public readonly string EventStreamId;
+		public readonly string GroupName;
+		public readonly long? StopAt;
+
+		public TruncateParkedMessages(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
+			string eventStreamId, string groupName, long? stopAt, ClaimsPrincipal user, DateTime? expires = null)
+			: base(internalCorrId, correlationId, envelope, user, expires) {
+			EventStreamId = eventStreamId;
+			GroupName = groupName;
+			StopAt = stopAt;
+		}
+	}
+
+	[DerivedMessage(CoreMessage.Client)]
+	public partial class TruncateParkedMessagesCompleted : ReadResponseMessage {
+		public readonly Guid CorrelationId;
+		public readonly string Reason;
+		public readonly TruncateParkedMessagesCompletedResult Result;
+
+		public TruncateParkedMessagesCompleted(Guid correlationId, TruncateParkedMessagesCompletedResult result, string reason) {
+			CorrelationId = Ensure.NotEmptyGuid(correlationId);
+			Result = result;
+			Reason = reason;
+		}
+
+		public enum TruncateParkedMessagesCompletedResult {
+			Success = 0,
+			DoesNotExist = 1,
+			Fail = 2,
+			AccessDenied = 3
+		}
+	}
+
 	//End of persistence subscriptions
 
 	[DerivedMessage(CoreMessage.Client)]

--- a/src/KurrentDB.Core/Messages/MonitoringMessage.cs
+++ b/src/KurrentDB.Core/Messages/MonitoringMessage.cs
@@ -135,6 +135,7 @@ public static partial class MonitoringMessage {
 		public long ParkedDueToClientNak { get; set; }
 		public long ParkedDueToMaxRetries { get; set; }
 		public long ParkedMessageReplays { get; set; }
+		public long ParkedMessageTruncations { get; set; }
 		public long OldestParkedMessage { get; set; }
 	}
 

--- a/src/KurrentDB.Core/Metrics/PersistentSubscriptionTracker.cs
+++ b/src/KurrentDB.Core/Metrics/PersistentSubscriptionTracker.cs
@@ -51,6 +51,13 @@ public class PersistentSubscriptionTracker : IPersistentSubscriptionTracker {
 				new("group_name", x.GroupName)
 			]));
 
+	public IEnumerable<Measurement<long>> ObserveParkedMessageTruncations() =>
+		_currentStats.Select(x =>
+			new Measurement<long>(x.ParkedMessageTruncations, [
+				new("event_stream_id", x.EventSource),
+				new("group_name", x.GroupName)
+			]));
+
 	public IEnumerable<Measurement<long>> ObserveInFlightMessages() =>
 		_currentStats.Select(x =>
 			new Measurement<long>(x.TotalInFlightMessages, [

--- a/src/KurrentDB.Core/MetricsBootstrapper.cs
+++ b/src/KurrentDB.Core/MetricsBootstrapper.cs
@@ -181,6 +181,7 @@ public static class MetricsBootstrapper {
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-last-known-event-commit-position", tracker.ObserveLastKnownEventCommitPosition);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-park-message-requests", tracker.ObserveParkMessageRequests);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-parked-message-replays", tracker.ObserveParkedMessageReplays);
+			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-parked-message-truncations", tracker.ObserveParkedMessageTruncations);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-checkpointed-event-number", tracker.ObserveLastCheckpointedEvent);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-checkpointed-event-commit-position", tracker.ObserveLastCheckpointedEventCommitPosition);
 

--- a/src/KurrentDB.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -12,12 +12,15 @@ public interface IPersistentSubscriptionMessageParker {
 	void BeginReadEndSequence(Action<long?> completed);
 	void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? oldestParkedMessageTimestamp, bool updateOldestParkedMessage);
 	void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed);
+	void NotifyReplay();
+	void NotifyTruncate();
 	long ParkedMessageCount { get; }
 	public void BeginLoadStats(Action completed);
 	DateTime? GetOldestParkedMessage { get; }
 	long ParkedDueToClientNak { get; }
 	long ParkedDueToMaxRetries { get; }
 	long ParkedMessageReplays { get; }
+	long ParkedMessageTruncations { get; }
 }
 
 public enum ParkReason {

--- a/src/KurrentDB.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -10,7 +10,7 @@ namespace KurrentDB.Core.Services.PersistentSubscription;
 public interface IPersistentSubscriptionMessageParker {
 	void BeginParkMessage(ResolvedEvent ev, string reason, ParkReason parkReason, Action<ResolvedEvent, OperationResult> completed);
 	void BeginReadEndSequence(Action<long?> completed);
-	void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? oldestParkedMessageTimestamp, bool updateOldestParkedMessage);
+	void BeginMarkParkedMessagesReprocessed(long sequence, Action completed = null);
 	void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed);
 	void NotifyReplay();
 	void NotifyTruncate();

--- a/src/KurrentDB.Core/Services/PersistentSubscription/ParkedMessageOperationResult.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/ParkedMessageOperationResult.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace KurrentDB.Core.Services.PersistentSubscription;
+
+// Outcome of a request to replay or truncate parked messages.
+public enum ParkedMessageOperationResult {
+	// Rejected because the subscription has not finished initializing.
+	NotReady,
+
+	// The operation was accepted and started.
+	Started,
+
+	// Rejected because a replay or truncate is already in progress.
+	AlreadyInProgress,
+}

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -558,39 +558,47 @@ public class PersistentSubscription {
 	}
 
 
-	public void RetryParkedMessages(long? stopAt) {
+	public ParkedMessageOperationResult RetryParkedMessages(long? stopAt) {
 		lock (_lock) {
 			if (_state == PersistentSubscriptionState.NotReady)
-				return;
+				return ParkedMessageOperationResult.NotReady;
 			if ((_state & PersistentSubscriptionState.ReplayingParkedMessages) > 0)
-				return; //already replaying
+				return ParkedMessageOperationResult.AlreadyInProgress;
 			_state |= PersistentSubscriptionState.ReplayingParkedMessages;
 			_settings.MessageParker.NotifyReplay();
 			_settings.MessageParker.BeginReadEndSequence(end => {
 				if (!end.HasValue) {
-					_state ^= PersistentSubscriptionState.ReplayingParkedMessages;
+					_state &= ~PersistentSubscriptionState.ReplayingParkedMessages;
 					return; //nothing to do.
 				}
 
 				var stopRead = stopAt.HasValue ? Math.Min(stopAt.Value, end.Value + 1) : end.Value + 1;
 				TryReadingParkedMessagesFrom(0, stopRead);
 			});
+			return ParkedMessageOperationResult.Started;
 		}
 	}
 
-	public void TruncateParkedMessages(long? stopAt) {
+	public ParkedMessageOperationResult TruncateParkedMessages(long? stopAt) {
 		lock (_lock) {
 			if (_state == PersistentSubscriptionState.NotReady)
-				return;
-
+				return ParkedMessageOperationResult.NotReady;
+			if ((_state & PersistentSubscriptionState.ReplayingParkedMessages) > 0)
+				return ParkedMessageOperationResult.AlreadyInProgress;
+			_state |= PersistentSubscriptionState.ReplayingParkedMessages;
 			_settings.MessageParker.NotifyTruncate();
 			_settings.MessageParker.BeginReadEndSequence(end => {
-				if (!end.HasValue)
+				if (!end.HasValue) {
+					_state &= ~PersistentSubscriptionState.ReplayingParkedMessages;
 					return;
+				}
 
 				var truncateBefore = stopAt.HasValue ? Math.Min(stopAt.Value, end.Value + 1) : end.Value + 1;
-				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(truncateBefore);
+				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(
+					sequence: truncateBefore,
+					completed: () => _state &= ~PersistentSubscriptionState.ReplayingParkedMessages);
 			});
+			return ParkedMessageOperationResult.Started;
 		}
 	}
 
@@ -645,9 +653,9 @@ public class PersistentSubscription {
 			if (isEndofStream || stopAt <= newStreamPosition.StreamEventNumber) {
 				var replayedEnd = newStreamPosition.StreamEventNumber == -1 ? stopAt : Math.Min(stopAt, newStreamPosition.StreamEventNumber);
 
-				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd);
-
-				_state ^= PersistentSubscriptionState.ReplayingParkedMessages;
+				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(
+					replayedEnd,
+					() => _state &= ~PersistentSubscriptionState.ReplayingParkedMessages);
 			} else {
 				TryReadingParkedMessagesFrom(newStreamPosition.StreamEventNumber, stopAt);
 			}

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -565,6 +565,7 @@ public class PersistentSubscription {
 			if ((_state & PersistentSubscriptionState.ReplayingParkedMessages) > 0)
 				return; //already replaying
 			_state |= PersistentSubscriptionState.ReplayingParkedMessages;
+			_settings.MessageParker.NotifyReplay();
 			_settings.MessageParker.BeginReadEndSequence(end => {
 				if (!end.HasValue) {
 					_state ^= PersistentSubscriptionState.ReplayingParkedMessages;
@@ -582,6 +583,7 @@ public class PersistentSubscription {
 			if (_state == PersistentSubscriptionState.NotReady)
 				return;
 
+			_settings.MessageParker.NotifyTruncate();
 			_settings.MessageParker.BeginReadEndSequence(end => {
 				if (!end.HasValue)
 					return;

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -589,7 +589,7 @@ public class PersistentSubscription {
 					return;
 
 				var truncateBefore = stopAt.HasValue ? Math.Min(stopAt.Value, end.Value + 1) : end.Value + 1;
-				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(truncateBefore, null, updateOldestParkedMessage: true);
+				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(truncateBefore);
 			});
 		}
 	}
@@ -645,28 +645,13 @@ public class PersistentSubscription {
 			if (isEndofStream || stopAt <= newStreamPosition.StreamEventNumber) {
 				var replayedEnd = newStreamPosition.StreamEventNumber == -1 ? stopAt : Math.Min(stopAt, newStreamPosition.StreamEventNumber);
 
-				if (isEndofStream) {
-					_settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd, null, updateOldestParkedMessage: true);
-				} else {
-					var (replayedEndTimeStamp, updateOldestParkedMessageTimeStamp) = GetOldestParkedMessageTimeStamp(events, replayedEnd);
-					_settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd, replayedEndTimeStamp, updateOldestParkedMessageTimeStamp);
-				}
+				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd);
 
 				_state ^= PersistentSubscriptionState.ReplayingParkedMessages;
 			} else {
 				TryReadingParkedMessagesFrom(newStreamPosition.StreamEventNumber, stopAt);
 			}
 		}
-	}
-
-	private static (DateTime?, bool) GetOldestParkedMessageTimeStamp(IReadOnlyList<ResolvedEvent> events, long replayedEnd) {
-		foreach (var resolvedEvent in events) {
-			if (resolvedEvent.OriginalEvent.EventNumber != replayedEnd)
-				continue;
-			return (resolvedEvent.OriginalEvent.TimeStamp, true);
-		}
-
-		return (null, false);
 	}
 
 	private void StartMessage(OutstandingMessage message, DateTime expires) {

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -577,6 +577,21 @@ public class PersistentSubscription {
 		}
 	}
 
+	public void TruncateParkedMessages(long? stopAt) {
+		lock (_lock) {
+			if (_state == PersistentSubscriptionState.NotReady)
+				return;
+
+			_settings.MessageParker.BeginReadEndSequence(end => {
+				if (!end.HasValue)
+					return;
+
+				var truncateBefore = stopAt.HasValue ? Math.Min(stopAt.Value, end.Value + 1) : end.Value + 1;
+				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(truncateBefore, null, true);
+			});
+		}
+	}
+
 	private void TryReadingParkedMessagesFrom(long position, long stopAt) {
 		if ((_state & PersistentSubscriptionState.ReplayingParkedMessages) == 0)
 			return; //not replaying

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -587,7 +587,7 @@ public class PersistentSubscription {
 					return;
 
 				var truncateBefore = stopAt.HasValue ? Math.Min(stopAt.Value, end.Value + 1) : end.Value + 1;
-				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(truncateBefore, null, true);
+				_settings.MessageParker.BeginMarkParkedMessagesReprocessed(truncateBefore, null, updateOldestParkedMessage: true);
 			});
 		}
 	}
@@ -644,7 +644,7 @@ public class PersistentSubscription {
 				var replayedEnd = newStreamPosition.StreamEventNumber == -1 ? stopAt : Math.Min(stopAt, newStreamPosition.StreamEventNumber);
 
 				if (isEndofStream) {
-					_settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd, null, true);
+					_settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd, null, updateOldestParkedMessage: true);
 				} else {
 					var (replayedEndTimeStamp, updateOldestParkedMessageTimeStamp) = GetOldestParkedMessageTimeStamp(events, replayedEnd);
 					_settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd, replayedEndTimeStamp, updateOldestParkedMessageTimeStamp);

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -253,29 +253,24 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 			}, Guid.NewGuid());
 	}
 
-	public void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? timestamp, bool updateOldestParkedMessage) {
-		BeginMarkParkedMessagesReprocessed(sequence, timestamp, updateOldestParkedMessage, null);
-	}
-
-	public void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? timestamp, bool updateOldestParkedMessage, Action completed) {
+	// updates the truncateBefore for the parked stream
+	public void BeginMarkParkedMessagesReprocessed(long sequence, Action completed = null) {
 		var metaStreamId = SystemStreams.MetastreamOf(ParkedStreamId);
 		_ioDispatcher.WriteEvent(
 			metaStreamId, ExpectedVersion.Any, CreateStreamMetadataEvent(sequence), SystemAccounts.System,
 			msg => {
 				switch (msg.Result) {
 					case OperationResult.Success:
-						_lastTruncateBefore = sequence;
-						if (updateOldestParkedMessage)
-							_oldestParkedMessage = timestamp;
-						completed?.Invoke();
 						break;
 					default:
 						Log.Error("An error occured truncating the parked message stream {stream} due to {e}.",
 							ParkedStreamId, msg.Result);
 						Log.Error("Messages were not removed on retry");
-						completed?.Invoke();
 						break;
 				}
+
+				// we've updated the tb, update the first/last parked message numbers/timestamps
+				BeginLoadStats(completed ?? Empty.Action);
 			});
 	}
 

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -35,6 +35,11 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	public long ParkedMessageReplays => Interlocked.Read(ref _parkedMessageReplays);
 	public long ParkedMessageTruncations => Interlocked.Read(ref _parkedMessageTruncations);
 
+	// The stats reads are best-effort and only feed ParkedMessageCount/oldest-timestamp. A timeout that
+	// fires would produce degraded stats, so we use a long one it should never hit in practice, while
+	// still guaranteeing the read completes (rather than stalling) if a response is ever truly lost.
+	private static readonly TimeSpan StatsReadTimeout = TimeSpan.FromMinutes(5);
+
 	private static readonly ILogger Log = Serilog.Log.ForContext<PersistentSubscriptionMessageParker>();
 
 	public PersistentSubscriptionMessageParker(string subscriptionId, IODispatcher ioDispatcher) {
@@ -157,7 +162,8 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 				Log.Error($"Timed out reading truncate-before for the parked message stream {ParkedStreamId}. Parked message stats may be incorrect.");
 				completed?.Invoke(null);
 			},
-			corrId: Guid.NewGuid());
+			corrId: Guid.NewGuid(),
+			timeout: StatsReadTimeout);
 	}
 
 	public void BeginReadEndSequence(Action<long?> completed) {
@@ -171,6 +177,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 						completed?.Invoke(comp.LastEventNumber);
 						break;
 					case ReadStreamResult.NoStream:
+					case ReadStreamResult.StreamDeleted:
 						completed?.Invoke(null);
 						break;
 					default:
@@ -179,7 +186,8 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 							ParkedStreamId, comp.Result);
 						break;
 				}
-			});
+			},
+			expires: ClientMessage.ReadRequestMessage.NeverExpires);
 	}
 
 	// for parked message stats
@@ -216,7 +224,8 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 					$"Timed out reading the first event in the parked message stream {ParkedStreamId}. Parked message stats may be incorrect.");
 				completed?.Invoke(null, null);
 			},
-			corrId: Guid.NewGuid());
+			corrId: Guid.NewGuid(),
+			timeout: StatsReadTimeout);
 	}
 
 	// for parked message stats
@@ -253,7 +262,8 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 					$"Timed out reading the last event in the parked message stream {ParkedStreamId}. Parked message stats may be incorrect.");
 				completed?.Invoke(null);
 			},
-			corrId: Guid.NewGuid());
+			corrId: Guid.NewGuid(),
+			timeout: StatsReadTimeout);
 	}
 
 	// updates the truncateBefore for the parked stream
@@ -261,6 +271,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 		var metaStreamId = SystemStreams.MetastreamOf(ParkedStreamId);
 		_ioDispatcher.WriteEvent(
 			metaStreamId, ExpectedVersion.Any, CreateStreamMetadataEvent(sequence), SystemAccounts.System,
+			// this callback is guaranteed to be called (writes get replies on timeout)
 			msg => {
 				switch (msg.Result) {
 					case OperationResult.Success:

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -134,6 +134,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 		});
 	}
 
+	// for parked message stats
 	private void BeginReadTruncateBefore(Action<long?> completed) {
 		_ioDispatcher.ReadBackward(
 			streamId: SystemStreams.MetastreamOf(ParkedStreamId),
@@ -209,11 +210,13 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 						completed?.Invoke(null, null);
 						break;
 				}
-			}, () => {
+			},
+			timeoutAction: () => {
 				Log.Error(
 					$"Timed out reading the first event in the parked message stream {ParkedStreamId}. Parked message stats may be incorrect.");
 				completed?.Invoke(null, null);
-			}, Guid.NewGuid());
+			},
+			corrId: Guid.NewGuid());
 	}
 
 	// for parked message stats
@@ -244,11 +247,13 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 						completed?.Invoke(null);
 						break;
 				}
-			}, () => {
+			},
+			timeoutAction: () => {
 				Log.Error(
 					$"Timed out reading the last event in the parked message stream {ParkedStreamId}. Parked message stats may be incorrect.");
 				completed?.Invoke(null);
-			}, Guid.NewGuid());
+			},
+			corrId: Guid.NewGuid());
 	}
 
 	// updates the truncateBefore for the parked stream

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -25,13 +25,12 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	private long _parkedMessageReplays;
 	private long _parkedMessageTruncations;
 
-	public long ParkedMessageCount {
-		get {
-			return _lastParkedEventNumber == -1 ? 0 :
-				_lastTruncateBefore == -1 ? _lastParkedEventNumber + 1 :
-				_lastParkedEventNumber - _lastTruncateBefore + 1;
-		}
-	}
+	public long ParkedMessageCount =>
+		_lastParkedEventNumber == -1
+			? 0
+			: _lastTruncateBefore == -1
+				? _lastParkedEventNumber + 1
+				: _lastParkedEventNumber - _lastTruncateBefore + 1;
 
 	public long ParkedDueToClientNak => Interlocked.Read(ref _parkedDueToClientNak);
 	public long ParkedDueToMaxRetries => Interlocked.Read(ref _parkedDueToMaxRetries);
@@ -116,16 +115,50 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	}
 
 	private void BeginReadParkedMessageStats(Action completed) {
-		BeginReadLastEvent(lastEventNumber => {
-			if (lastEventNumber is null)
-				completed();
-			BeginReadFirstEvent(0, (firstEventNumber, oldestParkedMessageTimeStamp) => {
-				_lastTruncateBefore = firstEventNumber ?? -1;
-				_lastParkedEventNumber = lastEventNumber ?? -1;
-				_oldestParkedMessage = oldestParkedMessageTimeStamp;
-				completed?.Invoke();
+		BeginReadTruncateBefore(truncateBefore => {
+			BeginReadLastEvent(lastEventNumber => {
+				if (lastEventNumber is null) {
+					// parked stream is empty
+					_lastTruncateBefore = truncateBefore ?? -1;
+					_lastParkedEventNumber = -1;
+					_oldestParkedMessage = null;
+					completed?.Invoke();
+					return;
+				}
+
+				BeginReadFirstEvent(0, (firstEventNumber, oldestParkedMessageTimeStamp) => {
+					_lastTruncateBefore = firstEventNumber ?? truncateBefore ?? -1;
+					_lastParkedEventNumber = lastEventNumber ?? -1;
+					_oldestParkedMessage = oldestParkedMessageTimeStamp;
+					completed?.Invoke();
+				});
 			});
 		});
+	}
+
+	private void BeginReadTruncateBefore(Action<long?> completed) {
+		_ioDispatcher.ReadBackward(
+			streamId: SystemStreams.MetastreamOf(ParkedStreamId),
+			fromEventNumber: -1,
+			maxCount: 1,
+			resolveLinks: false,
+			principal: SystemAccounts.System,
+			action: comp => {
+				switch (comp.Result) {
+					case ReadStreamResult.Success when comp.Events.Any():
+						var metadata = StreamMetadata.FromJsonBytes(comp.Events[0].Event.Data);
+						completed?.Invoke(metadata.TruncateBefore);
+						break;
+					default:
+						completed?.Invoke(null);
+						break;
+				}
+			},
+			timeoutAction: () => {
+				Log.Error($"Timed out reading truncate-before for the parked message stream {ParkedStreamId}. Parked message stats may be incorrect.");
+				completed?.Invoke(null);
+			},
+			corrId: Guid.NewGuid());
 	}
 
 	public void BeginReadEndSequence(Action<long?> completed) {
@@ -150,6 +183,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 			});
 	}
 
+	// for parked message stats
 	private void BeginReadFirstEvent(long fromEventNumber, Action<long?, DateTime?> completed) {
 		_ioDispatcher.ReadForward(
 			ParkedStreamId,
@@ -184,6 +218,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 			}, Guid.NewGuid());
 	}
 
+	// for parked message stats
 	private void BeginReadLastEvent(Action<long?> completed) {
 		_ioDispatcher.ReadBackward(
 			ParkedStreamId,

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -273,8 +273,17 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	// updates the truncateBefore for the parked stream
 	public void BeginMarkParkedMessagesReprocessed(long sequence, Action completed = null) {
 		var metaStreamId = SystemStreams.MetastreamOf(ParkedStreamId);
+		// The truncate-before only ever advances, so replaying/truncating to an already-passed point
+		// never resurrects previously removed parked messages.
+		var truncateBefore = Math.Max(_lastTruncateBefore, sequence);
+		if (truncateBefore == _lastTruncateBefore) {
+			// nothing would change: skip the redundant metastream write (and the stats reload it triggers).
+			completed?.Invoke();
+			return;
+		}
+
 		_ioDispatcher.WriteEvent(
-			metaStreamId, ExpectedVersion.Any, CreateStreamMetadataEvent(sequence), SystemAccounts.System,
+			metaStreamId, ExpectedVersion.Any, CreateStreamMetadataEvent(truncateBefore), SystemAccounts.System,
 			// this callback is guaranteed to be called (writes get replies on timeout)
 			msg => {
 				switch (msg.Result) {

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -23,6 +23,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	private long _parkedDueToClientNak;
 	private long _parkedDueToMaxRetries;
 	private long _parkedMessageReplays;
+	private long _parkedMessageTruncations;
 
 	public long ParkedMessageCount {
 		get {
@@ -35,6 +36,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	public long ParkedDueToClientNak => Interlocked.Read(ref _parkedDueToClientNak);
 	public long ParkedDueToMaxRetries => Interlocked.Read(ref _parkedDueToMaxRetries);
 	public long ParkedMessageReplays => Interlocked.Read(ref _parkedMessageReplays);
+	public long ParkedMessageTruncations => Interlocked.Read(ref _parkedMessageTruncations);
 
 	private static readonly ILogger Log = Serilog.Log.ForContext<PersistentSubscriptionMessageParker>();
 
@@ -127,8 +129,6 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	}
 
 	public void BeginReadEndSequence(Action<long?> completed) {
-		Interlocked.Increment(ref _parkedMessageReplays);
-
 		_ioDispatcher.ReadBackward(ParkedStreamId,
 			long.MaxValue,
 			1,
@@ -145,7 +145,6 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 						Log.Error(
 							"An error occured reading the last event in the parked message stream {stream} due to {e}.",
 							ParkedStreamId, comp.Result);
-						Log.Error("Messages were not removed on retry");
 						break;
 				}
 			});
@@ -243,6 +242,14 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 						break;
 				}
 			});
+	}
+
+	public void NotifyReplay() {
+		Interlocked.Increment(ref _parkedMessageReplays);
+	}
+
+	public void NotifyTruncate() {
+		Interlocked.Increment(ref _parkedMessageTruncations);
 	}
 
 	class ParkedMessageMetadata {

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -17,7 +17,7 @@ namespace KurrentDB.Core.Services.PersistentSubscription;
 public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessageParker {
 	private readonly IODispatcher _ioDispatcher;
 	public readonly string ParkedStreamId;
-	private long _lastTruncateBefore = -1;
+	private long _lastTruncateBefore = 0;
 	private long _lastParkedEventNumber = -1;
 	private DateTime? _oldestParkedMessage;
 	private long _parkedDueToClientNak;
@@ -28,9 +28,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	public long ParkedMessageCount =>
 		_lastParkedEventNumber == -1
 			? 0
-			: _lastTruncateBefore == -1
-				? _lastParkedEventNumber + 1
-				: _lastParkedEventNumber - _lastTruncateBefore + 1;
+			: _lastParkedEventNumber - _lastTruncateBefore + 1;
 
 	public long ParkedDueToClientNak => Interlocked.Read(ref _parkedDueToClientNak);
 	public long ParkedDueToMaxRetries => Interlocked.Read(ref _parkedDueToMaxRetries);
@@ -119,7 +117,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 			BeginReadLastEvent(lastEventNumber => {
 				if (lastEventNumber is null) {
 					// parked stream is empty
-					_lastTruncateBefore = truncateBefore ?? -1;
+					_lastTruncateBefore = truncateBefore ?? 0;
 					_lastParkedEventNumber = -1;
 					_oldestParkedMessage = null;
 					completed?.Invoke();
@@ -127,7 +125,7 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 				}
 
 				BeginReadFirstEvent(0, (firstEventNumber, oldestParkedMessageTimeStamp) => {
-					_lastTruncateBefore = firstEventNumber ?? truncateBefore ?? -1;
+					_lastTruncateBefore = firstEventNumber ?? truncateBefore ?? 0;
 					_lastParkedEventNumber = lastEventNumber ?? -1;
 					_oldestParkedMessage = oldestParkedMessageTimeStamp;
 					completed?.Invoke();

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -184,6 +184,10 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 						Log.Error(
 							"An error occured reading the last event in the parked message stream {stream} due to {e}.",
 							ParkedStreamId, comp.Result);
+						// Treat an unexpected read error as "nothing to do" rather than leaving the caller
+						// hanging: the operation is abandoned (logged above) and its mutual-exclusion flag
+						// released, instead of wedging all future replays/truncates on this subscription.
+						completed?.Invoke(null);
 						break;
 				}
 			},

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1167,7 +1167,17 @@ public class PersistentSubscriptionService<TStreamId> :
 			return;
 		}
 
-		subscription.RetryParkedMessages(message.StopAt);
+		switch (subscription.RetryParkedMessages(message.StopAt)) {
+			case ParkedMessageOperationResult.NotReady:
+				ReplyWithNotReady(message.Envelope, message.CorrelationId);
+				return;
+			case ParkedMessageOperationResult.AlreadyInProgress:
+				message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
+					ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Fail,
+					"A replay or truncate is already in progress."));
+				return;
+		}
+
 		message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
 			ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success, ""));
 	}
@@ -1209,7 +1219,17 @@ public class PersistentSubscriptionService<TStreamId> :
 			return;
 		}
 
-		subscription.TruncateParkedMessages(message.StopAt);
+		switch (subscription.TruncateParkedMessages(message.StopAt)) {
+			case ParkedMessageOperationResult.NotReady:
+				ReplyWithNotReady(message.Envelope, message.CorrelationId);
+				return;
+			case ParkedMessageOperationResult.AlreadyInProgress:
+				message.Envelope.ReplyWith(new ClientMessage.TruncateParkedMessagesCompleted(message.CorrelationId,
+					ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Fail,
+					"A replay or truncate is already in progress."));
+				return;
+		}
+
 		message.Envelope.ReplyWith(new ClientMessage.TruncateParkedMessagesCompleted(message.CorrelationId,
 			ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Success, ""));
 	}

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1146,6 +1146,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.ReplayParkedMessages message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		PersistentSubscription subscription;
 		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
 		Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}. Requested by {user}",
@@ -1183,6 +1188,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.ReplayParkedMessage message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
 		PersistentSubscription subscription;
 
@@ -1199,6 +1209,11 @@ public class PersistentSubscriptionService<TStreamId> :
 	}
 
 	public void Handle(ClientMessage.TruncateParkedMessages message) {
+		if (!_started) {
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
 		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
 		Log.Debug("Truncating parked messages for persistent subscription {subscriptionKey} {to}. Requested by {user}",
 			key,

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -38,6 +38,7 @@ public class PersistentSubscriptionService<TStreamId> :
 	IHandle<SubscriptionMessage.PersistentSubscriptionPushToClients>,
 	IHandle<ClientMessage.ReplayParkedMessages>,
 	IHandle<ClientMessage.ReplayParkedMessage>,
+	IHandle<ClientMessage.TruncateParkedMessages>,
 	IHandle<SystemMessage.StateChangeMessage>,
 	IAsyncHandle<ClientMessage.ConnectToPersistentSubscriptionToStream>,
 	IAsyncHandle<ClientMessage.ConnectToPersistentSubscriptionToAll>,
@@ -1185,6 +1186,32 @@ public class PersistentSubscriptionService<TStreamId> :
 		subscription.RetrySingleParkedMessage(message.Event);
 		message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
 			ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success, ""));
+	}
+
+	public void Handle(ClientMessage.TruncateParkedMessages message) {
+		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
+		Log.Debug("Truncating parked messages for persistent subscription {subscriptionKey} {to}. Requested by {user}",
+			key,
+			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)",
+			message.User?.Identity?.Name);
+
+		if (message.StopAt.HasValue && message.StopAt.Value < 0) {
+			message.Envelope.ReplyWith(new ClientMessage.TruncateParkedMessagesCompleted(message.CorrelationId,
+				ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Fail,
+				"Cannot truncate parked messages at a negative version."));
+			return;
+		}
+
+		if (!_subscriptionsById.TryGetValue(key, out var subscription)) {
+			message.Envelope.ReplyWith(new ClientMessage.TruncateParkedMessagesCompleted(message.CorrelationId,
+				ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.DoesNotExist,
+				"Unable to locate '" + key + "'"));
+			return;
+		}
+
+		subscription.TruncateParkedMessages(message.StopAt);
+		message.Envelope.ReplyWith(new ClientMessage.TruncateParkedMessagesCompleted(message.CorrelationId,
+			ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Success, ""));
 	}
 
 	private void LoadConfiguration(Action continueWith) {

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -120,6 +120,7 @@ public class PersistentSubscriptionStats {
 			ParkedDueToClientNak = _settings.MessageParker.ParkedDueToClientNak,
 			ParkedDueToMaxRetries = _settings.MessageParker.ParkedDueToMaxRetries,
 			ParkedMessageReplays = _settings.MessageParker.ParkedMessageReplays,
+			ParkedMessageTruncations = _settings.MessageParker.ParkedMessageTruncations,
 			OldestParkedMessage = oldestParkedMessage
 		};
 	}

--- a/src/KurrentDB.Core/Services/Transport/Grpc/PersistentSubscriptions.ReplayParked.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/PersistentSubscriptions.ReplayParked.cs
@@ -17,9 +17,7 @@ internal partial class PersistentSubscriptions {
 	private static readonly Operation ReplayParkedOperation = new(Plugins.Authorization.Operations.Subscriptions.ReplayParked);
 
 	public override async Task<ReplayParkedResp> ReplayParked(ReplayParkedReq request, ServerCallContext context) {
-		var replayParkedMessagesSource = new TaskCompletionSource<ReplayParkedResp>();
 		var correlationId = Guid.NewGuid();
-
 		var user = context.GetHttpContext().User;
 
 		if (!await _authorizationProvider.CheckAccessAsync(user, ReplayParkedOperation, context.CancellationToken)) {
@@ -38,46 +36,28 @@ internal partial class PersistentSubscriptions {
 			_ => throw new InvalidOperationException()
 		};
 
+		var envelope = new TcsEnvelope<Message>();
 		_publisher.Publish(new ClientMessage.ReplayParkedMessages(
 			correlationId,
 			correlationId,
-			new CallbackEnvelope(HandleReplayParkedMessagesCompleted),
+			envelope,
 			streamId,
 			request.Options.GroupName,
 			stopAt,
 			user));
-		return await replayParkedMessagesSource.Task;
 
-		void HandleReplayParkedMessagesCompleted(Message message) {
-			switch (message) {
-				case ClientMessage.NotHandled notHandled when TryHandleNotHandled(notHandled, out var ex):
-					replayParkedMessagesSource.TrySetException(ex);
-					return;
-				case ClientMessage.ReplayMessagesReceived completed:
-					switch (completed.Result) {
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success:
-							replayParkedMessagesSource.TrySetResult(new ReplayParkedResp());
-							return;
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist:
-							replayParkedMessagesSource.TrySetException(
-								PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
-							return;
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied:
-							replayParkedMessagesSource.TrySetException(AccessDenied());
-							return;
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Fail:
-							replayParkedMessagesSource.TrySetException(
-								PersistentSubscriptionFailed(streamId, request.Options.GroupName, completed.Reason));
-							return;
-
-						default:
-							replayParkedMessagesSource.TrySetException(UnknownError(completed.Result));
-							return;
-					}
-				default:
-					replayParkedMessagesSource.TrySetException(UnknownMessage<ClientMessage.ReplayMessagesReceived>(message));
-					break;
-			}
-		}
+		return await envelope.Task switch {
+			ClientMessage.NotHandled notHandled when TryHandleNotHandled(notHandled, out var ex) => throw ex,
+			ClientMessage.ReplayMessagesReceived { Result: ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success } =>
+				new ReplayParkedResp(),
+			ClientMessage.ReplayMessagesReceived { Result: ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist } =>
+				throw PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName),
+			ClientMessage.ReplayMessagesReceived { Result: ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied } =>
+				throw AccessDenied(),
+			ClientMessage.ReplayMessagesReceived completed =>
+				throw PersistentSubscriptionFailed(streamId, request.Options.GroupName, completed.Reason),
+			var message =>
+				throw UnknownMessage<ClientMessage.ReplayMessagesReceived>(message)
+		};
 	}
 }

--- a/src/KurrentDB.Core/Services/Transport/Grpc/PersistentSubscriptions.TruncateParked.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/PersistentSubscriptions.TruncateParked.cs
@@ -14,7 +14,7 @@ using static KurrentDB.Core.Services.Transport.Grpc.RpcExceptions;
 namespace EventStore.Core.Services.Transport.Grpc;
 
 internal partial class PersistentSubscriptions {
-	private static readonly Operation TruncateParkedOperation = new(Plugins.Authorization.Operations.Subscriptions.ReplayParked);
+	private static readonly Operation TruncateParkedOperation = new(Plugins.Authorization.Operations.Subscriptions.TruncateParked);
 
 	public override async Task<TruncateParkedResp> TruncateParked(TruncateParkedReq request, ServerCallContext context) {
 		var correlationId = Guid.NewGuid();

--- a/src/KurrentDB.Core/Services/Transport/Grpc/PersistentSubscriptions.TruncateParked.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/PersistentSubscriptions.TruncateParked.cs
@@ -17,9 +17,7 @@ internal partial class PersistentSubscriptions {
 	private static readonly Operation TruncateParkedOperation = new(Plugins.Authorization.Operations.Subscriptions.ReplayParked);
 
 	public override async Task<TruncateParkedResp> TruncateParked(TruncateParkedReq request, ServerCallContext context) {
-		var truncateParkedSource = new TaskCompletionSource<TruncateParkedResp>(TaskCreationOptions.RunContinuationsAsynchronously);
 		var correlationId = Guid.NewGuid();
-
 		var user = context.GetHttpContext().User;
 
 		if (!await _authorizationProvider.CheckAccessAsync(user, TruncateParkedOperation, context.CancellationToken)) {
@@ -38,46 +36,28 @@ internal partial class PersistentSubscriptions {
 			_ => throw new InvalidOperationException()
 		};
 
+		var envelope = new TcsEnvelope<Message>();
 		_publisher.Publish(new ClientMessage.TruncateParkedMessages(
 			correlationId,
 			correlationId,
-			new CallbackEnvelope(HandleTruncateParkedCompleted),
+			envelope,
 			streamId,
 			request.Options.GroupName,
 			stopAt,
 			user));
-		return await truncateParkedSource.Task;
 
-		void HandleTruncateParkedCompleted(Message message) {
-			switch (message) {
-				case ClientMessage.NotHandled notHandled when TryHandleNotHandled(notHandled, out var ex):
-					truncateParkedSource.TrySetException(ex);
-					return;
-				case ClientMessage.TruncateParkedMessagesCompleted completed:
-					switch (completed.Result) {
-						case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Success:
-							truncateParkedSource.TrySetResult(new TruncateParkedResp());
-							return;
-						case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.DoesNotExist:
-							truncateParkedSource.TrySetException(
-								PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
-							return;
-						case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.AccessDenied:
-							truncateParkedSource.TrySetException(AccessDenied());
-							return;
-						case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Fail:
-							truncateParkedSource.TrySetException(
-								PersistentSubscriptionFailed(streamId, request.Options.GroupName, completed.Reason));
-							return;
-
-						default:
-							truncateParkedSource.TrySetException(UnknownError(completed.Result));
-							return;
-					}
-				default:
-					truncateParkedSource.TrySetException(UnknownMessage<ClientMessage.TruncateParkedMessagesCompleted>(message));
-					break;
-			}
-		}
+		return await envelope.Task switch {
+			ClientMessage.NotHandled notHandled when TryHandleNotHandled(notHandled, out var ex) => throw ex,
+			ClientMessage.TruncateParkedMessagesCompleted { Result: ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Success } =>
+				new TruncateParkedResp(),
+			ClientMessage.TruncateParkedMessagesCompleted { Result: ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.DoesNotExist } =>
+				throw PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName),
+			ClientMessage.TruncateParkedMessagesCompleted { Result: ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.AccessDenied } =>
+				throw AccessDenied(),
+			ClientMessage.TruncateParkedMessagesCompleted completed =>
+				throw PersistentSubscriptionFailed(streamId, request.Options.GroupName, completed.Reason),
+			var message =>
+				throw UnknownMessage<ClientMessage.TruncateParkedMessagesCompleted>(message)
+		};
 	}
 }

--- a/src/KurrentDB.Core/Services/Transport/Grpc/PersistentSubscriptions.TruncateParked.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/PersistentSubscriptions.TruncateParked.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading.Tasks;
+using EventStore.Client.PersistentSubscriptions;
+using EventStore.Plugins.Authorization;
+using Grpc.Core;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using static KurrentDB.Core.Services.Transport.Grpc.RpcExceptions;
+
+// ReSharper disable once CheckNamespace
+namespace EventStore.Core.Services.Transport.Grpc;
+
+internal partial class PersistentSubscriptions {
+	private static readonly Operation TruncateParkedOperation = new(Plugins.Authorization.Operations.Subscriptions.ReplayParked);
+
+	public override async Task<TruncateParkedResp> TruncateParked(TruncateParkedReq request, ServerCallContext context) {
+		var truncateParkedSource = new TaskCompletionSource<TruncateParkedResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var correlationId = Guid.NewGuid();
+
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user, TruncateParkedOperation, context.CancellationToken)) {
+			throw AccessDenied();
+		}
+
+		string streamId = request.Options.StreamOptionCase switch {
+			TruncateParkedReq.Types.Options.StreamOptionOneofCase.All => "$all",
+			TruncateParkedReq.Types.Options.StreamOptionOneofCase.StreamIdentifier => request.Options.StreamIdentifier,
+			_ => throw new InvalidOperationException()
+		};
+
+		long? stopAt = request.Options.StopAtOptionCase switch {
+			TruncateParkedReq.Types.Options.StopAtOptionOneofCase.StopAt => request.Options.StopAt,
+			TruncateParkedReq.Types.Options.StopAtOptionOneofCase.NoLimit => null,
+			_ => throw new InvalidOperationException()
+		};
+
+		_publisher.Publish(new ClientMessage.TruncateParkedMessages(
+			correlationId,
+			correlationId,
+			new CallbackEnvelope(HandleTruncateParkedCompleted),
+			streamId,
+			request.Options.GroupName,
+			stopAt,
+			user));
+		return await truncateParkedSource.Task;
+
+		void HandleTruncateParkedCompleted(Message message) {
+			switch (message) {
+				case ClientMessage.NotHandled notHandled when TryHandleNotHandled(notHandled, out var ex):
+					truncateParkedSource.TrySetException(ex);
+					return;
+				case ClientMessage.TruncateParkedMessagesCompleted completed:
+					switch (completed.Result) {
+						case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Success:
+							truncateParkedSource.TrySetResult(new TruncateParkedResp());
+							return;
+						case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.DoesNotExist:
+							truncateParkedSource.TrySetException(
+								PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
+							return;
+						case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.AccessDenied:
+							truncateParkedSource.TrySetException(AccessDenied());
+							return;
+						case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Fail:
+							truncateParkedSource.TrySetException(
+								PersistentSubscriptionFailed(streamId, request.Options.GroupName, completed.Reason));
+							return;
+
+						default:
+							truncateParkedSource.TrySetException(UnknownError(completed.Result));
+							return;
+					}
+				default:
+					truncateParkedSource.TrySetException(UnknownMessage<ClientMessage.TruncateParkedMessagesCompleted>(message));
+					break;
+			}
+		}
+	}
+}

--- a/src/KurrentDB.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -64,7 +64,7 @@ public class PersistentSubscriptionController : CommunicationController {
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/replayParked?stopAt={stopAt}", HttpMethod.Post,
 			WithParameters(Operations.Subscriptions.ReplayParked), ReplayParkedMessages);
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/truncateParked?stopAt={stopAt}", HttpMethod.Post,
-			WithParameters(Operations.Subscriptions.ReplayParked), TruncateParkedMessages);
+			WithParameters(Operations.Subscriptions.TruncateParked), TruncateParkedMessages);
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack/{messageid}", HttpMethod.Post,
 			WithParameters(Operations.Subscriptions.ProcessMessages), AckMessage);
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/nack/{messageid}?action={action}",

--- a/src/KurrentDB.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -505,7 +505,7 @@ public class PersistentSubscriptionController : CommunicationController {
 		long? stopAt;
 		if (stopAtStr != null) {
 			if (!long.TryParse(stopAtStr, out var stopAtLong) || stopAtLong < 0) {
-				http.ReplyStatus(HttpStatusCode.BadRequest, "stopAt should be a properly formed positive long",
+				http.ReplyStatus(HttpStatusCode.BadRequest, "stopAt should be a properly formed positive integer",
 					exception => { });
 				return;
 			}

--- a/src/KurrentDB.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -63,6 +63,8 @@ public class PersistentSubscriptionController : CommunicationController {
 			Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/replayParked?stopAt={stopAt}", HttpMethod.Post,
 			WithParameters(Operations.Subscriptions.ReplayParked), ReplayParkedMessages);
+		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/truncateParked?stopAt={stopAt}", HttpMethod.Post,
+			WithParameters(Operations.Subscriptions.ReplayParked), TruncateParkedMessages);
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack/{messageid}", HttpMethod.Post,
 			WithParameters(Operations.Subscriptions.ProcessMessages), AckMessage);
 		RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/nack/{messageid}?action={action}",
@@ -461,6 +463,59 @@ public class PersistentSubscriptionController : CommunicationController {
 		}
 
 		var cmd = new ClientMessage.ReplayParkedMessages(Guid.NewGuid(), Guid.NewGuid(), envelope, stream,
+			groupname, stopAt, http.User);
+		Publish(cmd);
+	}
+
+	private void TruncateParkedMessages(HttpEntityManager http, UriTemplateMatch match) {
+		if (_httpForwarder.ForwardRequest(http))
+			return;
+		var envelope = new SendToHttpEnvelope(
+			_networkSendQueue, http,
+			(args, message) => http.ResponseCodec.To(message),
+			(args, message) => {
+				int code;
+				if (message is ClientMessage.NotHandled notHandled)
+					return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
+				var m = message as ClientMessage.TruncateParkedMessagesCompleted;
+				if (m == null)
+					throw new Exception("unexpected message " + message);
+				switch (m.Result) {
+					case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Success:
+						code = HttpStatusCode.OK;
+						break;
+					case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.DoesNotExist:
+						code = HttpStatusCode.NotFound;
+						break;
+					case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.AccessDenied:
+						code = HttpStatusCode.Unauthorized;
+						break;
+					default:
+						code = HttpStatusCode.InternalServerError;
+						break;
+				}
+
+				return new ResponseConfiguration(code, http.ResponseCodec.ContentType,
+					http.ResponseCodec.Encoding);
+			});
+		var groupname = match.BoundVariables["subscription"];
+		var stream = match.BoundVariables["stream"];
+		var stopAtStr = match.BoundVariables["stopAt"];
+
+		long? stopAt;
+		if (stopAtStr != null) {
+			if (!long.TryParse(stopAtStr, out var stopAtLong) || stopAtLong < 0) {
+				http.ReplyStatus(HttpStatusCode.BadRequest, "stopAt should be a properly formed positive long",
+					exception => { });
+				return;
+			}
+
+			stopAt = stopAtLong;
+		} else {
+			stopAt = null;
+		}
+
+		var cmd = new ClientMessage.TruncateParkedMessages(Guid.NewGuid(), Guid.NewGuid(), envelope, stream,
 			groupname, stopAt, http.User);
 		Publish(cmd);
 	}

--- a/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
@@ -218,6 +218,9 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			.When<ClientMessage.ConnectToPersistentSubscriptionToAll>().Do(HandleAsNonLeader)
 			.When<ClientMessage.UpdatePersistentSubscriptionToAll>().Do(HandleAsNonLeader)
 			.When<ClientMessage.DeletePersistentSubscriptionToAll>().Do(HandleAsNonLeader)
+			.When<ClientMessage.ReplayParkedMessages>().Do(HandleAsNonLeader)
+			.When<ClientMessage.ReplayParkedMessage>().Do(HandleAsNonLeader)
+			.When<ClientMessage.TruncateParkedMessages>().Do(HandleAsNonLeader)
 			.InStates(VNodeState.ReadOnlyLeaderless, VNodeState.PreReadOnlyReplica, VNodeState.ReadOnlyReplica)
 			.When<ClientMessage.WriteEvents>().Do(HandleAsReadOnlyReplica)
 			.When<ClientMessage.TransactionStart>().Do(HandleAsReadOnlyReplica)
@@ -820,6 +823,27 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	}
 
 	private void HandleAsNonLeader(ClientMessage.DeletePersistentSubscriptionToAll message) {
+		if (_leader is null)
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		else
+			DenyRequestBecauseNotLeader(message.CorrelationId, message.Envelope);
+	}
+
+	private void HandleAsNonLeader(ClientMessage.ReplayParkedMessages message) {
+		if (_leader is null)
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		else
+			DenyRequestBecauseNotLeader(message.CorrelationId, message.Envelope);
+	}
+
+	private void HandleAsNonLeader(ClientMessage.ReplayParkedMessage message) {
+		if (_leader is null)
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		else
+			DenyRequestBecauseNotLeader(message.CorrelationId, message.Envelope);
+	}
+
+	private void HandleAsNonLeader(ClientMessage.TruncateParkedMessages message) {
 		if (_leader is null)
 			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
 		else

--- a/src/KurrentDB.Plugins/Authorization/Operations.cs
+++ b/src/KurrentDB.Plugins/Authorization/Operations.cs
@@ -109,6 +109,7 @@ public static class Operations {
 		public static readonly OperationDefinition Delete = new(Resource, "delete");
 		public static readonly OperationDefinition ReplayParked = new(Resource, "replay");
 		public static readonly OperationDefinition Restart = new(Resource, "restart");
+		public static readonly OperationDefinition TruncateParked = new(Resource, "truncate");
 
 		public static readonly OperationDefinition ProcessMessages = new(Resource, "process");
 

--- a/src/KurrentDB/Components/PersistentSubscriptions/ParkedMessages.razor
+++ b/src/KurrentDB/Components/PersistentSubscriptions/ParkedMessages.razor
@@ -9,34 +9,43 @@
 <PageTitle>KurrentDB: Parked Messages — @GroupName on @StreamId</PageTitle>
 
 <MudStack Spacing="4">
-	<MudStack Row="true" AlignItems="AlignItems.Center">
+	<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="width: 100%;">
 		<MudButton Variant="Variant.Text" StartIcon="@KurrentIcons.Back"
-		           Href="@($"/ui/persistent-subscriptions/{Uri.EscapeDataString(StreamId)}/{Uri.EscapeDataString(GroupName)}")">Back</MudButton>
+				   Href="@($"/ui/persistent-subscriptions/{Uri.EscapeDataString(StreamId)}/{Uri.EscapeDataString(GroupName)}")">Back</MudButton>
 		<MudText Typo="Typo.h5">Parked Messages: @GroupName on @StreamId</MudText>
+		<MudSpacer/>
+		@if (IsLeader) {
+			<MudButton Variant="Variant.Outlined" Size="Size.Small"
+					   StartIcon="@Icons.Material.Filled.Replay"
+					   OnClick="ReplayParked">Replay Parked</MudButton>
+			<MudButton Variant="Variant.Outlined" Size="Size.Small"
+					   StartIcon="@Icons.Material.Filled.DeleteSweep"
+					   OnClick="TruncateParked">Truncate Parked</MudButton>
+		}
 	</MudStack>
 
 	<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="width: 100%;">
 		<MudButton Variant="Variant.Outlined" Size="Size.Small"
-		           Disabled="@(!_cursor.HasOlderPage)"
-		           StartIcon="@Icons.Material.Filled.FirstPage"
-		           OnClick="OldestPage">Oldest</MudButton>
+				   Disabled="@(!_cursor.HasOlderPage)"
+				   StartIcon="@Icons.Material.Filled.FirstPage"
+				   OnClick="OldestPage">Oldest</MudButton>
 		<MudButton Variant="Variant.Outlined" Size="Size.Small"
-		           Disabled="@(!_cursor.HasOlderPage)"
-		           StartIcon="@Icons.Material.Filled.ChevronLeft"
-		           OnClick="NextPage">Older</MudButton>
+				   Disabled="@(!_cursor.HasOlderPage)"
+				   StartIcon="@Icons.Material.Filled.ChevronLeft"
+				   OnClick="NextPage">Older</MudButton>
 		<MudButton Variant="Variant.Outlined" Size="Size.Small"
-		           Disabled="@(!_cursor.HasNewerPage)"
-		           EndIcon="@Icons.Material.Filled.ChevronRight"
-		           OnClick="PreviousPage">Newer</MudButton>
+				   Disabled="@(!_cursor.HasNewerPage)"
+				   EndIcon="@Icons.Material.Filled.ChevronRight"
+				   OnClick="PreviousPage">Newer</MudButton>
 		<MudButton Variant="Variant.Outlined" Size="Size.Small"
-		           Disabled="@(!_cursor.HasNewerPage)"
-		           EndIcon="@Icons.Material.Filled.LastPage"
-		           OnClick="NewestPage">Newest</MudButton>
+				   Disabled="@(!_cursor.HasNewerPage)"
+				   EndIcon="@Icons.Material.Filled.LastPage"
+				   OnClick="NewestPage">Newest</MudButton>
 		<MudSpacer/>
 		<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
 			<MudText Typo="Typo.body2">Show</MudText>
 			<MudSelect T="int" Value="_cursor.PageSize" ValueChanged="OnPageSizeChanged" Dense="true"
-			           Variant="Variant.Outlined" Margin="Margin.Dense" Style="width: 90px;">
+					   Variant="Variant.Outlined" Margin="Margin.Dense" Style="width: 90px;">
 				<MudSelectItem T="int" Value="10">10</MudSelectItem>
 				<MudSelectItem T="int" Value="20">20</MudSelectItem>
 				<MudSelectItem T="int" Value="100">100</MudSelectItem>
@@ -72,6 +81,26 @@
 						@(context.Item.Event?.TimeStamp.ToString("g") ?? "")
 					</CellTemplate>
 				</TemplateColumn>
+				@if (IsLeader) {
+					<TemplateColumn>
+						<CellTemplate>
+							<MudStack Row="true" Spacing="0">
+								<MudTooltip Text="Replay all parked messages up to here inclusive">
+									<MudIconButton
+										Icon="@Icons.Material.Filled.Replay"
+										Size="Size.Small"
+										OnClick="() => ReplayInclusive(context.Item)"/>
+								</MudTooltip>
+								<MudTooltip Text="Truncate all parked messages up to here inclusive">
+									<MudIconButton
+										Icon="@Icons.Material.Filled.DeleteSweep"
+										Size="Size.Small"
+										OnClick="() => TruncateInclusive(context.Item)"/>
+								</MudTooltip>
+							</MudStack>
+						</CellTemplate>
+					</TemplateColumn>
+				}
 			</Columns>
 			<NoRecordsContent>
 				<MudText>No parked messages.</MudText>

--- a/src/KurrentDB/Components/PersistentSubscriptions/ParkedMessages.razor.cs
+++ b/src/KurrentDB/Components/PersistentSubscriptions/ParkedMessages.razor.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using KurrentDB.Components.Cluster;
 using KurrentDB.Components.Shared;
 using KurrentDB.Core.Data;
 using Microsoft.AspNetCore.Components;
@@ -14,9 +16,11 @@ using MudBlazor;
 
 namespace KurrentDB.Components.PersistentSubscriptions;
 
-public partial class ParkedMessages : ComponentBase {
+public sealed partial class ParkedMessages : ComponentBase, IDisposable {
 	[Inject] PersistentSubscriptionsService PersistentSubscriptionsService { get; set; } = null!;
+	[Inject] IDialogService DialogService { get; set; } = null!;
 	[Inject] ISnackbar Snackbar { get; set; } = null!;
+	[Inject] GossipMonitor Gossip { get; set; } = null!;
 
 	[CascadingParameter] Task<AuthenticationState> AuthenticationState { get; set; }
 	[Parameter] public string StreamId { get; set; }
@@ -27,13 +31,25 @@ public partial class ParkedMessages : ComponentBase {
 	bool _loading = true;
 	ClaimsPrincipal _principal;
 
+	bool IsLeader => Gossip.CurrentState == VNodeState.Leader;
+
 	protected override async Task OnInitializedAsync() {
 		var authState = await AuthenticationState;
 		_principal = authState.User;
 		StreamId = Uri.UnescapeDataString(StreamId);
 		GroupName = Uri.UnescapeDataString(GroupName);
+		Gossip.Changed += OnGossipChanged;
 		await LoadPage();
 	}
+
+	async void OnGossipChanged() {
+		try {
+			await InvokeAsync(StateHasChanged);
+		} catch (ObjectDisposedException) {
+		}
+	}
+
+	public void Dispose() => Gossip.Changed -= OnGossipChanged;
 
 	async Task LoadPage() {
 		_loading = true;
@@ -63,5 +79,75 @@ public partial class ParkedMessages : ComponentBase {
 	async Task OnPageSizeChanged(int value) {
 		_cursor.ChangePageSize(value);
 		await LoadPage();
+	}
+
+	async Task ReplayParked() {
+		var confirmed = await DialogService.ShowMessageBox(
+			"Replay Parked Messages",
+			$"Are you sure you want to replay all parked messages for '{GroupName}' on '{StreamId}'?",
+			yesText: "Replay", cancelText: "Cancel");
+		if (confirmed == true) {
+			try {
+				using var cts = new CancellationTokenSource(10000);
+				await PersistentSubscriptionsService.ReplayParkedAsync(_principal, StreamId, GroupName, cts.Token);
+				Snackbar.Add("Parked messages replay started.", Severity.Success);
+				await LoadPage();
+			} catch (PersistentSubscriptionsException ex) {
+				Snackbar.Add(ex.Message, Severity.Error);
+			}
+		}
+	}
+
+	async Task ReplayInclusive(ResolvedEvent parkedEvent) {
+		var eventNumber = parkedEvent.OriginalEventNumber;
+		var confirmed = await DialogService.ShowMessageBox(
+			"Replay Parked Messages",
+			$"Are you sure you want to replay all parked messages up to and including #{eventNumber} for '{GroupName}' on '{StreamId}'?",
+			yesText: "Replay", cancelText: "Cancel");
+		if (confirmed == true) {
+			try {
+				using var cts = new CancellationTokenSource(10000);
+				await PersistentSubscriptionsService.ReplayParkedAsync(_principal, StreamId, GroupName, cts.Token, stopAt: eventNumber + 1);
+				_events = _events.Where(e => e.OriginalEventNumber > eventNumber).ToList();
+				Snackbar.Add("Parked messages replay started.", Severity.Success);
+			} catch (PersistentSubscriptionsException ex) {
+				Snackbar.Add(ex.Message, Severity.Error);
+			}
+		}
+	}
+
+	async Task TruncateInclusive(ResolvedEvent parkedEvent) {
+		var eventNumber = parkedEvent.OriginalEventNumber;
+		var confirmed = await DialogService.ShowMessageBox(
+			"Truncate Parked Messages",
+			$"Are you sure you want to truncate all parked messages up to and including #{eventNumber} for '{GroupName}' on '{StreamId}'?",
+			yesText: "Truncate", cancelText: "Cancel");
+		if (confirmed == true) {
+			try {
+				using var cts = new CancellationTokenSource(10000);
+				await PersistentSubscriptionsService.TruncateParkedAsync(_principal, StreamId, GroupName, cts.Token, stopAt: eventNumber + 1);
+				_events = _events.Where(e => e.OriginalEventNumber > eventNumber).ToList();
+				Snackbar.Add("Parked messages truncated.", Severity.Success);
+			} catch (PersistentSubscriptionsException ex) {
+				Snackbar.Add(ex.Message, Severity.Error);
+			}
+		}
+	}
+
+	async Task TruncateParked() {
+		var confirmed = await DialogService.ShowMessageBox(
+			"Truncate Parked Messages",
+			$"Are you sure you want to truncate all parked messages for '{GroupName}' on '{StreamId}'? This will permanently discard them without replaying.",
+			yesText: "Truncate", cancelText: "Cancel");
+		if (confirmed == true) {
+			try {
+				using var cts = new CancellationTokenSource(10000);
+				await PersistentSubscriptionsService.TruncateParkedAsync(_principal, StreamId, GroupName, cts.Token);
+				_events = [];
+				Snackbar.Add("Parked messages truncated.", Severity.Success);
+			} catch (PersistentSubscriptionsException ex) {
+				Snackbar.Add(ex.Message, Severity.Error);
+			}
+		}
 	}
 }

--- a/src/KurrentDB/Components/PersistentSubscriptions/ParkedMessages.razor.cs
+++ b/src/KurrentDB/Components/PersistentSubscriptions/ParkedMessages.razor.cs
@@ -127,7 +127,7 @@ public sealed partial class ParkedMessages : ComponentBase, IDisposable {
 				using var cts = new CancellationTokenSource(10000);
 				await PersistentSubscriptionsService.TruncateParkedAsync(_principal, StreamId, GroupName, cts.Token, stopAt: eventNumber + 1);
 				_events = _events.Where(e => e.OriginalEventNumber > eventNumber).ToList();
-				Snackbar.Add("Parked messages truncated.", Severity.Success);
+				Snackbar.Add("Parked messages truncation started.", Severity.Success);
 			} catch (PersistentSubscriptionsException ex) {
 				Snackbar.Add(ex.Message, Severity.Error);
 			}
@@ -144,7 +144,7 @@ public sealed partial class ParkedMessages : ComponentBase, IDisposable {
 				using var cts = new CancellationTokenSource(10000);
 				await PersistentSubscriptionsService.TruncateParkedAsync(_principal, StreamId, GroupName, cts.Token);
 				_events = [];
-				Snackbar.Add("Parked messages truncated.", Severity.Success);
+				Snackbar.Add("Parked messages truncation started.", Severity.Success);
 			} catch (PersistentSubscriptionsException ex) {
 				Snackbar.Add(ex.Message, Severity.Error);
 			}

--- a/src/KurrentDB/Components/PersistentSubscriptions/PersistentSubscriptionsService.cs
+++ b/src/KurrentDB/Components/PersistentSubscriptions/PersistentSubscriptionsService.cs
@@ -192,7 +192,7 @@ public class PersistentSubscriptionsService(IPublisher publisher, IAuthorization
 
 	public async ValueTask TruncateParkedAsync(ClaimsPrincipal principal, string streamId, string groupName,
 		CancellationToken ct, long? stopAt = null) {
-		await Authorize(principal, Scoped(Operations.Subscriptions.ReplayParked, streamId, groupName), ct);
+		await Authorize(principal, Scoped(Operations.Subscriptions.TruncateParked, streamId, groupName), ct);
 		var corrId = Guid.NewGuid();
 		var envelope = new TcsEnvelope<Message>();
 		publisher.Publish(new ClientMessage.TruncateParkedMessages(

--- a/src/KurrentDB/Components/PersistentSubscriptions/PersistentSubscriptionsService.cs
+++ b/src/KurrentDB/Components/PersistentSubscriptions/PersistentSubscriptionsService.cs
@@ -168,12 +168,13 @@ public class PersistentSubscriptionsService(IPublisher publisher, IAuthorization
 		}
 	}
 
-	public async ValueTask ReplayParkedAsync(ClaimsPrincipal principal, string streamId, string groupName, CancellationToken ct) {
+	public async ValueTask ReplayParkedAsync(ClaimsPrincipal principal, string streamId, string groupName,
+		CancellationToken ct, long? stopAt = null) {
 		await Authorize(principal, Scoped(Operations.Subscriptions.ReplayParked, streamId, groupName), ct);
 		var corrId = Guid.NewGuid();
 		var envelope = new TcsEnvelope<Message>();
 		publisher.Publish(new ClientMessage.ReplayParkedMessages(
-			corrId, corrId, envelope, streamId, groupName, stopAt: null, user: principal));
+			corrId, corrId, envelope, streamId, groupName, stopAt: stopAt, user: principal));
 
 		switch (await envelope.Task.WaitAsync(ct)) {
 			case ClientMessage.ReplayMessagesReceived { Result: ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success }:
@@ -184,6 +185,26 @@ public class PersistentSubscriptionsService(IPublisher publisher, IAuthorization
 				throw new PersistentSubscriptionsException("Access denied.");
 			default:
 				throw new PersistentSubscriptionsException("Failed to replay parked messages.");
+		}
+	}
+
+	public async ValueTask TruncateParkedAsync(ClaimsPrincipal principal, string streamId, string groupName,
+		CancellationToken ct, long? stopAt = null) {
+		await Authorize(principal, Scoped(Operations.Subscriptions.ReplayParked, streamId, groupName), ct);
+		var corrId = Guid.NewGuid();
+		var envelope = new TcsEnvelope<Message>();
+		publisher.Publish(new ClientMessage.TruncateParkedMessages(
+			corrId, corrId, envelope, streamId, groupName, stopAt: stopAt, user: principal));
+
+		switch (await envelope.Task.WaitAsync(ct)) {
+			case ClientMessage.TruncateParkedMessagesCompleted { Result: ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.Success }:
+				return;
+			case ClientMessage.TruncateParkedMessagesCompleted { Result: ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.DoesNotExist }:
+				throw new PersistentSubscriptionsException("Subscription does not exist.");
+			case ClientMessage.TruncateParkedMessagesCompleted { Result: ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.AccessDenied }:
+				throw new PersistentSubscriptionsException("Access denied.");
+			default:
+				throw new PersistentSubscriptionsException("Failed to truncate parked messages.");
 		}
 	}
 

--- a/src/KurrentDB/Components/PersistentSubscriptions/PersistentSubscriptionsService.cs
+++ b/src/KurrentDB/Components/PersistentSubscriptions/PersistentSubscriptionsService.cs
@@ -183,6 +183,8 @@ public class PersistentSubscriptionsService(IPublisher publisher, IAuthorization
 				throw new PersistentSubscriptionsException("Subscription does not exist.");
 			case ClientMessage.ReplayMessagesReceived { Result: ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied }:
 				throw new PersistentSubscriptionsException("Access denied.");
+			case ClientMessage.ReplayMessagesReceived { Reason: var reason }:
+				throw new PersistentSubscriptionsException($"Failed to replay parked messages: {reason}");
 			default:
 				throw new PersistentSubscriptionsException("Failed to replay parked messages.");
 		}
@@ -203,6 +205,8 @@ public class PersistentSubscriptionsService(IPublisher publisher, IAuthorization
 				throw new PersistentSubscriptionsException("Subscription does not exist.");
 			case ClientMessage.TruncateParkedMessagesCompleted { Result: ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesCompletedResult.AccessDenied }:
 				throw new PersistentSubscriptionsException("Access denied.");
+			case ClientMessage.TruncateParkedMessagesCompleted { Reason: var reason }:
+				throw new PersistentSubscriptionsException($"Failed to truncate parked messages: {reason}");
 			default:
 				throw new PersistentSubscriptionsException("Failed to truncate parked messages.");
 		}

--- a/src/KurrentDB/Components/PersistentSubscriptions/PersistentSubscriptionsService.cs
+++ b/src/KurrentDB/Components/PersistentSubscriptions/PersistentSubscriptionsService.cs
@@ -185,6 +185,8 @@ public class PersistentSubscriptionsService(IPublisher publisher, IAuthorization
 				throw new PersistentSubscriptionsException("Access denied.");
 			case ClientMessage.ReplayMessagesReceived { Reason: var reason }:
 				throw new PersistentSubscriptionsException($"Failed to replay parked messages: {reason}");
+			case ClientMessage.NotHandled:
+				throw new PersistentSubscriptionsException("The subscription is not ready. Please try again.");
 			default:
 				throw new PersistentSubscriptionsException("Failed to replay parked messages.");
 		}
@@ -207,6 +209,8 @@ public class PersistentSubscriptionsService(IPublisher publisher, IAuthorization
 				throw new PersistentSubscriptionsException("Access denied.");
 			case ClientMessage.TruncateParkedMessagesCompleted { Reason: var reason }:
 				throw new PersistentSubscriptionsException($"Failed to truncate parked messages: {reason}");
+			case ClientMessage.NotHandled:
+				throw new PersistentSubscriptionsException("The subscription is not ready. Please try again.");
 			default:
 				throw new PersistentSubscriptionsException("Failed to truncate parked messages.");
 		}

--- a/src/Protos/Grpc/persistent.proto
+++ b/src/Protos/Grpc/persistent.proto
@@ -11,6 +11,7 @@ service PersistentSubscriptions {
 	rpc Read (stream ReadReq) returns (stream ReadResp);
 	rpc GetInfo (GetInfoReq) returns (GetInfoResp);
 	rpc ReplayParked (ReplayParkedReq) returns (ReplayParkedResp);
+	rpc TruncateParked (TruncateParkedReq) returns (TruncateParkedResp);
 	rpc List (ListReq) returns (ListResp);
 	rpc RestartSubsystem (event_store.client.Empty) returns (event_store.client.Empty);
 }
@@ -346,6 +347,25 @@ message ReplayParkedReq {
 }
 
 message ReplayParkedResp {
+}
+
+message TruncateParkedReq {
+	Options options = 1;
+
+	message Options {
+		string group_name = 1;
+		oneof stream_option {
+			event_store.client.StreamIdentifier stream_identifier = 2;
+			event_store.client.Empty all = 3;
+		}
+		oneof stop_at_option {
+			int64 stop_at = 4;
+			event_store.client.Empty no_limit = 5;
+		}
+	}
+}
+
+message TruncateParkedResp {
 }
 
 message ListReq {


### PR DESCRIPTION
The parked message count metric uses a cached range calculation that
goes stale when the parked stream is truncated externally. This adds a
TruncateParked operation (gRPC + HTTP + UI) that truncates parked messages
and updates the cached value, keeping the metric accurate without
requiring a leader election.