### PR TITLE
Update Jint to 4.15.3 and adopt the newer embedding surface

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -57,7 +57,7 @@
     <PackageVersion Include="IdentityModel" Version="7.0.0" />
     <PackageVersion Include="IgnoresAccessChecksToGenerator" Version="0.8.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageVersion Include="Jint" Version="4.0.3" />
+    <PackageVersion Include="Jint" Version="4.15.3" />
     <PackageVersion Include="Kurrent.Connectors.Elasticsearch" Version="1.1.1-alpha.1.71" />
     <PackageVersion Include="Kurrent.Connectors.Http" Version="1.1.1-alpha.1.71" />
     <PackageVersion Include="Kurrent.Connectors.Kafka" Version="1.1.1-alpha.1.71" />

--- a/src/KurrentDB.Api.V2/Modules/Indexes/Validators/JsFunctionValidator.cs
+++ b/src/KurrentDB.Api.V2/Modules/Indexes/Validators/JsFunctionValidator.cs
@@ -2,21 +2,25 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using Jint;
+using KurrentDB.Scripting;
 
 namespace KurrentDB.Api.Modules.Indexes.Validators;
 
 internal static class JsFunctionValidator {
-	private static readonly Engine Engine = new();
+	// The engine outlives every request and evaluates user-supplied source, so each validation has its
+	// globals rolled back afterwards rather than leaving them for the next one. The engine's own
+	// configuration is unchanged.
+	private static readonly JsValidationEngine Engine = new(new Engine());
 
 	public static bool IsValidFunctionWithOneArgument(string? jsFunction) {
 		if (jsFunction is null)
 			return false;
 
 		try {
-			lock (Engine) {
-				var function = Engine.Evaluate(jsFunction).AsFunctionInstance();
+			return Engine.Validate(engine => {
+				var function = engine.Evaluate(jsFunction).AsFunctionInstance();
 				return function.FunctionDeclaration!.Params.Count == 1;
-			}
+			});
 		} catch {
 			return false;
 		}

--- a/src/KurrentDB.Kontext.Tests/Indexing/InteropArrayConversionAuditTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Indexing/InteropArrayConversionAuditTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Jint;
+using Kurrent.Surge.Schema.Serializers.Json;
+using KurrentDB.Scripting;
+using static KurrentDB.Kontext.Tests.Fakes.FakeSystemClient;
+
+namespace KurrentDB.Kontext.Tests.Indexing;
+
+/// <summary>
+/// Jint 4.14 changed the default for <c>Options.Interop.ArrayConversion</c> from <c>Copy</c> to
+/// <c>LiveView</c>, and the two differ in ways a script can observe: a live view writes through to the CLR
+/// array, <c>Array.isArray</c> is false for it, and resizing it throws a <c>TypeError</c>.
+/// <para>
+/// Whether that matters to us is a question about which values actually cross the interop boundary, and it
+/// was previously answerable only by reading every call site. Jint 4.15.1 counts the conversions, so this
+/// asserts the answer instead: mapping a record and running a filter and a field selector over it converts
+/// no CLR array at all, under either mode.
+/// </para>
+/// <para>
+/// Scope. This covers the scripting engines, which is where the question lives: <c>JsRecord</c> is the only
+/// object graph this repository projects into script, so it is the only place a CLR array could appear. The
+/// projections engine hands its handlers nothing but <c>JsValue</c>s and so cannot convert one. Note also
+/// what the counters deliberately exclude: under <c>LiveView</c> an array crossing under a non-array
+/// declared type (<c>IReadOnlyList&lt;T&gt;</c>) honours that declared contract through the ordinary wrapper
+/// lane and is not counted -- so this asserts "no array conversion", not "no array-shaped value".
+/// </para>
+/// </summary>
+public class InteropArrayConversionAuditTests {
+	static (Engine Engine, JsRecordEvaluator Evaluator) Make() {
+		var engine = JintEngineFactory.CreateEngine();
+		return (engine, new JsRecordEvaluator(engine, SystemJsonSchemaSerializerOptions.Default));
+	}
+
+	[Test]
+	public async Task Mapping_And_Filtering_A_Record_Converts_No_Clr_Array() {
+		var (engine, evaluator) = Make();
+		var filter = JsRecordEvaluator.Compile(engine, "rec => rec.value.org === 'acme'");
+		var selector = JsRecordEvaluator.Compile(engine, "rec => rec.value.items.length");
+
+		var evt = MakeEvent("ticket-1", 0, "TicketRaised", data: new { org = "acme", items = new[] { 1, 2, 3 } });
+		evaluator.MapRecord(evt, sequence: 1);
+
+		await Assert.That(evaluator.Match(filter)).IsTrue();
+		await Assert.That(evaluator.Select(selector)!.AsNumber()).IsEqualTo(3d);
+
+		var diagnostics = engine.Advanced.GetInteropConversionDiagnostics();
+		await Assert.That(diagnostics.ArrayLiveViewConversions).IsEqualTo(0L);
+		await Assert.That(diagnostics.ArrayCopyConversions).IsEqualTo(0L);
+	}
+
+	[Test]
+	public async Task Reading_Every_Projected_Member_Converts_No_Clr_Array() {
+		var (engine, evaluator) = Make();
+		var selector = JsRecordEvaluator.Compile(
+			engine,
+			"""
+			rec => [
+			  rec.id, rec.sequence, rec.redacted, rec.timestamp,
+			  rec.schema.name, rec.schema.format, rec.schema.id,
+			  rec.position.stream, rec.position.streamRevision, rec.position.logPosition,
+			  JSON.stringify(rec.value), JSON.stringify(rec.properties)
+			].join('|')
+			""");
+
+		evaluator.MapRecord(MakeEvent("ticket-1", 0, "TicketRaised", data: new { org = "acme" }), sequence: 1);
+		await Assert.That(evaluator.Select(selector)!.IsString()).IsTrue();
+
+		var diagnostics = engine.Advanced.GetInteropConversionDiagnostics();
+		await Assert.That(diagnostics.ArrayLiveViewConversions).IsEqualTo(0L);
+		await Assert.That(diagnostics.ArrayCopyConversions).IsEqualTo(0L);
+	}
+
+	[Test]
+	public async Task The_Counters_Would_Notice_An_Array_Crossing() {
+		// Positive control: without this, the two assertions above would also pass if the counters were
+		// never incremented at all.
+		var engine = JintEngineFactory.CreateEngine();
+		engine.SetValue("numbers", new[] { 1, 2, 3 });
+		engine.Evaluate("numbers[0]");
+
+		var diagnostics = engine.Advanced.GetInteropConversionDiagnostics();
+		await Assert.That(diagnostics.ArrayLiveViewConversions).IsEqualTo(1L);
+		await Assert.That(diagnostics.ArrayCopyConversions).IsEqualTo(0L);
+	}
+}

--- a/src/KurrentDB.Kontext.Tests/Indexing/JintHostContractVerification.cs
+++ b/src/KurrentDB.Kontext.Tests/Indexing/JintHostContractVerification.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Runtime.CompilerServices;
+using Jint;
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace KurrentDB.Kontext.Tests.Indexing;
+
+internal static class JintHostContractVerification {
+	/// <summary>
+	/// Turns on Jint's host-contract verifiers for this test assembly.
+	/// </summary>
+	/// <remarks>
+	/// These are the checks that catch host code answering one of the engine's extension points in a way
+	/// that contradicts another. The engine trusts those hooks on its hot paths and cannot re-verify them
+	/// there, so a violation is otherwise silent.
+	/// <para>
+	/// The switch has to be set before the first use of any Jint type: the flag behind it is read once at
+	/// type initialization, and flipping it afterwards does nothing for the rest of the process. A module
+	/// initializer runs before any test in the assembly, which is early enough. There is no cost to leaving
+	/// it off in production -- the guards fold away entirely when the switch is unset -- and it is
+	/// deliberately not set anywhere but here.
+	/// </para>
+	/// </remarks>
+	[ModuleInitializer]
+	internal static void Enable() => AppContext.SetSwitch("Jint.EnableHostContractVerification", true);
+}
+
+/// <summary>
+/// Positive control for the switch above. The scripting engines have no host <c>ObjectInstance</c>
+/// subclass today, so the verifiers currently guard against a future one rather than anything present --
+/// which makes it all the more worth proving the switch is actually live, since nothing else in this
+/// assembly would notice if it were not.
+/// </summary>
+public class JintHostContractVerificationTests {
+	/// <summary>
+	/// Claims every name as its own while <c>GetOwnProperty</c> reports them all absent, which is the
+	/// contradiction <c>TryGetOwnPropertyValue</c>'s contract forbids.
+	/// </summary>
+	sealed class LyingHostObject(Engine engine) : ObjectInstance(engine) {
+		protected override bool TryGetOwnPropertyValue(JsValue property, JsValue receiver, out JsValue value) {
+			value = JsValue.Null;
+			return true;
+		}
+	}
+
+	[Test]
+	public async Task The_verifiers_are_enabled_in_this_assembly() {
+		var engine = new Engine();
+		engine.SetValue("host", new LyingHostObject(engine));
+
+		var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("host.anything"));
+		await Assert.That(ex!.Message).Contains("TryGetOwnPropertyValue");
+	}
+}

--- a/src/KurrentDB.Kontext.Tests/Indexing/JsValidationEngineTests.cs
+++ b/src/KurrentDB.Kontext.Tests/Indexing/JsValidationEngineTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Jint;
+using KurrentDB.Scripting;
+
+namespace KurrentDB.Kontext.Tests.Indexing;
+
+public class JsValidationEngineTests {
+	[Test]
+	public async Task Globals_Defined_By_One_Validation_Are_Not_Visible_To_The_Next() {
+		var engine = new JsValidationEngine(JintEngineFactory.CreateEngine());
+
+		// A filter expression is evaluated as `(<expr>)`, and a comma expression lets one both define a
+		// global and produce the function that passes validation. On a shared, process-lifetime engine
+		// that global would otherwise outlive the request that created it.
+		engine.Validate(e => e.Evaluate("(globalThis.leaked = 1, r => true)"));
+
+		var stillThere = engine.Validate(e => e.Evaluate("typeof globalThis.leaked").AsString());
+		await Assert.That(stillThere).IsEqualTo("undefined");
+	}
+
+	[Test]
+	public async Task Globals_Are_Restored_Even_When_A_Validation_Throws() {
+		var engine = new JsValidationEngine(JintEngineFactory.CreateEngine());
+
+		Assert.Throws<Exception>(() => engine.Validate<object>(e => {
+			e.Evaluate("globalThis.leaked = 1");
+			throw new InvalidOperationException("rejected");
+		}));
+
+		var stillThere = engine.Validate(e => e.Evaluate("typeof globalThis.leaked").AsString());
+		await Assert.That(stillThere).IsEqualTo("undefined");
+	}
+
+	[Test]
+	public async Task Host_Configuration_Captured_At_Construction_Survives_A_Restore() {
+		var underlying = JintEngineFactory.CreateEngine();
+		underlying.SetValue("hostProvided", 42);
+		var engine = new JsValidationEngine(underlying);
+
+		engine.Validate(e => e.Evaluate("(globalThis.leaked = 1, r => true)"));
+
+		var stillThere = engine.Validate(e => e.Evaluate("hostProvided").AsNumber());
+		await Assert.That(stillThere).IsEqualTo(42d);
+	}
+}

--- a/src/KurrentDB.Kontext/Workspaces/ControlPlane/Workspace.cs
+++ b/src/KurrentDB.Kontext/Workspaces/ControlPlane/Workspace.cs
@@ -8,7 +8,7 @@ using KurrentDB.Scripting;
 namespace KurrentDB.Kontext.Workspaces.ControlPlane;
 
 public sealed class Workspace : Aggregate<WorkspaceState> {
-	static readonly Engine ValidateEngine = JintEngineFactory.CreateEngine();
+	static readonly JsValidationEngine ValidateEngine = new(JintEngineFactory.CreateEngine());
 
 	public void Create(CreateWorkspaceRequest cmd) {
 		ValidateName(cmd.Name);
@@ -110,8 +110,7 @@ public sealed class Workspace : Aggregate<WorkspaceState> {
 			if (string.IsNullOrWhiteSpace(rule.Filter))
 				continue;
 			try {
-				lock (ValidateEngine)
-					JsRecordEvaluator.Compile(ValidateEngine, rule.Filter);
+				ValidateEngine.Validate(engine => JsRecordEvaluator.Compile(engine, rule.Filter));
 			} catch (Exception ex) {
 				throw new WorkspaceInvalidException(
 					$"Filter for prefix '{rule.StreamPrefix}' failed to compile: {ex.Message}");

--- a/src/KurrentDB.MicroBenchmarks/ProjectionSerializationBenchmarks.cs
+++ b/src/KurrentDB.MicroBenchmarks/ProjectionSerializationBenchmarks.cs
@@ -12,34 +12,29 @@ using KurrentDB.Projections.Core.Tests.Services.Jint.Serialization;
 
 namespace KurrentDB.MicroBenchmarks;
 
+/// <summary>
+/// Measures the per-event state serialization a JS projection pays on every handled event. This used to
+/// be an A/B of a hand-written serializer against Jint's; the hand-written one is gone, so what is left
+/// is the production path.
+/// </summary>
 [MemoryDiagnoser]
 public class ProjectionSerializationBenchmarks {
-	private JsonSerializer _builtIn;
-	private JintProjectionStateHandler _handler;
-	private JsValue _stateInstance;
+	private readonly JintProjectionStateHandler _handler;
+	private readonly JsValue _stateInstance;
 
 	public ProjectionSerializationBenchmarks() {
 		var json = when_serializing_state.ReadJsonFromFile("big_state.json");
 
 		var engine = new Engine();
 		var parser = new JsonParser(engine);
-		_builtIn = new JsonSerializer(engine);
 		_handler = new JintProjectionStateHandler("", false, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(500),
 			new(IProjectionExecutionTracker.NoOp), new(IProjectionStateSerializationTracker.NoOp));
 
 		_stateInstance = parser.Parse(json);
-
-	}
-
-	[Benchmark(Baseline = true)]
-	public void JintSerializer() {
-		var s = _builtIn.Serialize(_stateInstance, JsValue.Undefined, JsValue.Undefined).AsString();
-		if (string.IsNullOrEmpty(s))
-			throw new Exception("something went wrong");
 	}
 
 	[Benchmark]
-	public void CustomSerializer() {
+	public void SerializeState() {
 		var s = _handler.Serialize(_stateInstance);
 		if (string.IsNullOrEmpty(s))
 			throw new Exception("something went wrong");

--- a/src/KurrentDB.Projections.JavaScript/KurrentDB.Projections.JavaScript.csproj
+++ b/src/KurrentDB.Projections.JavaScript/KurrentDB.Projections.JavaScript.csproj
@@ -8,4 +8,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\KurrentDB.Projections.Shared\KurrentDB.Projections.Shared.csproj" />
 	</ItemGroup>
+	<ItemGroup>
+		<InternalsVisibleTo Include="KurrentDB.Projections.Management.Tests" />
+	</ItemGroup>
 </Project>

--- a/src/KurrentDB.Projections.JavaScript/Metrics/JsSerializationMeasurer.cs
+++ b/src/KurrentDB.Projections.JavaScript/Metrics/JsSerializationMeasurer.cs
@@ -3,17 +3,23 @@
 
 using System;
 using Jint.Native;
+using Jint.Native.Json;
 using KurrentDB.Core.Time;
-using KurrentDB.Projections.Core.Services.Interpreted;
 
 namespace KurrentDB.Projections.Core.Metrics;
 
 public class JsSerializationMeasurer(IProjectionStateSerializationTracker tracker) {
-	private readonly JintProjectionStateHandler.Serializer _serializer = new();
-
-	public ReadOnlySpan<byte> Serialize(JsValue value) {
+	// The serializer is engine-bound and this measurer is constructed before the handler builds its
+	// engine, so it is passed in per call, the same way JsFunctionCallMeasurer takes the function it
+	// is timing. A JsonSerializer is reusable across calls -- it clears its own per-call state -- so
+	// the caller holds one for the life of the handler.
+	public string Serialize(JsonSerializer serializer, JsValue value) {
 		using var measurer = new Measurer(tracker);
-		return _serializer.Serialize(value).Span;
+
+		// Jint returns undefined for the values that have no JSON representation at all: undefined
+		// itself, and functions. Callers here treat the result as a JSON document, and the serializer
+		// this replaces wrote "null" for those, so keep that mapping rather than returning null.
+		return serializer.Serialize(value) is JsString json ? json.ToString() : "null";
 	}
 
 	readonly struct Measurer(IProjectionStateSerializationTracker tracker) : IDisposable {

--- a/src/KurrentDB.Projections.JavaScript/Services/Interpreted/JintProjectionStateHandler.cs
+++ b/src/KurrentDB.Projections.JavaScript/Services/Interpreted/JintProjectionStateHandler.cs
@@ -2,16 +2,11 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
-using System.Buffers;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
-using System.Text.Encodings.Web;
-using System.Text.Json;
 using Jint;
 using Jint.Native;
 using Jint.Native.Function;
@@ -41,6 +36,7 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 	private readonly List<EmittedEventEnvelope> _emitted;
 	private readonly InterpreterRuntime _interpreterRuntime;
 	private readonly JsonParser _parser;
+	private readonly JsonSerializer _serializer;
 	private readonly JsSerializationMeasurer _jsSerializer;
 
 	private CheckpointTag? _currentPosition;
@@ -60,10 +56,12 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 		_definitionBuilder.AllEvents();
 		TimeConstraint timeConstraint = new(compilationTimeout, executionTimeout);
 		_engine = new Engine(opts => opts.Constraint(timeConstraint).DisableStringCompilation());
+		_serializer = new JsonSerializer(_engine);
+		RestoreBigIntSerialization();
 		_state = JsValue.Undefined;
 		_sharedState = JsValue.Undefined;
 		_interpreterRuntime = new InterpreterRuntime(_engine, _definitionBuilder, jsFunctionCaller);
-		_engine.Global.FastAddProperty("log", new ClrFunction(_engine, "log", Log), false, false, false);
+		_engine.Global.FastSetProperty("log", new PropertyDescriptor(new ClrFunction(_engine, "log", Log), PropertyFlag.AllForbidden));
 
 		timeConstraint.Compiling();
 		_engine.Execute(source);
@@ -71,12 +69,43 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 		_parser = _interpreterRuntime.SwitchToExecutionMode();
 
 
-		_engine.Global.FastAddProperty("emit", new ClrFunction(_engine, "emit", Emit, 4), true, false, true);
-		_engine.Global.FastAddProperty("linkTo", new ClrFunction(_engine, "linkTo", LinkTo, 3), true, false, true);
-		_engine.Global.FastAddProperty("linkStreamTo", new ClrFunction(_engine, "linkStreamTo", LinkStreamTo, 3), true, false, true);
-		_engine.Global.FastAddProperty("copyTo", new ClrFunction(_engine, "copyTo", CopyTo, 3), true, false, true);
+		AddGlobalFunction("emit", Emit, 4);
+		AddGlobalFunction("linkTo", LinkTo, 3);
+		AddGlobalFunction("linkStreamTo", LinkStreamTo, 3);
+		AddGlobalFunction("copyTo", CopyTo, 3);
 		_emitted = new List<EmittedEventEnvelope>();
 	}
+
+	/// <summary>
+	/// Makes a BigInt in projection state serialize as a JSON string of its digits, which is what the
+	/// hand-written serializer this engine used to run wrote for one.
+	/// </summary>
+	/// <remarks>
+	/// A BigInt has no JSON representation, so JSON.stringify -- which state serialization now goes
+	/// through -- throws on one. For a projection already running with a BigInt in its state that would
+	/// mean faulting at serialization and halting checkpointing on upgrade, so the old rendering is
+	/// restored through the hook the specification leaves open for exactly this: JSON.stringify consults
+	/// toJSON before it decides a value has no representation, and quotes the digits this returns.
+	/// <para>
+	/// Deliberately not a replacer function passed to <c>Serialize</c>. A replacer is invoked for every
+	/// node of every state document, on the per-event hot path; this costs nothing until a BigInt is
+	/// actually present. It is installed only here, on the projection engines: the scripting engines
+	/// never ran the string-writing serializer and have no behaviour to preserve.
+	/// </para>
+	/// </remarks>
+	private void RestoreBigIntSerialization() {
+		var bigIntPrototype = _engine.Evaluate("BigInt.prototype").AsObject();
+		bigIntPrototype.FastSetProperty(
+			"toJSON",
+			new PropertyDescriptor(
+				new ClrFunction(_engine, "toJSON", static (thisValue, _) => thisValue.ToString()),
+				PropertyFlag.NonEnumerable));
+	}
+
+	// NonEnumerable is { writable: true, enumerable: false, configurable: true } -- the attribute shape a
+	// host-installed global function has always had here, now named rather than spelled as three bools.
+	private void AddGlobalFunction(string name, Func<JsValue, JsValue[], JsValue> func, int length) =>
+		_engine.Global.FastSetProperty(name, new PropertyDescriptor(new ClrFunction(_engine, name, func, length), PropertyFlag.NonEnumerable));
 
 	public void Dispose() {
 		_engine.Dispose();
@@ -400,6 +429,15 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 			_executing = true;
 
 		}
+		// Check() only reads a wall clock; it neither counts its own invocations nor budgets a quantity that
+		// can grow unboundedly between two checks, so it is sound for the engine to check it every N
+		// statements instead of before every single one. Jint's own TimeConstraint says the same about
+		// itself. Without this, a user-derived Constraint lands in the engine's "exact" partition, which
+		// costs a virtual Check() per statement and disarms the interpreter's tight-loop lanes for every
+		// projection that folds over an array. Only detection latency changes, and it stays bounded (the
+		// engine also re-checks whenever control returns from host code).
+		public override bool IsAmortizable => true;
+
 		public override void Reset() {
 			_start = _sw.Elapsed;
 		}
@@ -439,14 +477,14 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 		private readonly JsonParser _parser;
 
 		private static readonly Dictionary<string, Action<InterpreterRuntime>> _possibleProperties = new Dictionary<string, Action<InterpreterRuntime>>() {
-			["when"] = i => i.FastAddProperty("when", i._whenInstance, true, false, true),
-			["partitionBy"] = i => i.FastAddProperty("partitionBy", i._partitionByInstance, true, false, true),
-			["outputState"] = i => i.FastAddProperty("outputState", i._outputStateInstance, true, false, true),
-			["foreachStream"] = i => i.FastAddProperty("foreachStream", i._foreachStreamInstance, true, false, true),
-			["transformBy"] = i => i.FastAddProperty("transformBy", i._transformByInstance, true, false, true),
-			["filterBy"] = i => i.FastAddProperty("filterBy", i._filterByInstance, true, false, true),
-			["outputTo"] = i => i.FastAddProperty("outputTo", i._outputToInstance, true, false, true),
-			["$defines_state_transform"] = i => i.FastAddProperty("$defines_state_transform", i._definesStateTransformInstance, true, false, true),
+			["when"] = i => i.AddDslProperty("when", i._whenInstance),
+			["partitionBy"] = i => i.AddDslProperty("partitionBy", i._partitionByInstance),
+			["outputState"] = i => i.AddDslProperty("outputState", i._outputStateInstance),
+			["foreachStream"] = i => i.AddDslProperty("foreachStream", i._foreachStreamInstance),
+			["transformBy"] = i => i.AddDslProperty("transformBy", i._transformByInstance),
+			["filterBy"] = i => i.AddDslProperty("filterBy", i._filterByInstance),
+			["outputTo"] = i => i.AddDslProperty("outputTo", i._outputToInstance),
+			["$defines_state_transform"] = i => i.AddDslProperty("$defines_state_transform", i._definesStateTransformInstance),
 		};
 
 		private static readonly Dictionary<string, string[]> _availableProperties = new Dictionary<string, string[]>() {
@@ -506,9 +544,12 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 
 		}
 
+		private void AddDslProperty(string name, JsValue value) =>
+			FastSetProperty(name, new PropertyDescriptor(value, PropertyFlag.NonEnumerable));
+
 		private void AddDefinitionFunction(string name, Func<JsValue, JsValue[], JsValue> func, int length) {
 			_definitionFunctions.Add(name);
-			_engine.Global.FastAddProperty(name, new ClrFunction(_engine, name, func, length), true, false, true);
+			_engine.Global.FastSetProperty(name, new PropertyDescriptor(new ClrFunction(_engine, name, func, length), PropertyFlag.NonEnumerable));
 		}
 
 		private JsValue FromStream(JsValue _, JsValue[] parameters) {
@@ -714,9 +755,9 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 		public JsValue Handle(JsValue state, EventEnvelope eventEnvelope) {
 			JsValue newState;
 			if (_handlers.TryGetValue(eventEnvelope.EventType, out var handler)) {
-				newState = _jsFunctionCaller.Call(eventEnvelope.EventType, handler, state, FromObject(Engine, eventEnvelope));
+				newState = _jsFunctionCaller.Call(eventEnvelope.EventType, handler, state, eventEnvelope.Value);
 			} else if (_any != null) {
-				newState = _jsFunctionCaller.Call("$any", _any, state, FromObject(Engine, eventEnvelope));
+				newState = _jsFunctionCaller.Call("$any", _any, state, eventEnvelope.Value);
 			} else {
 				newState = eventEnvelope.IsJson ? eventEnvelope.Body : eventEnvelope.BodyRaw;
 			}
@@ -788,13 +829,13 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 
 		public JsValue GetPartition(EventEnvelope envelope) {
 			if (_partitionFunction != null)
-				return _jsFunctionCaller.Call("partitionBy", _partitionFunction, envelope);
+				return _jsFunctionCaller.Call("partitionBy", _partitionFunction, envelope.Value);
 			return Null;
 		}
 
 		public void HandleCreated(JsValue state, EventEnvelope envelope) {
 			for (int i = 0; i < _createdHandlers.Count; i++) {
-				_jsFunctionCaller.Call("$created", _createdHandlers[i], state, envelope);
+				_jsFunctionCaller.Call("$created", _createdHandlers[i], state, envelope.Value);
 			}
 		}
 
@@ -820,417 +861,153 @@ public class JintProjectionStateHandler : IProjectionStateHandler {
 		}
 	}
 
-	EventEnvelope CreateEnvelope(string partition, ResolvedEvent @event, string category) {
-		var envelope = new EventEnvelope(_engine, _parser, this);
-		envelope.Partition = partition;
-		envelope.Created = @event.Timestamp;
-		envelope.BodyRaw = @event.Data;
-		envelope.MetadataRaw = @event.Metadata;
-		envelope.StreamId = @event.EventStreamId;
-		envelope.EventId = @event.EventId.ToString("D");
-		envelope.EventType = @event.EventType;
-		envelope.LinkMetadataRaw = @event.PositionMetadata;
-		envelope.IsJson = @event.IsJson;
-		envelope.Category = category;
-		envelope.SequenceNumber = @event.EventSequenceNumber;
-		return envelope;
-	}
-	sealed class EventEnvelope : ObjectInstance {
+	EventEnvelope CreateEnvelope(string partition, ResolvedEvent @event, string category) =>
+		new(_engine, _parser, partition, @event, category);
+	/// <summary>
+	/// The per-event object handed to a projection handler, plus the host-side state behind it.
+	/// <para>
+	/// The JavaScript value is a plain <see cref="JsObject"/> built from a shared
+	/// <see cref="JsObjectLayout"/> rather than a custom <c>ObjectInstance</c> subclass. That matters
+	/// because a host subclass carries none of the engine's storage flags, so it reaches no member-read
+	/// inline cache at all: every <c>e.streamId</c> was a virtual call into a property dictionary. Every
+	/// envelope built from this layout in one engine shares one hidden class, so the handler's reads stay
+	/// monomorphic across events even though the object itself is new each time.
+	/// </para>
+	/// <para>
+	/// The members that must parse a JSON document are declared as lazy slots, so they exist as ordinary
+	/// properties -- they answer <c>in</c>, <c>hasOwnProperty</c> and <c>Object.keys</c> -- but the
+	/// document is only parsed by a read that actually observes the value. Before 4.15.1 a lazy member and
+	/// a shaped object were mutually exclusive, which is why this used to be a subclass.
+	/// </para>
+	/// </summary>
+	internal sealed class EventEnvelope {
+		// Slot order is the own-key order of every envelope. It reproduces the order the previous
+		// implementation ended up with: the eleven eager members in the order they were assigned, then the
+		// parsed members in the order they were materialized.
+		//
+		// There are two variants because the previous implementation's key set was not fixed. Reconstructing
+		// its conditions exactly: metadataRaw and linkMetadataRaw were assigned unconditionally, and a null
+		// string converts to JS null rather than undefined, so EnsureMetadata and EnsureLinkMetadata always
+		// succeeded -- metadata and linkMetadata were always present, with the value null when their document
+		// was absent. EnsureBody additionally required IsJson, so body and data -- which always appeared
+		// together, sharing one descriptor -- were present exactly when the event was JSON. IsJson is
+		// therefore the only condition, and two layouts cover it.
+		//
+		// Each variant is still one shared hidden class across every envelope built from it, so the inline
+		// cache win survives. A projection handling both JSON and non-JSON events sees two shapes at its read
+		// sites and goes polymorphic there, which is the honest cost of the key sets genuinely differing --
+		// and still far cheaper than the host-subclass path, which reached no cache at all.
+		//
+		// The factories are static and read everything item-specific out of the per-object state, because a
+		// layout is process-shared by design and a captured engine would leak one engine's state into
+		// another's objects. "body" and "data" are two names for one document, so both factories go through
+		// the same memo and a projection reading each of them parses once.
+		private static readonly JsObjectLayout JsonLayout = BuildLayout(withBody: true);
+		private static readonly JsObjectLayout NonJsonLayout = BuildLayout(withBody: false);
+
+		private static JsObjectLayout BuildLayout(bool withBody) {
+			var builder = JsObjectLayout.CreateBuilder()
+				.Add("partition")
+				.Add("created")
+				.Add("bodyRaw")
+				.Add("metadataRaw")
+				.Add("streamId")
+				.Add("eventId")
+				.Add("eventType")
+				.Add("linkMetadataRaw")
+				.Add("isJson")
+				.Add("category")
+				.Add("sequenceNumber");
+
+			if (withBody) {
+				builder
+					.AddLazy("body", static (_, state) => ((EventEnvelope)state!).Body)
+					.AddLazy("data", static (_, state) => ((EventEnvelope)state!).Body);
+			}
+
+			return builder
+				.AddLazy("metadata", static (_, state) => ((EventEnvelope)state!).Metadata)
+				.AddLazy("linkMetadata", static (_, state) => ((EventEnvelope)state!).LinkMetadata)
+				.Build();
+		}
+
 		private readonly JsonParser _parser;
-		private readonly JintProjectionStateHandler _parent;
+		private readonly string? _bodyRaw;
+		private readonly string? _metadataRaw;
+		private readonly string? _linkMetadataRaw;
 
-		public string StreamId {
-			set => SetOwnProperty("streamId", new PropertyDescriptor(value, false, true, false));
-		}
-		public long SequenceNumber {
-			set => SetOwnProperty("sequenceNumber", new PropertyDescriptor(value, false, true, false));
-		}
+		private JsValue? _body;
+		private JsValue? _metadata;
+		private JsValue? _linkMetadata;
 
-		public string EventType {
-			get => _parent.AsString(Get("eventType"), false) ?? "";
-			set => SetOwnProperty("eventType", new PropertyDescriptor(value, false, true, false));
-		}
+		/// <summary>The value passed to the projection handler.</summary>
+		public JsObject Value { get; }
 
-		public JsValue Body {
-			get {
-				if (TryGetValue("body", out var value) && value is ObjectInstance oi)
-					return oi;
-				if (EnsureBody(out JsValue objectInstance))
-					return objectInstance;
+		/// <summary>
+		/// The event type, read straight off the CLR record. It used to be read back out of the JavaScript
+		/// property table purely to key a CLR dictionary of handlers.
+		/// </summary>
+		public string EventType { get; }
 
-				return Undefined;
-			}
-		}
+		public bool IsJson { get; }
 
-		private bool EnsureBody(out JsValue value) {
-			if (IsJson && TryGetValue("bodyRaw", out var raw) && raw is not JsUndefined) {
-				var body = raw.IsNull() ? raw : _parser.Parse(raw.AsString());
-				var pd = new PropertyDescriptor(body, false, true, false);
-				SetOwnProperty("body", pd);
-				SetOwnProperty("data", pd);
-				value = body;
-				return true;
-			}
+		public string? BodyRaw => _bodyRaw;
 
-			value = Undefined;
-			return false;
-		}
-
-		public bool IsJson {
-			get => Get("isJson").AsBoolean();
-			set => SetOwnProperty("isJson", new PropertyDescriptor(value, false, true, false));
-		}
-
-		public string? BodyRaw {
-			get => _parent.AsString(Get("bodyRaw"), false);
-			set => SetOwnProperty("bodyRaw", new PropertyDescriptor(value, false, true, false));
-		}
-
-		private JsValue Metadata {
-			get {
-				if (TryGetValue("metadata", out var value) && value is ObjectInstance oi)
-					return oi;
-				if (EnsureMetadata(out value))
-					return value;
-
-				return Undefined;
-			}
-		}
-
-		private bool EnsureMetadata(out JsValue value) {
-			if (TryGetValue("metadataRaw", out var raw) && raw is not JsUndefined) {
-				var metadata = raw.IsNull() ? raw : _parser.Parse(raw.AsString());
-				SetOwnProperty("metadata", new PropertyDescriptor(metadata, false, true, false));
-				{
-					value = metadata;
-					return true;
-				}
-			}
-
-			value = Undefined;
-			return false;
-		}
-
-		public string MetadataRaw {
-			set => FastSetProperty("metadataRaw", new PropertyDescriptor(value, false, true, false));
-		}
-
-		private JsValue LinkMetadata {
-			get {
-				if (TryGetValue("linkMetadata", out var value) && value is ObjectInstance oi)
-					return oi;
-				if (EnsureLinkMetadata(out value))
-					return value;
-
-				return Undefined;
-			}
-		}
-
-		private bool EnsureLinkMetadata(out JsValue value) {
-			if (TryGetValue("linkMetadataRaw", out var raw) && raw is not JsUndefined) {
-				var metadata = raw.IsNull() ? raw : _parser.Parse(raw.AsString());
-				SetOwnProperty("linkMetadata", new PropertyDescriptor(metadata, false, true, false));
-				{
-					value = metadata;
-					return true;
-				}
-			}
-
-			value = Undefined;
-			return false;
-		}
-
-		public string LinkMetadataRaw {
-			set => SetOwnProperty("linkMetadataRaw", new PropertyDescriptor(value, false, true, false));
-		}
-
-		public string Partition {
-			set => SetOwnProperty("partition", new PropertyDescriptor(value, false, true, false));
-		}
-
-		public string Category {
-			set => SetOwnProperty("category", new PropertyDescriptor(value, false, true, false));
-		}
-
-		public DateTime Created {
-			// avoid new JsDate(_engine, value) because if the user stores it in their state it will be a date
-			// until the state is serialized and back, after which it will be a string, which would be a gotcha
-			set => SetOwnProperty("created", new PropertyDescriptor(value.ToString("o"), false, true, false));
-		}
-
-		public string EventId {
-			set => SetOwnProperty("eventId", new PropertyDescriptor(value, false, true, false));
-		}
-
-		public EventEnvelope(Engine engine, JsonParser parser, JintProjectionStateHandler parent) : base(engine) {
+		public EventEnvelope(Engine engine, JsonParser parser, string partition, ResolvedEvent @event, string category) {
 			_parser = parser;
-			_parent = parent;
+			_bodyRaw = @event.Data;
+			_metadataRaw = @event.Metadata;
+			_linkMetadataRaw = @event.PositionMetadata;
+			IsJson = @event.IsJson;
+
+			// ResolvedEvent.EventType is null whenever the resolved event carries no event record, and its
+			// declaring project has nullable reference types disabled, so the `string` annotation says
+			// nothing. The removed CLR getter read the value back out of the property table through
+			// AsString(...) ?? "", so "" is the dispatch key an untyped event has always produced; keeping
+			// the coalesce preserves that rather than deciding something new. The JS-visible property is
+			// fed the raw value below, so it stays null there exactly as it was.
+			EventType = @event.EventType ?? "";
+
+			// avoid new JsDate(engine, value) because if the user stores it in their state it will be a date
+			// until the state is serialized and back, after which it will be a string, which would be a gotcha
+			var created = @event.Timestamp.ToString("o");
+			var eventId = @event.EventId.ToString("D");
+
+			// The value lists are spelled out per variant rather than assembled from a shared array: the
+			// trailing nulls are the lazy slots, which Create requires to be null, and building a common
+			// prefix first would put an extra array allocation on the per-event path.
+			Value = IsJson
+				? JsObject.Create(engine, JsonLayout, [
+					partition, created, _bodyRaw, _metadataRaw, @event.EventStreamId, eventId,
+					@event.EventType, _linkMetadataRaw, IsJson, category, @event.EventSequenceNumber,
+					null, null, null, null,
+				], this)
+				: JsObject.Create(engine, NonJsonLayout, [
+					partition, created, _bodyRaw, _metadataRaw, @event.EventStreamId, eventId,
+					@event.EventType, _linkMetadataRaw, IsJson, category, @event.EventSequenceNumber,
+					null, null,
+				], this);
 		}
 
-		public override JsValue Get(JsValue property, JsValue receiver) {
-			if (property == "body" || property == "data") {
-				return Body;
-			}
+		// Only reached through the JSON layout, whose slots exist exactly when the event is JSON. A null raw
+		// document parses to null -- present with the value null, which is what the previous implementation
+		// produced too, and distinct from the property being absent.
+		public JsValue Body => _body ??= Parse(_bodyRaw);
 
-			if (property == "metadata") {
-				return Metadata;
-			}
+		private JsValue Metadata => _metadata ??= Parse(_metadataRaw);
 
-			if (property == "linkMetadata") {
-				return LinkMetadata;
-			}
-			return base.Get(property, receiver);
-		}
+		private JsValue LinkMetadata => _linkMetadata ??= Parse(_linkMetadataRaw);
 
-		public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol) {
-			var list = base.GetOwnPropertyKeys(types);
-			return list;
-		}
+		private JsValue Parse(string? raw) => raw is null ? JsValue.Null : _parser.Parse(raw);
 
-		public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties() {
-			if (!HasOwnProperty("body")) {
-				EnsureBody(out _);
-			}
-
-			if (!HasOwnProperty("metadata")) {
-				EnsureMetadata(out _);
-			}
-
-			if (!HasOwnProperty("linkMetadata")) {
-				EnsureLinkMetadata(out _);
-			}
-
-			var list = base.GetOwnProperties();
-
-			return list;
-		}
 	}
 
-	public string Serialize(JsValue value) {
-		var serialized = _jsSerializer.Serialize(value);
-		return Encoding.UTF8.GetString(serialized);
-	}
+	// Jint's JsonSerializer is JSON.stringify's own implementation, reachable directly. The
+	// hand-written serializer it replaces produced UTF-8, which this method then transcoded back to a
+	// string because every consumer of the result -- PartitionState, the emitted event body -- wants
+	// one. Going through the string-returning overload removes that encode and decode per event, drops
+	// the 1 MB ArrayBufferWriter each handler held, and picks up the shape-mode fast arm that walks a
+	// JsonParser-produced object by its hidden class instead of allocating a JsString per key.
+	public string Serialize(JsValue value) => _jsSerializer.Serialize(_serializer, value);
 
-	public class Serializer {
-		private readonly WriteState[] _iterators;
-		private readonly ArrayBufferWriter<byte> _bufferWriter;
-		private readonly Utf8JsonWriter _writer;
-		private readonly Dictionary<string, JsonEncodedText> _knownPropertyNames;
-		private int _depth;
-
-		public Serializer() {
-			_iterators = new WriteState[64];
-			_bufferWriter = new ArrayBufferWriter<byte>(1024 * 1024);
-			_writer = new Utf8JsonWriter(
-				_bufferWriter,
-				new JsonWriterOptions {
-					Indented = false,
-					SkipValidation = true,
-					Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-				});
-			_knownPropertyNames = new Dictionary<string, JsonEncodedText>();
-		}
-
-		public ReadOnlyMemory<byte> Serialize(JsValue value) {
-			_depth = 0;
-			_bufferWriter.Clear();
-			_writer.Reset();
-
-			if (value is JsArray array) {
-				_iterators[_depth] = new WriteState(array);
-			} else if (value is ObjectInstance oi) {
-				_iterators[_depth] = new WriteState(oi);
-			} else {
-				_iterators[_depth] = new WriteState(value);
-			}
-			ref var current = ref _iterators[0];
-
-			while (current.Write(_writer, ref _depth, _iterators, _knownPropertyNames)) {
-				current = ref _iterators[_depth];
-			}
-			_writer.Flush();
-			return _bufferWriter.WrittenMemory;
-
-		}
-
-		struct WriteState {
-			private enum Type {
-				Complete,
-				Array,
-				Object,
-				Primitive,
-			}
-
-			private static readonly IEnumerator<KeyValuePair<JsValue, PropertyDescriptor>> _emptyIterator =
-				new NoopIterator();
-
-			class NoopIterator : IEnumerator<KeyValuePair<JsValue, PropertyDescriptor>> {
-				public KeyValuePair<JsValue, PropertyDescriptor> Current => default;
-
-				object? IEnumerator.Current => default;
-
-				public void Dispose() {
-				}
-
-				public bool MoveNext() {
-					return false;
-				}
-
-				public void Reset() {
-				}
-			}
-
-			public WriteState(JsArray instance) {
-				_position = -1;
-				_length = (int)instance.Length;
-				_instance = instance;
-				_type = Type.Array;
-				_started = false;
-				_iterator = _emptyIterator;
-			}
-
-			public WriteState(ObjectInstance instance) {
-				_position = -1;
-				_length = -1;
-				_instance = JsValue.Null;
-				_type = Type.Object;
-				_started = false;
-				_iterator = instance.GetOwnProperties().GetEnumerator();
-			}
-
-			public WriteState(JsValue instance) {
-				if (instance.Type == Types.Object)
-					throw new ArgumentException("Primitive overload called for object instance");
-				_position = -1;
-				_length = -1;
-				_instance = instance;
-				_type = Type.Primitive;
-				_started = false;
-				_iterator = _emptyIterator;
-			}
-
-			private readonly JsValue _instance;
-			private readonly IEnumerator<KeyValuePair<JsValue, PropertyDescriptor>> _iterator;
-			private readonly Type _type;
-			private readonly int _length;
-			private int _position;
-			private bool _started;
-
-			[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-			public bool Write(
-				Utf8JsonWriter writer,
-				ref int depth,
-				WriteState[] writeStates,
-				Dictionary<string, JsonEncodedText> knownPropertyNames) {
-
-				switch (_type) {
-					case Type.Array:
-						if (_position == -1) {
-							writer.WriteStartArray();
-							_position++;
-						}
-						var instance = (JsArray)_instance;
-						for (; _position < _length; _position++) {
-							var value = instance[(uint)_position];
-							if (value.Type == Types.Object) {
-								if (value is JsArray ai) {
-									writeStates[++depth] = new WriteState(ai);
-								} else {
-									writeStates[++depth] = new WriteState(value.AsObject());
-								}
-								_position++;
-								return true;
-							}
-							SerializePrimitive(value, writer);
-						}
-						writer.WriteEndArray();
-						break;
-					case Type.Object:
-						if (!_started) {
-							writer.WriteStartObject();
-							_started = true;
-						}
-						while (_iterator.MoveNext()) {
-							var (name, propertyDescriptor) = _iterator.Current;
-							var value = propertyDescriptor.Value;
-							if (value.Type == Types.Undefined)
-								continue;
-
-							WriteMaybeCachedPropertyName(name.AsString(), knownPropertyNames, writer);
-							if (value.Type == Types.Object) {
-								if (value is JsArray ai) {
-									writeStates[++depth] = new WriteState(ai);
-								} else {
-									writeStates[++depth] = new WriteState(value.AsObject());
-								}
-								_position++;
-								return true;
-							} else {
-								SerializePrimitive(value, writer);
-							}
-
-						}
-
-						writer.WriteEndObject();
-						break;
-					case Type.Primitive:
-						SerializePrimitive(_instance, writer);
-						break;
-				}
-				writeStates[depth] = default;
-				depth--;
-				return depth >= 0;
-			}
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-		private static void WriteMaybeCachedPropertyName(string name, Dictionary<string, JsonEncodedText> knownPropertyNames, Utf8JsonWriter writer) {
-			if (!knownPropertyNames.TryGetValue(name, out var propertyName)) {
-				propertyName = JsonEncodedText.Encode(name);
-				if (knownPropertyNames.Count < 1000) {
-					knownPropertyNames.Add(name, propertyName);
-				}
-			}
-			writer.WritePropertyName(propertyName);
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-		static void SerializePrimitive(JsValue value, Utf8JsonWriter writer) {
-
-			switch (value.Type) {
-				case Types.Null:
-				case Types.Undefined:
-				case Types.Empty:
-					writer.WriteNullValue();
-					break;
-				case Types.Boolean:
-					if (ReferenceEquals(value, JsBoolean.False))
-						writer.WriteBooleanValue(false);
-					else
-						writer.WriteBooleanValue(true);
-					break;
-				case Types.Number:
-					var n = value.AsNumber();
-					if (double.IsFinite(n))
-						writer.WriteNumberValue(n);
-					else
-						writer.WriteNullValue();
-					break;
-				case Types.BigInt:
-					writer.WriteStringValue(value.ToString());
-					break;
-				case Types.String:
-					writer.WriteStringValue(value.AsString());
-					break;
-				default:
-					throw new Exception($"Cannot serialize {value.Type} as primitive");
-			}
-		}
-	}
-}
-
-internal static class ObjectInstanceExtensions {
-	public static void FastAddProperty(this ObjectInstance target, string name, JsValue value, bool writable, bool enumerable, bool configurable) {
-		target.FastSetProperty(name, new PropertyDescriptor(value, writable, enumerable, configurable));
-	}
 }

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/JintHostContractVerification.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/JintHostContractVerification.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Runtime.CompilerServices;
+using Jint;
+using Jint.Native;
+using Jint.Native.Object;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+internal static class JintHostContractVerification {
+	/// <summary>
+	/// Turns on Jint's host-contract verifiers for this test assembly.
+	/// </summary>
+	/// <remarks>
+	/// These are the checks that catch host code answering one of the engine's extension points in a way
+	/// that contradicts another -- a key that vanishes from every enumeration, a read that resolves on the
+	/// prototype for a property that exists. The engine trusts those hooks on its hot paths and cannot
+	/// re-verify them there, so a violation is otherwise silent.
+	/// <para>
+	/// The switch has to be set before the first use of any Jint type: the flag behind it is read once at
+	/// type initialization, and flipping it afterwards does nothing for the rest of the process. A module
+	/// initializer runs before any test in the assembly, which is early enough. There is no cost to leaving
+	/// it off in production -- the guards fold away entirely when the switch is unset -- and it is
+	/// deliberately not set anywhere but here.
+	/// </para>
+	/// </remarks>
+	[ModuleInitializer]
+	internal static void Enable() => AppContext.SetSwitch("Jint.EnableHostContractVerification", true);
+}
+
+/// <summary>
+/// Positive control for the switch above. Without it, every suite in this assembly would report exactly
+/// the same green whether the verifiers were running or silently disabled -- and a switch that has to be
+/// set before the first use of any Jint type is easy to render inert by accident.
+/// </summary>
+[TestFixture]
+public class when_a_host_object_violates_its_read_contract {
+	/// <summary>
+	/// Claims every name as its own while <c>GetOwnProperty</c> reports them all absent, which is the
+	/// contradiction <c>TryGetOwnPropertyValue</c>'s contract forbids.
+	/// </summary>
+	private sealed class LyingHostObject(Engine engine) : ObjectInstance(engine) {
+		protected override bool TryGetOwnPropertyValue(JsValue property, JsValue receiver, out JsValue value) {
+			value = JsValue.Null;
+			return true;
+		}
+	}
+
+	[Test, Category("js")]
+	public void the_verifiers_are_enabled_in_this_assembly() {
+		var engine = new Engine();
+		engine.SetValue("host", new LyingHostObject(engine));
+
+		var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("host.anything"));
+		StringAssert.Contains("TryGetOwnPropertyValue", ex.Message);
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/Serialization/when_serializing_state.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/Serialization/when_serializing_state.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using Jint;
 using Jint.Native;
 using Jint.Native.Json;
+using Jint.Runtime;
 using KurrentDB.Projections.Core.Metrics;
 using KurrentDB.Projections.Core.Services.Interpreted;
 using NUnit.Framework;
@@ -118,6 +119,10 @@ public class when_serializing_state {
 
 	[Test]
 	public void big_int() {
+		// JSON.stringify has no representation for a BigInt and throws on one, but the serializer this
+		// path used to run wrote the digits as a JSON string. The projection engine restores that through
+		// BigInt.prototype.toJSON so an already-running projection with a BigInt in its state keeps
+		// checkpointing across the upgrade.
 		var serialized = _sut.Serialize(new JsBigInt(BigInteger.Parse("20000000000000000000")));
 		Assert.AreEqual(@"""20000000000000000000""", serialized);
 	}

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_enumerating_the_event_envelope.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_enumerating_the_event_envelope.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Processing.Checkpointing;
+using NUnit.Framework;
+using ResolvedEvent = KurrentDB.Projections.Core.Services.Processing.ResolvedEvent;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+/// <summary>
+/// Pins the envelope's own-key set and order, which is the observable contract of the layouts the
+/// envelope is built from. Projections can and do branch on whether a member is present, so the key set
+/// has to keep matching what the previous implementation produced: body and data appear together and
+/// exactly when the event is JSON, while metadata and linkMetadata always appear, carrying null when
+/// their document is absent.
+/// <para>
+/// One deviation is deliberate and cannot be expressed with a fixed layout. The previous envelope
+/// materialized a parsed member as a side effect of the first read of it, so <c>'body' in event</c>
+/// answered false before anything had read <c>event.body</c> and true afterwards. The answer is now the
+/// same before and after -- it describes the event rather than the reading history.
+/// </para>
+/// </summary>
+public abstract class when_enumerating_the_event_envelope : specification_with_event_handled {
+	protected override void Given() {
+		_projection = @"
+            fromAll().when({$any:
+                function(state, event) {
+                    state.keys = Object.keys(event);
+                    state.hasBody = ('body' in event);
+                    state.hasData = ('data' in event);
+                    state.hasMetadata = event.hasOwnProperty('metadata');
+                    state.hasLinkMetadata = event.hasOwnProperty('linkMetadata');
+                    state.metadataIsNull = (event.metadata === null);
+                    state.linkMetadataIsNull = (event.linkMetadata === null);
+                    return state;
+                }
+            });
+        ";
+		_state = @"{}";
+		_handledEvent = MakeEvent();
+	}
+
+	protected abstract ResolvedEvent MakeEvent();
+
+	protected static ResolvedEvent Event(bool isJson, byte[] data, byte[] metadata, byte[] positionMetadata) =>
+		new(
+			positionStreamId: "test-stream",
+			positionSequenceNumber: 1,
+			eventStreamId: "test-stream",
+			eventSequenceNumber: 1,
+			resolvedLinkTo: false,
+			position: new TFPos(100, 50),
+			eventOrLinkTargetPosition: new TFPos(100, 50),
+			eventId: Guid.NewGuid(),
+			eventType: "TestEvent",
+			isJson: isJson,
+			data: data,
+			metadata: metadata,
+			positionMetadata: positionMetadata,
+			streamMetadata: null,
+			timestamp: new DateTime(2023, 4, 5, 12, 34, 56, DateTimeKind.Utc));
+
+	protected override void When() {
+		_stateHandler.ProcessEvent(
+			"test-partition",
+			CheckpointTag.FromPosition(0, _handledEvent.Position.CommitPosition, _handledEvent.Position.PreparePosition),
+			"test-category",
+			_handledEvent,
+			out _newState, out _newSharedState, out _emittedEventEnvelopes);
+	}
+
+	protected JsonElement State => JsonDocument.Parse(_newState).RootElement;
+
+	protected string[] Keys =>
+		State.GetProperty("keys").EnumerateArray().Select(x => x.GetString()).ToArray();
+
+	protected static readonly string[] EagerKeys = [
+		"partition", "created", "bodyRaw", "metadataRaw", "streamId", "eventId", "eventType",
+		"linkMetadataRaw", "isJson", "category", "sequenceNumber",
+	];
+
+	[TestFixture]
+	public class with_a_json_event : when_enumerating_the_event_envelope {
+		protected override ResolvedEvent MakeEvent() => Event(
+			isJson: true,
+			data: Encoding.UTF8.GetBytes("""{"the-key":"the-value"}"""),
+			metadata: Encoding.UTF8.GetBytes("""{"the-meta-key":"the-meta-value"}"""),
+			positionMetadata: Encoding.UTF8.GetBytes("""{"the-link-key":"the-link-value"}"""));
+
+		[Test, Category(_projectionType)]
+		public void own_keys_include_the_parsed_body_pair() =>
+			Assert.AreEqual(EagerKeys.Concat(["body", "data", "metadata", "linkMetadata"]).ToArray(), Keys);
+
+		[Test, Category(_projectionType)]
+		public void parsed_members_answer_existence_questions_without_being_read() {
+			// `in` and hasOwnProperty do not observe a lazy slot's value, so these are true whether or not
+			// the document behind them has been parsed.
+			Assert.IsTrue(State.GetProperty("hasBody").GetBoolean());
+			Assert.IsTrue(State.GetProperty("hasData").GetBoolean());
+			Assert.IsTrue(State.GetProperty("hasMetadata").GetBoolean());
+			Assert.IsTrue(State.GetProperty("hasLinkMetadata").GetBoolean());
+		}
+	}
+
+	[TestFixture]
+	public class with_a_non_json_event : when_enumerating_the_event_envelope {
+		protected override ResolvedEvent MakeEvent() => Event(
+			isJson: false,
+			data: Encoding.UTF8.GetBytes("this is not json"),
+			metadata: Encoding.UTF8.GetBytes("""{"the-meta-key":"the-meta-value"}"""),
+			positionMetadata: Encoding.UTF8.GetBytes("""{"the-link-key":"the-link-value"}"""));
+
+		[Test, Category(_projectionType)]
+		public void body_and_data_are_absent() {
+			// The previous envelope only created these when the event was JSON, and a projection may be
+			// branching on exactly that.
+			Assert.AreEqual(EagerKeys.Concat(["metadata", "linkMetadata"]).ToArray(), Keys);
+			Assert.IsFalse(State.GetProperty("hasBody").GetBoolean());
+			Assert.IsFalse(State.GetProperty("hasData").GetBoolean());
+		}
+
+		[Test, Category(_projectionType)]
+		public void metadata_members_are_still_present() {
+			Assert.IsTrue(State.GetProperty("hasMetadata").GetBoolean());
+			Assert.IsTrue(State.GetProperty("hasLinkMetadata").GetBoolean());
+		}
+	}
+
+	[TestFixture]
+	public class with_no_metadata_documents : when_enumerating_the_event_envelope {
+		protected override ResolvedEvent MakeEvent() => Event(
+			isJson: true,
+			data: Encoding.UTF8.GetBytes("""{"the-key":"the-value"}"""),
+			metadata: null,
+			positionMetadata: null);
+
+		[Test, Category(_projectionType)]
+		public void metadata_members_are_present_and_null() {
+			// An absent document was never expressed by omitting the property: the raw slots were always
+			// assigned, so the parsed members existed and read as null.
+			Assert.AreEqual(EagerKeys.Concat(["body", "data", "metadata", "linkMetadata"]).ToArray(), Keys);
+			Assert.IsTrue(State.GetProperty("hasMetadata").GetBoolean());
+			Assert.IsTrue(State.GetProperty("hasLinkMetadata").GetBoolean());
+			Assert.IsTrue(State.GetProperty("metadataIsNull").GetBoolean());
+			Assert.IsTrue(State.GetProperty("linkMetadataIsNull").GetBoolean());
+		}
+	}
+}

--- a/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_shaping_the_event_envelope.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/Jint/when_shaping_the_event_envelope.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Text;
+using Jint;
+using Jint.Native.Json;
+using KurrentDB.Core.Data;
+using KurrentDB.Projections.Core.Services.Interpreted;
+using NUnit.Framework;
+using ResolvedEvent = KurrentDB.Projections.Core.Services.Processing.ResolvedEvent;
+
+namespace KurrentDB.Projections.Core.Tests.Services.Jint;
+
+/// <summary>
+/// The reason the envelope is built from a layout rather than assembled property by property is that
+/// every envelope of a variant then shares one hidden class, which is what keeps a handler's member
+/// reads monomorphic across events. That is invisible from script -- the representations behave
+/// identically and differ only in speed -- so without asking the engine directly it can only ever be
+/// observed once, by hand, and then silently lost.
+/// <para>
+/// <c>JsObject.Create</c> falls back to the ordinary property dictionary quietly and correctly when it
+/// cannot shape an object, and two of the triggers depend on what the engine has already built rather
+/// than on anything visible at the call site. This asserts the fallback did not happen.
+/// </para>
+/// </summary>
+[TestFixture]
+public class when_shaping_the_event_envelope {
+	private static ResolvedEvent Event(bool isJson) => new(
+		positionStreamId: "test-stream",
+		positionSequenceNumber: 1,
+		eventStreamId: "test-stream",
+		eventSequenceNumber: 1,
+		resolvedLinkTo: false,
+		position: new TFPos(100, 50),
+		eventOrLinkTargetPosition: new TFPos(100, 50),
+		eventId: Guid.NewGuid(),
+		eventType: "TestEvent",
+		isJson: isJson,
+		data: Encoding.UTF8.GetBytes(isJson ? """{"the-key":"the-value"}""" : "this is not json"),
+		metadata: Encoding.UTF8.GetBytes("""{"the-meta-key":"the-meta-value"}"""),
+		positionMetadata: null,
+		streamMetadata: null,
+		timestamp: new DateTime(2023, 4, 5, 12, 34, 56, DateTimeKind.Utc));
+
+	private static JintProjectionStateHandler.EventEnvelope Create(Engine engine, bool isJson) =>
+		new(engine, new JsonParser(engine), "test-partition", Event(isJson), "test-category");
+
+	[Test, Category("js")]
+	public void both_layout_variants_produce_shaped_objects() {
+		var engine = new Engine();
+
+		Assert.IsTrue(
+			engine.Advanced.HasSharedShape(Create(engine, isJson: true).Value),
+			"the JSON envelope variant fell back to the property dictionary");
+		Assert.IsTrue(
+			engine.Advanced.HasSharedShape(Create(engine, isJson: false).Value),
+			"the non-JSON envelope variant fell back to the property dictionary");
+	}
+
+	[Test, Category("js")]
+	public void envelopes_of_one_variant_share_their_shape_across_events() {
+		// The point of the layout is cross-event sharing, so a second envelope built from the same variant
+		// must be shaped too -- one shaped object would prove nothing about the handler's steady state.
+		var engine = new Engine();
+
+		for (var i = 0; i < 5; i++) {
+			Assert.IsTrue(engine.Advanced.HasSharedShape(Create(engine, isJson: true).Value));
+		}
+	}
+}

--- a/src/KurrentDB.Scripting/JintEngineFactory.cs
+++ b/src/KurrentDB.Scripting/JintEngineFactory.cs
@@ -3,8 +3,6 @@
 
 using System.Globalization;
 using Jint;
-using Jint.Native;
-using Jint.Runtime.Interop;
 
 namespace KurrentDB.Scripting;
 
@@ -19,22 +17,16 @@ public static class JintEngineFactory {
 				.Strict()
 				.Culture(CultureInfo.InvariantCulture)
 				.DisableStringCompilation()
-				.TimeoutInterval(timeout)
-				.AddObjectConverter(EnumToStringConverter.Instance);
+				.TimeoutInterval(timeout);
+
+			// Renders CLR enums as their member name rather than the underlying number, which is what the
+			// scripts expect of record.schema.format. This replaces a hand-written IObjectConverter that did
+			// exactly the same thing (Enum.GetName(...) ?? e.ToString(), which is what Jint's String mode
+			// produces): registering any object converter makes engine-wide interop reads fall back to
+			// reflection + boxing, because a converter must be offered every CLR value before it becomes a
+			// JsValue, so one converter for one enum cost the compiled member-read lane for every property
+			// and field read on every wrapped object in the engine.
+			options.Interop.EnumConversion = EnumConversionMode.String;
 		});
-	}
-
-	sealed class EnumToStringConverter : IObjectConverter {
-		public static readonly EnumToStringConverter Instance = new();
-
-		public bool TryConvert(Engine engine, object value, out JsValue result) {
-			if (value is Enum e) {
-				result = Enum.GetName(e.GetType(), e) ?? e.ToString();
-				return true;
-			}
-
-			result = JsValue.Null;
-			return false;
-		}
 	}
 }

--- a/src/KurrentDB.Scripting/JsValidationEngine.cs
+++ b/src/KurrentDB.Scripting/JsValidationEngine.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Jint;
+
+namespace KurrentDB.Scripting;
+
+/// <summary>
+/// A long-lived engine used to compile and check user-supplied JavaScript before it is stored.
+/// Validation evaluates arbitrary source on an engine that outlives every request, which needs two
+/// things to be true: only one validation at a time, because a Jint engine is not thread safe, and
+/// no validation leaving anything behind for the next one.
+/// <para>
+/// The second part is not automatic. Evaluating an expression can define globals -- <c>(g = 1,
+/// function (r) { ... })</c> both validates and leaks -- and on a process-lifetime engine those
+/// accumulate forever and are visible to every later validation. Jint's global snapshot is the
+/// primitive for it: capture the configured global surface once at construction, restore it after
+/// each use.
+/// </para>
+/// <para>
+/// It reverses global bindings, not everything a script can do: mutations of built-in prototypes
+/// survive it, so this bounds accidental accumulation rather than making hostile input safe.
+/// </para>
+/// </summary>
+public sealed class JsValidationEngine {
+	readonly Engine _engine;
+	readonly GlobalSnapshot _snapshot;
+
+	/// <param name="engine">
+	/// The engine to validate on, already configured. Ownership transfers: nothing else may use it,
+	/// since a restore would roll back whatever another caller had just set up.
+	/// </param>
+	public JsValidationEngine(Engine engine) {
+		_engine = engine;
+		_snapshot = engine.Advanced.CaptureGlobalSnapshot();
+	}
+
+	/// <summary>
+	/// Runs <paramref name="validate"/> against the engine under a lock, then returns the engine's
+	/// globals to the state they were captured in, whether or not it threw.
+	/// </summary>
+	/// <remarks>
+	/// The restore is Jint's own <c>WithRestoredGlobals</c> rather than a hand-written try/finally. The
+	/// lock stays ours: an engine is single-threaded, and that helper is a finally, not a sandbox.
+	/// </remarks>
+	public T Validate<T>(Func<Engine, T> validate) {
+		lock (_engine) {
+			var result = default(T)!;
+			_engine.Advanced.WithRestoredGlobals(_snapshot, () => result = validate(_engine));
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
Updates Jint from **4.0.3** (released 2024-09-23) to **4.15.3**, and adopts the parts of the newer embedding surface that fit what this repository already does. Draft, because a few commits are judgement calls the maintainers should make rather than inherit, and each is flagged below.

Qodo's bot review findings are addressed — see the section at the end.

---

## What changed

Three commits, one per area of the codebase, each independently reviewable:

| Commit | |
|---|---|
| **Update Jint 4.0.3 → 4.15.3 and align the scripting engines with its interop defaults** | the bump, the behaviour-default audit, `EnumConversionMode` replacing the one `IObjectConverter`, and the array-conversion audit test |
| **Rebuild the projection envelope on a shared layout and serialize state with Jint** | the headline: layout-built envelope with lazy parsed members, `JsonSerializer` replacing ~215 hand-written lines, and the amortizable execution constraint |
| **Roll back global pollution between JavaScript validations** | `JsValidationEngine` for the two process-lifetime validation engines |
| **Run Jint's host-contract verifiers in the JavaScript test suites** | an `AppContext` switch per test assembly, each with a positive control |

Net: **+770 / −461** across 16 files.

The second commit groups three changes because they share the per-event path and were measured together; the amortizable constraint sits with it rather than with the bump because it lives in the projection handler. The fourth is separate because it is test-harness policy spanning two assemblies and belongs to none of the other three.

---

## The headline: the envelope is now a shaped object

`EventEnvelope` was a custom `ObjectInstance` subclass. A host subclass carries none of the engine's storage flags, so it reaches **no member-read inline cache at all**: every `event.streamId` in a handler was a virtual call into a property dictionary, on an object rebuilt for every event.

It is now a plain `JsObject` built from a static `JsObjectLayout`, so every envelope in an engine shares one hidden class and a handler's reads stay monomorphic across events even though the object itself is new each time.

**This was not expressible when the branch started.** A layout's slots held values, so a member that must parse a JSON document could only be a raw descriptor — which deopts the object to the dictionary representation and forfeits the point. That is exactly why the envelope was a subclass, and the branch first worked around it with `TryGetOwnPropertyValue` on a still-subclassed envelope. Jint 4.15.1's `JsObjectLayout.Builder.AddLazy` declares a slot whose factory runs on the first read that *observes* its value, so `body`, `data`, `metadata` and `linkMetadata` stay lazy on an object that is hidden-class throughout. The two names for the same document share one memo, so a handler reading both parses once.

Consequences worth reviewing:

- The parsed members are ordinary properties, so `'body' in event` and `Object.keys(event)` answer for them **without parsing anything** — only reading a value parses. The key *set* still matches the old envelope exactly: `body`/`data` appear together and only for JSON events, `metadata`/`linkMetadata` always appear and carry `null` when their document is absent. That needs two layout variants; see the review findings below.
- **Own-key order is now fixed by the layout** instead of by the order members happened to be materialized in. It reproduces the order the previous implementation ended up with, and `when_enumerating_the_event_envelope` pins it.
- **Layout slots are configurable/enumerable/writable**, where the old descriptors were non-writable and non-configurable. A handler assigning to `event.streamId` used to silently do nothing and now mutates the envelope — a per-event object discarded when the handler returns. `Object.freeze` would restore the old attributes exactly, but it drops the object to the dictionary representation and would undo the reason for the change, so this is a deliberate trade rather than an oversight. **This is the change most worth a second opinion.**

Two things fall out. `TryGetOwnPropertyValue` is gone — it existed to make a host subclass cheap to read, and there is no longer a host subclass on this path. And `event.eventType` is no longer round-tripped out of the JavaScript property table to key the CLR handler dictionary; it is read straight off the record, as are `isJson` and `bodyRaw`.

### Why the version moved twice mid-branch

Adopting an API surface is a good way to find out where it does not fit, and the gaps this branch hit were reported upstream rather than worked around permanently. Seven of them shipped while the branch was open, which is why the pin moved from 4.15.0 to 4.15.3:

| What did not fit | Shipped as |
|---|---|
| A lazy member could not live in a shaped object, so the envelope had to be a subclass | `JsObjectLayout.Builder.AddLazy` — **4.15.1** |
| No way to tell whether a CLR array crosses into script, so the `LiveView` audit was prose | `GetInteropConversionDiagnostics` — **4.15.1** |
| `PropertyFlag` had no name for the combinations a host builds | Named combinations + docs — **4.15.1** |
| A lazy slot's entry must be `null`, but the values span's element type was non-nullable, forcing `null!` | `ReadOnlySpan<JsValue?>` — **4.15.2** |
| The documented correctness checker for host contracts required cloning Jint and building it in Debug | Verifiers gated on an `AppContext` switch, live in the shipped Release package — **4.15.3** |
| Restoring a global snapshot correctly meant hand-writing a lock/try/finally recipe each time | `Engine.Advanced.WithRestoredGlobals` — **4.15.3** |
| The shaping a layout is adopted for could be observed once but not asserted | `Engine.Advanced.HasSharedShape` — **4.15.3** |

Two of these close loops this branch opened by name. The `null!` one landed the same week it was reported and removed four null-forgiving operators from the envelope. The verifier one is larger: this PR earlier had to clone Jint, build it in Debug and hand-copy `Jint.dll` over the one in a test output directory to reach the checks that guard host contracts — the report said that made the documented checker unreachable for anyone who was not already a Jint contributor. 4.15.3 gates them on `AppContext.SetSwitch("Jint.EnableHostContractVerification", true)` instead, so the shipped Release package runs them; both JavaScript test assemblies now enable it in a module initializer, each with a positive control proving the switch actually took effect. One further gap remains open by choice rather than oversight: `Engine.Advanced.GetPropertyAccessSemantics` also shipped, but by then the type it would have protected had stopped being a host type — see the verdicts below.

The branch went through an intermediate shape worth knowing about when reading the diff: on 4.15.0 the envelope stayed a host subclass and used `TryGetOwnPropertyValue` to make its reads cheap. That was verified against a Debug build of Jint, whose verifier checks the hook's contract on every read — it passed, and the verifier was confirmed live by deliberately breaking the hook and watching the run fail. `AddLazy` then made the subclass unnecessary, so the hook is gone and none of it survives in the final diff.

---

## The 4.14.0 interop defaults

4.14.0 changed two defaults. Both were audited against our usage and both are **inherited deliberately** rather than pinned back.

**`Options.Interop.ArrayConversion`: `Copy` → `LiveView`.** A CLR `T[]` crossing into script is now a live fixed-size view: `Array.isArray` returns `false` (while `instanceof Array` stays `true`), and `push`/`pop`/`length` writes throw `TypeError`.

Originally this was answered by reading every call site. It is now **asserted** (`InteropArrayConversionAuditTests`): 4.15.1 counts array conversions per engine, and mapping a record then running a filter and a field selector over it — including a selector that walks a JSON array in the payload — converts no CLR array under either mode. A third case is a positive control, so the assertion cannot pass by the counters simply never incrementing.

Scope, stated honestly: the test covers the scripting engines, because `JsRecord` is the only object graph this repository projects into script and therefore the only place a CLR array could appear. The projections engine hands its handlers nothing but `JsValue`s. And the counters deliberately exclude an array crossing under a non-array *declared* type (`IReadOnlyList<T>`), which honours that contract through the ordinary wrapper lane — so this asserts "no array conversion", not "no array-shaped value".

**`Options.Interop.CacheRecentObjectWrappers`: `false` → `true`.** `JsRecordEvaluator` already creates exactly one wrapper and mutates the target behind it, so the cache is a no-op there. Where it does bite is the `JsonNode` dictionary lane, where a fresh `ObjectWrapper` was previously allocated at every level on every access — an improvement, not a hazard: the ring is bounded, `Engine.Dispose()` releases it, and no filter or selector mutates the record.

### Other deltas across the 17 releases

Audited and **not applicable**: `Error.prototype.stack` became an accessor (4.9.3 — we never read it); `Function.prototype.toString()` stopped returning source text (4.11.0 — `JsFunctionValidator` reads `FunctionDeclaration`); static CLR members left instance wrappers (4.1.0 — `JsRecord` has none); writes to read-only CLR members became a strict-mode `TypeError` (4.15.0 — every projected member has a setter); `TimeoutInterval` now replaces instead of accumulating (we call it once); saturated constraint sentinels register nothing (we use none).

Audited and **applicable — behaviour changes, not bugs**:

- **JSON grammar alignment (4.14.0).** `-09` and `1.` are now rejected as in V8, while raw U+2028/U+2029 in strings and escaped control characters in keys are now accepted. Persisted state or event bodies containing those malformed number forms parsed before and now raise `SyntaxError`.
- **`Options.Culture` (4.6.0)** stopped driving `toLocaleString` / `localeCompare`; they route through `Intl`, and `InvariantCulture` resolves to the Intl locale `"en"`. No script in our tests uses them.
- **Runtime error message text was rewritten to match V8/Node (4.7.0)**, stack traces became V8-styled (4.3.0). Our tests assert only on messages scripts throw themselves; anything downstream parsing Jint's own error text will see different strings.

### Blast radius outside this repository

`Kurrent.Surge.Core` carries its own transitive Jint **4.0.3** reference and builds its own engines for `JintRecordTransformer` and `JintSqlReducer`. Central package management lifts it to 4.15.3 **without recompilation**, and because it predates the option it cannot have pinned `ArrayConversion`. The audit test above cannot reach those engines — it asserts for the ones this repository constructs. Worth a look from whoever owns Surge.

---

## Per-feature verdicts

### Adopted

| Feature | |
|---|---|
| `Constraint.IsAmortizable` | `TimeConstraint.Check()` reads a wall clock and nothing else — it neither counts its own invocations nor budgets a quantity that can grow unboundedly between checks. Being in the exact partition cost a virtual `Check()` per statement and, since 4.13.0, disarmed the interpreter's tight-loop lanes. |
| `Options.Interop.EnumConversion = String` | Deletes a one-type `IObjectConverter` whose mere presence disabled the compiled member-read lane for **every** wrapped member in the engine. |
| `JsonSerializer` (string overload) | Deletes ~215 lines of hand-written JSON. See compatibility below. |
| `JsObjectLayout` + `AddLazy` | The headline, above. |
| `Capture`/`RestoreGlobalSnapshot` | For the two shared validation engines that compile user-supplied JavaScript on a process-lifetime engine and reset nothing. |
| `Engine.Advanced.GetInteropConversionDiagnostics` | Turns the `LiveView` audit into an assertion. |
| `PropertyFlag` named combinations | Replaces a local three-bool shim; `AllForbidden` for `log`, `NonEnumerable` for the functions a projection calls. |

The ten explicit `Constraints.Reset()` calls were reviewed and **kept**: `Engine.Call`/`Execute` reset around themselves, but `GetSourceDefinition()` runs no script and `Load`/`LoadShared` call `JsonParser.Parse`, which checks constraints from inside its own loops without going through `ExecuteWithConstraints`.

### Skipped, with reasons

| Feature | Verdict |
|---|---|
| `JsonSerializer.Serialize(IBufferWriter<byte>)` | **Wrong direction for us.** Every consumer downstream wants a `string`; `PartitionState` even re-parses it with Newtonsoft. The old code produced UTF-8 and immediately transcoded back, so the string overload is the fit. |
| `JsonParser.Parse(ReadOnlySpan<byte>)` | **Skipped for projections, follow-up for indexing.** In projections the transcode is unavoidable: `ResolvedEvent` decodes eagerly into a public `string` field used all over V1, and `bodyRaw` is script-visible. In `KurrentDB.Scripting` it is a real opportunity — `JsRecord.Value`/`Properties` deserialize `evt.Data.Span` into a `JsonNode` tree that then crosses as an `ObjectWrapper` — but that is a model change with its own script-visible surface. |
| `Engine.Advanced.GetPropertyAccessSemantics` | **Skipped — the type it would have protected no longer exists.** The pin guards a *host-defined* type silently flipping `Exotic`↔`Ordinary` when a `Get` override moves. The envelope is now an in-box `JsObject`, for which Jint documents the answer as an internal classification that may be refined in any release. The only remaining host subclass, `InterpreterRuntime`, is definition-phase only and not reachable from a test project. |
| `TryGetOwnPropertyValue` | **Adopted, then removed.** It earned its place while the envelope was a host subclass, and nothing else here is one. |
| `CaptureGlobalSnapshot` for projection handlers | A handler's engine state is *meant* to persist — the accumulated `_state`, the installed globals. Nothing to reset between events. |
| Typed `AddObjectConverter(converter, params Type[])` | Superseded: `EnumConversionMode` removes the converter outright. |
| `Options.AddLazyGlobal` | Would change definition-phase visibility. `emit`/`linkTo`/`linkStreamTo`/`copyTo` are installed *after* `Execute(source)` precisely so the definition phase cannot see them. |
| `Prepared<Script>` / `ReferencedGlobals` | Needs a host-side refactor, not an API adoption. `PrepareScript` is used nowhere, so the V2 partition fan-out reparses per partition and on every restart. Real win, own change. |
| `ArrayLikeObject`, `JsObjectShape` | No host type projects an indexed collection; `JsObjectShape` describes singleton prototypes, not per-item records. |
| `NullPropagatingReferenceResolver` | Changes language semantics for projection authors. |
| Constraint factory overload | Not needed: each handler builds its own `Options` inline with a fresh `TimeConstraint`. |
| `Options.AddImmutableCrossing` (4.15.3) | **Declined — the promise is false where it would pay.** See below. |
| `PropertyDescriptor.CreateLazy` (4.15.3) | **N/A.** It installs a lazy descriptor on a host `ObjectInstance` subclass; our lazy members are layout slots, and there is no host subclass left on this path. |

---

## Serializer compatibility

`when_serializing_state` **already asserted** that our output was byte-identical to Jint's built-in serializer — for every object, array, value, string and number case it covers, plus the `big_state.json` production fixture. Those assertions pass unchanged after the swap. That is the compatibility oracle, and this repository wrote it.

Two deliberate deviations were pinned by their own tests:

- **Top-level `undefined`.** The old serializer wrote `"null"`; Jint reports "no JSON representation". Kept as `"null"`, because every caller treats the result as a JSON document. This now also covers functions, which the old serializer rendered as an object of their non-enumerable members.
- **BigInt.** The old serializer wrote the digits as a JSON string. `JSON.stringify` has no representation for a BigInt and throws, so the projection engines install `BigInt.prototype.toJSON` to restore the old rendering byte for byte. See the review findings below for why, and for the two consequences.

Everything else the swap changes is a correctness gain: a cycle raises a `TypeError` instead of running off a fixed 64-entry stack with `IndexOutOfRangeException`; state nested deeper than 64 levels serializes at all; `toJSON` is honoured; non-enumerable and symbol-keyed own properties are excluded per spec rather than emitted (or, for symbols, throwing).

---

## Measurements

Projection event processing, end to end. **One operation = 100 `ProcessEvent` calls**, each building the event envelope, invoking a handler that reads several members, and serializing the resulting state — the loop a running projection actually executes.

Read the delta for what it is: it spans **fifteen Jint releases plus this migration**, measured from the merge base to the tip of this branch. It is not the effect of any one commit; it is what an upgrader gets.

BenchmarkDotNet v0.15.2, default job, `[MemoryDiagnoser]`, .NET 10.0.10, AMD Ryzen 9 5950X, quiet machine, both sides run serially from an identical harness compiled against each.

| Scenario | | Before (4.0.3) | After (4.15.1) | |
|---|---|---|---|---|
| Handler reads 3 eager envelope members | Mean | 176.4 µs | 103.0 µs | **−41.6%** |
| | Allocated | 367.19 KB | 178.91 KB | **−51.3%** |
| …and one member requiring a body parse | Mean | 275.9 µs | 217.7 µs | **−21.1%** |
| | Allocated | 533.47 KB | 260.89 KB | **−51.1%** |

The pin has since moved to 4.15.3; the table is left as measured rather than re-run, since nothing in 4.15.2 or 4.15.3 touches these paths beyond a nullable annotation, a probe-lane fast path, and additions this PR adopts only in tests.

StdDev was under 1.3% of the mean on every row and one outlier was removed per row; no row was multimodal, so no re-pairing was needed. The body-parse row improves less in time because the JSON parse it adds is work neither version avoids — the envelope and serialization around it are what got cheaper. Gen1 collections also disappear: the before side promoted on both rows, the after side reports none.

The allocation figures were independently confirmed by a deterministic probe (`GC.GetAllocatedBytesForCurrentThread` over the same harness, byte-identical across repeated runs on both sides): 380,713 → 183,913 B/op and 549,898 → 270,778 B/op, agreeing with BenchmarkDotNet at ≈−51%. That is ≈1,968 B and ≈2,791 B saved per event.

**Allocation, state serialization in isolation** (`big_state.json`, 210,509 chars, 500 iterations, deterministic probe):

```
OLD  hand-written + UTF8.GetString :      667,896 B/op
NEW  Jint JsonSerializer           :      403,096 B/op   (-39.6%)
```

Steady state only; excludes the 1 MB `ArrayBufferWriter` the old serializer allocated once per handler — i.e. **per partition worker** under the V2 engine.

The benchmark harness itself is deliberately not part of this PR: it has to compile unchanged against both sides to be a valid A/B, which makes it scaffolding rather than something the repository should carry.

---

## Gates

Full solution build, `dotnet build -c Release KurrentDB.slnx`: **0 errors**, and the only warnings are pre-existing (GitInfo not finding a fork point for a branch named off `master`, and unused protobuf imports).

| Suite | Result |
|---|---|
| `KurrentDB.Projections.Management.Tests` | 523 — 452 passed, 71 skipped, **0 failed** |
| `KurrentDB.Projections.JavaScript.Tests` | 235 — **235 passed** |
| `KurrentDB.Projections.V2.Tests` | 59 — **59 passed** |
| `KurrentDB.Kontext.Tests` | 407 — **407 passed** |
| `KurrentDB.SecondaryIndexing.Tests` | 101 — **101 passed** |

Both JavaScript test assemblies now run with Jint's host-contract verifiers enabled, so those totals are green *with the checks on*.

Not run locally: anything requiring Docker or a live cluster.

While the envelope was still a host subclass, the projections suites were additionally run against a **Debug build of Jint**, whose verifier checks the `TryGetOwnPropertyValue` contract on every read; they passed, and the verifier was confirmed live by deliberately breaking the hook and watching the run fail. That is no longer needed — the envelope is an in-box `JsObject` with no host-implemented read contract to verify. What replaced it as the check is `when_enumerating_the_event_envelope`, which pins each layout variant's observable key set and order.

---

## Why `AddImmutableCrossing` was declined

4.15.3 added it, and this branch's own friction report is where it came from — the walk `record.value.customer.country` re-wrapping every node on every access. Having asked for it, the honest answer on inspection is that it does not fit here.

The memo is rooted on a wrapper, and the root of every such walk is `JsRecord`. `Remap` mutates that object in place for each event — along with its `Schema` and `Position` children — so the promise is simply false at the root and the type cannot be declared. The memo could only be rooted one level in, at the per-event `JsonNode` documents, which genuinely are built fresh per event and never mutated by us.

That is where it stops being worth it. Those documents are reachable and writable from user-supplied filter scripts, and while Jint evicts a key's memo on a write through the wrapper, a wrong promise on this path would surface as a wrong value written to a DuckDB index column and served to queries — silent and persisted. A stale read in an indexing path is a worse outcome than a missed optimization, and nothing here needs the win badly enough to take that trade.

The redundancy it would paper over is also better removed than memoized: a four-field index makes one JS call per field, each re-walking the record from scratch, so fusing the selectors into a single call eliminates the repeated walks outright. And the deeper fix is the one the envelope rework already applies on the projections side — parsing the payload into native JS values, so there is no wrapper in the path at all. The friction turned out to want that, not a memo.

---

## Review findings addressed

Qodo's bot review raised three. All three are resolved; two were real.

**1. `EventType` falls back to `""` (rule violation).** Kept, and made explicit. `ResolvedEvent.EventType` really is null whenever the resolved event carries no event record, and its declaring project has nullable reference types **disabled**, so the `string` annotation asserts nothing — dropping the coalesce would not have been safe. The removed CLR getter read the value back out of the property table through `AsString(...) ?? ""`, so `""` is the dispatch key an untyped event has always produced. Making it throw instead would be a real behaviour change on a path that previously dispatched, which is worse than the style violation. Both halves of the parity were checked: the CLR dispatch key stays `""`, and the JS-visible `event.eventType` is still fed the raw value, so it stays `null` there exactly as before. A comment at the assignment now states this.

**2. Envelope presence semantics changed (real — fixed).** The fixed layout made `body`/`data` exist on non-JSON events, and a projection distinguishing them with `('body' in event)` would have silently changed meaning. The old conditions were reconstructed from the removed code rather than guessed: `metadataRaw` and `linkMetadataRaw` were assigned unconditionally and a null string converts to JS `null`, not `undefined`, so `metadata` and `linkMetadata` were **always** present carrying `null` when absent; only `EnsureBody` additionally required `IsJson`, and `body`/`data` always appeared together. `IsJson` is therefore the sole condition, so **two** layout variants reproduce the old key sets exactly — not the eight a general treatment would need. Each variant is still one shared hidden class, so the cache win survives; a projection handling both kinds of event goes polymorphic at its read sites, which is the honest cost of the key sets genuinely differing.

  One deviation is kept deliberately because a fixed layout cannot express it: the old envelope materialized a parsed member as a side effect of the first read, so `'body' in event` answered **false** before anything had read `event.body` and **true** afterwards. The answer is now the same before and after — it describes the event, not the reading history. `when_enumerating_the_event_envelope` now pins the key set and order per variant, covering a JSON event, a non-JSON event, and an event with no metadata documents.

**3. BigInt serialization now throws (real — fixed).** The blast radius is the point: an already-running projection with a BigInt in its state would fault at serialization and halt checkpointing on upgrade. The old output format was verified from the removed serializer (`WriteStringValue(value.ToString())` — quoted decimal digits) and is restored exactly, through `BigInt.prototype.toJSON`, which `JSON.stringify` consults before deciding a value has no representation. Installed on the projection engines only; the scripting engines never ran that serializer. Not a replacer passed to `Serialize`, because a replacer is invoked for every node of every state document on the per-event path whereas `toJSON` costs nothing until a BigInt is present. Two consequences: round-tripped state turns a BigInt into a string, the same gotcha the `created` comment describes for dates; and a projection's own `JSON.stringify(123n)` now succeeds where it used to throw — strictly more lenient, and confined to projection engines. The test pins the string output again.

---

## Adjacent findings, not changed here

Noticed while auditing; none is in this PR.

1. **`JsFunctionValidator` uses a bare `new Engine()`** — no timeout, no `DisableStringCompilation` — to `Evaluate` user-supplied text, so `(function(){}) + (function(){while(1){}})()` hangs the caller. `JintEngineFactory.CreateEngine()` would fix it, but it is also `Strict()`, which could reject validators accepted today.
2. **`LinkStreamTo` has an empty `if (parameters.Length == 3) { }`**, then reads `parameters.At(4)` inside a second `if (parameters.Length == 3)`. `At` returns `undefined` out of range and `Undefined.AsObject()` throws, so `linkStreamTo(a, b, meta)` always throws.
3. **`LoadCurrentSharedState` assigns `_state = jsValue`** in its non-bi-state branch, overwriting the main state with the shared state.
4. **`LinkTo` uses `|` instead of `||`** in a `TryGetValue` chain.
5. **The projections engine sets no `LimitMemory`, `MaxStatements` or `LimitRecursion`.** Untrusted projection JavaScript is bounded by wall clock alone.
6. **Partitioned projections build two envelopes per event**, so a `partitionBy` that reads `e.body` parses the body twice.
7. **`UserIndexProcessor.TryExtractFieldValues` makes one JS call per field**, each re-walking `record.value.…`: a 4-field index runs 5 JS calls per event.
8. **`JsRecord.Remap` allocates two closures per record** capturing `evt` and `options` even when unused, plus a `Guid.ToString` and a reflective `Enum.Parse`.
9. **Per-JS-call metrics are tagged with the event type**, which is unbounded metric cardinality driven by user data.
