### PR TITLE
Update TUnit to 1.60.0

### DIFF
--- a/KurrentDB.ContainerTests.slnf
+++ b/KurrentDB.ContainerTests.slnf
@@ -75,6 +75,7 @@
       "src\\KurrentDB.TestClient\\KurrentDB.TestClient.csproj",
       "src\\KurrentDB.Testing.ClusterVNodeApp\\KurrentDB.Testing.ClusterVNodeApp.csproj",
       "src\\KurrentDB.Testing\\KurrentDB.Testing.csproj",
+      "src\\KurrentDB.Testing.Tests\\KurrentDB.Testing.Tests.csproj",
       "src\\KurrentDB.Transport.Http\\KurrentDB.Transport.Http.csproj",
       "src\\KurrentDB.Transport.Tcp\\KurrentDB.Transport.Tcp.csproj",
       "src\\KurrentDB\\KurrentDB.csproj",

--- a/KurrentDB.slnx
+++ b/KurrentDB.slnx
@@ -4,6 +4,7 @@
     <Project Path="src/KurrentDB.Api.V2/KurrentDB.Api.V2.csproj" />
     <Project Path="src/KurrentDB.Plugins.Api.V2/KurrentDB.Plugins.Api.V2.csproj" />
     <Project Path="src/KurrentDB.Testing.ClusterVNodeApp/KurrentDB.Testing.ClusterVNodeApp.csproj" />
+    <Project Path="src/KurrentDB.Testing.Tests/KurrentDB.Testing.Tests.csproj" />
     <Project Path="src/KurrentDB.Testing/KurrentDB.Testing.csproj" />
   </Folder>
   <Folder Name="/Plugins/">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -192,6 +192,7 @@
     <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageVersion Include="Testcontainers" Version="4.7.0" />
     <PackageVersion Include="TUnit" Version="1.60.0" />
+    <PackageVersion Include="TUnit.Assertions" Version="1.60.0" />
     <PackageVersion Include="TUnit.Core" Version="1.60.0" />
     <PackageVersion Include="WaffleGenerator.Bogus" Version="4.2.2" />
     <!-- When updating to 4.x, switch back to xunit.v3 that uses MTP v2 by default -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -191,10 +191,10 @@
     <PackageVersion Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageVersion Include="Testcontainers" Version="4.7.0" />
-    <PackageVersion Include="TUnit" Version="1.0.39" />
-    <PackageVersion Include="TUnit.Core" Version="1.0.39" />
+    <PackageVersion Include="TUnit" Version="1.60.0" />
+    <PackageVersion Include="TUnit.Core" Version="1.60.0" />
     <PackageVersion Include="WaffleGenerator.Bogus" Version="4.2.2" />
