### PR TITLE
[DB-2179] Cancel open gRPC streaming calls on shutdown so Kestrel drains promptly

### DIFF
--- a/proto/kurrent/rpc/errors.proto
+++ b/proto/kurrent/rpc/errors.proto
@@ -78,11 +78,10 @@ enum ServerError {
     status_code: DEADLINE_EXCEEDED
   }];
 
-  // The server is starting up or shutting down and cannot process requests.
+  // The server is starting up and cannot process requests.
   //
   // Common causes:
   // - Server is initializing (loading indexes, recovering state)
-  // - Server is performing graceful shutdown
   // - Server is performing maintenance operations
   //
   // Client action: Retry with exponential backoff. Wait for server to become ready.
@@ -118,6 +117,19 @@ enum ServerError {
   // May be retriable, but likely indicates a server-side issue requiring investigation.
   SERVER_ERROR_SERVER_MALFUNCTION = 9 [(kurrent.rpc.error) = {
     status_code: INTERNAL
+  }];
+
+  // The server is shutting down and can no longer handle requests.
+  //
+  // Common causes:
+  // - Graceful shutdown or restart
+  //
+  // Client action: Retry with exponential backoff. For single node clusters, consider
+  //   delaying longer to give the node time to restart.
+  // Retriable - the server will become available after restarting or the client
+  //   connects to another node.
+  SERVER_ERROR_SERVER_SHUTTING_DOWN = 10 [(kurrent.rpc.error) = {
+    status_code: UNAVAILABLE
   }];
 }
 

--- a/src/KurrentDB.Api.V2.Tests/Infrastructure/Grpc/ServerShuttingDownInterceptorTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Infrastructure/Grpc/ServerShuttingDownInterceptorTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Google.Rpc;
+using Grpc.Core;
+using KurrentDB.Api.Errors;
+using KurrentDB.Api.Infrastructure.Grpc;
+using KurrentDB.Core;
+using Microsoft.Extensions.Hosting;
+
+namespace KurrentDB.Api.Tests.Infrastructure.Grpc;
+
+[Category("Grpc")]
+public class ServerShuttingDownInterceptorTests {
+	// ApiErrors.ServerShuttingDown() is the payload the interceptor throws — verify it is the canonical
+	// retryable status with the ServerShuttingDown reason (distinct from ServerNotReady) and a retry hint.
+	[Test]
+	public async Task server_shutting_down_is_unavailable_with_shutdown_reason() {
+		var rex = ApiErrors.ServerShuttingDown();
+
+		await Assert.That(rex.StatusCode).IsEqualTo(StatusCode.Unavailable);
+
+		var errorInfo = rex.GetRpcStatus()?.GetDetail<ErrorInfo>();
+		await Assert.That(errorInfo).IsNotNull();
+		await Assert.That(errorInfo!.Reason).IsEqualTo("SERVER_SHUTTING_DOWN");
+	}
+
+	[Test]
+	public async Task server_shutting_down_carries_retry_info() {
+		var rex = ApiErrors.ServerShuttingDown(TimeSpan.FromSeconds(30));
+
+		var retryInfo = rex.GetRpcStatus()?.GetDetail<RetryInfo>();
+		await Assert.That(retryInfo).IsNotNull();
+		await Assert.That(retryInfo!.RetryDelay.ToTimeSpan()).IsEqualTo(TimeSpan.FromSeconds(30));
+	}
+
+	// When the call was cancelled AND the server is shutting down, the interceptor translates the resulting
+	// OperationCanceledException into the ServerShuttingDown status. (The three streaming overrides share this
+	// logic; ServerStreaming is exercised here as the representative case.)
+	[Test]
+	public async Task translates_shutdown_cancellation_to_server_shutting_down() {
+		using var callCts = new CancellationTokenSource();
+		using var stoppingCts = new CancellationTokenSource();
+		await callCts.CancelAsync();
+		await stoppingCts.CancelAsync();
+
+		var rex = await Assert.That(async () => await CreateSut(stoppingCts.Token)
+				.ServerStreamingServerHandler<string, string>(
+					"request", new FakeServerStreamWriter<string>(), new FakeServerCallContext(callCts.Token),
+					(_, _, _) => Task.FromException(new OperationCanceledException())))
+			.Throws<RpcException>();
+
+		await Assert.That(rex!.StatusCode).IsEqualTo(StatusCode.Unavailable);
+		await Assert.That(rex.GetRpcStatus()?.GetDetail<ErrorInfo>()?.Reason).IsEqualTo("SERVER_SHUTTING_DOWN");
+	}
+
+	// The suggested retry delay depends on cluster size: a single node must restart (longer wait), whereas a
+	// cluster client can fail over to another node (shorter wait).
+	[Test]
+	[Arguments(1, 5)]
+	[Arguments(3, 1)]
+	public async Task retry_after_reflects_cluster_size(int clusterSize, int expectedSeconds) {
+		using var callCts = new CancellationTokenSource();
+		using var stoppingCts = new CancellationTokenSource();
+		await callCts.CancelAsync();
+		await stoppingCts.CancelAsync();
+
+		var rex = await Assert.That(async () => await CreateSut(stoppingCts.Token, clusterSize)
+				.ServerStreamingServerHandler<string, string>(
+					"request", new FakeServerStreamWriter<string>(), new FakeServerCallContext(callCts.Token),
+					(_, _, _) => Task.FromException(new OperationCanceledException())))
+			.Throws<RpcException>();
+
+		var retryInfo = rex!.GetRpcStatus()?.GetDetail<RetryInfo>();
+		await Assert.That(retryInfo).IsNotNull();
+		await Assert.That(retryInfo!.RetryDelay.ToTimeSpan()).IsEqualTo(TimeSpan.FromSeconds(expectedSeconds));
+	}
+
+	// A client-initiated cancel (server NOT shutting down) is left to propagate unchanged.
+	[Test]
+	public async Task propagates_client_cancellation_when_not_shutting_down() {
+		using var callCts = new CancellationTokenSource();
+		await callCts.CancelAsync();
+
+		await Assert.That(async () => await CreateSut(CancellationToken.None)
+				.ServerStreamingServerHandler<string, string>(
+					"request", new FakeServerStreamWriter<string>(), new FakeServerCallContext(callCts.Token),
+					(_, _, _) => Task.FromException(new OperationCanceledException())))
+			.Throws<OperationCanceledException>();
+	}
+
+	// A call that completes normally passes straight through.
+	[Test]
+	public async Task passes_through_a_successful_call() {
+		var continuationRan = false;
+
+		await CreateSut(CancellationToken.None).ServerStreamingServerHandler<string, string>(
+			"request", new FakeServerStreamWriter<string>(), new FakeServerCallContext(CancellationToken.None),
+			(_, _, _) => {
+				continuationRan = true;
+				return Task.CompletedTask;
+			});
+
+		await Assert.That(continuationRan).IsTrue();
+	}
+
+	static ServerShuttingDownInterceptor CreateSut(CancellationToken stopping, int clusterSize = 1) =>
+		new(new FakeLifetime(stopping), new ClusterVNodeOptions { Cluster = new() { ClusterSize = clusterSize } });
+
+	sealed class FakeLifetime(CancellationToken stopping) : IHostApplicationLifetime {
+		public CancellationToken ApplicationStarted => CancellationToken.None;
+		public CancellationToken ApplicationStopping => stopping;
+		public CancellationToken ApplicationStopped => CancellationToken.None;
+		public void StopApplication() { }
+	}
+
+	sealed class FakeServerStreamWriter<T> : IServerStreamWriter<T> {
+		public WriteOptions? WriteOptions { get; set; }
+		public Task WriteAsync(T message) => Task.CompletedTask;
+	}
+
+	sealed class FakeServerCallContext(CancellationToken cancellationToken) : ServerCallContext {
+		protected override CancellationToken CancellationTokenCore => cancellationToken;
+		protected override Metadata RequestHeadersCore { get; } = new();
+		protected override Metadata ResponseTrailersCore { get; } = new();
+		protected override global::Grpc.Core.Status StatusCore { get; set; }
+		protected override WriteOptions? WriteOptionsCore { get; set; }
+		protected override AuthContext AuthContextCore { get; } = new(string.Empty, new Dictionary<string, List<AuthProperty>>());
+		protected override string MethodCore => "method";
+		protected override string HostCore => "host";
+		protected override string PeerCore => "peer";
+		protected override DateTime DeadlineCore => DateTime.MaxValue;
+		protected override IDictionary<object, object> UserStateCore { get; } = new Dictionary<object, object>();
+		protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions? options) => throw new NotSupportedException();
+		protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders) => Task.CompletedTask;
+	}
+}

