### PR TITLE
[DB-2194] Reduce temp space needed for secondary index migration

### DIFF
--- a/src/KurrentDB.SecondaryIndexing.Tests/Migration/MigrationTests.SchemaParity.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Migration/MigrationTests.SchemaParity.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Kurrent.Quack;
+using KurrentDB.SecondaryIndexing.Indexes.User;
+using KurrentDB.SecondaryIndexing.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace KurrentDB.SecondaryIndexing.Tests.Migration;
+
+partial class MigrationTests {
+	// A migrated database should have the same schema a fresh install creates from 1_Schema.sql.
+
+	// Must match the user index table SetupV0Schema creates
+	private const string UserIndexName = "myindex";
+	private const string UserIndexFieldName = "myfield";
+
+	private static void StartFromV0(DuckDBAdvancedConnection connection) {
+		// nothing to do, the constructor leaves the database at V0
+	}
+
+	// A database upgraded by the originally shipped V1 (V1A), which added record_id with
+	// DEFAULT ''::BLOB.
+	private static void StartFromV1A(DuckDBAdvancedConnection connection) {
+		IndexingDbSchema.UpgradeToV1A(connection);
+	}
+
+	[Fact]
+	public async Task SchemaAfterMigratingFromV0MatchesFreshInstall() =>
+		await AssertSchemaMatchesFreshInstall(StartFromV0, startingVersion: 0);
+
+	// a database that was upgraded to V1 before the V1 migration was patched to V1B
+	[Fact]
+	public async Task SchemaAfterMigratingFromV1AMatchesFreshInstall() =>
+		await AssertSchemaMatchesFreshInstall(StartFromV1A, startingVersion: 1);
+
+	private async Task AssertSchemaMatchesFreshInstall(
+		Action<DuckDBAdvancedConnection> migrateFromV0ToStartingVersion,
+		int startingVersion) {
+
+		// Apply initial migrations, allows the test to choose between A/B variations of migrations.
+		migrateFromV0ToStartingVersion(_connection);
+
+		// Apply the rest of the migrations in turn
+		IndexingDbSchema.PerformMigration(
+			startingVersion,
+			IndexingDbSchema.TargetVersion,
+			_connection,
+			IndexingDbSchema.MigrationActions,
+			NullLogger<IndexingDbSchema>.Instance);
+
+		var expected = await ReadFreshInstallShape();
+		var actual = ReadShape(_connection);
+
+		Assert.Equal(expected, actual);
+	}
+
+	private async Task<List<ColumnShape>> ReadFreshInstallShape() {
+		var dbPath = Fixture.GetFilePathFor($"{GetType().Name}.fresh.db");
+		await using DuckDBAdvancedConnection connection = new() { ConnectionString = $"Data Source={dbPath};" };
+		connection.Open();
+
+		// An empty database takes the fresh setup branch, which builds the schema from 1_Schema.sql
+		IndexingDbSchema.PerformMigration(connection);
+
+		// 1_Schema.sql contains no user index tables - they are created on demand - so create one the
+		// way production does, giving the comparison something to hold the migrated one against. The
+		// index name and field type must match the table SetupV0Schema creates.
+		new UserIndexSql<Int32Field>(UserIndexName, UserIndexFieldName).CreateUserIndex(connection);
+
+		return ReadShape(connection);
+	}
+
+	private static List<ColumnShape> ReadShape(DuckDBAdvancedConnection connection) =>
+		connection.ExecuteQuery<ColumnShape, SchemaShapeQuery>().ToList();
+
+	private readonly record struct ColumnShape(
+		string Table,
+		long Position,
+		string Name,
+		string DataType,
+		string IsNullable,
+		string Default);
+
+	// Everything in the database, including user index tables, so a table or view added to 1_Schema.sql
+	// or created by a later migration gets compared without anyone having to remember to add it here.
+	private readonly struct SchemaShapeQuery : IQuery<ColumnShape> {
+		public static ReadOnlySpan<byte> CommandText => """
+			select
+				table_name,
+				cast(ordinal_position as bigint),
+				column_name,
+				data_type,
+				is_nullable,
+				coalesce(column_default, 'NONE')
+			from information_schema.columns
+			order by table_name, ordinal_position;
+			"""u8;
+
+		public static ColumnShape Parse(ref DataChunk.Row row) => new(
+			Table: row.ReadString(),
+			Position: row.ReadInt64(),
+			Name: row.ReadString(),
+			DataType: row.ReadString(),
+			IsNullable: row.ReadString(),
+			Default: row.ReadString());
+	}
+}