-		<!-- When updating to 4.x, switch back to xunit.v3 that uses MTP v2 by default -->
+    <!-- When updating to 4.x, switch back to xunit.v3 that uses MTP v2 by default -->
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="YamlDotnet" Version="16.3.0" />

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/AppendRecordsMiscTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/AppendRecordsMiscTests.cs
@@ -35,7 +35,7 @@ public class AppendRecordsMiscTests {
 
 		var response = await Fixture.StreamsClient.AppendRecordsAsync(request, cancellationToken: ct);
 
-		await Assert.That(response.Revisions).HasCount(2);
+		await Assert.That(response.Revisions).Count().IsEqualTo(2);
 
 		var revA = response.Revisions.First(r => r.Stream == streamA);
 		var revB = response.Revisions.First(r => r.Stream == streamB);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingDeleted.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingDeleted.cs
@@ -36,7 +36,7 @@ public class WhenExpectingDeleted {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}
@@ -66,7 +66,7 @@ public class WhenExpectingDeleted {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Deleted);
@@ -99,7 +99,7 @@ public class WhenExpectingDeleted {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Deleted);
@@ -132,7 +132,7 @@ public class WhenExpectingDeleted {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Deleted);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingExists.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingExists.cs
@@ -36,7 +36,7 @@ public class WhenExpectingExists {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}
@@ -66,7 +66,7 @@ public class WhenExpectingExists {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Exists);
@@ -99,7 +99,7 @@ public class WhenExpectingExists {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Exists);
@@ -132,7 +132,7 @@ public class WhenExpectingExists {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Exists);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingNoStream.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingNoStream.cs
@@ -41,7 +41,7 @@ public class WhenExpectingNoStream {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.NoStream);
@@ -68,7 +68,7 @@ public class WhenExpectingNoStream {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}
@@ -94,7 +94,7 @@ public class WhenExpectingNoStream {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}
@@ -120,7 +120,7 @@ public class WhenExpectingNoStream {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingRevision.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingRevision.cs
@@ -38,7 +38,7 @@ public class WhenExpectingRevision {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}
@@ -68,7 +68,7 @@ public class WhenExpectingRevision {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedRevision);
@@ -101,7 +101,7 @@ public class WhenExpectingRevision {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedRevision);
@@ -134,7 +134,7 @@ public class WhenExpectingRevision {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedRevision);
@@ -167,7 +167,7 @@ public class WhenExpectingRevision {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedRevision);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingTombstoned.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenExpectingTombstoned.cs
@@ -36,7 +36,7 @@ public class WhenExpectingTombstoned {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}
@@ -66,7 +66,7 @@ public class WhenExpectingTombstoned {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Tombstoned);
@@ -99,7 +99,7 @@ public class WhenExpectingTombstoned {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Tombstoned);
@@ -132,7 +132,7 @@ public class WhenExpectingTombstoned {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Tombstoned);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenMultipleChecks.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/CheckOnly/WhenMultipleChecks.cs
@@ -45,7 +45,7 @@ public class WhenMultipleChecks {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}
@@ -87,7 +87,7 @@ public class WhenMultipleChecks {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(writeStream);
 		await Assert.That(response.Revisions[0].Revision).IsEqualTo(0L);
 	}
@@ -127,7 +127,7 @@ public class WhenMultipleChecks {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(1);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStreamB);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(5L);
@@ -168,7 +168,7 @@ public class WhenMultipleChecks {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(2);
+		await Assert.That(details!.Violations).Count().IsEqualTo(2);
 
 		var violationA = details.Violations.First(v => v.StreamState.Stream == checkStreamA);
 		var violationB = details.Violations.First(v => v.StreamState.Stream == checkStreamB);
@@ -225,7 +225,7 @@ public class WhenMultipleChecks {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(3);
+		await Assert.That(details!.Violations).Count().IsEqualTo(3);
 
 		var deletedViolation = details.Violations.First(v => v.StreamState.Stream == deletedStream);
 		var tombstonedViolation = details.Violations.First(v => v.StreamState.Stream == tombstonedStream);
@@ -274,7 +274,7 @@ public class WhenMultipleChecks {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStreamA);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(3L);
@@ -324,7 +324,7 @@ public class WhenMultipleChecks {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(2);
+		await Assert.That(details!.Violations).Count().IsEqualTo(2);
 
 		var violationB = details.Violations.First(v => v.StreamState.Stream == checkStreamB);
 		var violationC = details.Violations.First(v => v.StreamState.Stream == checkStreamC);
@@ -372,7 +372,7 @@ public class WhenMultipleChecks {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(checkStream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(5L);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingAny.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingAny.cs
@@ -27,7 +27,7 @@ public class WhenExpectingAny {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(stream);
 	}
 
@@ -42,7 +42,7 @@ public class WhenExpectingAny {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(stream);
 	}
 
@@ -58,7 +58,7 @@ public class WhenExpectingAny {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(stream);
 	}
 
@@ -79,7 +79,7 @@ public class WhenExpectingAny {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Any);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingDeleted.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingDeleted.cs
@@ -35,7 +35,7 @@ public class WhenExpectingDeleted {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(stream);
 	}
 
@@ -63,7 +63,7 @@ public class WhenExpectingDeleted {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Deleted);
@@ -95,7 +95,7 @@ public class WhenExpectingDeleted {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Deleted);
@@ -127,7 +127,7 @@ public class WhenExpectingDeleted {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Deleted);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingExists.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingExists.cs
@@ -35,7 +35,7 @@ public class WhenExpectingExists {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(stream);
 	}
 
@@ -63,7 +63,7 @@ public class WhenExpectingExists {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Exists);
@@ -95,7 +95,7 @@ public class WhenExpectingExists {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Exists);
@@ -127,7 +127,7 @@ public class WhenExpectingExists {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Exists);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingNoStream.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingNoStream.cs
@@ -40,7 +40,7 @@ public class WhenExpectingNoStream {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.NoStream);
@@ -66,7 +66,7 @@ public class WhenExpectingNoStream {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(stream);
 	}
 
@@ -90,7 +90,7 @@ public class WhenExpectingNoStream {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(stream);
 	}
 
@@ -119,7 +119,7 @@ public class WhenExpectingNoStream {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.NoStream);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingRevision.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingRevision.cs
@@ -37,7 +37,7 @@ public class WhenExpectingRevision {
 			cancellationToken: ct
 		);
 
-		await Assert.That(response.Revisions).HasCount(1);
+		await Assert.That(response.Revisions).Count().IsEqualTo(1);
 		await Assert.That(response.Revisions[0].Stream).IsEqualTo(stream);
 	}
 
@@ -65,7 +65,7 @@ public class WhenExpectingRevision {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedRevision);
@@ -97,7 +97,7 @@ public class WhenExpectingRevision {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedRevision);
@@ -129,7 +129,7 @@ public class WhenExpectingRevision {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedRevision);
@@ -161,7 +161,7 @@ public class WhenExpectingRevision {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedRevision);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingTombstoned.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/AppendRecords/WriteOnly/WhenExpectingTombstoned.cs
@@ -39,7 +39,7 @@ public class WhenExpectingTombstoned {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Tombstoned);
@@ -71,7 +71,7 @@ public class WhenExpectingTombstoned {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Tombstoned);
@@ -103,7 +103,7 @@ public class WhenExpectingTombstoned {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Tombstoned);
@@ -135,7 +135,7 @@ public class WhenExpectingTombstoned {
 
 		var details = rex.GetRpcStatus()?.GetDetail<AppendConsistencyViolationErrorDetails>();
 		await Assert.That(details).IsNotNull();
-		await Assert.That(details!.Violations).HasCount(1);
+		await Assert.That(details!.Violations).Count().IsEqualTo(1);
 		await Assert.That(details.Violations[0].CheckIndex).IsEqualTo(0);
 		await Assert.That(details.Violations[0].StreamState.Stream).IsEqualTo(stream);
 		await Assert.That(details.Violations[0].StreamState.ExpectedState).IsEqualTo(ExpectedStreamCondition.Tombstoned);

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/StreamsServiceTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/StreamsServiceTests.cs
@@ -57,7 +57,7 @@ public class StreamsServiceTests {
         Fixture.Logger.LogInformation("Append session completed at position {Position}", response.Position);
 
         // Assert
-        await Assert.That(response.Output).HasCount(numberOfStreams);
+        await Assert.That(response.Output).Count().IsEqualTo(numberOfStreams);
         await Assert.That(response.Position).IsGreaterThanOrEqualTo(numberOfStreams);
     }
 

--- a/src/KurrentDB.Api.V2.Tests/Modules/Streams/Validators/AppendRecordsRequestValidatorTests.cs
+++ b/src/KurrentDB.Api.V2.Tests/Modules/Streams/Validators/AppendRecordsRequestValidatorTests.cs
@@ -158,7 +158,7 @@ public class AppendRecordsRequestValidatorTests {
 		var result = Validator.Validate(request);
 
 		await Assert.That(result.IsValid).IsTrue();
-		await Assert.That(request.Checks).HasCount(0);
+		await Assert.That(request.Checks).Count().IsEqualTo(0);
 	}
 
 	static AppendRecordsRequest CreateValidRequest() {

--- a/src/KurrentDB.Kontext.Tests/Indexing/USearch/NearestMatchesTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Indexing/USearch/NearestMatchesTests.cs
@@ -46,6 +46,6 @@ public class NearestMatchesTests {
 		var matches = new NearestMatches();
 		matches.Offer(1, 0.1f);
 		matches.Offer(2, 0.2f);
-		await Assert.That(matches.Nearest(100)).HasCount().EqualTo(2);
+		await Assert.That(matches.Nearest(100)).Count().IsEqualTo(2);
 	}
 }

--- a/src/KurrentDB.Kontext.Tests/Indexing/USearch/SegmentsTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Indexing/USearch/SegmentsTests.cs
@@ -47,7 +47,7 @@ public class SegmentsTests : IDisposable {
 		var group = segments.FindMergeGroup();
 		await Assert.That(group).IsNotNull();
 		await Assert.That(group!.Value.TargetLevel).IsEqualTo(1);
-		await Assert.That(group.Value.Group).HasCount().EqualTo(5);
+		await Assert.That(group.Value.Group).Count().IsEqualTo(5);
 	}
 
 	[Test]

--- a/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/ForgetToolTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/ForgetToolTests.cs
@@ -41,7 +41,7 @@ public class ForgetToolTests {
 
 		var result = await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid, queries: ["order"]);
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(0);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(0);
 	}
 
 	[Test]

--- a/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/InquiryManagerTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/InquiryManagerTests.cs
@@ -52,6 +52,6 @@ public class InquiryManagerTests {
 		await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid1, queries: ["order"]);
 		var result = await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid2, queries: ["order"]);
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(1);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(1);
 	}
 }

--- a/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/ReadToolTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/ReadToolTests.cs
@@ -18,7 +18,7 @@ public class ReadToolTests {
 		var result = await ReadTool.Read(reader, new FakeWorkspaceContext(), TestWorkspace.Registry(),new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid,
 			eventRef: new EventRef { Stream = "order-1", EventNumber = 0 });
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(1);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(1);
 		await Assert.That(result.NewEvents[0].EventType).IsEqualTo("OrderPlaced");
 	}
 
@@ -34,7 +34,7 @@ public class ReadToolTests {
 		var result = await ReadTool.Read(reader, new FakeWorkspaceContext(), TestWorkspace.Registry(),new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid,
 			eventRef: new EventRef { Stream = "order-1", EventNumber = 0, Count = 3 });
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(3);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(3);
 	}
 
 	[Test]
@@ -50,7 +50,7 @@ public class ReadToolTests {
 		var result = await ReadTool.Read(reader, new FakeWorkspaceContext(), TestWorkspace.Registry(),new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid,
 			eventRef: new EventRef { Stream = "order-1", EventNumber = 0 });
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(0);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(0);
 		await Assert.That(result.WorkingSetSize).IsEqualTo(1);
 	}
 
@@ -69,7 +69,7 @@ public class ReadToolTests {
 		var result = await ReadTool.Read(reader, new FakeWorkspaceContext(), TestWorkspace.Registry(),new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid,
 			eventRef: new EventRef { Stream = "order-1", EventNumber = 0 });
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(0);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(0);
 		await Assert.That(result.WorkingSetSize).IsEqualTo(0);
 	}
 
@@ -84,7 +84,7 @@ public class ReadToolTests {
 			eventRef: new EventRef { Stream = "order-1", EventNumber = 0, Count = 6 });
 
 		await Assert.That(result.EndOfStream).IsTrue();
-		await Assert.That(result.NewEvents).HasCount().EqualTo(1);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(1);
 	}
 
 	[Test]
@@ -100,7 +100,7 @@ public class ReadToolTests {
 			eventRef: new EventRef { Stream = "order-1", EventNumber = 0, Count = 2 });
 
 		await Assert.That(result.EndOfStream).IsFalse();
-		await Assert.That(result.NewEvents).HasCount().EqualTo(2);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(2);
 	}
 
 	[Test]
@@ -113,7 +113,7 @@ public class ReadToolTests {
 			eventRef: new EventRef { Stream = "nothing-here", EventNumber = 0 });
 
 		await Assert.That(result.EndOfStream).IsTrue();
-		await Assert.That(result.NewEvents).HasCount().EqualTo(0);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(0);
 	}
 
 	[Test]
