### PR TITLE
Fix disposing ObjectPool after an overflow

### DIFF
--- a/src/KurrentDB.Core.XUnit.Tests/DataStructures/ObjectPoolTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/DataStructures/ObjectPoolTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using KurrentDB.Core.DataStructures;
+using Xunit;
+
+namespace KurrentDB.Core.XUnit.Tests.DataStructures;
+
+public class ObjectPoolTests {
+
+	[Fact]
+	public void creates_new_object_on_each_request() {
+		int id = 0;
+		using var pool = new ObjectPool<int>(
+			objectPoolName: "test",
+			initialCount: 0,
+			maxCount: 3,
+			factory: () => ++id
+		);
+
+		Assert.Equal(1, pool.Get());
+		Assert.Equal(2, pool.Get());
+		Assert.Equal(3, pool.Get());
+	}
+
+	[Fact]
+	public void reuses_returned_objects() {
+		int id = 0;
+		using var pool = new ObjectPool<int>(
+			objectPoolName: "test",
+			initialCount: 0,
+			maxCount: 3,
+			factory: () => ++id
+		);
+
+		Assert.Equal(1, pool.Get());
+		pool.Return(1);
+		Assert.Equal(1, pool.Get());
+
+		Assert.Equal(2, pool.Get());
+		pool.Return(1);
+		Assert.Equal(1, pool.Get());
+
+		Assert.Equal(2, id);
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public void does_not_return_more_objects_than_max_count(bool markDisposingBeforeReturn) {
+		int disposedObjCounter = 0;
+		int disposedPoolCounter = 0;
+
+		{
+			using var pool = new ObjectPool<int>(
+				objectPoolName: "test",
+				initialCount: 0,
+				maxCount: 3,
+				factory: () => 0,
+				dispose: _ => disposedObjCounter++,
+				onPoolDisposed: _ => disposedPoolCounter++
+			);
+
+			var first = pool.Get();
+			var second = pool.Get();
+			var third = pool.Get();
+
+			Assert.Throws<ObjectPoolMaxLimitReachedException>(() => pool.Get());
+
+			if (markDisposingBeforeReturn) {
+				pool.MarkForDisposal();
+			}
+
+			pool.Return(first);
+			pool.Return(second);
+			pool.Return(third);
+
+			if (!markDisposingBeforeReturn) {
+				pool.MarkForDisposal();
+			}
+		}
+
+		Assert.Equal(3, disposedObjCounter);
+		Assert.Equal(1, disposedPoolCounter);
+	}
+}

--- a/src/KurrentDB.Core/DataStructures/ObjectPool.cs
+++ b/src/KurrentDB.Core/DataStructures/ObjectPool.cs
@@ -14,8 +14,7 @@ public class ObjectPoolDisposingException : Exception {
 	}
 
 	public ObjectPoolDisposingException(string poolName, Exception innerException)
-		: base(string.Format("Object pool '{0}' is disposing/disposed while Get operation is requested.", poolName),
-			innerException) {
+		: base($"Object pool '{poolName}' is disposing/disposed while Get operation is requested.", innerException) {
 		Ensure.NotNullOrEmpty(poolName, "poolName");
 	}
 }
@@ -26,25 +25,22 @@ public class ObjectPoolMaxLimitReachedException : Exception {
 	}
 
 	public ObjectPoolMaxLimitReachedException(string poolName, int maxLimit, Exception innerException)
-		: base(string.Format("Object pool '{0}' has reached its max limit for items: {1}.", poolName, maxLimit),
-			innerException) {
+		: base($"Object pool '{poolName}' has reached its max limit for items: {maxLimit}.", innerException) {
 		Ensure.NotNullOrEmpty(poolName, "poolName");
 		Ensure.Nonnegative(maxLimit, "maxLimit");
 	}
 }
 
 public class ObjectPool<T> : IDisposable {
-	public readonly string ObjectPoolName;
-
+	private readonly string _objectPoolName;
 	private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
 	private readonly int _maxCount;
 	private readonly Func<T> _factory;
 	private readonly Action<T> _dispose;
-	private readonly Action<ObjectPool<T>> _onPoolDisposed;
+	[CanBeNull] private Action<ObjectPool<T>> _onPoolDisposed;
 
 	private int _count;
 	private volatile bool _disposing;
-	private int _poolDisposed;
 
 	public ObjectPool(string objectPoolName,
 		int initialCount,
@@ -59,12 +55,12 @@ public class ObjectPool<T> : IDisposable {
 			throw new ArgumentOutOfRangeException("initialCount", "initialCount is greater than maxCount.");
 		Ensure.NotNull(factory, "factory");
 
-		ObjectPoolName = objectPoolName;
+		_objectPoolName = objectPoolName;
 		_maxCount = maxCount;
 		_count = initialCount;
 		_factory = factory;
-		_dispose = dispose ?? (x => { });
-		_onPoolDisposed = onPoolDisposed ?? (x => { });
+		_dispose = dispose ?? (static _ => { });
+		_onPoolDisposed = onPoolDisposed;
 
 		for (int i = 0; i < initialCount; ++i) {
 			_queue.Enqueue(factory());
@@ -83,23 +79,33 @@ public class ObjectPool<T> : IDisposable {
 
 	public T Get() {
 		if (_disposing)
-			throw new ObjectPoolDisposingException(ObjectPoolName);
+			throw new ObjectPoolDisposingException(_objectPoolName);
 
-		T item;
-		if (_queue.TryDequeue(out item))
+		if (_queue.TryDequeue(out var item))
 			return item;
 
 		if (_disposing)
-			throw new ObjectPoolDisposingException(ObjectPoolName);
+			throw new ObjectPoolDisposingException(_objectPoolName);
 
 		var newCount = Interlocked.Increment(ref _count);
-		if (newCount > _maxCount)
-			throw new ObjectPoolMaxLimitReachedException(ObjectPoolName, _maxCount);
 
-		if (_disposing) {
-			if (Interlocked.Decrement(ref _count) == 0)
-				OnPoolDisposed(); // now we possibly should "turn light off"
-			throw new ObjectPoolDisposingException(ObjectPoolName);
+		// An overflow after increment means that we can't allocate a new resource instance.
+		// "Disposing" after increment means that the pool can already be disposed.
+		// In both cases, we roll back the counter and run compensation logic.
+		var overflow = newCount > _maxCount;
+		if (overflow || _disposing) {
+			var rolledBackCount = Interlocked.Decrement(ref _count);
+
+			// After decrementing, we can be in "disposing" state even if we entered this block on overflow.
+			// So we check again if we should complete the disposing.
+			if (_disposing && rolledBackCount == 0) {
+				OnPoolDisposed();
+			}
+
+			// Finally, when the pool is in valid state again, throw the appropriate exception.
+			throw overflow
+				? new ObjectPoolMaxLimitReachedException(_objectPoolName, _maxCount)
+				: new ObjectPoolDisposingException(_objectPoolName);
 		}
 
 		// if we get here, then it is safe to return newly created item to user, object pool won't be disposed
@@ -117,8 +123,7 @@ public class ObjectPool<T> : IDisposable {
 	private void TryDestruct() {
 		int count = int.MaxValue;
 
-		T item;
-		while (_queue.TryDequeue(out item)) {
+		while (_queue.TryDequeue(out var item)) {
 			_dispose(item);
 			count = Interlocked.Decrement(ref _count);
 		}
@@ -131,7 +136,6 @@ public class ObjectPool<T> : IDisposable {
 
 	private void OnPoolDisposed() {
 		// ensure that we call _onPoolDisposed just once
-		if (Interlocked.CompareExchange(ref _poolDisposed, 1, 0) == 0)
-			_onPoolDisposed(this);
+		Interlocked.Exchange(ref _onPoolDisposed, value: null)?.Invoke(this);
 	}
 }


### PR DESCRIPTION
On overflow, `ObjectPool<>` doesn't roll back the incremented counter. This prevents the pool from ever reaching `_count == 0` and calling `_onPoolDisposed` callback. 

I suspect that this problem has not actually occurred before, given that an overflow in Get is an issue in itself, and current clients are unlikely to ever reach this condition. However, the issue was technically present.