### PR TITLE
[DB-2160] Make gRPC response compression level configurable

### DIFF
--- a/src/KurrentDB.Api.V2/Infrastructure/DependencyInjection/GrpcServerBuilderExtensions.cs
+++ b/src/KurrentDB.Api.V2/Infrastructure/DependencyInjection/GrpcServerBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using Grpc.AspNetCore.Server;
-using KurrentDB.Api.Infrastructure.Grpc.Compression;
 using KurrentDB.Api.Infrastructure.Grpc.Validation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -20,7 +19,6 @@ public static class GrpcServerBuilderExtensions {
         configureValidation?.Invoke(new RequestValidationBuilder(builder.Services));
 
         builder.AddServiceOptions<TService>(options => {
-            options.WithCompression();
             options.Interceptors.Add<RequestValidationInterceptor>();
             configureGrpc?.Invoke(options);
         });

--- a/src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using FluentAssertions;
@@ -335,6 +336,22 @@ public class ClusterVNodeOptionsTests {
 		var options = ClusterVNodeOptions.FromConfiguration(config);
 
 		options.Logging.LogLevel.Should().Be(LogLevel.Fatal);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void can_set_grpc_compression_level(bool useEventStorePrefix) {
+		var builder = new ConfigurationBuilder();
+		if (useEventStorePrefix)
+			builder.AddLegacyEventStoreEnvironmentVariables(($"{EventStoreEnvVarPrefix}_COMPRESSION_LEVEL", nameof(CompressionLevel.NoCompression)));
+		else
+			builder.AddKurrentEnvironmentVariables(($"{KurrentEnvVarPrefix}_COMPRESSION_LEVEL", nameof(CompressionLevel.NoCompression)));
+		var config = builder.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Grpc.CompressionLevel.Should().Be(CompressionLevel.NoCompression);
 	}
 
 	[Fact]

--- a/src/KurrentDB.Core/ClusterVNodeStartup.cs
+++ b/src/KurrentDB.Core/ClusterVNodeStartup.cs
@@ -302,11 +302,16 @@ public class ClusterVNodeStartup<TStreamId>
 
 				options.Interceptors.Add<LogRetriesInterceptor>();
 
-				// Enable gzip compression
-				// The client must still need to opt-in
-				options.ResponseCompressionAlgorithm = "gzip";
-				options.ResponseCompressionLevel = CompressionLevel.Optimal;
-				options.CompressionProviders.Add(new Rfc1952GzipCompressionProvider(CompressionLevel.Optimal));
+				// gRPC response compression (gzip). The client must still opt in by advertising gzip in
+				// grpc-accept-encoding, and cannot override the level — it's a server-side setting.
+				// The provider is always registered so gzip-compressed client requests can be decompressed,
+				// but responses are only compressed when the level is not NoCompression.
+				var compressionLevel = _options.Grpc.CompressionLevel;
+				options.CompressionProviders.Add(new Rfc1952GzipCompressionProvider(compressionLevel));
+				if (compressionLevel != CompressionLevel.NoCompression) {
+					options.ResponseCompressionAlgorithm = "gzip";
+					options.ResponseCompressionLevel = compressionLevel;
+				}
 			})
 			.AddServiceOptions<Streams<TStreamId>>(options => options.MaxReceiveMessageSize = TFConsts.EffectiveMaxLogRecordSize);
 

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
@@ -485,6 +486,11 @@ public partial record ClusterVNodeOptions {
 
 	[Description("gRPC Options")]
 	public record GrpcOptions {
+		[Description("The gzip compression level applied to gRPC responses. Higher levels reduce network traffic at the cost of more CPU. " +
+					 "Allowed values: 'NoCompression', 'Fastest', 'Optimal', 'SmallestSize'. " +
+					 "Only applies when the client advertises gzip support.")]
+		public CompressionLevel CompressionLevel { get; init; } = CompressionLevel.Optimal;
+
 		[Description("Controls the period (in milliseconds) after which a keepalive ping " +
 					 "is sent on the transport."),
 		 Unit("ms")]
@@ -497,6 +503,7 @@ public partial record ClusterVNodeOptions {
 		public int KeepAliveTimeout { get; init; } = 10_000;
 
 		internal static GrpcOptions FromConfiguration(IConfiguration configurationRoot) => new() {
+			CompressionLevel = configurationRoot.GetValue<CompressionLevel>(nameof(CompressionLevel)),
 			KeepAliveInterval = configurationRoot.GetValue<int>(nameof(KeepAliveInterval)),
 			KeepAliveTimeout = configurationRoot.GetValue<int>(nameof(KeepAliveTimeout))
 		};


### PR DESCRIPTION
Previously (since 25.1 when compression was introduced) the gRPC response compression level was hardcoded to CompressionLevel.Optimal.

It can be now be configured 'CompressionLevel' (default Optimal). NoCompression disables response compression entirely rather than emitting gzip-framed but uncompressed responses. The provider stays registered so gzip-compressed client requests can still be decompressed.