### PR TITLE
Register UiStatsService via factory so startup survives disabled secondary indexing

### DIFF
--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -330,10 +330,14 @@ try {
 			});
 			builder.Services.AddScoped<PersistentSubscriptionsService>();
 			builder.Services.AddScoped<ServerInfoService>();
-			// UI-layer authorizing wrapper over the SecondaryIndexing StatsService (which does no auth of its
-			// own). Resolved lazily by StatsPage and only when the plugin is enabled, so registering it here
-			// unconditionally is safe even though the inner StatsService is only registered by the plugin.
-			builder.Services.AddScoped<KurrentDB.Components.Stats.UiStatsService>();
+			builder.Services.AddScoped(sp => {
+				// Register via a factory (like ProjectionsService above) rather than by type:
+				// ValidateOnBuild constructs every type-registered descriptor up front and
+				// would fail resolving StatsService when secondary indexing is disabled.
+				return new KurrentDB.Components.Stats.UiStatsService(
+					sp.GetRequiredService<KurrentDB.SecondaryIndexing.Stats.StatsService>(),
+					sp.GetRequiredService<EventStore.Plugins.Authorization.IAuthorizationProvider>());
+			});
 			builder.Services.AddSingleton(TimeProvider.System);
 			Log.Information("Environment Name: {0}", builder.Environment.EnvironmentName);
 			Log.Information("ContentRoot Path: {0}", builder.Environment.ContentRootPath);


### PR DESCRIPTION
(but introduced recently, not released)

UiStatsService was registered by type (AddScoped<UiStatsService>()), so the host's ValidateOnBuild eagerly constructed it at startup. Its constructor depends on SecondaryIndexing's StatsService, which the plugin only registers when secondary indexing is enabled — so with it disabled the container build threw "Some services are not able to be constructed", crashing the server.

StatsPage already guards resolution behind PluginsService.IsPluginEnabled, so the only problem was build-time validation. Register via a factory (like the neighbouring ProjectionsService) which ValidateOnBuild treats as opaque, deferring resolution to the guarded page request.