### PR TITLE
Add SQL over logs (kdb.logs / kdb.stats)

### DIFF
--- a/docs/server/diagnostics/logs.md
+++ b/docs/server/diagnostics/logs.md
@@ -211,6 +211,12 @@ You can completely disable logging to a file by changing the `DisableLogFile` op
 
 **Default**: `false`
 
+## Querying logs with SQL
+
+<Badge type="info" vertical="middle" text="License Required"/>
+
+A node's logs can be queried through the Arrow Flight SQL endpoint, as the `kdb.logs` and `kdb.stats` tables, without requiring file system access. Queries are read-only and node-local. See [SQL over logs](../features/queries/flightsql.md#querying-node-logs) for the table columns and query examples.
+
 ## Logs download
 
 <Badge type="info" vertical="middle" text="License Required"/>

--- a/docs/server/features/queries/flightsql.md
+++ b/docs/server/features/queries/flightsql.md
@@ -30,6 +30,7 @@ Note that only **SELECT** statements are allowed. **INSERT**, **UPDATE**, stored
 
 - The default index is available through the **`kdb.records`** table.
 - User-defined indexes are available through **`usr.<user-defined-index>`** tables.
+- This node's own log files are available through the **`kdb.logs`** and **`kdb.stats`** tables.
 
 ### Examples
 
@@ -92,6 +93,66 @@ List of available columns:
 * `data` of type `VARCHAR`
 * `metadata` of type `VARCHAR`
 * The custom field configured in the index