--- a/src/KurrentDB.Api.V2.Tests/Infrastructure/Grpc/ServerShuttingDownInterceptorTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Infrastructure/Grpc/ServerShuttingDownInterceptorTests.cs
@@ -46,15 +46,14 @@ public class ServerShuttingDownInterceptorTests {
 	// logic; ServerStreaming is exercised here as the representative case.)
 	[Test]
 	public async Task translates_shutdown_cancellation_to_server_shutting_down() {
-		using var callCts = new CancellationTokenSource();
 		using var stoppingCts = new CancellationTokenSource();
-		await callCts.CancelAsync();
+		using var callCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingCts.Token);
 		await stoppingCts.CancelAsync();
 
 		var rex = await Assert.That(async () => await CreateSut(stoppingCts.Token)
 				.ServerStreamingServerHandler<string, string>(
 					"request", new FakeServerStreamWriter<string>(), new FakeServerCallContext(callCts.Token),
-					(_, _, _) => Task.FromException(new OperationCanceledException())))
+					(_, _, context) => Task.FromCanceled(context.CancellationToken)))
 			.Throws<RpcException>();
 
 		await Assert.That(rex!.StatusCode).IsEqualTo(StatusCode.Unavailable);
@@ -67,15 +66,14 @@ public class ServerShuttingDownInterceptorTests {
 	[Arguments(1, 5)]
 	[Arguments(3, 1)]
 	public async Task retry_after_reflects_cluster_size(int clusterSize, int expectedSeconds) {
-		using var callCts = new CancellationTokenSource();
 		using var stoppingCts = new CancellationTokenSource();
-		await callCts.CancelAsync();
+		using var callCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingCts.Token);
 		await stoppingCts.CancelAsync();
 
 		var rex = await Assert.That(async () => await CreateSut(stoppingCts.Token, clusterSize)
 				.ServerStreamingServerHandler<string, string>(
 					"request", new FakeServerStreamWriter<string>(), new FakeServerCallContext(callCts.Token),
-					(_, _, _) => Task.FromException(new OperationCanceledException())))
+					(_, _, context) => Task.FromCanceled(context.CancellationToken)))
 			.Throws<RpcException>();
 
 		var retryInfo = rex!.GetRpcStatus()?.GetDetail<RetryInfo>();
@@ -86,13 +84,14 @@ public class ServerShuttingDownInterceptorTests {
 	// A client-initiated cancel (server NOT shutting down) is left to propagate unchanged.
 	[Test]
 	public async Task propagates_client_cancellation_when_not_shutting_down() {
-		using var callCts = new CancellationTokenSource();
+		using var stoppingCts = new CancellationTokenSource();
+		using var callCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingCts.Token);
 		await callCts.CancelAsync();
 
-		await Assert.That(async () => await CreateSut(CancellationToken.None)
+		await Assert.That(async () => await CreateSut(stoppingCts.Token)
 				.ServerStreamingServerHandler<string, string>(
 					"request", new FakeServerStreamWriter<string>(), new FakeServerCallContext(callCts.Token),
-					(_, _, _) => Task.FromException(new OperationCanceledException())))
+					(_, _, context) => Task.FromCanceled(context.CancellationToken)))
 			.Throws<OperationCanceledException>();
 	}
 