@@ -163,7 +163,7 @@ public class ReadToolTests {
 			new StaticHttpContextAccessor(), inquiries, sid,
 			eventRef: new EventRef { Stream = "ticket-1", EventNumber = 0, Count = 2 });
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(1);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(1);
 		await Assert.That(result.NewEvents[0].Id).IsEqualTo(100L);
 	}
 }

--- a/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/SearchToolTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/SearchToolTests.cs
@@ -28,7 +28,7 @@ public class SearchToolTests {
 
 		var result = await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid, queries: ["order"]);
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(1);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(1);
 		await Assert.That(result.NewEvents[0].Stream).IsEqualTo("order-1");
 		await Assert.That(result.NewEvents[0].EventType).IsEqualTo("OrderPlaced");
 		await Assert.That(result.NewEvents[0].Score).IsEqualTo(0.95f);
@@ -48,7 +48,7 @@ public class SearchToolTests {
 		await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid, queries: ["order"]);
 		var result = await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid, queries: ["order"]);
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(0);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(0);
 		await Assert.That(result.Searches[0].New).IsEqualTo(0);
 	}
 
@@ -65,7 +65,7 @@ public class SearchToolTests {
 
 		var result = await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid, queries: ["order", "payment"]);
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(2);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(2);
 	}
 
 	[Test]
