### PR TITLE
[DB-2182] Remove redundant MSBuild Platform configurations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Detailed reference docs live in `.claude/docs/` — fetch them when working in a
 ## Development Commands
 
 ### Build
-- `dotnet build -c Release /p:Platform=x64 --framework=net10.0 KurrentDB.slnx`
+- `dotnet build -c Release --framework=net10.0 KurrentDB.slnx`
 
 ### Test
 - `dotnet test --solution KurrentDB.slnx` - Run all tests

--- a/KurrentDB.ContainerTests.slnf
+++ b/KurrentDB.ContainerTests.slnf
@@ -19,7 +19,6 @@
       "src\\KurrentDB.AutoScavenge\\KurrentDB.AutoScavenge.csproj",
       "src\\KurrentDB.BufferManagement.Tests\\KurrentDB.BufferManagement.Tests.csproj",
       "src\\KurrentDB.BufferManagement\\KurrentDB.BufferManagement.csproj",
-      "src\\KurrentDB.ClusterNode.Web\\KurrentDB.ClusterNode.Web.csproj",
       "src\\KurrentDB.Common.Tests\\KurrentDB.Common.Tests.csproj",
       "src\\KurrentDB.Common\\KurrentDB.Common.csproj",
       "src\\KurrentDB.Core.Testing.NUnit\\KurrentDB.Core.Testing.NUnit.csproj",

--- a/KurrentDB.slnx
+++ b/KurrentDB.slnx
@@ -1,224 +1,69 @@
 ﻿<Solution>
-  <Configurations>
-    <Platform Name="Any CPU" />
-    <Platform Name="ARM64" />
-    <Platform Name="x64" />
-  </Configurations>
   <Folder Name="/Api/">
-    <Project Path="src/KurrentDB.Api.V2.Tests/KurrentDB.Api.V2.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Api.V2/KurrentDB.Api.V2.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Plugins.Api.V2/KurrentDB.Plugins.Api.V2.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Testing.ClusterVNodeApp/KurrentDB.Testing.ClusterVNodeApp.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Testing/KurrentDB.Testing.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/KurrentDB.Api.V2.Tests/KurrentDB.Api.V2.Tests.csproj" />
+    <Project Path="src/KurrentDB.Api.V2/KurrentDB.Api.V2.csproj" />
+    <Project Path="src/KurrentDB.Plugins.Api.V2/KurrentDB.Plugins.Api.V2.csproj" />
+    <Project Path="src/KurrentDB.Testing.ClusterVNodeApp/KurrentDB.Testing.ClusterVNodeApp.csproj" />
+    <Project Path="src/KurrentDB.Testing/KurrentDB.Testing.csproj" />
   </Folder>
   <Folder Name="/Plugins/">
-    <Project Path="src/KurrentDB.AutoScavenge.Tests/KurrentDB.AutoScavenge.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.AutoScavenge/KurrentDB.AutoScavenge.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Diagnostics.LogsEndpointPlugin.Tests/KurrentDB.Diagnostics.LogsEndpointPlugin.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Diagnostics.LogsEndpointPlugin/KurrentDB.Diagnostics.LogsEndpointPlugin.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.OtlpExporterPlugin/KurrentDB.OtlpExporterPlugin.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Plugins.Tests/KurrentDB.Plugins.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Plugins/KurrentDB.Plugins.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.POC.ConnectedSubsystemsPlugin/KurrentDB.POC.ConnectedSubsystemsPlugin.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Security.EncryptionAtRest.Tests/KurrentDB.Security.EncryptionAtRest.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Security.EncryptionAtRest/KurrentDB.Security.EncryptionAtRest.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.TcpPlugin.Tests/KurrentDB.TcpPlugin.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.TcpPlugin/KurrentDB.TcpPlugin.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/KurrentDB.AutoScavenge.Tests/KurrentDB.AutoScavenge.Tests.csproj" />
+    <Project Path="src/KurrentDB.AutoScavenge/KurrentDB.AutoScavenge.csproj" />
+    <Project Path="src/KurrentDB.Diagnostics.LogsEndpointPlugin.Tests/KurrentDB.Diagnostics.LogsEndpointPlugin.Tests.csproj" />
+    <Project Path="src/KurrentDB.Diagnostics.LogsEndpointPlugin/KurrentDB.Diagnostics.LogsEndpointPlugin.csproj" />
+    <Project Path="src/KurrentDB.OtlpExporterPlugin/KurrentDB.OtlpExporterPlugin.csproj" />
+    <Project Path="src/KurrentDB.Plugins.Tests/KurrentDB.Plugins.Tests.csproj" />
+    <Project Path="src/KurrentDB.Plugins/KurrentDB.Plugins.csproj" />
+    <Project Path="src/KurrentDB.POC.ConnectedSubsystemsPlugin/KurrentDB.POC.ConnectedSubsystemsPlugin.csproj" />
+    <Project Path="src/KurrentDB.Security.EncryptionAtRest.Tests/KurrentDB.Security.EncryptionAtRest.Tests.csproj" />
+    <Project Path="src/KurrentDB.Security.EncryptionAtRest/KurrentDB.Security.EncryptionAtRest.csproj" />
+    <Project Path="src/KurrentDB.TcpPlugin.Tests/KurrentDB.TcpPlugin.Tests.csproj" />
+    <Project Path="src/KurrentDB.TcpPlugin/KurrentDB.TcpPlugin.csproj" />
   </Folder>
   <Folder Name="/Plugins/Auth/">