--- a/src/KurrentDB.Api.V2/Infrastructure/Grpc/ServerShuttingDownInterceptor.cs
+++ b/src/KurrentDB.Api.V2/Infrastructure/Grpc/ServerShuttingDownInterceptor.cs
@@ -28,8 +28,11 @@ public sealed class ServerShuttingDownInterceptor(
 		? TimeSpan.FromSeconds(5)
 		: TimeSpan.FromSeconds(1);
 
-	bool IsShuttingDown(ServerCallContext context) =>
-		context.CancellationToken.IsCancellationRequested &&
+	// Best effort. Here we do not know if the context was cancelled because of the original http context RequestAborted
+	// or because of the lifetime ApplicationStopping which we linked, or the deadline cancellation which can also be linked.
+	// It's not that bad to attribute any of these to shutting down if we are, in fact, shutting down.
+	bool IsCausedByShutdown(ServerCallContext context, OperationCanceledException ex) =>
+		ex.CancellationToken == context.CancellationToken &&
 		lifetime.ApplicationStopping.IsCancellationRequested;
 
 	public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
@@ -39,7 +42,7 @@ public sealed class ServerShuttingDownInterceptor(
 
 		try {
 			return await continuation(requestStream, context);
-		} catch (OperationCanceledException) when (IsShuttingDown(context)) {
+		} catch (OperationCanceledException ex) when (IsCausedByShutdown(context, ex)) {
 			throw ApiErrors.ServerShuttingDown(_retryAfter);
 		}
 	}
@@ -52,7 +55,7 @@ public sealed class ServerShuttingDownInterceptor(
 
 		try {
 			await continuation(request, responseStream, context);
-		} catch (OperationCanceledException) when (IsShuttingDown(context)) {
+		} catch (OperationCanceledException ex) when (IsCausedByShutdown(context, ex)) {
 			throw ApiErrors.ServerShuttingDown(_retryAfter);
 		}
 	}
@@ -65,7 +68,7 @@ public sealed class ServerShuttingDownInterceptor(
 
 		try {
 			await continuation(requestStream, responseStream, context);
-		} catch (OperationCanceledException) when (IsShuttingDown(context)) {
+		} catch (OperationCanceledException ex) when (IsCausedByShutdown(context, ex)) {
 			throw ApiErrors.ServerShuttingDown(_retryAfter);
 		}
 	}

--- a/src/KurrentDB.Api.V2/Infrastructure/Grpc/ServerShuttingDownInterceptor.cs
+++ b/src/KurrentDB.Api.V2/Infrastructure/Grpc/ServerShuttingDownInterceptor.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using KurrentDB.Api.Errors;
+using KurrentDB.Core;
+using Microsoft.Extensions.Hosting;
+
+namespace KurrentDB.Api.Infrastructure.Grpc;
+
+// Gives clients an actionable status when a streaming call ends because the server is shutting down.
+//
+// GrpcStreamingShutdownMiddleware cancels open streaming calls on ApplicationStopping so Kestrel drains promptly.
+// This interceptor translates the shutdown-driven cancellations into ApiErrors.ServerShuttingDown() (UNAVAILABLE
+// + rich ErrorInfo reason ServerShuttingDown). Rich-status-aware clients read the reason and can
+// distinguish a planned shutdown from an unknown disconnection (which is just UNAVAILABLE).
+// Without this interceptor the OperationCanceledException is translated to status UNKNOWN.
+// Unary calls are not dealt with because they are not canceled on shutdown but left to complete.
+public sealed class ServerShuttingDownInterceptor(
+	IHostApplicationLifetime lifetime,
+	ClusterVNodeOptions options)
+	: Interceptor {
+
+	// A single node has to restart before it is available again, so suggest a longer backoff; in a multi-node
+	// cluster the client can fail over to another node instead, so a short backoff is enough.
+	readonly TimeSpan _retryAfter = options.Cluster.ClusterSize <= 1
+		? TimeSpan.FromSeconds(5)
+		: TimeSpan.FromSeconds(1);
+
+	bool IsShuttingDown(ServerCallContext context) =>
+		context.CancellationToken.IsCancellationRequested &&
+		lifetime.ApplicationStopping.IsCancellationRequested;
+
+	public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
+		IAsyncStreamReader<TRequest> requestStream,
+		ServerCallContext context,
+		ClientStreamingServerMethod<TRequest, TResponse> continuation) {
+
+		try {
+			return await continuation(requestStream, context);
+		} catch (OperationCanceledException) when (IsShuttingDown(context)) {
+			throw ApiErrors.ServerShuttingDown(_retryAfter);
+		}
+	}
+
+	public override async Task ServerStreamingServerHandler<TRequest, TResponse>(
+		TRequest request,
+		IServerStreamWriter<TResponse> responseStream,
+		ServerCallContext context,
+		ServerStreamingServerMethod<TRequest, TResponse> continuation) {
+
+		try {
+			await continuation(request, responseStream, context);
+		} catch (OperationCanceledException) when (IsShuttingDown(context)) {
+			throw ApiErrors.ServerShuttingDown(_retryAfter);
+		}
+	}
+
+	public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(
+		IAsyncStreamReader<TRequest> requestStream,
+		IServerStreamWriter<TResponse> responseStream,
+		ServerCallContext context,
+		DuplexStreamingServerMethod<TRequest, TResponse> continuation) {
+
+		try {
+			await continuation(requestStream, responseStream, context);
+		} catch (OperationCanceledException) when (IsShuttingDown(context)) {
+			throw ApiErrors.ServerShuttingDown(_retryAfter);
+		}
+	}
+}

