### PR TITLE
fix: terminate gRPC subscription streams on server-initiated drops

### DIFF
--- a/src/KurrentDB.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscription.Tests.cs
+++ b/src/KurrentDB.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscription.Tests.cs
@@ -8,6 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.Data;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using KurrentDB.Core.Services;
 using KurrentDB.Core.Services.Storage.ReaderIndex;
 using KurrentDB.Core.Services.Transport.Common;
 using KurrentDB.Core.Services.Transport.Enumerators;
@@ -57,6 +60,34 @@ public partial class EnumeratorTests {
 			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
 			Assert.AreEqual(new TFPos(350, 300), caughtUp.Wrapped.AllCheckpoint);
 			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class all_subscription_dropped_by_server<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
+		private IEnvelope _subscriptionEnvelope;
+
+		protected override void Given() {
+			EnableReadAll();
+			WriteEvent("test-stream", "type1", "{}", "{Data: 1}");
+			_bus.Subscribe(new AdHocHandler<ClientMessage.SubscribeToStream>(msg => _subscriptionEnvelope = msg.Envelope));
+		}
+
+		[Test]
+		public async Task server_initiated_unsubscribe_terminates_the_enumeration() {
+			await using var sub = CreateAllSubscription(_publisher, checkpoint: null);
+
+			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+			Assert.True(await sub.GetNext() is Event);
+			Assert.True(await sub.GetNext() is CaughtUp);
+
+			// simulate e.g. SubscriptionsService handling SystemMessage.BecomeShuttingDown, which
+			// drops all subscriptions with reason Unsubscribed while the client still wants them.
+			Assert.NotNull(_subscriptionEnvelope);
+			_subscriptionEnvelope.ReplyWith(new ClientMessage.SubscriptionDropped(Guid.NewGuid(), SubscriptionDropReason.Unsubscribed));
+
+			// the enumeration must terminate so the gRPC stream ends instead of dangling open.
+			Assert.ThrowsAsync<ReadResponseException.SubscriptionDropped>(async () => await sub.GetNext());
 		}
 	}
 

--- a/src/KurrentDB.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.Tests.cs
+++ b/src/KurrentDB.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.Tests.cs
@@ -7,6 +7,9 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using KurrentDB.Core.Bus;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using KurrentDB.Core.Services;
 using KurrentDB.Core.Services.Storage.ReaderIndex;
 using KurrentDB.Core.Services.Transport.Common;
 using KurrentDB.Core.Services.Transport.Enumerators;