-    <Project Path="src/KurrentDB.Auth.Ldaps.Tests/KurrentDB.Auth.Ldaps.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.Ldaps/KurrentDB.Auth.Ldaps.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.OAuth.Tests/KurrentDB.Auth.OAuth.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.OAuth/KurrentDB.Auth.OAuth.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.StreamPolicyPlugin.Tests/KurrentDB.Auth.StreamPolicyPlugin.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.StreamPolicyPlugin/KurrentDB.Auth.StreamPolicyPlugin.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.UserCertificates.Tests/KurrentDB.Auth.UserCertificates.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Auth.UserCertificates/KurrentDB.Auth.UserCertificates.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/KurrentDB.Auth.Ldaps.Tests/KurrentDB.Auth.Ldaps.Tests.csproj" />
+    <Project Path="src/KurrentDB.Auth.Ldaps/KurrentDB.Auth.Ldaps.csproj" />
+    <Project Path="src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.Tests.csproj" />
+    <Project Path="src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.csproj" />
+    <Project Path="src/KurrentDB.Auth.OAuth.Tests/KurrentDB.Auth.OAuth.Tests.csproj" />
+    <Project Path="src/KurrentDB.Auth.OAuth/KurrentDB.Auth.OAuth.csproj" />
+    <Project Path="src/KurrentDB.Auth.StreamPolicyPlugin.Tests/KurrentDB.Auth.StreamPolicyPlugin.Tests.csproj" />
+    <Project Path="src/KurrentDB.Auth.StreamPolicyPlugin/KurrentDB.Auth.StreamPolicyPlugin.csproj" />
+    <Project Path="src/KurrentDB.Auth.UserCertificates.Tests/KurrentDB.Auth.UserCertificates.Tests.csproj" />
+    <Project Path="src/KurrentDB.Auth.UserCertificates/KurrentDB.Auth.UserCertificates.csproj" />
   </Folder>
   <Folder Name="/Plugins/Connectors/">
-    <Project Path="src/Connectors/KurrentDB.Connectors.Contracts/KurrentDB.Connectors.Contracts.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/Connectors/KurrentDB.Connectors/KurrentDB.Connectors.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/Connectors/KurrentDB.Plugins.Connectors/KurrentDB.Plugins.Connectors.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/Connectors/KurrentDB.Connectors.Contracts/KurrentDB.Connectors.Contracts.csproj" />
+    <Project Path="src/Connectors/KurrentDB.Connectors/KurrentDB.Connectors.csproj" />
+    <Project Path="src/Connectors/KurrentDB.Plugins.Connectors/KurrentDB.Plugins.Connectors.csproj" />
   </Folder>
   <Folder Name="/Plugins/Connectors/Tests/">
-    <Project Path="src/Connectors/KurrentDB.Connectors.Tests/KurrentDB.Connectors.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/Connectors/KurrentDB.Connectors.TestServer/KurrentDB.Connectors.TestServer.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/Connectors/KurrentDB.Connectors.Tests/KurrentDB.Connectors.Tests.csproj" />
+    <Project Path="src/Connectors/KurrentDB.Connectors.TestServer/KurrentDB.Connectors.TestServer.csproj" />
   </Folder>
   <Folder Name="/Projections/">