--- a/src/KurrentDB.SecondaryIndexing.Tests/Migration/MigrationTests.TempBudget.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Migration/MigrationTests.TempBudget.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Kurrent.Quack;
+using KurrentDB.SecondaryIndexing.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace KurrentDB.SecondaryIndexing.Tests.Migration;
+
+partial class MigrationTests {
+	// A migration must not need temp space proportional to the size of the index. V1A did: its
+	// DEFAULT ''::BLOB drove DuckDB to rewrite the ADD COLUMN into an UPDATE of every row, needing
+	// ~20 bytes of transaction local memory per row where V1B needs ~2. On a large index that exhausts
+	// max_temp_directory_size, and the rollback fails for the same reason and takes the node down.
+	//
+	// Rather than build an index large enough to exhaust a realistic budget, this shrinks the budget:
+	// transient space is capped at a few bytes per row. That makes the assertion a statement about per
+	// row cost, which is the part that scales to production, and it runs in well under a second.
+	private const int TempBudgetRows = 400_000;
+
+	private const int TempBudgetBytesPerRow = 5;
+
+	// Chosen so that the migrations we ship need no temp space at all here, which keeps the test
+	// deterministic: at 4MB they spill ~1.1MiB against a ~1.9MiB budget, and DuckDB's spill volume
+	// varies enough run to run that it intermittently crossed. At 8MB they spill nothing, while V1A
+	// still needs ~15MiB and so fails by a wide margin. Measured 10/10 either way.
+	//
+	// Note the budget therefore bounds memory and temp together rather than temp alone. That is the
+	// useful invariant: a migration must not need transient space proportional to the index.
+	private const string TempBudgetMemoryLimit = "8MB";
+
+	[Fact]
+	public async Task MigratingFromV0FitsInTempBudget() =>
+		await AssertMigrationsFitInTempBudget(StartFromV0, startingVersion: 0, TempBudgetBytesPerRow);
+
+	// From V1A only V2 remains, which is catalog only, so it should need next to nothing. V1A itself
+	// cannot fit any budget - that is the bug - so it runs while the database is being built, before the
+	// budget is imposed.
+	[Fact]
+	public async Task MigratingFromV1AFitsInTempBudget() =>
+		await AssertMigrationsFitInTempBudget(StartFromV1A, startingVersion: 1, bytesPerRow: 1);
+
+	// The control for the two above: replay V1A under the same budget they pass under, and confirm it
+	// blows it. Without this they could be passing because the budget was never applied, or because the
+	// migrations never ran. Asserts why it failed, not just that it did, so an unrelated breakage cannot
+	// masquerade as the budget working.
+	[Fact]
+	public async Task MigratingWithTheOriginalV1ExceedsTempBudget() {
+		Dictionary<int, Action<DuckDBAdvancedConnection>> justV1A = new() {
+			[1] = IndexingDbSchema.UpgradeToV1A,
+		};
+
+		var logs = await MigrateUnderTempBudget(
+			StartFromV0,
+			startingVersion: 0,
+			desiredVersion: 1,
+			TempBudgetBytesPerRow,
+			justV1A);
+
+		var failure = logs.Entries.FirstOrDefault(x => x.Level >= LogLevel.Error);
+
+		Assert.NotNull(failure.Exception);
+		Assert.Contains("max_temp_directory_size", failure.Exception.ToString());
+	}
+
+	private async Task AssertMigrationsFitInTempBudget(
+		Action<DuckDBAdvancedConnection> migrateFromV0ToStartingVersion,
+		int startingVersion,
+		int bytesPerRow) {
+
+		var logs = await MigrateUnderTempBudget(
+			migrateFromV0ToStartingVersion,
+			startingVersion,
+			IndexingDbSchema.TargetVersion,
+			bytesPerRow,
+			IndexingDbSchema.MigrationActions,
+			AssertSeededRowsSurvived);
+
+		var failure = logs.Entries.FirstOrDefault(x => x.Level >= LogLevel.Error);
+
+		Assert.True(failure.Exception is null,
+			$"migration failed: {failure.Message}{Environment.NewLine}{failure.Exception}");
+	}
+
+	// Returns whatever the migration logged. PerformMigration swallows failures into LogCritical, so
+	// without capturing them a failure surfaces only as a confusing error from a later assertion.
+	private async Task<CapturingLoggerFactory> MigrateUnderTempBudget(
+		Action<DuckDBAdvancedConnection> migrateFromV0ToStartingVersion,
+		int startingVersion,
+		int desiredVersion,
+		int bytesPerRow,
+		IReadOnlyDictionary<int, Action<DuckDBAdvancedConnection>> actions,
+		Action<DuckDBAdvancedConnection>? inspect = null) {
+
+		var dbPath = Fixture.GetFilePathFor($"{GetType().Name}.budget.v{startingVersion}to{desiredVersion}.db");
+
+		// Build a populated database, then close it. Seeding leaves the buffer pool warm, which would
+		// absorb the spilling the budget exists to constrain, and a migrating node is reopening a
+		// database rather than continuing with one it has just written.
+		await using (DuckDBAdvancedConnection seeding = new() { ConnectionString = $"Data Source={dbPath};" }) {
+			seeding.Open();
+			SetupV0Schema(seeding);
+			SeedV0Rows(seeding, TempBudgetRows);
+			migrateFromV0ToStartingVersion(seeding);
+			seeding.ExecuteAdHocNonQuery("CHECKPOINT;"u8, multipleStatements: false);
+		}
+
+		await using DuckDBAdvancedConnection connection = new() { ConnectionString = $"Data Source={dbPath};" };
+		connection.Open();
+
+		// threads is pinned because how much gets spilled varies with how much runs in parallel
+		connection.ExecuteAdHocNonQuery(
+			$"""
+			 SET memory_limit='{TempBudgetMemoryLimit}';
+			 SET threads=2;
+			 PRAGMA max_temp_directory_size='{TempBudgetRows * bytesPerRow}B';
+			 """,
+			multipleStatements: true);
+
+		CapturingLoggerFactory logs = new();
+
+		IndexingDbSchema.PerformMigration(
+			startingVersion,
+			desiredVersion,
+			connection,
+			actions,
+			logs.CreateLogger<IndexingDbSchema>());
+
+		// Only worth inspecting when the migration got through - exceeding the budget invalidates the
+		// connection, so every subsequent query fails too.
+		if (!logs.Entries.Exists(x => x.Level >= LogLevel.Error))
+			inspect?.Invoke(connection);
+
+		return logs;
+	}
+
+	private static void AssertSeededRowsSurvived(DuckDBAdvancedConnection connection) {
+		var stats = connection.ExecuteQuery<RecordIdStats, RecordIdStatsQuery>().ToList();
+		string[] tables = ["idx_all", "idx_user__myindex"];
+
+		foreach (var table in tables) {
+			var rows = stats.Single(x => x.Table == table);
+
+			Assert.Equal(TempBudgetRows, rows.Rows);
+			Assert.Equal(0, rows.Nulls);
+			Assert.Equal(0, rows.NonEmptyBytes);
+		}
+	}
+
+	private sealed class CapturingLoggerFactory : ILoggerFactory {
+		public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = [];
+
+		public ILogger CreateLogger(string categoryName) => new Recorder(Entries);
+
+		public void AddProvider(ILoggerProvider provider) {
+		}
+
+		public void Dispose() {
+		}
+
+		private sealed class Recorder(List<(LogLevel, string, Exception?)> entries) : ILogger {
+			public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+			public bool IsEnabled(LogLevel logLevel) => true;
+
+			public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+				Func<TState, Exception?, string> formatter)
+				=> entries.Add((logLevel, formatter(state, exception), exception));
+		}
+	}
+}

