### PR TITLE
[DB-2183] Add launchSettings.json with a profile that runs dev instance of the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -465,9 +465,6 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 
-# Visual Studio Launch Settings
-**/launchSettings.json
-
 # es-gencert-cli
 certs/
 /es-gencert-cli

--- a/README.md
+++ b/README.md
@@ -128,7 +128,13 @@ dotnet build -c Release
 To start a single node, you can then run:
 
 ```
-dotnet ./src/KurrentDB/bin/Release/net10.0/KurrentDB.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
+dotnet run --project ./src/KurrentDB/KurrentDB.csproj -c Release -e ASPNETCORE_ENVIRONMENT=Development -- --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
+```
+
+Alternatively, you can run the `KurrentDB - Dev DB` profile pre-configured in `launchSettings.json`:
+
+```
+dotnet run --project ./src/KurrentDB/KurrentDB.csproj -c Release -lp "KurrentDB - Dev DB"
 ```
 
 ### Running the tests

--- a/src/KurrentDB/.gitignore
+++ b/src/KurrentDB/.gitignore
@@ -1,0 +1,2 @@
+﻿# dev-mode profile database
+dev-db/

--- a/src/KurrentDB/Properties/launchSettings.json
+++ b/src/KurrentDB/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+﻿{
+	"$schema": "http://json.schemastore.org/launchsettings.json",
+	"profiles": {
+		"KurrentDB": {
+			"commandName": "Project",
+			"dotnetRunMessages": true
+		},
+		"KurrentDB - Dev DB": {
+			"commandName": "Project",
+			"dotnetRunMessages": true,
+			"commandLineArgs": "--dev --db ./dev-db/data --index ./dev-db/index --log ./dev-db/log",
+			"applicationUrl": "https://127.0.0.1:2113",
+			"launchUrl": "ui/cluster",
+			"launchBrowser": true,
+			"environmentVariables": {
+				"ASPNETCORE_ENVIRONMENT": "Development"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Web UI is broken if the database runs locally without `ASPNETCORE_ENVIRONMENT: Development` env variable.

- Adjusted the documentation to include this variable
- To streamline the process, also added `launchSettings.json` with a pre-configured dev mode profile. This file is not a VS-specific thing anymore but rather a first-class part of .NET SDK, and it is supported by any IDE and dotnet CLI. 