-    <Project Path="src/KurrentDB.Projections.JavaScript.Tests/KurrentDB.Projections.JavaScript.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.JavaScript/KurrentDB.Projections.JavaScript.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.Management.Tests/KurrentDB.Projections.Management.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.Management/KurrentDB.Projections.Management.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.Shared.Tests/KurrentDB.Projections.Shared.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.Shared/KurrentDB.Projections.Shared.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.V1.Tests/KurrentDB.Projections.V1.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.V1.XUnit.Tests/KurrentDB.Projections.V1.XUnit.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.V1/KurrentDB.Projections.V1.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.V2.Tests/KurrentDB.Projections.V2.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Projections.V2/KurrentDB.Projections.V2.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/KurrentDB.Projections.JavaScript.Tests/KurrentDB.Projections.JavaScript.Tests.csproj" />
+    <Project Path="src/KurrentDB.Projections.JavaScript/KurrentDB.Projections.JavaScript.csproj" />
+    <Project Path="src/KurrentDB.Projections.Management.Tests/KurrentDB.Projections.Management.Tests.csproj" />
+    <Project Path="src/KurrentDB.Projections.Management/KurrentDB.Projections.Management.csproj" />
+    <Project Path="src/KurrentDB.Projections.Shared.Tests/KurrentDB.Projections.Shared.Tests.csproj" />
+    <Project Path="src/KurrentDB.Projections.Shared/KurrentDB.Projections.Shared.csproj" />
+    <Project Path="src/KurrentDB.Projections.V1.Tests/KurrentDB.Projections.V1.Tests.csproj" />
+    <Project Path="src/KurrentDB.Projections.V1.XUnit.Tests/KurrentDB.Projections.V1.XUnit.Tests.csproj" />
+    <Project Path="src/KurrentDB.Projections.V1/KurrentDB.Projections.V1.csproj" />
+    <Project Path="src/KurrentDB.Projections.V2.Tests/KurrentDB.Projections.V2.Tests.csproj" />
+    <Project Path="src/KurrentDB.Projections.V2/KurrentDB.Projections.V2.csproj" />
   </Folder>
   <Folder Name="/Schema Registry/">
-    <Project Path="src/SchemaRegistry/KurrentDB.Plugins.SchemaRegistry/KurrentDB.Plugins.SchemaRegistry.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/SchemaRegistry/KurrentDB.SchemaRegistry.Protocol/KurrentDB.SchemaRegistry.Protocol.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/SchemaRegistry/KurrentDB.SchemaRegistry.Tests/KurrentDB.SchemaRegistry.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/SchemaRegistry/KurrentDB.SchemaRegistry/KurrentDB.SchemaRegistry.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/SchemaRegistry/KurrentDB.Plugins.SchemaRegistry/KurrentDB.Plugins.SchemaRegistry.csproj" />
+    <Project Path="src/SchemaRegistry/KurrentDB.SchemaRegistry.Protocol/KurrentDB.SchemaRegistry.Protocol.csproj" />
+    <Project Path="src/SchemaRegistry/KurrentDB.SchemaRegistry.Tests/KurrentDB.SchemaRegistry.Tests.csproj" />
+    <Project Path="src/SchemaRegistry/KurrentDB.SchemaRegistry/KurrentDB.SchemaRegistry.csproj" />
   </Folder>
   <Folder Name="/SecondaryIndexes/">
-    <Project Path="src/KurrentDB.SecondaryIndexing.LoadTesting/KurrentDB.SecondaryIndexing.LoadTesting.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.SecondaryIndexing.Tests/KurrentDB.SecondaryIndexing.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.SecondaryIndexing/KurrentDB.SecondaryIndexing.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/KurrentDB.SecondaryIndexing.LoadTesting/KurrentDB.SecondaryIndexing.LoadTesting.csproj" />
+    <Project Path="src/KurrentDB.SecondaryIndexing.Tests/KurrentDB.SecondaryIndexing.Tests.csproj" />
+    <Project Path="src/KurrentDB.SecondaryIndexing/KurrentDB.SecondaryIndexing.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".github/CODEOWNERS" />
@@ -230,177 +75,48 @@
     <File Path="src/Directory.Packages.props" />
   </Folder>
   <Folder Name="/Tests/">