@@ -79,7 +79,7 @@ public class SearchToolTests {
 
 		var result = await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid, queries: ["order", "placed"]);
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(1);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(1);
 	}
 
 	[Test]
@@ -91,7 +91,7 @@ public class SearchToolTests {
 
 		var result = await SearchTool.Search(search, new FakeWorkspaceContext(), new FakeAuthorizationProvider(), new StaticHttpContextAccessor(), inquiries, sid, queries: ["nonexistent"]);
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(0);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(0);
 	}
 
 	[Test]
@@ -138,7 +138,7 @@ public class SearchToolTests {
 		var result = await SearchTool.Search(search, new FakeWorkspaceContext(), authz,
 			new StaticHttpContextAccessor(), inquiries, sid, queries: ["any"]);
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(2);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(2);
 		var publicEvt = result.NewEvents.Single(e => e.Stream == "public-1");
 		var secretEvt = result.NewEvents.Single(e => e.Stream == "secret-1");
 

--- a/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/ViewToolTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Mcp/Inquiry/ViewToolTests.cs
@@ -15,7 +15,7 @@ public class ViewToolTests {
 		var result = await ViewTool.View(inquiries, new FakeWorkspaceContext(), sid);
 
 		await Assert.That(result.WorkingSetSize).IsEqualTo(0);
-		await Assert.That(result.Events).HasCount().EqualTo(0);
+		await Assert.That(result.Events).Count().IsEqualTo(0);
 	}
 
 	[Test]

--- a/src/KurrentDB.Kontext.Tests/Mcp/Memory/RecallToolTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Mcp/Memory/RecallToolTests.cs
@@ -37,7 +37,7 @@ public class RecallToolTests {
 		var fact = result.Facts[0];
 		await Assert.That(fact.Topic).IsEqualTo("alice-hobbies");
 		await Assert.That(fact.Fact).IsEqualTo("Alice has a dog named Max.");
-		await Assert.That(fact.SourceEvents).HasCount().EqualTo(2);
+		await Assert.That(fact.SourceEvents).Count().IsEqualTo(2);
 		await Assert.That(fact.SourceEvents[0].Stream).IsEqualTo("alice-pets");
 		await Assert.That(fact.SourceEvents[0].EventNumber).IsEqualTo(3L);
 		await Assert.That(fact.Superseded).IsFalse();
@@ -50,7 +50,7 @@ public class RecallToolTests {
 			new FakeSearchService(), new FakeSystemClient(), Workspace(), TestWorkspace.Registry(), "nonexistent");
 
 		await Assert.That(result.Count).IsEqualTo(0);
-		await Assert.That(result.Facts).HasCount().EqualTo(0);
+		await Assert.That(result.Facts).Count().IsEqualTo(0);
 	}
 
 	[Test]

--- a/src/KurrentDB.Kontext.Tests/Mcp/Memory/TopicsToolTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Mcp/Memory/TopicsToolTests.cs
@@ -33,7 +33,7 @@ public class TopicsToolTests {
 
 		var result = await TopicsTool.Topics(search, client, Workspace(), TestWorkspace.Registry(), keywords: "alice");
 
-		await Assert.That(result.Topics).HasCount().EqualTo(2);
+		await Assert.That(result.Topics).Count().IsEqualTo(2);
 		await Assert.That(result.Topics[0].Topic).IsEqualTo("alice-current-employer");
 		await Assert.That(result.Topics[0].Score).IsEqualTo(0.9f);
 		await Assert.That(result.Topics[0].LatestFact).IsEqualTo("Alice works at Globex.");

--- a/src/KurrentDB.Kontext.Tests/Mcp/Workspace/StreamsToolTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Mcp/Workspace/StreamsToolTests.cs
@@ -12,7 +12,7 @@ public class StreamsToolTests {
 
 		var result = await StreamsTool.Streams(search, new FakeWorkspaceContext(), keywords: "alice");
 
-		await Assert.That(result.Streams).HasCount().EqualTo(2);
+		await Assert.That(result.Streams).Count().IsEqualTo(2);
 		await Assert.That(result.Streams[0].Name).IsEqualTo("alice-hobbies");
 		await Assert.That(result.Streams[0].Score).IsEqualTo(0.9f);
 	}

--- a/src/KurrentDB.Kontext.Tests/Search/RetrieverTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Search/RetrieverTests.cs
@@ -185,7 +185,7 @@ public class RetrieverTests : IDisposable {
 
 		var docs = _retriever.ListDocs(Idx("test"), limit: 2);
 
-		await Assert.That(docs).HasCount().EqualTo(2);
+		await Assert.That(docs).Count().IsEqualTo(2);
 	}
 
 	[Test]

--- a/src/KurrentDB.Plugins.Kontext.Tests/IntegrationTests.cs
+++ b/src/KurrentDB.Plugins.Kontext.Tests/IntegrationTests.cs
@@ -155,7 +155,7 @@ public class IntegrationTests {
 		var result = await ReadTool.Read(_client, _workspaceContext, _workspaces, _authz, _httpAccessor, _inquiries, sid,
 			new EventRef { Stream = _testStream, EventNumber = 0, Count = 1 });
 
-		await Assert.That(result.NewEvents).HasCount().EqualTo(1);
+		await Assert.That(result.NewEvents).Count().IsEqualTo(1);
 		await Assert.That(result.NewEvents[0].EventType).IsEqualTo("OrderPlaced");
 	}
 
@@ -165,7 +165,7 @@ public class IntegrationTests {
 
 		var read = await ReadTool.Read(_client, _workspaceContext, _workspaces, _authz, _httpAccessor, _inquiries, sid,
 			new EventRef { Stream = _testStream, EventNumber = 0, Count = 3 });
-		await Assert.That(read.NewEvents).HasCount().EqualTo(3);
+		await Assert.That(read.NewEvents).Count().IsEqualTo(3);
 
 		var forget = ForgetTool.Forget(_workspaceContext, _inquiries, sid, [read.NewEvents[0].Id]);
 		await Assert.That(forget.Forgotten).IsEqualTo(1);
@@ -206,7 +206,7 @@ public class IntegrationTests {
 
 		var fact = recalled!.Facts.First(f => f.Topic == topic);
 		await Assert.That(fact.Fact).Contains("Alice orders Widgets");
-		await Assert.That(fact.SourceEvents).HasCount().EqualTo(2);
+		await Assert.That(fact.SourceEvents).Count().IsEqualTo(2);
 		await Assert.That(fact.SourceEvents[0].Stream).IsEqualTo(_testStream);
 		await Assert.That(fact.SourceEvents[0].EventNumber).IsEqualTo(0L);
 	}

--- a/src/KurrentDB.Projections.V2.Tests/Unit/OutputBufferTests.cs
+++ b/src/KurrentDB.Projections.V2.Tests/Unit/OutputBufferTests.cs
@@ -47,7 +47,7 @@ public class OutputBufferTests {
 		buffer.SetPartitionState("partition-1", "state-stream-1", "{\"count\":1}", 0);
 		buffer.SetPartitionState("partition-1", "state-stream-1", "{\"count\":2}", 1);
 
-		await Assert.That(buffer.DirtyStates).HasCount(1);
+		await Assert.That(buffer.DirtyStates).Count().IsEqualTo(1);
 
 		var (streamName, stateJson, expectedVersion) = buffer.DirtyStates["partition-1"];
 		await Assert.That(streamName).IsEqualTo("state-stream-1");
@@ -83,7 +83,7 @@ public class OutputBufferTests {
 			CreateTestEmittedEvent("stream-3", "EventC")
 		]);
 
-		await Assert.That(buffer.EmittedEvents).HasCount(3);
+		await Assert.That(buffer.EmittedEvents).Count().IsEqualTo(3);
 	}
 
 	[Test]
@@ -94,7 +94,7 @@ public class OutputBufferTests {
 		buffer.SetPartitionState("partition-2", "state-stream-2", "{\"b\":2}", 0);
 		buffer.SetPartitionState("partition-3", "state-stream-3", "{\"c\":3}", 0);
 
-		await Assert.That(buffer.DirtyStates).HasCount(3);
+		await Assert.That(buffer.DirtyStates).Count().IsEqualTo(3);
 		await Assert.That(buffer.DirtyStates.ContainsKey("partition-1")).IsTrue();
 		await Assert.That(buffer.DirtyStates.ContainsKey("partition-2")).IsTrue();
 		await Assert.That(buffer.DirtyStates.ContainsKey("partition-3")).IsTrue();

--- a/src/KurrentDB.Testing.ClusterVNodeApp/NodeShim.cs
+++ b/src/KurrentDB.Testing.ClusterVNodeApp/NodeShim.cs
@@ -15,10 +15,12 @@ public enum NodeType {
 	External,
 };
 
-public interface INode : IAsyncInitializer, IAsyncDisposable {
+public interface INode : IAsyncDisposable {
 	ClusterVNodeOptions ClusterVNodeOptions { get; }
 	IServiceProvider Services { get; }
 	Uri Uri { get; }
+
+	Task InitializeAsync();
 }
 
 static class INodeExtensions {

--- a/src/KurrentDB.Testing.Tests/KurrentDB.Testing.Tests.csproj
+++ b/src/KurrentDB.Testing.Tests/KurrentDB.Testing.Tests.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsKurrentTUnit>true</IsKurrentTUnit>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<EnablePreviewFeatures>true</EnablePreviewFeatures>
+	</PropertyGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\KurrentDB.Testing\KurrentDB.Testing.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/KurrentDB.Testing.Tests/Sample/HomeAutomation/HomeAutomationDataSetTests.cs
+++ b/src/KurrentDB.Testing.Tests/Sample/HomeAutomation/HomeAutomationDataSetTests.cs
@@ -3,9 +3,10 @@
 
 using Bogus;
 using KurrentDB.Testing.Bogus;
+using KurrentDB.Testing.Sample.HomeAutomation;
 using Serilog;
 
-namespace KurrentDB.Testing.Sample.HomeAutomation;
+namespace KurrentDB.Testing.Tests.Sample.HomeAutomation;
 
 /// <summary>
 /// Test class to verify HomeAutomation DataSet functionality

--- a/src/KurrentDB.Testing.Tests/Shouldly/ShouldlyObjectGraphTestExtensionsTests.cs
+++ b/src/KurrentDB.Testing.Tests/Shouldly/ShouldlyObjectGraphTestExtensionsTests.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using KurrentDB.Testing.Shouldly;
 using Shouldly;
 
-namespace KurrentDB.Testing.Shouldly;
+namespace KurrentDB.Testing.Tests.Shouldly;
 
 public class ShouldlyObjectGraphTestExtensionsTests {
     [Test]

--- a/src/KurrentDB.Testing.Tests/TestEnvironmentWireUp.cs
+++ b/src/KurrentDB.Testing.Tests/TestEnvironmentWireUp.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using KurrentDB.Testing;
+using TUnit.Core.Executors;
+
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: ToolkitTestConfigurator]
+[assembly: TestExecutor<ToolkitTestExecutor>]
+
+namespace KurrentDB.Testing.Tests;
+
+public class TestEnvironmentWireUp {
+	[Before(Assembly)]
+	public static ValueTask BeforeAssembly(AssemblyHookContext context) =>
+		ToolkitTestEnvironment.Initialize();
+
+	[After(Assembly)]
+	public static ValueTask AfterAssembly(AssemblyHookContext context) =>
+		ToolkitTestEnvironment.Reset();
+}

--- a/src/KurrentDB.Testing/KurrentDB.Testing.csproj
+++ b/src/KurrentDB.Testing/KurrentDB.Testing.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -35,7 +34,8 @@
     <PackageReference Include="Serilog.Sinks.Seq" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="System.Reactive" />
-    <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit.Assertions" />
+    <PackageReference Include="TUnit.Core" />
     <PackageReference Include="WaffleGenerator.Bogus" />
     <PackageReference Include="Grpc.StatusProto" />
   </ItemGroup>

--- a/src/KurrentDB.Testing/TUnit/ValueAssertionExtensions.cs
+++ b/src/KurrentDB.Testing/TUnit/ValueAssertionExtensions.cs
@@ -17,6 +17,6 @@ public static class ValueAssertionExtensions {
 		JsonDocument.Parse(json),
 		SerializerOptions);
 
-	public static StringEqualsAssertion<string> IsJson(this ValueAssertion<string> source, string expectedJson) =>
+	public static StringEqualsAssertion IsJson(this ValueAssertion<string> source, string expectedJson) =>
 		new(source.Context.Map(actualJson => Normalize(actualJson!)), Normalize(expectedJson!));
 }

--- a/src/KurrentDB.Testing/Toolkit/ToolkitTestEnvironment.cs
+++ b/src/KurrentDB.Testing/Toolkit/ToolkitTestEnvironment.cs
@@ -3,7 +3,6 @@
 
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Reflection;
 using KurrentDB.Testing.OpenTelemetry;
 using Microsoft.Extensions.Configuration;
 using Serilog;
@@ -93,7 +92,8 @@ public static class ToolkitTestEnvironment {
             .WriteTo.OpenTelemetry()
             .WriteTo.Observers(o => o.Subscribe(LogEvents.OnNext))
             .WriteTo.Console(
-                theme: AnsiConsoleTheme.Code,
+                // TUnit breaks escape sequences, showing them in the console literally
+                theme: AnsiConsoleTheme.None,
                 outputTemplate: ConsoleOutputTemplate,
                 applyThemeToRedirectedOutput: true
             )
@@ -115,7 +115,8 @@ public static class ToolkitTestEnvironment {
             .ReadFrom.Configuration(Configuration)
             .Enrich.WithProperty("TestUid", testUid)
             .WriteTo.Console(
-                theme: AnsiConsoleTheme.Code,
+	            // TUnit breaks escape sequences, showing them in the console literally
+                theme: AnsiConsoleTheme.None,
                 outputTemplate: ConsoleOutputTemplate,
                 applyThemeToRedirectedOutput: true
             )


### PR DESCRIPTION
- Updated TUnit
- Updated obsolete assertion method usages and fixed test data initialization to work on the new version
- Fixed TUnit messing with Serilog's colored logs and producing unreadable output for some tests