--- a/src/KurrentDB.SecondaryIndexing.Tests/Migration/MigrationTests.V1.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Migration/MigrationTests.V1.cs
@@ -36,7 +36,7 @@ partial class MigrationTests {
 
 		static void CheckUserIndexTable(DuckDBAdvancedConnection connection) {
 			var columns = connection
-				.ExecuteQuery<ValueTuple<string>, string, ColumnNamesQuery>(new("idx_user__MyIndex"))
+				.ExecuteQuery<ValueTuple<string>, string, ColumnNamesQuery>(new("idx_user__myindex"))
 				.ToHashSet();
 
 			Assert.Contains("record_id", columns);
@@ -46,5 +46,56 @@ partial class MigrationTests {
 			Assert.DoesNotContain("created", columns);
 			Assert.DoesNotContain("event_number", columns);
 		}
+	}
+
+	[Fact]
+	public void UpgradeToV1BackfillsRecordIdWithEmptyBlob() {
+		// record_id is added with a bare DEFAULT '' so DuckDB takes the cheap metadata path rather
+		// than rewriting every row - see the comment on IndexingDbSchema.UpgradeToV1B. '' is a VARCHAR
+		// literal that DuckDB implicitly casts to BLOB, so pin down what that cast produces for the
+		// existing rows: a zero-length BLOB. Not NULL, and not the single 0x00 byte that a
+		// NUL-terminated string representation would yield. If a future DuckDB ever changes the cast,
+		// this fails instead of silently writing a one-byte value into every indexed record.
+		const int rows = 10;
+		SeedV0Rows(_connection, rows);
+
+		UpgradeTo(desiredVersion: 1);
+
+		var stats = _connection.ExecuteQuery<RecordIdStats, RecordIdStatsQuery>().ToList();
+		string[] tables = ["idx_all", "idx_user__myindex"];
+
+		foreach (var table in tables) {
+			var actual = stats.Single(x => x.Table == table);
+
+			Assert.Equal(rows, actual.Rows);
+			Assert.Equal(0, actual.Nulls);
+			Assert.Equal(0, actual.NonEmptyBytes);
+			Assert.Equal(0, actual.SingleNulByte);
+		}
+	}
+
+	private readonly record struct RecordIdStats(string Table, long Rows, long Nulls, long NonEmptyBytes, long SingleNulByte);
+
+	private readonly struct RecordIdStatsQuery : IQuery<RecordIdStats> {
+		// Backslashes are literal in a raw string literal, so DuckDB receives '\x00' and parses it as
+		// a one byte blob.
+		public static ReadOnlySpan<byte> CommandText => """
+			select 'idx_all',
+					count(*),
+					count(*) filter (where record_id is null),
+					count(*) filter (where octet_length(record_id) <> 0),
+					count(*) filter (where record_id = '\x00'::blob)
+			from idx_all
+			union all
+			select 'idx_user__myindex',
+					count(*),
+					count(*) filter (where record_id is null),
+					count(*) filter (where octet_length(record_id) <> 0),
+					count(*) filter (where record_id = '\x00'::blob)
+			from idx_user__myindex;
+			"""u8;
+
+		public static RecordIdStats Parse(ref DataChunk.Row row) =>
+			new(row.ReadString(), row.ReadInt64(), row.ReadInt64(), row.ReadInt64(), row.ReadInt64());
 	}
 }