-    <Project Path="src/KurrentDB.BufferManagement.Tests/KurrentDB.BufferManagement.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Common.Tests/KurrentDB.Common.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Components.Tests/KurrentDB.Components.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Core.Testing.NUnit/KurrentDB.Core.Testing.NUnit.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Core.Testing.XUnit/KurrentDB.Core.Testing.XUnit.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Core.Testing/KurrentDB.Core.Testing.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Core.Tests/KurrentDB.Core.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Core.TUnit.Tests/KurrentDB.Core.TUnit.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Core.XUnit.Tests/KurrentDB.Core.XUnit.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Licensing.Tests/KurrentDB.Licensing.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.OtlpExporterPlugin.Tests/KurrentDB.OtlpExporterPlugin.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.Plugins.TestHelpers/KurrentDB.Plugins.TestHelpers.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.SourceGenerators.Tests/KurrentDB.SourceGenerators.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-    <Project Path="src/KurrentDB.SystemRuntime.Tests/KurrentDB.SystemRuntime.Tests.csproj">
-      <Platform Solution="*|ARM64" Project="ARM64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
+    <Project Path="src/KurrentDB.BufferManagement.Tests/KurrentDB.BufferManagement.Tests.csproj" />
+    <Project Path="src/KurrentDB.Common.Tests/KurrentDB.Common.Tests.csproj" />
+    <Project Path="src/KurrentDB.Components.Tests/KurrentDB.Components.Tests.csproj" />
+    <Project Path="src/KurrentDB.Core.Testing.NUnit/KurrentDB.Core.Testing.NUnit.csproj" />
+    <Project Path="src/KurrentDB.Core.Testing.XUnit/KurrentDB.Core.Testing.XUnit.csproj" />
+    <Project Path="src/KurrentDB.Core.Testing/KurrentDB.Core.Testing.csproj" />
+    <Project Path="src/KurrentDB.Core.Tests/KurrentDB.Core.Tests.csproj" />
+    <Project Path="src/KurrentDB.Core.TUnit.Tests/KurrentDB.Core.TUnit.Tests.csproj" />
+    <Project Path="src/KurrentDB.Core.XUnit.Tests/KurrentDB.Core.XUnit.Tests.csproj" />
+    <Project Path="src/KurrentDB.Licensing.Tests/KurrentDB.Licensing.Tests.csproj" />
+    <Project Path="src/KurrentDB.OtlpExporterPlugin.Tests/KurrentDB.OtlpExporterPlugin.Tests.csproj" />
+    <Project Path="src/KurrentDB.Plugins.TestHelpers/KurrentDB.Plugins.TestHelpers.csproj" />
+    <Project Path="src/KurrentDB.SourceGenerators.Tests/KurrentDB.SourceGenerators.Tests.csproj" />
+    <Project Path="src/KurrentDB.SystemRuntime.Tests/KurrentDB.SystemRuntime.Tests.csproj" />
   </Folder>