--- a/src/KurrentDB.Api.V2/Modules/ApiErrors.cs
+++ b/src/KurrentDB.Api.V2/Modules/ApiErrors.cs
@@ -226,7 +226,7 @@ public static partial class ApiErrors {
 	/// The exception includes retry information to guide client behavior.
 	/// </summary>
 	/// <param name="retryAfter">
-	/// An optional suggested retry delay. If not provided, defaults to 3 seconds.
+	/// An optional suggested retry delay. If not provided, defaults to <see cref="DefaultRetryDelay"/>.
 	/// This indicates how long clients should wait before retrying the request.
 	/// </param>
 	/// <returns>
@@ -243,6 +243,25 @@ public static partial class ApiErrors {
 		var details = new RetryInfo { RetryDelay = Duration.FromTimeSpan(retryAfter.Value) };
 
 		return RpcExceptions.FromError(ServerError.ServerNotReady, message, details);
+	}
+
+	/// <summary>
+	/// Creates an RPC exception indicating that the server is shutting down and can no longer handle the call.
+	/// Uses the ServerShuttingDown reason (status code <see cref="StatusCode.Unavailable"/>).
+	/// </summary>
+	/// <param name="retryAfter">
+	/// An optional suggested retry delay. If not provided, defaults to <see cref="DefaultRetryDelay"/>.
+	/// This indicates how long clients should wait before retrying the request.
+	/// </param>
+	public static RpcException ServerShuttingDown(TimeSpan? retryAfter = null) {
+		retryAfter ??= DefaultRetryDelay;
+
+		var message = $"The server is shutting down. "
+		            + $"Please retry after {retryAfter.Value.Humanize()}.";
+
+		var details = new RetryInfo { RetryDelay = Duration.FromTimeSpan(retryAfter.Value) };
+
+		return RpcExceptions.FromError(ServerError.ServerShuttingDown, message, details);
 	}
 
 	/// <summary>

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/GrpcStreamingShutdownMiddlewareTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/GrpcStreamingShutdownMiddlewareTests.cs
@@ -17,6 +17,7 @@ public class GrpcStreamingShutdownMiddlewareTests {
 	// A streaming call is open-ended, so it must observe shutdown: while the call is in flight the middleware
 	// should have linked ApplicationStopping into the token the handler reads (HttpContext.RequestAborted).
 	[Theory]
+	[InlineData(MethodType.ClientStreaming)]
 	[InlineData(MethodType.ServerStreaming)]
 	[InlineData(MethodType.DuplexStreaming)]
 	public async Task cancels_streaming_call_when_application_is_stopping(MethodType methodType) {

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/GrpcStreamingShutdownMiddlewareTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/GrpcStreamingShutdownMiddlewareTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.AspNetCore.Server;
@@ -19,7 +20,7 @@ public class GrpcStreamingShutdownMiddlewareTests {
 	[InlineData(MethodType.ServerStreaming)]
 	[InlineData(MethodType.DuplexStreaming)]
 	public async Task cancels_streaming_call_when_application_is_stopping(MethodType methodType) {
-		var lifetime = new FakeLifetime();
+		using var lifetime = new FakeLifetime();
 		var context = ContextForMethod(methodType);
 		var tokenObservedCancelled = false;
 
@@ -38,7 +39,7 @@ public class GrpcStreamingShutdownMiddlewareTests {
 	// so beginning shutdown while it runs does not cancel the call.
 	[Fact]
 	public async Task does_not_cancel_unary_call_when_application_is_stopping() {
-		var lifetime = new FakeLifetime();
+		using var lifetime = new FakeLifetime();
 		var context = ContextForMethod(MethodType.Unary);
 		var tokenObservedCancelled = true;
 
@@ -56,7 +57,7 @@ public class GrpcStreamingShutdownMiddlewareTests {
 	// The linked token must still fire on the original trigger (client disconnect), not only on shutdown.
 	[Fact]
 	public async Task streaming_call_still_observes_client_disconnect() {
-		var lifetime = new FakeLifetime();
+		using var lifetime = new FakeLifetime();
 		using var clientDisconnect = new CancellationTokenSource();
 		var context = ContextForMethod(MethodType.ServerStreaming);
 		context.RequestAborted = clientDisconnect.Token;
@@ -76,7 +77,7 @@ public class GrpcStreamingShutdownMiddlewareTests {
 	// Non-gRPC requests (no GrpcMethodMetadata) pass straight through and are unaffected by shutdown.
 	[Fact]
 	public async Task ignores_non_grpc_request() {
-		var lifetime = new FakeLifetime();
+		using var lifetime = new FakeLifetime();
 		var context = new DefaultHttpContext(); // no endpoint / no gRPC metadata
 		var nextCalled = false;
 		var tokenObservedCancelled = true;
@@ -110,11 +111,12 @@ public class GrpcStreamingShutdownMiddlewareTests {
 		public string FullName => "/svc/method";
 	}
 
-	sealed class FakeLifetime : IHostApplicationLifetime {
+	sealed class FakeLifetime : IHostApplicationLifetime, IDisposable {
 		readonly CancellationTokenSource _stopping = new();
 		public CancellationToken ApplicationStarted => CancellationToken.None;
 		public CancellationToken ApplicationStopping => _stopping.Token;
 		public CancellationToken ApplicationStopped => CancellationToken.None;
 		public void StopApplication() => _stopping.Cancel();
+		public void Dispose() => _stopping.Dispose();
 	}
 }

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/GrpcStreamingShutdownMiddlewareTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/GrpcStreamingShutdownMiddlewareTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.AspNetCore.Server;
+using Grpc.Core;
+using KurrentDB.Core.Services.Transport.Grpc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace KurrentDB.Core.XUnit.Tests.Services.Transport.Grpc;
+
+public class GrpcStreamingShutdownMiddlewareTests {
+	// A streaming call is open-ended, so it must observe shutdown: while the call is in flight the middleware
+	// should have linked ApplicationStopping into the token the handler reads (HttpContext.RequestAborted).
+	[Theory]
+	[InlineData(MethodType.ServerStreaming)]
+	[InlineData(MethodType.DuplexStreaming)]
+	public async Task cancels_streaming_call_when_application_is_stopping(MethodType methodType) {
+		var lifetime = new FakeLifetime();
+		var context = ContextForMethod(methodType);
+		var tokenObservedCancelled = false;
+
+		var sut = new GrpcStreamingShutdownMiddleware(ctx => {
+			lifetime.StopApplication();
+			tokenObservedCancelled = ctx.RequestAborted.IsCancellationRequested;
+			return Task.CompletedTask;
+		}, lifetime);
+
+		await sut.Invoke(context);
+
+		Assert.True(tokenObservedCancelled);
+	}
+
+	// A unary call is finite and should keep draining gracefully: the middleware must NOT link shutdown into it,
+	// so beginning shutdown while it runs does not cancel the call.
+	[Fact]
+	public async Task does_not_cancel_unary_call_when_application_is_stopping() {
+		var lifetime = new FakeLifetime();
+		var context = ContextForMethod(MethodType.Unary);
+		var tokenObservedCancelled = true;
+
+		var sut = new GrpcStreamingShutdownMiddleware(ctx => {
+			lifetime.StopApplication();
+			tokenObservedCancelled = ctx.RequestAborted.IsCancellationRequested;
+			return Task.CompletedTask;
+		}, lifetime);
+
+		await sut.Invoke(context);
+
+		Assert.False(tokenObservedCancelled);
+	}
+
+	// The linked token must still fire on the original trigger (client disconnect), not only on shutdown.
+	[Fact]
+	public async Task streaming_call_still_observes_client_disconnect() {
+		var lifetime = new FakeLifetime();
+		using var clientDisconnect = new CancellationTokenSource();
+		var context = ContextForMethod(MethodType.ServerStreaming);
+		context.RequestAborted = clientDisconnect.Token;
+		var tokenObservedCancelled = false;
+
+		var sut = new GrpcStreamingShutdownMiddleware(ctx => {
+			clientDisconnect.Cancel();
+			tokenObservedCancelled = ctx.RequestAborted.IsCancellationRequested;
+			return Task.CompletedTask;
+		}, lifetime);
+
+		await sut.Invoke(context);
+
+		Assert.True(tokenObservedCancelled);
+	}
+
+	// Non-gRPC requests (no GrpcMethodMetadata) pass straight through and are unaffected by shutdown.
+	[Fact]
+	public async Task ignores_non_grpc_request() {
+		var lifetime = new FakeLifetime();
+		var context = new DefaultHttpContext(); // no endpoint / no gRPC metadata
+		var nextCalled = false;
+		var tokenObservedCancelled = true;
+
+		var sut = new GrpcStreamingShutdownMiddleware(ctx => {
+			nextCalled = true;
+			lifetime.StopApplication();
+			tokenObservedCancelled = ctx.RequestAborted.IsCancellationRequested;
+			return Task.CompletedTask;
+		}, lifetime);
+
+		await sut.Invoke(context);
+
+		Assert.True(nextCalled);
+		Assert.False(tokenObservedCancelled);
+	}
+
+	static DefaultHttpContext ContextForMethod(MethodType methodType) {
+		var context = new DefaultHttpContext();
+		context.SetEndpoint(new Endpoint(
+			_ => Task.CompletedTask,
+			new EndpointMetadataCollection(new GrpcMethodMetadata(typeof(object), new FakeMethod(methodType))),
+			displayName: "test"));
+		return context;
+	}
+
+	sealed class FakeMethod(MethodType type) : IMethod {
+		public MethodType Type => type;
+		public string ServiceName => "svc";
+		public string Name => "method";
+		public string FullName => "/svc/method";
+	}
+
+	sealed class FakeLifetime : IHostApplicationLifetime {
+		readonly CancellationTokenSource _stopping = new();
+		public CancellationToken ApplicationStarted => CancellationToken.None;
+		public CancellationToken ApplicationStopping => _stopping.Token;
+		public CancellationToken ApplicationStopped => CancellationToken.None;
+		public void StopApplication() => _stopping.Cancel();
+	}
+}

--- a/src/KurrentDB.Core/ClusterVNodeStartup.cs
+++ b/src/KurrentDB.Core/ClusterVNodeStartup.cs
@@ -134,6 +134,7 @@ public class ClusterVNodeStartup<TStreamId>
 		// is driven by the HttpContext.User established above
 		app.UseAuthentication();
 		app.UseRouting();
+		app.UseMiddleware<GrpcStreamingShutdownMiddleware>();
 		app.UseAuthorization();
 		app.UseAntiforgery();
 

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
@@ -30,6 +30,7 @@ static partial class Enumerator {
 		private readonly bool _requiresLeader;
 		private readonly int _readBatchSize;
 		private readonly CancellationTokenSource _cts;
+		private readonly CancellationToken _cancellationToken;
 		private readonly Channel<ReadResponse> _channel;
 		private readonly Channel<(ulong SequenceNumber, ResolvedEvent ResolvedEvent)> _liveEvents;
 
@@ -58,6 +59,7 @@ static partial class Enumerator {
 			_user = user;
 			_requiresLeader = requiresLeader;
 			_readBatchSize = Ensure.Positive(readBatchSize);
+			_cancellationToken = cancellationToken;
 			_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			_channel = CreateCatchUpChannel(catchUpBufferSize);
 			_liveEvents = CreateLiveChannel<(ulong SequenceNumber, ResolvedEvent ResolvedEvent)>(liveBufferSize);
@@ -84,33 +86,37 @@ static partial class Enumerator {
 		}
 
 		public async ValueTask<bool> MoveNextAsync() {
-			ReadLoop:
+			try {
+ReadLoop:
 
-			if (!await _channel.Reader.WaitToReadAsync(_cts.Token)) {
-				return false;
-			}
-
-			var readResponse = await _channel.Reader.ReadAsync(_cts.Token);
-
-			if (readResponse is ReadResponse.EventReceived eventReceived) {
-				var eventPos = eventReceived.Event.OriginalPosition!.Value;
-				var position = Position.FromInt64(eventPos.CommitPosition, eventPos.PreparePosition);
-
-				if (_currentPosition.HasValue && position <= _currentPosition.Value) {
-					// this should no longer happen
-					Log.Warning("Subscription {subscriptionId} to $all skipping event {position} as it is less than {currentPosition}.",
-						_subscriptionId, position, _currentPosition);
-					goto ReadLoop;
+				if (!await _channel.Reader.WaitToReadAsync(_cts.Token)) {
+					return false;
 				}
 
-				Log.Verbose("Subscription {subscriptionId} to $all seen event {position}.", _subscriptionId, position);
+				var readResponse = await _channel.Reader.ReadAsync(_cts.Token);
 
-				_currentPosition = position;
+				if (readResponse is ReadResponse.EventReceived eventReceived) {
+					var eventPos = eventReceived.Event.OriginalPosition!.Value;
+					var position = Position.FromInt64(eventPos.CommitPosition, eventPos.PreparePosition);
+
+					if (_currentPosition.HasValue && position <= _currentPosition.Value) {
+						// this should no longer happen
+						Log.Warning("Subscription {subscriptionId} to $all skipping event {position} as it is less than {currentPosition}.",
+							_subscriptionId, position, _currentPosition);
+						goto ReadLoop;
+					}
+
+					Log.Verbose("Subscription {subscriptionId} to $all seen event {position}.", _subscriptionId, position);
+
+					_currentPosition = position;
+				}
+
+				_current = readResponse;
+
+				return true;
+			} catch (OperationCanceledException ex) when (ex.CancellationToken == _cts.Token && _cancellationToken.IsCancellationRequested) {
+				throw new OperationCanceledException(ex.Message, ex, _cancellationToken);
 			}
-
-			_current = readResponse;
-
-			return true;
 		}
 
 		private void Subscribe(Position? checkpoint, CancellationToken ct) {

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -33,6 +33,7 @@ partial class Enumerator {
 		private readonly uint _maxSearchWindow;
 		private readonly uint _checkpointInterval;
 		private readonly CancellationTokenSource _cts;
+		private readonly CancellationToken _cancellationToken;
 		private readonly Channel<ReadResponse> _channel;
 		private readonly Channel<(ulong SequenceNumber, ResolvedEvent? ResolvedEvent, TFPos? Checkpoint)> _liveEvents;
 
@@ -65,6 +66,7 @@ partial class Enumerator {
 			_requiresLeader = requiresLeader;
 			_maxSearchWindow = maxSearchWindow ?? DefaultReadBatchSize;
 			_checkpointInterval = checkpointIntervalMultiplier * _maxSearchWindow;
+			_cancellationToken = cancellationToken;
 			_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			_channel = Channel.CreateBounded<ReadResponse>(DefaultCatchUpChannelOptions);
 			_liveEvents = Channel.CreateBounded<(ulong, ResolvedEvent?, TFPos?)>(DefaultLiveChannelOptions);
@@ -91,47 +93,51 @@ partial class Enumerator {
 		}
 
 		public async ValueTask<bool> MoveNextAsync() {
+			try {
 ReadLoop:
 
-			if (!await _channel.Reader.WaitToReadAsync(_cts.Token)) {
-				return false;
-			}
-
-			var readResponse = await _channel.Reader.ReadAsync(_cts.Token);
-
-			if (readResponse is ReadResponse.EventReceived eventReceived) {
-				var eventPos = eventReceived.Event.OriginalPosition!.Value;
-				var position = Position.FromInt64(eventPos.CommitPosition, eventPos.PreparePosition);
-
-				if (_currentPosition.HasValue && position <= _currentPosition.Value) {
-					// this should no longer happen
-					Log.Warning("Subscription {subscriptionId} to $all:{eventFilter} skipping event {position} as it is less than {currentPosition}.",
-						_subscriptionId, _eventFilter, position, _currentPosition);
-					goto ReadLoop;
+				if (!await _channel.Reader.WaitToReadAsync(_cts.Token)) {
+					return false;
 				}
 
-				Log.Verbose("Subscription {subscriptionId} to $all:{eventFilter} seen event {position}.", _subscriptionId, _eventFilter, position);
+				var readResponse = await _channel.Reader.ReadAsync(_cts.Token);
 
-				_currentPosition = position;
-			} else if (readResponse is ReadResponse.CheckpointReceived checkpointReceived) {
-				var checkpointPos = new Position(checkpointReceived.CommitPosition, checkpointReceived.PreparePosition);
+				if (readResponse is ReadResponse.EventReceived eventReceived) {
+					var eventPos = eventReceived.Event.OriginalPosition!.Value;
+					var position = Position.FromInt64(eventPos.CommitPosition, eventPos.PreparePosition);
 
-				if (_currentCheckpoint.HasValue && checkpointPos <= _currentCheckpoint.Value) {
-					// in some cases, it's possible to receive the same checkpoint twice for example:
-					// i) when the subscription goes live, and it turns out that the next thing on the live channel is a checkpoint
-					// ii) when catching-up, reaching the checkpoint interval and the next page read reaches the end of the stream
+					if (_currentPosition.HasValue && position <= _currentPosition.Value) {
+						// this should no longer happen
+						Log.Warning("Subscription {subscriptionId} to $all:{eventFilter} skipping event {position} as it is less than {currentPosition}.",
+							_subscriptionId, _eventFilter, position, _currentPosition);
+						goto ReadLoop;
+					}
 
-					goto ReadLoop;
+					Log.Verbose("Subscription {subscriptionId} to $all:{eventFilter} seen event {position}.", _subscriptionId, _eventFilter, position);
+
+					_currentPosition = position;
+				} else if (readResponse is ReadResponse.CheckpointReceived checkpointReceived) {
+					var checkpointPos = new Position(checkpointReceived.CommitPosition, checkpointReceived.PreparePosition);
+
+					if (_currentCheckpoint.HasValue && checkpointPos <= _currentCheckpoint.Value) {
+						// in some cases, it's possible to receive the same checkpoint twice for example:
+						// i) when the subscription goes live, and it turns out that the next thing on the live channel is a checkpoint
+						// ii) when catching-up, reaching the checkpoint interval and the next page read reaches the end of the stream
+
+						goto ReadLoop;
+					}
+
+					Log.Verbose("Subscription {subscriptionId} to $all:{eventFilter} received checkpoint {position}.", _subscriptionId, _eventFilter, checkpointPos);
+
+					_currentCheckpoint = checkpointPos;
 				}
 
-				Log.Verbose("Subscription {subscriptionId} to $all:{eventFilter} received checkpoint {position}.", _subscriptionId, _eventFilter, checkpointPos);
+				_current = readResponse;
 
-				_currentCheckpoint = checkpointPos;
+				return true;
+			} catch (OperationCanceledException ex) when (ex.CancellationToken == _cts.Token && _cancellationToken.IsCancellationRequested) {
+				throw new OperationCanceledException(ex.Message, ex, _cancellationToken);
 			}
-
-			_current = readResponse;
-
-			return true;
 		}
 
 		private void Subscribe(Position? checkpoint, CancellationToken ct) {

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.IndexSubscription.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.IndexSubscription.cs
@@ -31,6 +31,7 @@ partial class Enumerator {
 		private readonly bool _requiresLeader;
 		private readonly DuckDBConnectionPool _pool;
 		private readonly CancellationTokenSource _cts;
+		private readonly CancellationToken _cancellationToken;
 		private readonly Channel<ReadResponse> _channel;
 		private readonly Channel<(ulong SequenceNumber, ResolvedEvent? ResolvedEvent, TFPos? Checkpoint)> _liveEvents;
 
@@ -56,6 +57,7 @@ partial class Enumerator {
 			_user = user;
 			_requiresLeader = requiresLeader;
 			_pool = pool;
+			_cancellationToken = cancellationToken;
 			_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			_channel = Channel.CreateBounded<ReadResponse>(DefaultCatchUpChannelOptions);
 			_liveEvents = Channel.CreateBounded<(ulong, ResolvedEvent?, TFPos?)>(DefaultLiveChannelOptions);
@@ -118,21 +120,25 @@ partial class Enumerator {
 		}
 
 		public async ValueTask<bool> MoveNextAsync() {
-			if (!await _channel.Reader.WaitToReadAsync(_cts.Token)) {
-				return false;
+			try {
+				if (!await _channel.Reader.WaitToReadAsync(_cts.Token)) {
+					return false;
+				}
+
+				var readResponse = await _channel.Reader.ReadAsync(_cts.Token);
+
+				if (readResponse is ReadResponse.EventReceived eventReceived) {
+					var eventPos = eventReceived.Event.OriginalPosition!.Value;
+					var position = Position.FromInt64(eventPos.CommitPosition, eventPos.PreparePosition);
+					Log.Verbose("Subscription {SubscriptionId} to {IndexName} seen event {Position}.", _subscriptionId, _indexName, position);
+				}
+
+				Current = readResponse;
+
+				return true;
+			} catch (OperationCanceledException ex) when (ex.CancellationToken == _cts.Token && _cancellationToken.IsCancellationRequested) {
+				throw new OperationCanceledException(ex.Message, ex, _cancellationToken);
 			}
-
-			var readResponse = await _channel.Reader.ReadAsync(_cts.Token);
-
-			if (readResponse is ReadResponse.EventReceived eventReceived) {
-				var eventPos = eventReceived.Event.OriginalPosition!.Value;
-				var position = Position.FromInt64(eventPos.CommitPosition, eventPos.PreparePosition);
-				Log.Verbose("Subscription {SubscriptionId} to {IndexName} seen event {Position}.", _subscriptionId, _indexName, position);
-			}
-
-			Current = readResponse;
-
-			return true;
 		}
 
 		private async ValueTask<(TFPos, ulong)> GoLive(TFPos checkpoint, ulong sequenceNumber, CancellationToken ct) {

--- a/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
+++ b/src/KurrentDB.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
@@ -37,6 +37,7 @@ static partial class Enumerator {
 		private readonly bool _requiresLeader;
 		private readonly int _readBatchSize;
 		private readonly CancellationTokenSource _cts;
+		private readonly CancellationToken _cancellationToken;
 		private readonly Channel<ReadResponse> _channel;
 		private readonly Channel<(ulong SequenceNumber, ResolvedEvent ResolvedEvent)> _liveEvents;
 
@@ -67,6 +68,7 @@ static partial class Enumerator {
 			_user = user;
 			_requiresLeader = requiresLeader;
 			_readBatchSize = readBatchSize;
+			_cancellationToken = cancellationToken;
 			_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			_channel = CreateCatchUpChannel(catchUpBufferSize);
 			_liveEvents = CreateLiveChannel<(ulong, ResolvedEvent)>(liveBufferSize);
@@ -94,35 +96,39 @@ static partial class Enumerator {
 		}
 
 		public override async ValueTask<bool> MoveNextAsync() {
+			try {
 ReadLoop:
 
-			if (!await _channel.Reader.WaitToReadAsync(_cts.Token)) {
-				return false;
-			}
-
-			var readResponse = await _channel.Reader.ReadAsync(_cts.Token);
-
-			if (readResponse is ReadResponse.EventReceived eventReceived) {
-				var @event = eventReceived.Event;
-				var streamRevision = StreamRevision.FromInt64(@event.OriginalEventNumber);
-
-				if (_currentRevision.HasValue && streamRevision <= _currentRevision.Value) {
-					// this should no longer happen
-					Log.Warning(
-						"Subscription {subscriptionId} to {streamName} skipping event {streamRevision} as it is less than {currentRevision}.",
-						_subscriptionId, _streamName, streamRevision, _currentRevision);
-
-					goto ReadLoop;
+				if (!await _channel.Reader.WaitToReadAsync(_cts.Token)) {
+					return false;
 				}
 
-				_currentRevision = streamRevision;
+				var readResponse = await _channel.Reader.ReadAsync(_cts.Token);
 
-				Log.Verbose("Subscription {subscriptionId} to {streamName} seen event {streamRevision}.", _subscriptionId, _streamName, streamRevision);
+				if (readResponse is ReadResponse.EventReceived eventReceived) {
+					var @event = eventReceived.Event;
+					var streamRevision = StreamRevision.FromInt64(@event.OriginalEventNumber);
+
+					if (_currentRevision.HasValue && streamRevision <= _currentRevision.Value) {
+						// this should no longer happen
+						Log.Warning(
+							"Subscription {subscriptionId} to {streamName} skipping event {streamRevision} as it is less than {currentRevision}.",
+							_subscriptionId, _streamName, streamRevision, _currentRevision);
+
+						goto ReadLoop;
+					}
+
+					_currentRevision = streamRevision;
+
+					Log.Verbose("Subscription {subscriptionId} to {streamName} seen event {streamRevision}.", _subscriptionId, _streamName, streamRevision);
+				}
+
+				_current = readResponse;
+
+				return true;
+			} catch (OperationCanceledException ex) when (ex.CancellationToken == _cts.Token && _cancellationToken.IsCancellationRequested) {
+				throw new OperationCanceledException(ex.Message, ex, _cancellationToken);
 			}
-
-			_current = readResponse;
-
-			return true;
 		}
 
 		private void Subscribe(StreamRevision? checkpoint, CancellationToken ct) {

--- a/src/KurrentDB.Core/Services/Transport/Grpc/GrpcStreamingShutdownMiddleware.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/GrpcStreamingShutdownMiddleware.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using DotNext.Threading;
 using Grpc.AspNetCore.Server;
 using Grpc.Core;
 using Microsoft.AspNetCore.Http;
@@ -36,10 +38,15 @@ public sealed class GrpcStreamingShutdownMiddleware(RequestDelegate next, IHostA
 	}
 
 	async Task InvokeStreaming(HttpContext context) {
-		using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+		using var linked = CancellationToken.Combine(
 			context.RequestAborted,
 			lifetime.ApplicationStopping);
 		context.RequestAborted = linked.Token;
-		await next(context);
+
+		try {
+			await next(context);
+		} catch (OperationCanceledException ex) when (ex.CancellationToken == linked.Token) {
+			throw new OperationCanceledException(ex.Message, ex, linked.CancellationOrigin);
+		}
 	}
 }

--- a/src/KurrentDB.Core/Services/Transport/Grpc/GrpcStreamingShutdownMiddleware.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/GrpcStreamingShutdownMiddleware.cs
@@ -20,14 +20,16 @@ namespace KurrentDB.Core.Services.Transport.Grpc;
 // ServerCallContext.CancellationToken is backed by RequestAborted, so the handler's existing read loop ends
 // immediately and Kestrel drains in milliseconds. No per-handler or per-service changes are needed.
 //
-// Applies only to server-streaming / duplex methods — unary calls are finite and keep draining gracefully.
+// Applies to every streaming method (client-, server-, and duplex-streaming) — any of them can stay open under
+// client control and stall the drain; only unary calls are inherently finite and keep draining gracefully.
 // It swaps RequestAborted BEFORE the gRPC ServerCallContext is constructed, so the swap is guaranteed to
 // propagate even when the call carries a deadline (this would not be the case if implemented as an interceptor).
 public sealed class GrpcStreamingShutdownMiddleware(RequestDelegate next, IHostApplicationLifetime lifetime) {
 	public Task Invoke(HttpContext context) {
 		var methodType = context.GetEndpoint()?.Metadata.GetMetadata<GrpcMethodMetadata>()?.Method.Type;
 		return methodType
-			is MethodType.ServerStreaming
+			is MethodType.ClientStreaming
+			or MethodType.ServerStreaming
 			or MethodType.DuplexStreaming
 			? InvokeStreaming(context)
 			: next(context);

--- a/src/KurrentDB.Core/Services/Transport/Grpc/GrpcStreamingShutdownMiddleware.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/GrpcStreamingShutdownMiddleware.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.AspNetCore.Server;
+using Grpc.Core;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace KurrentDB.Core.Services.Transport.Grpc;
+
+// Cancels open streaming gRPC calls when the server begins shutting down.
+//
+// On a graceful shutdown Kestrel waits for calls to end of their own accord before forcing the shutdown, but
+// streaming gRPC calls (e.g. subscriptions) can be long lived, resulting in a timeout and forced shutdown.
+//
+// This middleware links IHostApplicationLifetime.ApplicationStopping (which trips the instant shutdown begins)
+// into the call by swapping HttpContext.RequestAborted for a linked token. gRPC's
+// ServerCallContext.CancellationToken is backed by RequestAborted, so the handler's existing read loop ends
+// immediately and Kestrel drains in milliseconds. No per-handler or per-service changes are needed.
+//
+// Applies only to server-streaming / duplex methods — unary calls are finite and keep draining gracefully.
+// It swaps RequestAborted BEFORE the gRPC ServerCallContext is constructed, so the swap is guaranteed to
+// propagate even when the call carries a deadline (this would not be the case if implemented as an interceptor).
+public sealed class GrpcStreamingShutdownMiddleware(RequestDelegate next, IHostApplicationLifetime lifetime) {
+	public Task Invoke(HttpContext context) {
+		var methodType = context.GetEndpoint()?.Metadata.GetMetadata<GrpcMethodMetadata>()?.Method.Type;
+		return methodType
+			is MethodType.ServerStreaming
+			or MethodType.DuplexStreaming
+			? InvokeStreaming(context)
+			: next(context);
+	}
+
+	async Task InvokeStreaming(HttpContext context) {
+		using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+			context.RequestAborted,
+			lifetime.ApplicationStopping);
+		context.RequestAborted = linked.Token;
+		await next(context);
+	}
+}

--- a/src/KurrentDB.Core/Services/Transport/Grpc/GrpcStreamingShutdownMiddleware.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/GrpcStreamingShutdownMiddleware.cs
@@ -38,8 +38,9 @@ public sealed class GrpcStreamingShutdownMiddleware(RequestDelegate next, IHostA
 	}
 
 	async Task InvokeStreaming(HttpContext context) {
-		using var linked = CancellationToken.Combine(
-			context.RequestAborted,
+		var requestAborted = context.RequestAborted;
+		var linked = CancellationToken.Combine(
+			requestAborted,
 			lifetime.ApplicationStopping);
 		context.RequestAborted = linked.Token;
 
@@ -47,6 +48,9 @@ public sealed class GrpcStreamingShutdownMiddleware(RequestDelegate next, IHostA
 			await next(context);
 		} catch (OperationCanceledException ex) when (ex.CancellationToken == linked.Token) {
 			throw new OperationCanceledException(ex.Message, ex, linked.CancellationOrigin);
+		} finally {
+			context.RequestAborted = requestAborted;
+			linked.Dispose();
 		}
 	}
 }

--- a/src/KurrentDB.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -81,14 +81,10 @@ internal partial class Streams<TStreamId> {
 					httpContext,
 					context.CancellationToken);
 
-				async void DisposeEnumerator() => await enumerator.DisposeAsync();
-
 				await using (enumerator) {
-					await using (context.CancellationToken.Register(DisposeEnumerator)) {
-						while (await enumerator.MoveNextAsync()) {
-							if (ResponseConverter.TryConvertReadResponse(enumerator.Current, uuidOption, out var readResponse))
-								await responseStream.WriteAsync(readResponse);
-						}
+					while (await enumerator.MoveNextAsync()) {
+						if (ResponseConverter.TryConvertReadResponse(enumerator.Current, uuidOption, out var readResponse))
+							await responseStream.WriteAsync(readResponse);
 					}
 				}
 			} catch (ReadResponseException ex) {

--- a/src/KurrentDB.Plugins.Api.V2/ApiV2Plugin.cs
+++ b/src/KurrentDB.Plugins.Api.V2/ApiV2Plugin.cs
@@ -8,6 +8,7 @@ using Grpc.AspNetCore.Server;
 using Kurrent.Rpc;
 using KurrentDB.Api.Errors;
 using KurrentDB.Api.Infrastructure.DependencyInjection;
+using KurrentDB.Api.Infrastructure.Grpc;
 using KurrentDB.Api.Infrastructure.Grpc.Validation;
 using KurrentDB.Api.Modules.Indexes;
 using KurrentDB.Api.Streams.Validators;
@@ -22,8 +23,14 @@ namespace KurrentDB.Plugins.Api.V2;
 [UsedImplicitly]
 public class ApiV2Plugin() : SubsystemsPlugin("APIV2") {
 	public override void ConfigureServices(IServiceCollection services, IConfiguration configuration) {
+        // Global gRPC interceptor (applies to every service, v1 and v2): on shutdown it translates the
+        // cancellation of open streaming calls into a retryable UNAVAILABLE carrying the ServerShuttingDown
+        // reason, so clients reconnect / re-establish subscriptions. Pairs with GrpcStreamingShutdownMiddleware,
+        // which performs the cancellation.
+        services.AddSingleton<ServerShuttingDownInterceptor>();
+
         services
-            .AddGrpc()
+            .AddGrpc(options => options.Interceptors.Add<ServerShuttingDownInterceptor>())
             .AddJsonTranscoding(options => {
                 options.TypeRegistry = TypeRegistry.FromFiles(
                     KurrentDB.Protocol.V2.Indexes.Errors.ErrorsReflection.Descriptor,


### PR DESCRIPTION
On a graceful shutdown Kestrel waits for calls to end of their own accord before forcing the shutdown, but streaming gRPC calls (e.g. subscriptions) can be long lived, resulting in a timeout and forced shutdown.

This change cancels gRPC streaming calls on graceful shutdown so they end promptly.

Done as middleware rather than a gRPC interceptor: an interceptor runs after the ServerCallContext is constructed, so swapping RequestAborted there is not guaranteed to propagate to context.CancellationToken. In particular, when a call sets a deadline the deadline manager has already captured the original token and the swap is silently ignored. Middleware runs before the context exists, so the linked token always propagates.

Another alternative here could have been to shutdown the IHostedServices in parallel (Kestrel has a flag for this) rather than sequentially (by default it shuts them down in reverse registration ordre so the web host shuts down first, draining the requests), but we want to keep the shutdown deterministic, and some services may rely on others during shutdown (writing checkpoints and so on)

A second mechanism (grpc interceptor) intercepts the OperationCancelledExceptions and sends status UNAVAILABLE: SERVER_ERROR_SERVER_SHUTTING_DOWN to the client, which explains why the server is unavailable.