@@ -57,6 +60,35 @@ public partial class EnumeratorTests {
 			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
 			Assert.Null(caughtUp.Wrapped.AllCheckpoint);
 			Assert.AreEqual(0, caughtUp.Wrapped.StreamCheckpoint);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class stream_subscription_dropped_by_server<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId> {
+		private IEnvelope _subscriptionEnvelope;
+
+		protected override void Given() {
+			EnableReadAll();
+			WriteEvent("test-stream", "type1", "{}", "{Data: 1}");
+			_bus.Subscribe(new AdHocHandler<ClientMessage.SubscribeToStream>(msg => _subscriptionEnvelope = msg.Envelope));
+		}
+
+		[Test]
+		public async Task server_initiated_unsubscribe_terminates_the_enumeration() {
+			await using var sub = CreateStreamSubscription<TStreamId>(
+				_publisher, streamName: "test-stream");
+
+			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+			Assert.True(await sub.GetNext() is Event);
+			Assert.True(await sub.GetNext() is CaughtUp);
+
+			// simulate e.g. SubscriptionsService handling SystemMessage.BecomeShuttingDown, which
+			// drops all subscriptions with reason Unsubscribed while the client still wants them.
+			Assert.NotNull(_subscriptionEnvelope);
+			_subscriptionEnvelope.ReplyWith(new ClientMessage.SubscriptionDropped(Guid.NewGuid(), SubscriptionDropReason.Unsubscribed));
+
+			// the enumeration must terminate so the gRPC stream ends instead of dangling open.
+			Assert.ThrowsAsync<ReadResponseException.SubscriptionDropped>(async () => await sub.GetNext());
 		}
 	}
 

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
@@ -154,6 +154,9 @@ static partial class Enumerator {
 			} catch (ReadResponseException.NotHandled.ServerNotReady ex) {
 				Log.Warning("Subscription {subscriptionId} to $all terminated because server is not ready.", _subscriptionId);
 				_channel.Writer.TryComplete(ex);
+			} catch (ReadResponseException.SubscriptionDropped ex) {
+				Log.Warning("Subscription {subscriptionId} to $all was dropped by the server.", _subscriptionId);
+				_channel.Writer.TryComplete(ex);
 			} catch (Exception ex) {
 				if (ex is not (OperationCanceledException or ReadResponseException.InvalidPosition))
 					Log.Error(ex, "Subscription {subscriptionId} to $all experienced an error.", _subscriptionId);
@@ -319,7 +322,15 @@ static partial class Enumerator {
 								case SubscriptionDropReason.AccessDenied:
 									throw new ReadResponseException.AccessDenied();
 								case SubscriptionDropReason.Unsubscribed:
-									return;
+									if (_disposed) {
+										// this enumerator initiated the unsubscribe and is being torn down.
+										return;
+									}
+
+									// the server dropped the subscription (e.g. BecomeShuttingDown drops all
+									// subscriptions with reason Unsubscribed). Terminate the enumeration,
+									// otherwise the gRPC stream dangles open and never produces anything.
+									throw new ReadResponseException.SubscriptionDropped();
 								case SubscriptionDropReason.StreamDeleted: // applies only to regular streams
 								case SubscriptionDropReason.NotFound: // applies only to persistent subscriptions
 								default:

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -174,7 +174,9 @@ ReadLoop:
 					(checkpoint, sequenceNumber) = await GoLive(checkpoint, sequenceNumber, ct);
 				}
 			} catch (Exception ex) {
-				if (ex is not (OperationCanceledException or ReadResponseException.InvalidPosition)) {
+				if (ex is ReadResponseException.SubscriptionDropped) {
+					Log.Warning("Subscription {subscriptionId} to $all:{eventFilter} was dropped by the server.", _subscriptionId, _eventFilter);
+				} else if (ex is not (OperationCanceledException or ReadResponseException.InvalidPosition)) {
 					Log.Error(ex, "Subscription {subscriptionId} to $all:{eventFilter} experienced an error.", _subscriptionId, _eventFilter);
 				}
 
@@ -407,7 +409,15 @@ ReadLoop:
 								case SubscriptionDropReason.AccessDenied:
 									throw new ReadResponseException.AccessDenied();
 								case SubscriptionDropReason.Unsubscribed:
-									return;
+									if (_disposed) {
+										// this enumerator initiated the unsubscribe and is being torn down.
+										return;
+									}
+
+									// the server dropped the subscription (e.g. BecomeShuttingDown drops all
+									// subscriptions with reason Unsubscribed). Terminate the enumeration,
+									// otherwise the gRPC stream dangles open and never produces anything.
+									throw new ReadResponseException.SubscriptionDropped();
 								case SubscriptionDropReason.StreamDeleted: // applies only to regular streams
 								case SubscriptionDropReason.NotFound: // applies only to persistent subscriptions
 								default:

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.IndexSubscription.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.IndexSubscription.cs
@@ -91,7 +91,9 @@ partial class Enumerator {
 					(checkpoint, sequenceNumber) = await GoLive(checkpoint, sequenceNumber, ct);
 				}
 			} catch (Exception ex) {
-				if (ex is not (
+				if (ex is ReadResponseException.SubscriptionDropped) {
+					Log.Warning("Subscription {SubscriptionId} to {IndexName} was dropped by the server.", _subscriptionId, _indexName);
+				} else if (ex is not (
 				    OperationCanceledException or
 				    ReadResponseException.InvalidPosition or
 				    ReadResponseException.IndexNotFound)) {
@@ -275,7 +277,15 @@ partial class Enumerator {
 								case SubscriptionDropReason.AccessDenied:
 									throw new ReadResponseException.AccessDenied();
 								case SubscriptionDropReason.Unsubscribed:
-									return;
+									if (_disposed) {
+										// this enumerator initiated the unsubscribe and is being torn down.
+										return;
+									}
+
+									// the server dropped the subscription (e.g. BecomeShuttingDown drops all
+									// subscriptions with reason Unsubscribed). Terminate the enumeration,
+									// otherwise the gRPC stream dangles open and never produces anything.
+									throw new ReadResponseException.SubscriptionDropped();
 								case SubscriptionDropReason.NotFound:
 									throw new ReadResponseException.IndexNotFound(_indexName);
 								case SubscriptionDropReason.StreamDeleted: // applies only to regular streams

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
@@ -163,7 +163,9 @@ ReadLoop:
 					(checkpoint, sequenceNumber) = await GoLive(checkpoint, sequenceNumber, ct);
 				}
 			} catch (Exception ex) {
-				if (ex is not (OperationCanceledException or ReadResponseException.StreamDeleted)) {
+				if (ex is ReadResponseException.SubscriptionDropped) {
+					Log.Warning("Subscription {subscriptionId} to {streamName} was dropped by the server.", _subscriptionId, _streamName);
+				} else if (ex is not (OperationCanceledException or ReadResponseException.StreamDeleted)) {
 					Log.Error(ex, "Subscription {subscriptionId} to {streamName} experienced an error.", _subscriptionId, _streamName);
 				}
 
@@ -331,7 +333,15 @@ ReadLoop:
 								case SubscriptionDropReason.StreamDeleted:
 									throw new ReadResponseException.StreamDeleted(_streamName);
 								case SubscriptionDropReason.Unsubscribed:
-									return;
+									if (_disposed) {
+										// this enumerator initiated the unsubscribe and is being torn down.
+										return;
+									}
+
+									// the server dropped the subscription (e.g. BecomeShuttingDown drops all
+									// subscriptions with reason Unsubscribed). Terminate the enumeration,
+									// otherwise the gRPC stream dangles open and never produces anything.
+									throw new ReadResponseException.SubscriptionDropped();
 								case SubscriptionDropReason.NotFound: // applies only to persistent subscriptions
 								default:
 									throw ReadResponseException.UnknownError.Create(dropped.Reason);

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/ReadResponseException.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/ReadResponseException.cs
@@ -30,6 +30,10 @@ public abstract class ReadResponseException : Exception {
 
 	public class AccessDenied : ReadResponseException;
 
+	// The server dropped the subscription while the client still wanted it, e.g. because the node
+	// is shutting down. The enumeration must terminate so that the client can resubscribe elsewhere.
+	public class SubscriptionDropped : ReadResponseException;
+
 	public class InvalidPosition : ReadResponseException;
 
 	public class Timeout(string errorMessage) : ReadResponseException {

--- a/src/KurrentDB.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -19,6 +19,9 @@ public static class RpcExceptions {
 	internal static RpcException ServerBusy() =>
 		new(new Status(StatusCode.Unavailable, "Server Is Too Busy"));
 
+	internal static RpcException SubscriptionDropped() =>
+		new(new Status(StatusCode.Unavailable, "Subscription was dropped by the server, e.g. because the node is shutting down. Resubscribe to continue."));
+
 	internal static Exception NoLeaderInfo() =>
 		new RpcException(new Status(StatusCode.Unknown, "No leader info available in response"));
 

--- a/src/KurrentDB.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -368,6 +368,8 @@ static class ResponseConverter {
 				throw RpcExceptions.StreamDeleted(streamDeleted.StreamName);
 			case ReadResponseException.AccessDenied:
 				throw RpcExceptions.AccessDenied();
+			case ReadResponseException.SubscriptionDropped:
+				throw RpcExceptions.SubscriptionDropped();
 			case ReadResponseException.Timeout timeout:
 				throw RpcExceptions.Timeout(timeout.ErrorMessage);
 			case ReadResponseException.InvalidPosition:

--- a/src/KurrentDB.SecondaryIndexing/Subscriptions/DefaultIndexSubscription.cs
+++ b/src/KurrentDB.SecondaryIndexing/Subscriptions/DefaultIndexSubscription.cs
@@ -69,6 +69,9 @@ public sealed partial class DefaultIndexSubscription(
 			} catch (ReadResponseException.NotHandled.ServerNotReady) {
 				LogStoppingBecauseServerIsNotReady(log);
 				break;
+			} catch (ReadResponseException.SubscriptionDropped) {
+				LogStoppingBecauseSubscriptionDropped(log);
+				break;
 			}
 
 			if (_subscription.Current is ReadResponse.SubscriptionCaughtUp caughtUp) {
@@ -149,6 +152,9 @@ public sealed partial class DefaultIndexSubscription(
 
 	[LoggerMessage(LogLevel.Information, "Default indexing subscription is stopping because server is not ready")]
 	static partial void LogStoppingBecauseServerIsNotReady(ILogger logger);
+
+	[LoggerMessage(LogLevel.Information, "Default indexing subscription is stopping because it was dropped by the server")]
+	static partial void LogStoppingBecauseSubscriptionDropped(ILogger logger);
 
 	[LoggerMessage(LogLevel.Error, "Error while processing event {eventType}")]
 	static partial void LogErrorWhileProcessing(ILogger logger, Exception exception, string eventType);

--- a/src/KurrentDB.SecondaryIndexing/Subscriptions/UserIndexSubscription.cs
+++ b/src/KurrentDB.SecondaryIndexing/Subscriptions/UserIndexSubscription.cs
@@ -72,6 +72,9 @@ internal sealed class UserIndexSubscription<TField>(
 			} catch (ReadResponseException.NotHandled.ServerNotReady) {
 				log.LogUserIndexIsStoppingBecauseServerIsNotReady(indexProcessor.IndexName);
 				break;
+			} catch (ReadResponseException.SubscriptionDropped) {
+				log.LogUserIndexIsStoppingBecauseSubscriptionDropped(indexProcessor.IndexName);
+				break;
 			}
 
 			if (_subscription.Current is ReadResponse.SubscriptionCaughtUp caughtUp) {
@@ -171,6 +174,9 @@ static partial class UserIndexSubscriptionLogMessages {
 
 	[LoggerMessage(LogLevel.Information, "User index: {index} is stopping because server is not ready")]
 	internal static partial void LogUserIndexIsStoppingBecauseServerIsNotReady(this ILogger logger, string index);
+
+	[LoggerMessage(LogLevel.Information, "User index: {index} is stopping because the subscription was dropped by the server")]
+	internal static partial void LogUserIndexIsStoppingBecauseSubscriptionDropped(this ILogger logger, string index);
 
 	[LoggerMessage(LogLevel.Trace, "User index: {index} caught up at {time}")]
 	internal static partial void LogUserIndexCaughtUp(this ILogger logger, string index, DateTime time);


### PR DESCRIPTION
## Summary

Server-initiated subscription drops leave gRPC `Read` streams dangling open forever. This PR makes the subscription enumerators terminate the stream when the server drops the subscription, so clients receive an actionable status instead of a permanently silent, healthy-looking call.

## Problem

When a node shuts down, `SubscriptionsService.Handle(SystemMessage.BecomeShuttingDown)` drops every live subscription with `SubscriptionDropReason.Unsubscribed`:

```csharp
public void Handle(SystemMessage.BecomeShuttingDown message) {
    foreach (var subscription in subscriptions) {
        DropSubscription(subscription, SubscriptionDropReason.Unsubscribed, sendDropNotification: true);
    }
    ...
}
```

All four gRPC subscription enumerators (`Enumerator.StreamSubscription`, `Enumerator.AllSubscription`, `Enumerator.AllSubscriptionFiltered`, `Enumerator.IndexSubscription`) handle that notification like this:

```csharp
case SubscriptionDropReason.Unsubscribed:
    return;
```

Every other drop reason throws, which completes the live-events channel and ends the gRPC stream. `Unsubscribed` alone completes nothing — the assumption being that `Unsubscribed` is always the reply to a client-initiated unsubscribe, where the call is being torn down anyway. That assumption breaks for server-initiated drops.

The result: the server-side subscription is destroyed, but the gRPC `Read` stream stays open. From the client's perspective the subscription is confirmed and the transport is healthy (gRPC keepalive pings are answered — the process is still alive), yet no event will ever arrive again. There is no error, no completion, no signal of any kind.

Two variants:

- **Post-confirmation**: the live-events channel is never completed, so the enumerator parks in `GoLive` forever.
- **Pre-confirmation race**: if the drop arrives before `SubscriptionConfirmation` (e.g. a subscribe lands during the shutdown window), the confirmation `TaskCompletionSource` is never completed and the call hangs before ever confirming.

## Impact

Observed in production: catch-up subscriptions stalling permanently during rolling upgrades. Projections consuming via catch-up subscriptions silently stopped updating on one node's worth of connections while the application, the transport, and all health checks looked fine. The failure mode is invisible to gRPC keepalive (transport is alive) and to error-driven retry logic in any client (there is no error). It affects all gRPC clients equally, since the missing signal is server-side.

## Why connection teardown on shutdown is not enough

When the process exits cleanly the connection dies and the client sees UNAVAILABLE, so it may look like the shutdown case takes care of itself. It does not, for three reasons:

- `BecomeShuttingDown` drops the subscriptions early in the shutdown sequence, but the client only notices when the transport actually goes away. Until then the stream is confirmed, open, and dead — and the server is meanwhile spending its graceful-shutdown window waiting on calls that can never complete. Ending the stream promptly also lets shutdown drain cleanly instead of slamming the call at the timeout.

- Connection-drop detection relies on the FIN/RST reaching the client, and upgrades are exactly when that can get lost (hard kill at the end of the drain window, container/VM network teardown ordering, NAT/conntrack state loss). What's left is a half-open connection, and gRPC keepalive only helps when the transport is truly dead. This is how the issue was found: catch-up subscriptions stalling permanently across rolling upgrades in production — the connection-level detection demonstrably did not fire in all cases.

- There's also a pre-confirmation race: a subscribe landing in the shutdown window (after the subscriptions queue has stopped) is accepted but never confirmed and never dropped — same dangle, before the client even has a confirmed subscription.

More generally, every other drop reason (`AccessDenied`, `StreamDeleted`, `NotFound`) already terminates the stream in-band. Relying on TCP teardown as the cleanup mechanism for `Unsubscribed` is accidental correctness — the stream's lifetime should be tied to the subscription it serves, not to how the transport happens to die.

## Fix

`SubscriptionDropReason.Unsubscribed` now distinguishes the two cases the reason conflates:

- **Client-initiated** (the enumerator is being disposed, which is what publishes `UnsubscribeFromStream`): unchanged — the notification is ignored, the call is already being torn down.
- **Server-initiated** (enumerator not disposed): throws the new `ReadResponseException.SubscriptionDropped`, which flows the established error path (live channel → main loop → output channel) and terminates the gRPC stream. The same throw also faults the confirmation TCS, covering the pre-confirmation race.

The new exception maps to `UNAVAILABLE` ("Subscription was dropped by the server, e.g. because the node is shutting down. Resubscribe to continue."), which clients already treat as a retryable connection failure. What clients do with it — resubscribe automatically, fire a callback, give up — remains their choice. The server's only obligation is to not pretend a dead subscription is alive, and that is the correctness this change restores.

Additional changes:

- Server-initiated drops log as `Warning` (expected during shutdown) instead of falling into the generic `Error` path.
- The in-process secondary indexing subscriptions (`DefaultIndexSubscription`, `UserIndexSubscription`) previously hung on the dangling enumerator until cancellation; they now stop gracefully on drop, mirroring their existing `ServerNotReady` handling.

## Testing

- New tests `stream_subscription_dropped_by_server` and `all_subscription_dropped_by_server`: subscribe → confirm → caught up → inject `SubscriptionDropped(Unsubscribed)` via the captured subscribe envelope → assert the enumeration terminates with `ReadResponseException.SubscriptionDropped` instead of hanging.
- Full enumerator suite passes (199/199).

## Design note for reviewers

The root ambiguity is that `SubscriptionDropReason.Unsubscribed` carries two meanings: "client asked to stop" (benign ack) and "server evicted the subscription" (must act). This PR resolves the ambiguity at the receiver via the enumerator's `_disposed` state, keeping the change minimal. The arguably cleaner alternative is to resolve it at the sender — a dedicated reason such as `ServerShuttingDown` used by `BecomeShuttingDown`, making the enumerator switch purely declarative. That route was deliberately not taken here: the drop-reason values also surface in the legacy TCP protocol, so a new enum member has wire-compatibility implications best weighed by the maintainers.