-  <Project Path="src/KurrentDB.Ammeter/KurrentDB.Ammeter.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.BufferManagement/KurrentDB.BufferManagement.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Common/KurrentDB.Common.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Core/KurrentDB.Core.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.DuckDB/KurrentDB.DuckDB.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Kontext.Models/KurrentDB.Kontext.Models.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Kontext.Tests/KurrentDB.Kontext.Tests.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Kontext/KurrentDB.Kontext.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Licensing/KurrentDB.Licensing.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.LogCommon/KurrentDB.LogCommon.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Logging/KurrentDB.Logging.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.MicroBenchmarks/KurrentDB.MicroBenchmarks.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Native/KurrentDB.Native.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.NETCore.Compatibility/KurrentDB.NETCore.Compatibility.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.PluginHosting/KurrentDB.PluginHosting.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Plugins.Kontext.Tests/KurrentDB.Plugins.Kontext.Tests.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Plugins.Kontext/KurrentDB.Plugins.Kontext.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.POC.IO.Core/KurrentDB.POC.IO.Core.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Scripting/KurrentDB.Scripting.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.SourceGenerators/KurrentDB.SourceGenerators.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Surge.Testing.Messages/KurrentDB.Surge.Testing.Messages.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Surge.Testing/KurrentDB.Surge.Testing.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Surge.Tests/KurrentDB.Surge.Tests.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Surge/KurrentDB.Surge.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.SystemRuntime/KurrentDB.SystemRuntime.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.TestClient/KurrentDB.TestClient.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Transport.Http/KurrentDB.Transport.Http.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB.Transport.Tcp/KurrentDB.Transport.Tcp.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/KurrentDB/KurrentDB.csproj">
-    <Platform Solution="*|ARM64" Project="ARM64" />
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
+  <Project Path="src/KurrentDB.Ammeter/KurrentDB.Ammeter.csproj" />
+  <Project Path="src/KurrentDB.BufferManagement/KurrentDB.BufferManagement.csproj" />
+  <Project Path="src/KurrentDB.Common/KurrentDB.Common.csproj" />
+  <Project Path="src/KurrentDB.Core/KurrentDB.Core.csproj" />
+  <Project Path="src/KurrentDB.DuckDB/KurrentDB.DuckDB.csproj" />
+  <Project Path="src/KurrentDB.Kontext.Models/KurrentDB.Kontext.Models.csproj" />
+  <Project Path="src/KurrentDB.Kontext.Tests/KurrentDB.Kontext.Tests.csproj" />
+  <Project Path="src/KurrentDB.Kontext/KurrentDB.Kontext.csproj" />
+  <Project Path="src/KurrentDB.Licensing/KurrentDB.Licensing.csproj" />
+  <Project Path="src/KurrentDB.LogCommon/KurrentDB.LogCommon.csproj" />
+  <Project Path="src/KurrentDB.Logging/KurrentDB.Logging.csproj" />
+  <Project Path="src/KurrentDB.MicroBenchmarks/KurrentDB.MicroBenchmarks.csproj" />
+  <Project Path="src/KurrentDB.Native/KurrentDB.Native.csproj" />
+  <Project Path="src/KurrentDB.NETCore.Compatibility/KurrentDB.NETCore.Compatibility.csproj" />
+  <Project Path="src/KurrentDB.PluginHosting/KurrentDB.PluginHosting.csproj" />
+  <Project Path="src/KurrentDB.Plugins.Kontext.Tests/KurrentDB.Plugins.Kontext.Tests.csproj" />
+  <Project Path="src/KurrentDB.Plugins.Kontext/KurrentDB.Plugins.Kontext.csproj" />
+  <Project Path="src/KurrentDB.POC.IO.Core/KurrentDB.POC.IO.Core.csproj" />
+  <Project Path="src/KurrentDB.Scripting/KurrentDB.Scripting.csproj" />
+  <Project Path="src/KurrentDB.SourceGenerators/KurrentDB.SourceGenerators.csproj" />
+  <Project Path="src/KurrentDB.Surge.Testing.Messages/KurrentDB.Surge.Testing.Messages.csproj" />
+  <Project Path="src/KurrentDB.Surge.Testing/KurrentDB.Surge.Testing.csproj" />
+  <Project Path="src/KurrentDB.Surge.Tests/KurrentDB.Surge.Tests.csproj" />
+  <Project Path="src/KurrentDB.Surge/KurrentDB.Surge.csproj" />
+  <Project Path="src/KurrentDB.SystemRuntime/KurrentDB.SystemRuntime.csproj" />
+  <Project Path="src/KurrentDB.TestClient/KurrentDB.TestClient.csproj" />
+  <Project Path="src/KurrentDB.Transport.Http/KurrentDB.Transport.Http.csproj" />
+  <Project Path="src/KurrentDB.Transport.Tcp/KurrentDB.Transport.Tcp.csproj" />
+  <Project Path="src/KurrentDB/KurrentDB.csproj" />
 </Solution>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,6 @@
 		<PackageReleaseNotes>https://docs.kurrent.io/server/latest/release-schedule/release-notes</PackageReleaseNotes>
 		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>14.0</LangVersion>
-		<Platforms>AnyCPU;x64;ARM64</Platforms>
 		<IsPackable>false</IsPackable>
 		<VersionPrefix>26.2.0</VersionPrefix>
 		<VersionSuffix>prerelease</VersionSuffix>