+
+## Querying node logs
+
+KurrentDB exposes this node's own structured log files as SQL tables:
+
+- **`kdb.logs`** covers the main log (every level).
+- **`kdb.stats`** covers the periodic statistics snapshots (written every 30 seconds by default).
+
+Both are read-only and **node-local**: a query only sees the log files present on the node it connects to. Query each node individually to inspect its own logs.
+
+The tables reflect the log files currently on disk. Their location, rotation, and retained history are controlled by the `Log`, `LogFileInterval`, and `LogFileRetentionCount` options (see [Database logs](../../diagnostics/logs.md)). With `DisableLogFile` set, the tables are empty.
+
+### Example queries
+
+```sql
+-- the most recent errors on this node
+SELECT timestamp, source_context, message, exception
+FROM kdb.logs
+WHERE level IN ('Error', 'Fatal')
+ORDER BY timestamp DESC
+LIMIT 100;
+
+-- log volume by level over the last hour
+SELECT level, count(*)
+FROM kdb.logs
+WHERE timestamp >= now() - INTERVAL '1 hour'
+GROUP BY level;
+
+-- full-text search over the rendered message
+SELECT timestamp, message FROM kdb.logs WHERE message ILIKE '%projection%';
+
+-- CPU and process memory from the latest stats snapshot
+SELECT
+  timestamp,
+  (raw->'stats'->'sys'->>'cpu')::DOUBLE cpu,
+  (raw->'stats'->'proc'->>'mem')::DOUBLE mem_bytes
+FROM kdb.stats
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### `kdb.logs` Table
+
+Each row is one log entry, projected from the [CLEF](https://clef-json.org/) record. List of available columns:
+
+* `timestamp` of type `TIMESTAMP` (with time zone) - when the entry was written (CLEF `@t`)
+* `level` of type `VARCHAR` - log level, e.g. `Information`, `Warning`, `Error` (CLEF `@l`; defaults to `Information` when absent)
+* `message` of type `VARCHAR` - the rendered message, with template placeholders filled in from the entry's properties
+* `message_template` of type `VARCHAR` - the raw message template before rendering (CLEF `@mt`)
+* `event_id` of type `UINT64` - the log entry identifier (CLEF `@i`)
+* `exception` of type `VARCHAR` - the exception text, if any (CLEF `@x`)
+* `source_context` of type `VARCHAR` - the component that emitted the entry (the `SourceContext` property)
+* `process_id` of type `INT64` - the emitting process id (the `ProcessId` property)
+* `thread_id` of type `INT64` - the emitting thread id (the `ThreadId` property)
+* `file` of type `VARCHAR` - name of the log file the row was read from
+* `raw` of type `JSON` - the complete CLEF record. Use the JSON navigation operators to read any property not projected into its own column
+
+### `kdb.stats` Table
+
+`kdb.stats` has the same columns as `kdb.logs`. The statistics themselves are not projected into columns - they live in the `raw` column under the `stats` object. Read the individual metrics from there with the JSON navigation operators, as in the stats example above.
 
 ## Supported FlightSQL Features
 Arrow Flight SQL is a rich protocol with many features. Its implementation in KurrentDB supports the following functionality:

--- a/src/KurrentDB.Core.XUnit.Tests/DuckDB/DuckDBConnectionPoolLifetimeTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/DuckDB/DuckDBConnectionPoolLifetimeTests.cs
@@ -18,7 +18,7 @@ public class DuckDBConnectionPoolLifetimeTests : DirectoryPerTest<DuckDBConnecti
 	private string DefaultTempDirectory => Path.Combine(DbDirectory, "kurrent.ddb.tmp");
 
 	private DuckDBConnectionPoolLifetime CreateSut(string sqlEngineTempDirectory = "") =>
-		new(CreateDbConfig(sqlEngineTempDirectory), setups: [], log: null);
+		new(CreateDbConfig(sqlEngineTempDirectory), new ClusterVNodeOptions(), setups: [], log: null);
 
 	private TFChunkDbConfig CreateDbConfig(string sqlEngineTempDirectory) =>
 		new(DbDirectory,

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.Framework.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.Framework.cs
@@ -15,6 +15,7 @@ using System.Text.RegularExpressions;
 using KurrentDB.Common.Configuration;
 using KurrentDB.Core.Configuration;
 using KurrentDB.Core.Configuration.Sources;
+using System.IO;
 using Microsoft.Extensions.Configuration;
 
 namespace KurrentDB.Core;
@@ -23,6 +24,11 @@ public partial record ClusterVNodeOptions {
 	private static readonly IEnumerable<Type> OptionSections;
 	public static readonly string HelpText;
 	public string GetComponentName() => $"{Interface.NodeIp}-{Interface.NodePort}-cluster-node";
+
+	// The directory this node writes its own log files to (component-specific subdirectory of the
+	// configured log path). Shared by the log endpoint, the SQL-over-logs feature, and the DuckDB
+	// pool's file-access allow-list.
+	public string GetLogsDirectory() => Path.GetFullPath(Path.Combine(Logging.Log, GetComponentName()));
 	public static readonly List<SectionMetadata> Metadata;
 
 	static ClusterVNodeOptions() {

--- a/src/KurrentDB.Core/DuckDB/DuckDBConnectionPoolLifetime.cs
+++ b/src/KurrentDB.Core/DuckDB/DuckDBConnectionPoolLifetime.cs
@@ -22,6 +22,7 @@ namespace KurrentDB.Core.DuckDB;
 // Also produces additional pools on demand that the caller should dispose.
 public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 	private readonly string _path;
+	private readonly string _logsDir;
 	private readonly string _tempDirectory;
 	private readonly long _maxTempDirectorySizeBytes;
 	private readonly IReadOnlyList<IDuckDBSetup> _repeated;
@@ -32,10 +33,12 @@ public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 
 	public DuckDBConnectionPoolLifetime(
 		TFChunkDbConfig config,
+		ClusterVNodeOptions nodeOptions,
 		IEnumerable<IDuckDBSetup> setups,
 		[CanBeNull] ILogger<DuckDBConnectionPoolLifetime> log) {
 
 		_path = config.InMemDb ? GetTempPath() : $"{config.Path}/kurrent.ddb";
+		_logsDir = nodeOptions.GetLogsDirectory();
 		_tempDirectory = Path.GetFullPath(config.SqlEngineTempDirectory is { Length: > 0 } tempPath
 			? tempPath
 			: $"{_path}.tmp"); // the same directory DuckDB would pick by default. explicit so we can clean it up
@@ -54,11 +57,7 @@ public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 		}
 		_repeated = repeated;
 
-		Shared = CreatePool(isReadOnly: false, log: true);
-		using (Shared.Rent(out var connection)) {
-			foreach (var s in once)
-				s.Execute(connection);
-		}
+		Shared = CreatePool(isReadOnly: false, log: true, oneTime: once, allowedDirectories: [_logsDir]);
 
 		return;
 
@@ -69,25 +68,45 @@ public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 		}
 	}
 
-	public DuckDBConnectionPool CreatePool() => CreatePool(isReadOnly: true, log: false); // no writes go through here so set read only
+	public DuckDBConnectionPool CreatePool() =>
+		CreatePool(isReadOnly: true, log: false, oneTime: [], allowedDirectories: []); // no writes go through here so set read only
 
-	private ConnectionPoolWithFunctions CreatePool(bool isReadOnly, bool log) {
+	// The only way to obtain a pool - never returns one unlocked. Opens the first connection, runs
+	// the one-time setups on it, then locks the instance configuration.
+	private ConnectionPoolWithFunctions CreatePool(bool isReadOnly, bool log,
+		IReadOnlyList<IDuckDBSetup> oneTime, IReadOnlyList<string> allowedDirectories) {
 		var availableRamMib = CalculateRam();
 		var duckDbRamMib = (int)(availableRamMib * 0.25);
 		var settings = new Dictionary<string, string> {
 			["memory_limit"] = $"{duckDbRamMib}MB", // total, not per connection
 			["access_mode"] = isReadOnly ? "READ_ONLY" : "READ_WRITE",
 			["temp_directory"] = _tempDirectory,
-			// security settings
+			// security settings; the rest (allowed_directories, external access, config lock) are
+			// order-dependent, so every pool applies them post-open on the first connection below
 			["allow_community_extensions"] = "false",
-			["enable_external_access"] = "false",
-			["lock_configuration"] = "true",
 		};
 
 		if (_maxTempDirectorySizeBytes > 0L)
 			settings["max_temp_directory_size"] = $"{_maxTempDirectorySizeBytes}B";
 
 		var pool = new ConnectionPoolWithFunctions($"Data Source={_path};{GetParamsString()}", _repeated);
+
+		using (pool.Rent(out var connection)) {
+			foreach (var s in oneTime)
+				s.Execute(connection);
+
+			// Restrict the instance's file access to the allowed directories (the node's own log
+			// directory for the Shared pool, nothing for read-only pools), then lock it down. Order
+			// matters and can't be expressed in the connection string: allowed_directories must be
+			// set while external access is still on, then external access is disabled, then the
+			// config is locked. These are global settings, so applying them once on the first
+			// connection covers the whole pool. The lock comes after the one-time setups because
+			// function registration needs the unlocked state.
+			var dirs = string.Join(", ", allowedDirectories.Select(d => $"'{d.Replace('\\', '/').Replace("'", "''")}'"));
+			connection.ExecuteAdHocNonQuery(
+				$"SET allowed_directories=[{dirs}]; SET enable_external_access=false; SET lock_configuration=true;",
+				multipleStatements: true);
+		}
 
 		if (log)
 			_log.LogInformation("Created DuckDB connection pool at {path} with {settings}", _path, settings);

--- a/src/KurrentDB.Core/DuckDB/DuckDBConnectionPoolLifetime.cs
+++ b/src/KurrentDB.Core/DuckDB/DuckDBConnectionPoolLifetime.cs
@@ -27,6 +27,7 @@ public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 	private readonly long _maxTempDirectorySizeBytes;
 	private readonly IReadOnlyList<IDuckDBSetup> _repeated;
 	private readonly ILogger<DuckDBConnectionPoolLifetime> _log;
+	private readonly object _hardenLock = new();
 	[CanBeNull] private string _tempPath;
 
 	public DuckDBConnectionPool Shared { get; }
@@ -72,7 +73,7 @@ public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 		CreatePool(isReadOnly: true, log: false, oneTime: [], allowedDirectories: []); // no writes go through here so set read only
 
 	// The only way to obtain a pool - never returns one unlocked. Opens the first connection, runs
-	// the one-time setups on it, then locks the instance configuration.
+	// the one-time setups on it, then hardens and locks the instance configuration.
 	private ConnectionPoolWithFunctions CreatePool(bool isReadOnly, bool log,
 		IReadOnlyList<IDuckDBSetup> oneTime, IReadOnlyList<string> allowedDirectories) {
 		var availableRamMib = CalculateRam();
@@ -81,8 +82,9 @@ public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 			["memory_limit"] = $"{duckDbRamMib}MB", // total, not per connection
 			["access_mode"] = isReadOnly ? "READ_ONLY" : "READ_WRITE",
 			["temp_directory"] = _tempDirectory,
-			// security settings; the rest (allowed_directories, external access, config lock) are
-			// order-dependent, so every pool applies them post-open on the first connection below
+			// security settings; allowed_directories, external access and the config lock can't be
+			// carried in the connection string - DuckDB refuses to set allowed_directories before
+			// the database is started - so every pool applies them post-open via HardenInstance
 			["allow_community_extensions"] = "false",
 		};
 
@@ -95,17 +97,7 @@ public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 			foreach (var s in oneTime)
 				s.Execute(connection);
 
-			// Restrict the instance's file access to the allowed directories (the node's own log
-			// directory for the Shared pool, nothing for read-only pools), then lock it down. Order
-			// matters and can't be expressed in the connection string: allowed_directories must be
-			// set while external access is still on, then external access is disabled, then the
-			// config is locked. These are global settings, so applying them once on the first
-			// connection covers the whole pool. The lock comes after the one-time setups because
-			// function registration needs the unlocked state.
-			var dirs = string.Join(", ", allowedDirectories.Select(d => $"'{d.Replace('\\', '/').Replace("'", "''")}'"));
-			connection.ExecuteAdHocNonQuery(
-				$"SET allowed_directories=[{dirs}]; SET enable_external_access=false; SET lock_configuration=true;",
-				multipleStatements: true);
+			HardenInstance(connection, allowedDirectories);
 		}
 
 		if (log)
@@ -145,6 +137,34 @@ public class DuckDBConnectionPoolLifetime : Disposable, IHostedService {
 					tempObj.Delete();
 				}
 			}
+		}
+	}
+
+	// Harden the underlying DuckDB instance once: allow-list, external access off, config lock - in
+	// that order (allowed_directories is only settable while external access is on), and only after
+	// the setups, which need the unlocked state. Pools with the same connection string share an
+	// instance, so a later pool finds it already locked with the same settings and skips;
+	// _hardenLock closes the check-then-set race.
+	private void HardenInstance(DuckDBAdvancedConnection connection, IReadOnlyList<string> allowedDirectories) {
+		lock (_hardenLock) {
+			if (IsLocked(connection))
+				return;
+
+			var dirs = string.Join(", ", allowedDirectories.Select(d => $"'{d.Replace('\\', '/').Replace("'", "''")}'"));
+			connection.ExecuteAdHocNonQuery(
+				$"SET allowed_directories=[{dirs}]; SET enable_external_access=false; SET lock_configuration=true;",
+				multipleStatements: true);
+		}
+
+		return;
+
+		static bool IsLocked(DuckDBAdvancedConnection connection) {
+			using var result = connection.ExecuteAdHocQuery("SELECT current_setting('lock_configuration')::VARCHAR"u8);
+			while (result.TryFetch(out var chunk))
+				using (chunk)
+					if (chunk.TryRead(out var row))
+						return row.ReadString() == "true";
+			return false;
 		}
 	}
 

--- a/src/KurrentDB.SecondaryIndexing.Tests/IntegrationTests/LogsFlightSqlTests.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/IntegrationTests/LogsFlightSqlTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Apache.Arrow.Adbc.Client;
+using Apache.Arrow.Adbc.Drivers.FlightSql;
+using KurrentDB.Core.Configuration.Sources;
+using KurrentDB.Core.Tests;
+using KurrentDB.SecondaryIndexing.Tests.Fixtures;
+using KurrentDB.Surge.Testing;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KurrentDB.SecondaryIndexing.Tests.IntegrationTests;
+
+// Points the node's log directory at a writable temp dir so these tests can seed CLEF files, and so
+// the DuckDB pool's allow-list (GetLogsDirectory) covers it. The running node also writes its own
+// logs there; seeded rows are isolated by unique markers.
+public sealed class LogsQueryFixture : SecondaryIndexingEnabledFixture {
+	public LogsQueryFixture() {
+		var logsRoot = Path.Combine(Path.GetTempPath(), $"logs-query-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(logsRoot);
+		Configuration = new Dictionary<string, string?>(Configuration!) {
+			[$"{KurrentConfigurationKeys.Prefix}:Logging:Log"] = logsRoot,
+		};
+
+		var baseTearDown = OnTearDown;
+		OnTearDown = async () => {
+			await baseTearDown();
+			await DirectoryDeleter.TryForceDeleteDirectoryAsync(logsRoot, retries: 10);
+		};
+	}
+}
+
+[Trait("Category", "Integration")]
+public class LogsFlightSqlTests(LogsQueryFixture fixture, ITestOutputHelper output)
+	: ClusterVNodeTests<LogsQueryFixture>(fixture, output) {
+
+	[Fact]
+	public async Task QueriesSeededLogsRow() {
+		var marker = $"log-marker-{Guid.NewGuid():N}";
+		Seed("log20200101.json",
+			$$"""{"@t":"2020-01-01T00:00:00.0000000+00:00","@mt":"{{marker}}","@l":"Warning","@i":42,"ProcessId":1,"ThreadId":9}""");
+
+		Assert.Equal("Warning", await QueryStringAsync($"SELECT level FROM kdb.logs WHERE message = '{marker}'"));
+		Assert.Equal(marker, await QueryStringAsync($"SELECT message FROM kdb.logs WHERE message = '{marker}'"));
+	}
+
+	[Fact]
+	public async Task QueriesSeededStatsRow() {
+		Seed("log-stats20200101.json",
+			"""{"@t":"2020-01-01T00:00:00.0000000+00:00","@mt":"{@stats}","@l":"Information","@i":987654321,"stats":{"proc":{"cpu":0.5}}}""");
+
+		Assert.Equal(1, await QueryCountAsync("SELECT count(*) FROM kdb.stats WHERE event_id = 987654321"));
+		Assert.Equal("0.5", await QueryStringAsync("SELECT raw->'stats'->'proc'->>'cpu' FROM kdb.stats WHERE event_id = 987654321"));
+	}
+
+	// One query touching both kdb.logs and kdb.stats - both reads are inlined into the same statement.
+	[Fact]
+	public async Task QueriesAcrossLogsAndStats() {
+		var marker = $"union-{Guid.NewGuid():N}";
+		Seed("log20200102.json", $$"""{"@t":"2020-01-02T00:00:00.0000000+00:00","@mt":"{{marker}}","@l":"Information","@i":1}""");
+		Seed("log-stats20200102.json", $$"""{"@t":"2020-01-02T00:00:00.0000000+00:00","@mt":"{@stats}","@l":"Information","@i":555000001}""");
+
+		Assert.Equal(2, await QueryCountAsync(
+			$"SELECT count(*) FROM (SELECT message FROM kdb.logs WHERE message = '{marker}' " +
+			"UNION ALL SELECT message_template FROM kdb.stats WHERE event_id = 555000001)"));
+	}
+
+	// Aliased + qualified reference resolves against the inlined subquery.
+	[Fact]
+	public async Task ResolvesAliasedQualifiedColumn() {
+		var marker = $"alias-{Guid.NewGuid():N}";
+		Seed("log20200103.json", $$"""{"@t":"2020-01-03T00:00:00.0000000+00:00","@mt":"{{marker}}","@l":"Error","@i":7}""");
+
+		Assert.Equal("Error", await QueryStringAsync($"SELECT l.level FROM kdb.logs l WHERE l.message = '{marker}'"));
+	}
+
+	[Fact]
+	public async Task TimeBoundedQueryReturnsOnlyInWindowRows() {
+		var oldMarker = $"old-{Guid.NewGuid():N}";
+		var newMarker = $"new-{Guid.NewGuid():N}";
+		Seed("log20200101.json", $$"""{"@t":"2020-01-01T00:00:00.0000000+00:00","@mt":"{{oldMarker}}","@l":"Information","@i":1}""");
+		Seed("log20300101.json", $$"""{"@t":"2030-01-01T00:00:00.0000000+00:00","@mt":"{{newMarker}}","@l":"Information","@i":2}""");
+
+		Assert.Equal(newMarker, await QueryStringAsync(
+			$"SELECT message FROM kdb.logs WHERE timestamp >= TIMESTAMP '2030-01-01' AND message IN ('{oldMarker}', '{newMarker}')"));
+	}
+
+	[Fact]
+	public async Task RejectsUnknownKdbTable() =>
+		await Assert.ThrowsAnyAsync<Exception>(() => ExecuteAsync("SELECT * FROM kdb.nope"));
+
+	// Table functions are rejected outright - a user can't read arbitrary files (the CVE #5673 guard).
+	[Fact]
+	public async Task RejectsTableFunction() =>
+		await Assert.ThrowsAnyAsync<Exception>(() => ExecuteAsync("SELECT * FROM read_json_objects('/etc/passwd')"));
+
+	// The specific bypass #5673 closed: a table function smuggled in as a JOIN operand. Confirms the
+	// guard still fires after the pre-order -> post-order walk change.
+	[Fact]
+	public async Task RejectsTableFunctionInJoinOperand() =>
+		await Assert.ThrowsAnyAsync<Exception>(() =>
+			ExecuteAsync("SELECT * FROM kdb.records r JOIN read_json_objects('/etc/passwd') p ON true"));
+
+	// json_serialize_sql is SELECT-only, so non-SELECT statements are rejected at parse.
+	[Fact]
+	public async Task RejectsCreateTableAsSelect() =>
+		await Assert.ThrowsAnyAsync<Exception>(() => ExecuteAsync("CREATE TABLE t AS SELECT * FROM kdb.logs"));
+
+	[Fact]
+	public async Task RejectsCopyToFileWrite() =>
+		await Assert.ThrowsAnyAsync<Exception>(() => ExecuteAsync("COPY (SELECT 1) TO '/tmp/x.csv' (FORMAT CSV)"));
+
+	private void Seed(string fileName, string clefLine) {
+		var dir = Fixture.NodeOptions.GetLogsDirectory();
+		Directory.CreateDirectory(dir);
+		File.WriteAllText(Path.Combine(dir, fileName), clefLine + "\n");
+	}
+
+	private async Task<string?> QueryStringAsync(string sql) {
+		await foreach (var value in QueryFirstColumnAsync(sql))
+			return value?.ToString();
+
+		return null;
+	}
+
+	private async Task<long> QueryCountAsync(string sql) {
+		await foreach (var value in QueryFirstColumnAsync(sql))
+			return Convert.ToInt64(value);
+
+		return 0;
+	}
+
+	private async Task ExecuteAsync(string sql) {
+		await foreach (var _ in QueryFirstColumnAsync(sql)) { }
+	}
+
+	private async IAsyncEnumerable<object?> QueryFirstColumnAsync(string sql) {
+		using var driver = new FlightSqlDriver();
+		var parameters = new Dictionary<string, string> { [FlightSqlParameters.ServerAddress] = HostingAddress };
+		await using var connection = new AdbcConnection(driver, parameters, parameters);
+		await connection.OpenAsync(TestContext.Current.CancellationToken);
+		await using var command = connection.CreateCommand();
+		command.CommandText = sql;
+		await using var reader = await command.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+		while (await reader.ReadAsync(TestContext.Current.CancellationToken))
+			yield return reader[0];
+	}
+
+	private string HostingAddress {
+		get {
+			var urls = Fixture
+				.NodeServices
+				.GetRequiredService<IServer>()
+				.Features
+				.Get<IServerAddressesFeature>()
+				?.Addresses ?? [];
+
+			var port = new Uri(urls.First()).Port;
+			return $"http://localhost:{port}";
+		}
+	}
+}

--- a/src/KurrentDB.SecondaryIndexing.Tests/LogsQuery/LogViewsTests.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/LogsQuery/LogViewsTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text;
+using Kurrent.Quack;
+using Kurrent.Quack.ConnectionPool;
+using KurrentDB.Core.XUnit.Tests;
+using KurrentDB.SecondaryIndexing.LogsQuery;
+
+namespace KurrentDB.SecondaryIndexing.Tests.LogsQuery;
+
+// Exercises the LogViews glob-source builder directly on a (non-hardened) pool connection. The
+// rewriter's job of splicing the built SQL into a query AST is covered separately.
+public sealed class LogViewsTests : DirectoryPerTest<LogViewsTests> {
+	private const string InfoLine =
+		"""{"@t":"2026-07-06T09:28:00.6878711+00:00","@mt":"Current version of KurrentDB is : {dbVersion}","@l":"Information","@i":2803721463,"dbVersion":"26.1.0.3443","SourceContext":"Foo.Bar","ProcessId":7,"ThreadId":9}""";
+
+	private const string ErrorLine =
+		"""{"@t":"2026-07-06T09:28:01.0000000+00:00","@mt":"boom","@l":"Error","@i":1,"@x":"System.Exception: nope","ProcessId":1,"ThreadId":9}""";
+
+	private const string StatsLine =
+		"""{"@t":"2026-07-06T07:14:19.3286989+00:00","@mt":"{@stats}","@l":"Information","@i":3047155976,"stats":{"proc":{"cpu":0.5,"mem":1024}}}""";
+
+	private readonly DuckDBConnectionPool _duckDb;
+	private readonly string _logsDir;
+
+	public LogViewsTests() {
+		_logsDir = Path.Combine(Fixture.Directory, "component-logs");
+		Directory.CreateDirectory(_logsDir);
+		_duckDb = new($"Data Source={Fixture.GetFilePathFor("logs.db")};");
+		using (_duckDb.Rent(out var connection))
+			new RenderMessageFunction().Register(connection);
+	}
+
+	private void Write(string fileName, params string[] lines) =>
+		File.WriteAllText(Path.Combine(_logsDir, fileName), string.Join('\n', lines) + "\n");
+
+	private string Logs => new LogViews(_logsDir).BuildLogsSql();
+	private string Stats => new LogViews(_logsDir).BuildStatsSql();
+
+	[Fact]
+	public void ReadsEveryLevel() {
+		Write("log20260706.json", InfoLine, ErrorLine);
+		Assert.Equal(2, ScalarLong($"SELECT count(*) FROM ({Logs})"));
+	}
+
+	[Fact]
+	public void ExcludesErrorAndStatsFilesFromLogs() {
+		Write("log20260706.json", InfoLine, ErrorLine);
+		Write("log-err20260706.json", ErrorLine);
+		Write("log-stats20260706.json", StatsLine);
+		Assert.Equal(2, ScalarLong($"SELECT count(*) FROM ({Logs})"));
+	}
+
+	[Fact]
+	public void ReadsUndatedMainLog() {
+		// RollingInterval.Infinite writes a bare log.json with no date suffix; the glob must catch it.
+		Write("log.json", InfoLine);
+		Assert.Equal(1, ScalarLong($"SELECT count(*) FROM ({Logs})"));
+	}
+
+	[Fact]
+	public void RendersMessageTemplate() {
+		Write("log20260706.json", InfoLine);
+		Assert.Equal("Current version of KurrentDB is : 26.1.0.3443",
+			ScalarString($"SELECT message FROM ({Logs}) WHERE level = 'Information'"));
+	}
+
+	[Fact]
+	public void ExtractsPlainColumns() {
+		Write("log20260706.json", InfoLine);
+		Assert.Equal("Foo.Bar", ScalarString($"SELECT source_context FROM ({Logs})"));
+		Assert.Equal(7, ScalarLong($"SELECT process_id FROM ({Logs})"));
+		Assert.Equal(9, ScalarLong($"SELECT thread_id FROM ({Logs})"));
+		Assert.Equal("log20260706.json", ScalarString($"SELECT file FROM ({Logs})"));
+	}
+
+	[Fact]
+	public void ExposesException() {
+		Write("log20260706.json", ErrorLine);
+		Assert.Equal("System.Exception: nope",
+			ScalarString($"SELECT exception FROM ({Logs}) WHERE level = 'Error'"));
+	}
+
+	[Fact]
+	public void NoFilesYieldsEmptyWithoutError() {
+		Assert.Equal(0, ScalarLong($"SELECT count(*) FROM ({Logs})"));
+		Assert.Equal(0, ScalarLong($"SELECT count(*) FROM ({Stats})"));
+	}
+
+	[Fact]
+	public void StatsReadsFileAndExposesRawPayload() {
+		Write("log-stats20260706.json", StatsLine);
+		Assert.Equal(1, ScalarLong($"SELECT count(*) FROM ({Stats})"));
+		Assert.Equal("0.5", ScalarString($"SELECT raw->'stats'->'proc'->>'cpu' FROM ({Stats})"));
+	}
+
+	private long ScalarLong(string sql) {
+		using (_duckDb.Rent(out var connection)) {
+			using var result = connection.ExecuteAdHocQuery(Encoding.UTF8.GetBytes(sql));
+			while (result.TryFetch(out var chunk))
+				using (chunk)
+					if (chunk.TryRead(out var row))
+						return row.ReadInt64();
+		}
+
+		throw new InvalidOperationException("query returned no rows");
+	}
+
+	private string ScalarString(string sql) {
+		using (_duckDb.Rent(out var connection)) {
+			using var result = connection.ExecuteAdHocQuery(Encoding.UTF8.GetBytes(sql));
+			while (result.TryFetch(out var chunk))
+				using (chunk)
+					if (chunk.TryRead(out var row))
+						return row.ReadString();
+		}
+
+		throw new InvalidOperationException("query returned no rows");
+	}
+
+	public override async ValueTask DisposeAsync() {
+		_duckDb.Dispose();
+		await base.DisposeAsync();
+	}
+}

--- a/src/KurrentDB.SecondaryIndexing.Tests/LogsQuery/LogViewsTests.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/LogsQuery/LogViewsTests.cs
@@ -67,6 +67,17 @@ public sealed class LogViewsTests : DirectoryPerTest<LogViewsTests> {
 	}
 
 	[Fact]
+	public void RendersFormattedAndAlignedTokens() {
+		// Serilog writes format-specifier tokens into @r pre-padded (PropertyToken.Render applies
+		// the alignment), so the rendering must be used verbatim - not re-padded. A token with
+		// alignment but no format isn't in @r and is padded from the JSON property.
+		Write("log20260706.json",
+			"""{"@t":"2026-07-06T09:28:02.0000000+00:00","@mt":"waited {ms,8:N0} ms during {op,-8}!","@l":"Information","@i":2,"@r":["   1,234"],"ms":1234,"op":"flush"}""");
+		Assert.Equal("waited    1,234 ms during flush   !",
+			ScalarString($"SELECT message FROM ({Logs})"));
+	}
+
+	[Fact]
 	public void ExtractsPlainColumns() {
 		Write("log20260706.json", InfoLine);
 		Assert.Equal("Foo.Bar", ScalarString($"SELECT source_context FROM ({Logs})"));

--- a/src/KurrentDB.SecondaryIndexing/KurrentDB.SecondaryIndexing.csproj
+++ b/src/KurrentDB.SecondaryIndexing/KurrentDB.SecondaryIndexing.csproj
@@ -5,6 +5,7 @@
 		<Nullable>enable</Nullable>
 		<EnableDynamicLoading>true</EnableDynamicLoading>
 		<IncludeHttpRuleProtos>true</IncludeHttpRuleProtos>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<NoWarn>$(NoWarn);DuckDBNET001</NoWarn>
 	</PropertyGroup>
 
@@ -23,6 +24,7 @@
 		<PackageReference Include="Eventuous.Application" />
 		<PackageReference Include="Eventuous.Extensions.DependencyInjection" />
 		<PackageReference Include="Microsoft.AspNetCore.Grpc.JsonTranscoding" />
+		<PackageReference Include="Serilog" />
 		<PackageReference Include="System.Linq.Async">
 			<ExcludeAssets>compile</ExcludeAssets>
 		</PackageReference>

--- a/src/KurrentDB.SecondaryIndexing/LogsQuery/LogViews.cs
+++ b/src/KurrentDB.SecondaryIndexing/LogsQuery/LogViews.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace KurrentDB.SecondaryIndexing.LogsQuery;
+
+// Builds the SQL the rewriter inlines for kdb.logs / kdb.stats: the CLEF projection over a
+// read_json_objects glob of the node's log directory, or a typed zero-row source when the directory
+// has no matching files. read_json_objects hard-errors on an empty glob match (fresh node /
+// DisableLogFile), so we must not emit it then - hence the C# gate. The glob is expanded by DuckDB
+// at execute time, so a reused prepared statement tracks files that rotate in/out.
+internal sealed class LogViews(string logsDir) {
+	public string BuildLogsSql() => Build("log[!-]*json", IsMainLog);
+
+	public string BuildStatsSql() => Build("log-stats*.json", IsStatsLog);
+
+	private string Build(string glob, Func<string, bool> match) {
+		var source = HasMatchingFile(match)
+			? $"read_json_objects({SqlString(Path.Combine(logsDir, glob))}, format='newline_delimited', filename=true, ignore_errors=true)"
+			: "(SELECT NULL::JSON AS json, NULL::VARCHAR AS filename WHERE false)";
+
+		return $"{Projection} FROM {source}";
+	}
+
+	// Main logs are log*.json but not the log-err* / log-stats* siblings; excluding "log-" (rather
+	// than matching a date) holds for any RollingInterval, including the undated log.json. The glob
+	// 'log[!-]*json' has the same match set for real log files.
+	private static bool IsMainLog(string name) =>
+		name.StartsWith("log", StringComparison.Ordinal) && !name.StartsWith("log-", StringComparison.Ordinal);
+
+	private static bool IsStatsLog(string name) => name.StartsWith("log-stats", StringComparison.Ordinal);
+
+	// The gate: does the glob have anything to match? Mirrors the glob's selection so a positive gate
+	// never yields a zero-match glob (which would throw at execute).
+	private bool HasMatchingFile(Func<string, bool> match) {
+		if (!Directory.Exists(logsDir))
+			return false;
+
+		try {
+			foreach (var path in Directory.EnumerateFiles(logsDir, "log*.json"))
+				if (match(Path.GetFileName(path)))
+					return true;
+
+			return false;
+		} catch (Exception e) when (e is IOException or UnauthorizedAccessException) {
+			// An unreadable log dir degrades to the empty source - reading logs must never fail an
+			// otherwise valid query.
+			return false;
+		}
+	}
+
+	private static string SqlString(string path) => $"'{path.Replace('\\', '/').Replace("'", "''")}'";
+
+	private const string Projection = """
+		SELECT
+			TRY_CAST(json->>'@t' AS TIMESTAMPTZ) AS timestamp,
+			coalesce(json->>'@l', 'Information') AS level,
+			render_message(json->>'@mt', json) AS message,
+			json->>'@mt' AS message_template,
+			TRY_CAST(json->>'@i' AS UBIGINT) AS event_id,
+			json->>'@x' AS exception,
+			json->>'SourceContext' AS source_context,
+			TRY_CAST(json->>'ProcessId' AS BIGINT) AS process_id,
+			TRY_CAST(json->>'ThreadId' AS BIGINT) AS thread_id,
+			regexp_extract(filename, '[^/\\]+$') AS file,
+			json AS raw
+		""";
+}

--- a/src/KurrentDB.SecondaryIndexing/LogsQuery/RenderMessageFunction.cs
+++ b/src/KurrentDB.SecondaryIndexing/LogsQuery/RenderMessageFunction.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text;
+using System.Text.Json;
+using DuckDB.NET.Native;
+using Kurrent.Quack;
+using Kurrent.Quack.Functions;
+using KurrentDB.DuckDB;
+using Serilog.Parsing;
+
+namespace KurrentDB.SecondaryIndexing.LogsQuery;
+
+// render_message(@mt, json) -> the rendered CLEF message. A format-specifier token takes its value
+// from the CLEF `@r` array (in token order) so numeric/hex/date formats like {n:N0} / {id:B} match
+// what the logger wrote; an unformatted token renders from the JSON property. Serilog's parser
+// handles tokenization, {{/}} escaping, and alignment.
+internal sealed class RenderMessageFunction() : ScalarFunction(FunctionName) {
+	public const string FunctionName = "render_message";
+
+	private static readonly MessageTemplateParser Parser = new();
+
+	protected override IReadOnlyList<ParameterDefinition> Parameters => [new(DuckDBType.Varchar), new(DuckDBType.Varchar)];
+
+	protected override LogicalType ReturnType => new(DuckDBType.Varchar);
+
+	protected override void Bind(BindingContext context) {
+	}
+
+	protected override void Execute(ExecutionContext context, in DataChunk input, in DataChunk.ColumnBuilder builder) {
+		var templates = input[0].BlobRows;
+		var payloads = input[1].BlobRows;
+		var output = builder;
+		var count = (int)input.RowCount;
+		for (var row = 0; row < count; row++)
+			output.SetValue(row, Render(Utf8(templates[row]), Utf8(payloads[row])).AsSpan());
+	}
+
+	private static unsafe string Utf8(DuckDBString value) =>
+		value.Length is 0 || value.Data == null
+			? string.Empty
+			: Encoding.UTF8.GetString(new ReadOnlySpan<byte>((byte*)value.Data, value.Length));
+
+	private static string Render(string? messageTemplate, string? json) {
+		if (string.IsNullOrEmpty(messageTemplate))
+			return string.Empty;
+
+		try {
+			using var document = json is null ? null : JsonDocument.Parse(json);
+			var root = document?.RootElement;
+			var renderings = Renderings(root);
+
+			var output = new StringBuilder(messageTemplate.Length + 16);
+			var renderingIndex = 0;
+			foreach (var token in Parser.Parse(messageTemplate).Tokens) {
+				switch (token) {
+					case TextToken text:
+						output.Append(text.Text);
+						break;
+					case PropertyToken { Format: not null } formatted:
+						if (renderings is { } r && renderingIndex < r.GetArrayLength() && r[renderingIndex].ValueKind is JsonValueKind.String)
+							output.Append(r[renderingIndex].GetString());
+						else
+							AppendProperty(output, root, formatted);
+						renderingIndex++;
+						break;
+					case PropertyToken property:
+						AppendProperty(output, root, property);
+						break;
+				}
+			}
+
+			return output.ToString();
+		} catch (Exception) {
+			// Never fail the whole query over one odd line: degrade to the raw template.
+			return messageTemplate;
+		}
+	}
+
+	private static JsonElement? Renderings(JsonElement? root) =>
+		root is { ValueKind: JsonValueKind.Object } obj
+		&& obj.TryGetProperty("@r", out var r)
+		&& r.ValueKind is JsonValueKind.Array
+			? r
+			: null;
+
+	private static void AppendProperty(StringBuilder output, JsonElement? root, PropertyToken token) {
+		string? value = null;
+		if (root is { ValueKind: JsonValueKind.Object } obj && obj.TryGetProperty(token.PropertyName, out var v))
+			value = v.ValueKind is JsonValueKind.String ? v.GetString() : v.GetRawText();
+
+		if (value is null) {
+			output.Append(token.ToString()); // unresolved property -> the raw {token}
+			return;
+		}
+
+		if (token.Alignment is { } alignment && alignment.Width > value.Length)
+			value = alignment.Direction is AlignmentDirection.Left
+				? value.PadRight(alignment.Width)
+				: value.PadLeft(alignment.Width);
+
+		output.Append(value);
+	}
+}
+
+// Registered once (not per query): the scalar function goes in the DuckDB instance catalog (shared
+// across pooled connections) and registration isn't idempotent.
+internal sealed class RenderMessageSetup : DuckDBOneTimeSetup {
+	protected override void ExecuteCore(DuckDBAdvancedConnection connection) =>
+		new RenderMessageFunction().Register(connection);
+}

--- a/src/KurrentDB.SecondaryIndexing/Query/QueryEngine.Rewriter.cs
+++ b/src/KurrentDB.SecondaryIndexing/Query/QueryEngine.Rewriter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using DotNext.Buffers;
@@ -43,11 +44,14 @@ partial class QueryEngine {
 	private void RewriteNode(JsonNode? ast, ref PreparedQueryBuilder builder) {
 		switch (ast) {
 			case JsonObject obj:
-				RewriteKnownNode(obj, ref builder);
+				// Post-order: recurse into children first, then handle this node. A node we replace
+				// (see SpliceLogSource) must not be re-descended - post-order means it isn't - and the
+				// splice clears/re-adds this object's keys, which would throw mid-enumeration otherwise.
 				foreach (var property in obj) {
 					RewriteNode(property.Value, ref builder);
 				}
 
+				RewriteKnownNode(obj, ref builder);
 				break;
 			case JsonArray array:
 				foreach (var element in array) {
@@ -98,10 +102,21 @@ partial class QueryEngine {
 		// validate schema name
 		switch (tableReference[schemaNameProperty]?.ToString()) {
 			case "kdb":
-				// rewrite system table name
 				var tableName = tableReference[tableNameProperty]?.ToString() ?? string.Empty;
-				tableName = RewriteSystemTableName(tableName, ref builder);
-				tableReference[tableNameProperty] = tableName;
+				// logs/stats are not real tables: replace the reference with an inlined read of the
+				// node's own CLEF files. The whole node becomes a SUBQUERY, so return before the
+				// schema/table fixups below.
+				switch (tableName) {
+					case "logs":
+						SpliceLogSource(tableReference.AsObject(), logViews.BuildLogsSql(), defaultAlias: "logs");
+						return;
+					case "stats":
+						SpliceLogSource(tableReference.AsObject(), logViews.BuildStatsSql(), defaultAlias: "stats");
+						return;
+				}
+
+				// rewrite system table name (records)
+				tableReference[tableNameProperty] = RewriteSystemTableName(tableName, ref builder);
 				break;
 			case "usr":
 				// rewrite user index
@@ -125,5 +140,26 @@ partial class QueryEngine {
 			default:
 				throw new UnsupportedSystemTableException(tableName);
 		}
+	}
+
+	// Replaces a kdb.logs / kdb.stats BASE_TABLE node in place with an inlined SUBQUERY over the
+	// node's CLEF files. Rather than hand-build the SUBQUERY node shape, parse a wrapper select and
+	// lift its from_table (DuckDB produces the correct shape), then copy it over the base-table node.
+	private void SpliceLogSource(JsonObject tableReference, string sourceSql, string defaultAlias) {
+		var alias = tableReference["alias"]?.ToString();
+
+		JsonNode lifted;
+		using (sharedPool.Rent(out var connection))
+			lifted = connection.ParseSyntaxTree(Encoding.UTF8.GetBytes($"SELECT * FROM ({sourceSql}) AS __t"))
+				!["statements"]![0]!["node"]!["from_table"]!;
+
+		foreach (var key in tableReference.Select(p => p.Key).ToArray())
+			tableReference.Remove(key);
+		foreach (var kv in lifted.AsObject())
+			tableReference[kv.Key] = kv.Value?.DeepClone();
+
+		// preserve the original reference's alias so qualified columns still resolve; an unaliased
+		// reference defaults to the table name (so `logs.message` / `stats.x` keep working).
+		tableReference["alias"] = string.IsNullOrEmpty(alias) ? defaultAlias : alias;
 	}
 }

--- a/src/KurrentDB.SecondaryIndexing/Query/QueryEngine.cs
+++ b/src/KurrentDB.SecondaryIndexing/Query/QueryEngine.cs
@@ -14,6 +14,7 @@ using Kurrent.Quack.ConnectionPool;
 using Kurrent.Quack.Threading;
 using KurrentDB.SecondaryIndexing.Indexes.Default;
 using KurrentDB.SecondaryIndexing.Indexes.User;
+using KurrentDB.SecondaryIndexing.LogsQuery;
 
 namespace KurrentDB.SecondaryIndexing.Query;
 
@@ -25,7 +26,8 @@ namespace KurrentDB.SecondaryIndexing.Query;
 /// <param name="sharedPool"></param>
 internal sealed partial class QueryEngine(DefaultIndexProcessor defaultIndex,
 	UserIndexEngine userIndex,
-	DuckDBConnectionPool sharedPool) : IQueryEngine {
+	DuckDBConnectionPool sharedPool,
+	LogViews logViews) : IQueryEngine {
 	// 32 bytes key is aligned with HMAC SHA-3 256 hash length
 	private readonly ReadOnlyMemory<byte> _signatureKey = RandomNumberGenerator.GetBytes(32);
 

--- a/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
+++ b/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
@@ -60,10 +60,8 @@ public class SecondaryIndexingPlugin(SecondaryIndexReaders secondaryIndexReaders
 		services.AddSingleton<UserIndexEngine>();
 		services.AddDuckDBSetup<IndexingDbSchema>();
 		services.AddDuckDBSetup<RenderMessageSetup>();
-		services.AddSingleton(static sp => {
-			var nodeOptions = sp.GetRequiredService<ClusterVNodeOptions>();
-			return new LogViews(Path.GetFullPath(Path.Combine(nodeOptions.Logging.Log, nodeOptions.GetComponentName())));
-		});
+		services.AddSingleton(static sp =>
+			new LogViews(sp.GetRequiredService<ClusterVNodeOptions>().GetLogsDirectory()));
 		services.AddSingleton<FlightSqlLicense>();
 		services.AddFlightSqlServer();
 

--- a/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
+++ b/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
@@ -21,6 +21,7 @@ using KurrentDB.SecondaryIndexing.Indexes.Default;
 using KurrentDB.SecondaryIndexing.Indexes.EventType;
 using KurrentDB.SecondaryIndexing.Indexes.User;
 using KurrentDB.SecondaryIndexing.Indexes.User.Management;
+using KurrentDB.SecondaryIndexing.LogsQuery;
 using KurrentDB.SecondaryIndexing.Query;
 using KurrentDB.SecondaryIndexing.Stats;
 using KurrentDB.SecondaryIndexing.Storage;
@@ -58,6 +59,11 @@ public class SecondaryIndexingPlugin(SecondaryIndexReaders secondaryIndexReaders
 		services.AddSingleton<IQueryEngine>(static sp => sp.GetRequiredService<QueryEngine>());
 		services.AddSingleton<UserIndexEngine>();
 		services.AddDuckDBSetup<IndexingDbSchema>();
+		services.AddDuckDBSetup<RenderMessageSetup>();
+		services.AddSingleton(static sp => {
+			var nodeOptions = sp.GetRequiredService<ClusterVNodeOptions>();
+			return new LogViews(Path.GetFullPath(Path.Combine(nodeOptions.Logging.Log, nodeOptions.GetComponentName())));
+		});
 		services.AddSingleton<FlightSqlLicense>();
 		services.AddFlightSqlServer();
 


### PR DESCRIPTION
Exposes a node's own CLEF log files as two queryable tables, `kdb.logs` and `kdb.stats`, over the existing Arrow Flight SQL surface in the SecondaryIndexing plugin. Read-only and node-local: a query only sees the log files on the node it connects to.

- **`LogViews`** builds the CLEF projection over a `read_json_objects` glob of the node's log directory, with a typed zero-row fallback when no files match (`read_json_objects` errors on an empty set / fresh node). The main-log predicate excludes `log-*` siblings so it holds for any `RollingInterval`, including the undated `log.json`.
- **`QueryEngine` rewriter** inlines the read: a `kdb.logs` / `kdb.stats` reference is replaced in place with the projection as a subquery, preserving the reference's alias. `RewriteKnownNode` moved to post-order so the injected `read_json_objects` isn't re-walked by the table-function guard, which still rejects user-written table functions (including the JOIN-operand bypass).
- **`render_message` scalar function** renders CLEF `@mt` templates, taking format-specifier tokens from the `@r` renderings (which Serilog writes pre-padded) and falling back to the JSON properties. Degrades to the raw template rather than failing the whole query on a malformed line. Registered once per DuckDB instance.
- **DuckDB pool hardening** moves post-open into a single `CreatePool` path: run the one-time setups, then set `allowed_directories` (the node's log dir for the Shared pool, nothing for read-only pools), disable external access, and lock the configuration - in that order, which DuckDB requires and the connection string can't carry (`allowed_directories` is rejected before the database is started). Pools with the same connection string share one DuckDB instance, so hardening skips an instance that is already locked.
- **`ClusterVNodeOptions.GetLogsDirectory`** is the single source for the node's component log dir, shared by the pool allow-list and `LogViews`.
- **Docs** add a "Querying node logs" section to the Flight SQL page (both tables, their columns, and example queries) and a cross-link from the Database logs page.
- **Tests** cover the projection and rendering including `@r` alignment handling (`LogViewsTests`), the end-to-end Flight SQL surface and table-function rejection (`LogsFlightSqlTests`), and temp-dir cleanup against the new pool constructor (`DuckDBConnectionPoolLifetimeTests`); the shared-instance hardening is exercised by the existing Api V2 index-read suites.