--- a/src/KurrentDB.SecondaryIndexing.Tests/Migration/MigrationTests.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Migration/MigrationTests.cs
@@ -54,17 +54,36 @@ public sealed partial class MigrationTests : DirectoryPerTest<MigrationTests> {
 		                              created bigint not null
 		                            );
 
-		                            create table if not exists idx_user__MyIndex (
+		                            create table if not exists idx_user__myindex (
 		                                log_position bigint not null,
 		                                commit_position bigint null,
 		                                event_number bigint not null,
 		                                created bigint not null,
-		                                my_field integer not null
+		                                field_myfield integer not null
 		                            );
 		                            """u8;
 
 		using var transaction = connection.BeginTransaction();
 		connection.ExecuteAdHocNonQuery(schema, multipleStatements: true);
+		transaction.CommitOnDispose();
+	}
+
+	// Populates some V0 data so that migrations affecting data can be exercised.
+	private static void SeedV0Rows(DuckDBAdvancedConnection connection, int count) {
+		using var transaction = connection.BeginTransaction();
+		connection.ExecuteAdHocNonQuery(
+			$"""
+			insert into idx_all
+			select range, range, range, 1700000000 + range, null,
+				'account-' || range, hash(range), 'SomethingHappened',
+				'account', false, null, 'application/json'
+			from range({count});
+
+			insert into idx_user__myindex
+			select range, range, range, 1700000000 + range, cast(range as integer)
+			from range({count});
+			""",
+			multipleStatements: true);
 		transaction.CommitOnDispose();
 	}
 

--- a/src/KurrentDB.SecondaryIndexing/Indexes/User/UserIndexSql.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/User/UserIndexSql.cs
@@ -47,7 +47,16 @@ internal abstract partial class UserIndexSql(string indexName, string fieldName)
 			.CopyTo(records);
 	}
 
-	public static bool IsUserIndexTable(ReadOnlySpan<char> tableName) => tableName.StartsWith(TableNamePrefix);
+	// Applies the same validation GetTableNameFor applies when the table is created, so a prefixed name
+	// that we could not have produced - anything outside [a-z0-9_-] - is not recognised. The migrations
+	// interpolate the names this returns into DDL, so keeping the character set to what creation allows
+	// means there is nothing there to escape.
+	//
+	// Because it reuses IdentifierRegex rather than a second pattern, this cannot reject a table we did
+	// create. That does assume IdentifierRegex has always been the rule; it arrived with the feature
+	// that creates these tables, so there should be no older name that fails it.
+	public static bool IsUserIndexTable(ReadOnlySpan<char> tableName) =>
+		tableName.StartsWith(TableNamePrefix) && IdentifierRegex.IsMatch(tableName);
 
 	private static string GetTableNameFor(string indexName) {
 		var tableName = string.Concat(TableNamePrefix, indexName);
@@ -84,6 +93,8 @@ internal abstract partial class UserIndexSql(string indexName, string fieldName)
 		connection.ExecuteNonQuery(ref query);
 	}
 
+	// do not change this without consideration for effect on migrations
+	// where this protects against sql injection
 	[GeneratedRegex("^[a-z][a-z0-9_-]*$", RegexOptions.Compiled)]
 	private static partial Regex ValidationRegex();
 }

--- a/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.Migration.cs
+++ b/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.Migration.cs
@@ -61,7 +61,7 @@ partial class IndexingDbSchema {
 		}
 	}
 
-	private static void PerformMigration(
+	internal static void PerformMigration(
 		int baseVersion,
 		int targetVersion,
 		DuckDBAdvancedConnection connection,

--- a/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.V1.A.cs
+++ b/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.V1.A.cs
@@ -9,7 +9,11 @@ using KurrentDB.SecondaryIndexing.Indexes.User;
 namespace KurrentDB.SecondaryIndexing.Storage;
 
 partial class IndexingDbSchema {
-	private static void UpgradeToV1(DuckDBAdvancedConnection connection) {
+	// The V1 migration exactly as it originally shipped.
+	// It is superseded in V1B and deliberately NOT registered in MigrationActions
+	// This is kept in its original form so that we can test the migration path
+	// that some databases will have taken through it.
+	internal static void UpgradeToV1A(DuckDBAdvancedConnection connection) {
 		// Add record_id column and rename columns
 		connection.ExecuteAdHocNonQuery("""
 		                                CREATE TABLE idx_metadata(key varchar primary key not null, value varchar);

--- a/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.V1.B.cs
+++ b/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.V1.B.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text;
+using DuckDB.NET.Data;
+using Kurrent.Quack;
+using KurrentDB.SecondaryIndexing.Indexes.User;
+
+namespace KurrentDB.SecondaryIndexing.Storage;
+
+partial class IndexingDbSchema {
+	// Replaces the original V1 migration (which is now renamed to V1A).
+	//
+	// Does the same thing but uses a record_id DEFAULT of '' instead of ''::BLOB
+	//
+	// DuckDB identifies '' as a constant and materializes approximately 10x less temporary data during
+	// the migration than with the cast (which prevents it from being detected as a constant, see transform_alter_table.cpp).
+	// The new version is less likely to exhaust max_temp_directory_size and fail.
+	//
+	// Databases already upgraded by the earlier version of this migration have the same row data
+	// (every pre-upgrade row holds the empty BLOB), but their catalog records the default as CAST('' AS "BLOB").
+	// Both forms evaluate to the same value. The only difference is the catalog.
+	private static void UpgradeToV1B(DuckDBAdvancedConnection connection) {
+		// Add record_id column and rename columns
+		connection.ExecuteAdHocNonQuery(
+			"""
+			CREATE TABLE idx_metadata(key varchar primary key not null, value varchar);
+			ALTER TABLE idx_all ADD COLUMN record_id BLOB DEFAULT '';
+			ALTER TABLE idx_all RENAME COLUMN event_number TO stream_revision;
+			ALTER TABLE idx_all RENAME COLUMN created TO created_at;
+			ALTER TABLE idx_all RENAME COLUMN event_type TO schema_name;
+			ALTER TABLE idx_all RENAME COLUMN is_deleted TO deleted;
+			ALTER TABLE idx_all RENAME COLUMN expires TO expires_at;
+			"""u8,
+			multipleStatements: true);
+
+		// Find and rename all secondary index tables
+		foreach (var tableNameUtf8 in connection.GetTables()) {
+			var tableName = Encoding.UTF8.GetString(tableNameUtf8);
+
+			if (UserIndexSql.IsUserIndexTable(tableName))
+				RenameUserIndexColumns(connection, tableName);
+		}
+
+		static void RenameUserIndexColumns(DuckDBConnection connection, string tableName) {
+			// Add record_id column
+			connection.ExecuteAdHocNonQuery(
+				$"""
+				ALTER TABLE "{tableName}" ADD COLUMN record_id BLOB DEFAULT '';
+				ALTER TABLE "{tableName}" RENAME COLUMN event_number TO stream_revision;
+				ALTER TABLE "{tableName}" RENAME COLUMN created TO created_at;
+				""",
+				multipleStatements: true);
+		}
+	}
+}

--- a/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.V2.cs
+++ b/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.V2.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text;
+using DuckDB.NET.Data;
+using Kurrent.Quack;
+using KurrentDB.SecondaryIndexing.Indexes.User;
+
+namespace KurrentDB.SecondaryIndexing.Storage;
+
+partial class IndexingDbSchema {
+	// Gives record_id the same shape a fresh install creates: `blob not null` with no default.
+	//
+	// V1 could only add the column by giving it a default, since DuckDB cannot add a column and a
+	// constraint in one statement ("Adding columns with constraints not yet supported"). So every
+	// migrated database ends up with record_id nullable and carrying a default, where 1_Schema.sql and
+	// CreateUserIndexNonQuery declare it not null with no default. This reconciles the two.
+	//
+	// Neither statement rewrites data, so the database file comes out unchanged whatever the size of the
+	// index: DuckDB stores validity as its own segment per row group, and one holding no NULLs is
+	// already Constant compressed, exactly as it is for a not null column. There is nothing to drop, so
+	// SET NOT NULL only has to validate - roughly 60ms per 50M rows. Both statements are no-ops on a
+	// column already in this shape, which is how user index tables created after V1B by
+	// CreateUserIndexNonQuery are handled.
+	//
+	// SET NOT NULL is safe because no row can hold a NULL record_id: V1 backfilled every pre-upgrade
+	// row with a zero length BLOB, and the appenders always supply the value explicitly
+	// (DefaultIndexProcessor, UserIndexProcessor). If one ever did, this fails the migration rather
+	// than accepting it.
+	private static void UpgradeToV2(DuckDBAdvancedConnection connection) {
+		AlignRecordIdWithFreshInstall(connection, "idx_all");
+
+		// Same treatment for every user index table, which V1 gave the same default
+		foreach (var tableNameUtf8 in connection.GetTables()) {
+			var tableName = Encoding.UTF8.GetString(tableNameUtf8);
+
+			if (UserIndexSql.IsUserIndexTable(tableName))
+				AlignRecordIdWithFreshInstall(connection, tableName);
+		}
+
+		static void AlignRecordIdWithFreshInstall(DuckDBConnection connection, string tableName) =>
+			connection.ExecuteAdHocNonQuery(
+				$"""
+				 ALTER TABLE "{tableName}" ALTER COLUMN record_id DROP DEFAULT;
+				 ALTER TABLE "{tableName}" ALTER COLUMN record_id SET NOT NULL;
+				 """,
+				multipleStatements: true);
+	}
+}

--- a/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.Versioning.cs
+++ b/src/KurrentDB.SecondaryIndexing/Storage/IndexingDbSchema.Versioning.cs
@@ -9,11 +9,16 @@ namespace KurrentDB.SecondaryIndexing.Storage;
 // 1. Add migration action to MigrationActions with appropriate version
 // 2. Modify DDL (*.sql files or in-place SQL statements)
 // 3. Bump TargetVersion constant below
+//
+// Do not edit migrations that have been shipped.
+// If a migration must be patched, create a new one with B/C/D suffix and ensure all upgrade
+// path variations are covered in MigrationTests.SchemaParity
 partial class IndexingDbSchema {
-	private const int TargetVersion = 1;
+	internal const int TargetVersion = 2;
 
-	private static SortedDictionary<int, Action<DuckDBAdvancedConnection>> MigrationActions
+	internal static SortedDictionary<int, Action<DuckDBAdvancedConnection>> MigrationActions
 		=> new() {
-			{ 1, UpgradeToV1 }
+			{ 1, UpgradeToV1B }, // V1 renamed to V1A and replaced with V1B
+			{ 2, UpgradeToV2 },
 		};
 }


### PR DESCRIPTION
The V1 migration added idx_all.record_id with DEFAULT ''::BLOB. The cast makes the default a non-constant expression, which sends DuckDB down its workaround path and rewrites the statement into ADD COLUMN plus an UPDATE of every row (see transform_alter_table.cpp). That UPDATE needs ~20 bytes of transaction local memory per row rather than ~2, so on a large index it can exhaust max_temp_directory_size.

Dropping the cast keeps the same value and the same backfill while taking the cheap metadata path.

- V1 is frozen as V1A: internal, unregistered, and kept only so tests can reproduce the database state it left behind. It must not be edited.
- V1B replaces it at version 1, identical except for the bare DEFAULT ''.

Also identified other small descrepancies:

- V2 gives record_id the shape a fresh install creates, not null with no default, on idx_all and on every user index table. DuckDB cannot add a column and a constraint in one statement, so a migrated column is necessarily nullable with a default until this runs. Both statements are catalog only and leave the database file unchanged.

MigrationTests.SchemaParity asserts that a migrated schema matches what 1_Schema.sql and CreateUserIndex produce, via V1A and V1B paths, comparing every table including user index tables.