--- a/src/KurrentDB.Auth.Ldaps.Tests/KurrentDB.Auth.Ldaps.Tests.csproj
+++ b/src/KurrentDB.Auth.Ldaps.Tests/KurrentDB.Auth.Ldaps.Tests.csproj
@@ -8,9 +8,6 @@
       <IsKurrentXUnit>true</IsKurrentXUnit>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-      <DebugSymbols>true</DebugSymbols>
-    </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Ductus.FluentDocker.XUnit" />

--- a/src/KurrentDB.Auth.Ldaps/KurrentDB.Auth.Ldaps.csproj
+++ b/src/KurrentDB.Auth.Ldaps/KurrentDB.Auth.Ldaps.csproj
@@ -9,9 +9,6 @@
 	<PropertyGroup>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-	  <DebugSymbols>true</DebugSymbols>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Novell.Directory.Ldap.NETStandard" />
 		<PackageReference Include="System.ComponentModel.Composition" />

--- a/src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.csproj
+++ b/src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled.csproj
@@ -9,9 +9,6 @@
 	<PropertyGroup>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-	  <DebugSymbols>true</DebugSymbols>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.ComponentModel.Composition" />
 		<PackageReference Include="Serilog" />

--- a/src/KurrentDB.Auth.OAuth/KurrentDB.Auth.OAuth.csproj
+++ b/src/KurrentDB.Auth.OAuth/KurrentDB.Auth.OAuth.csproj
@@ -9,9 +9,6 @@
 	<PropertyGroup>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-	  <DebugSymbols>true</DebugSymbols>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="IdentityModel" />
 		<PackageReference Include="LruCacheNet" />

--- a/src/KurrentDB.Diagnostics.LogsEndpointPlugin/KurrentDB.Diagnostics.LogsEndpointPlugin.csproj
+++ b/src/KurrentDB.Diagnostics.LogsEndpointPlugin/KurrentDB.Diagnostics.LogsEndpointPlugin.csproj
@@ -8,9 +8,6 @@
 	<PropertyGroup>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-		<DebugSymbols>true</DebugSymbols>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Serilog" />
 	</ItemGroup>

--- a/src/KurrentDB.Security.EncryptionAtRest/KurrentDB.Security.EncryptionAtRest.csproj
+++ b/src/KurrentDB.Security.EncryptionAtRest/KurrentDB.Security.EncryptionAtRest.csproj
@@ -9,9 +9,6 @@
 	<PropertyGroup>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-	  <DebugSymbols>true</DebugSymbols>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Scrutor" />
 		<PackageReference Include="Serilog" />

--- a/src/KurrentDB.TestClient/KurrentDB.TestClient.csproj
+++ b/src/KurrentDB.TestClient/KurrentDB.TestClient.csproj
@@ -4,9 +4,6 @@
 		<OutputType>Exe</OutputType>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<NoWarn>1701;1702;1591</NoWarn>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" />
 		<PackageReference Include="EventStore.Client.Grpc.Streams" />

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -51,6 +51,11 @@ var exitCodeSource = new TaskCompletionSource<int>();
 
 Log.Logger = KurrentLoggerConfiguration.ConsoleLog;
 try {
+	if (!Environment.Is64BitProcess) {
+		Log.Fatal("KurrentDB requires a 64-bit process to run.");
+		return 1;
+	}
+
 	var options = ClusterVNodeOptions.FromConfiguration(configuration);
 
 	Log.Logger = KurrentLoggerConfiguration


### PR DESCRIPTION
Architecture is driven entirely by the publish RuntimeIdentifier
(-r <rid>), not the MSBuild Platform axis, so the AnyCPU/x64/ARM64
platform machinery was pure ceremony for this all-C# solution:

- Strip <Configurations> and per-project <Platform> mappings from
  KurrentDB.slnx.
- Remove <Platforms> from Directory.Build.props (defaults to AnyCPU).
- Drop /p:Platform=x64 from the CLAUDE.md build command.
- Delete the dead Release|x64 / Debug|x64 PropertyGroups from the
  plugin/test csprojs: DebugSymbols is already covered by the Release
  DebugType=pdbonly default; CS1701/1702 are suppressed by the SDK and
  CS1591 never fires without doc generation.

Also prune a dangling KurrentDB.ClusterNode.Web reference from
KurrentDB.ContainerTests.slnf.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>