### PR TITLE
[DB-2197] Add PTable benchmarks and fix a few perf issues

### DIFF
--- a/src/KurrentDB.Core/Index/HashListMemTable.cs
+++ b/src/KurrentDB.Core/Index/HashListMemTable.cs
@@ -119,7 +119,7 @@ public class HashListMemTable : IMemTable {
 				if (endIdx is -1)
 					return false;
 
-				var key = list.Keys[endIdx];
+				var key = list.GetKeyAtIndex(endIdx);
 				if (key.EvNum == number) {
 					position = key.LogPos;
 					return true;
@@ -141,7 +141,7 @@ public class HashListMemTable : IMemTable {
 				throw new UnableToAcquireLockInReasonableTimeException();
 			try {
 				// requires the list to be non-empty before we are able to acquire a lock on it.
-				var latest = list.Keys[list.Count - 1];
+				var latest = list.GetKeyAtIndex(list.Count - 1);
 				entry = new IndexEntry(hash, latest.EvNum, latest.LogPos);
 				return true;
 			} finally {
@@ -175,7 +175,7 @@ public class HashListMemTable : IMemTable {
 			if (endIdx is -1)
 				return null;
 
-			var latestBeforePosition = list.Keys[endIdx];
+			var latestBeforePosition = list.GetKeyAtIndex(endIdx);
 			return new(hash, latestBeforePosition.EvNum, latestBeforePosition.LogPos);
 		} catch (SearchStoppedException) {
 			// fall back to linear search if there was a hash collision
@@ -187,7 +187,7 @@ public class HashListMemTable : IMemTable {
 			if (maxIdx is -1)
 				return null;
 
-			var latestBeforePosition = list.Keys[maxIdx];
+			var latestBeforePosition = list.GetKeyAtIndex(maxIdx);
 			return new(hash, latestBeforePosition.EvNum, latestBeforePosition.LogPos);
 		} finally {
 			list.Lock.Release();
@@ -202,7 +202,7 @@ public class HashListMemTable : IMemTable {
 			if (!list.Lock.TryEnterReadLock(DefaultLockTimeout))
 				throw new UnableToAcquireLockInReasonableTimeException();
 			try {
-				var oldest = list.Keys[0];
+				var oldest = list.GetKeyAtIndex(0);
 				entry = new IndexEntry(hash, oldest.EvNum, oldest.LogPos);
 				return true;
 			} finally {
@@ -230,7 +230,7 @@ public class HashListMemTable : IMemTable {
 				if (endIdx is -1)
 					return false;
 
-				var e = list.Keys[endIdx];
+				var e = list.GetKeyAtIndex(endIdx);
 				entry = new IndexEntry(hash, e.EvNum, e.LogPos);
 				return true;
 			} finally {
@@ -258,7 +258,7 @@ public class HashListMemTable : IMemTable {
 				if (endIdx is -1)
 					return false;
 
-				var e = list.Keys[endIdx];
+				var e = list.GetKeyAtIndex(endIdx);
 				entry = new IndexEntry(hash, e.EvNum, e.LogPos);
 				return true;
 			} finally {
@@ -273,21 +273,17 @@ public class HashListMemTable : IMemTable {
 		//Log.Trace("Sorting array in HashListMemTable.IterateAllInOrder...");
 
 		var keys = _hash.Keys.ToArray();
-		Array.Sort(keys, new ReverseComparer<ulong>());
+		Array.Sort(keys, ReverseComparer<ulong>.Instance);
 
 		foreach (var key in keys) {
 			var list = _hash[key];
 			for (int i = list.Count - 1; i >= 0; --i) {
-				var x = list.Keys[i];
+				var x = list.GetKeyAtIndex(i);
 				yield return new IndexEntry(key, x.EvNum, x.LogPos);
 			}
 		}
 
 		//Log.Trace("Sorting array in HashListMemTable.IterateAllInOrder... DONE!");
-	}
-
-	public void Clear() {
-		_hash.Clear();
 	}
 
 	public IReadOnlyList<IndexEntry> GetRange(ulong stream, long startNumber, long endNumber, int? limit = null) {
@@ -303,7 +299,7 @@ public class HashListMemTable : IMemTable {
 			try {
 				var endIdx = list.UpperBound(new Entry(endNumber, long.MaxValue));
 				for (int i = endIdx; i >= 0; i--) {
-					var key = list.Keys[i];
+					var key = list.GetKeyAtIndex(i);
 					if (key.EvNum < startNumber || ret.Count == limit)
 						break;
 					ret.Add(new IndexEntry(hash, version: key.EvNum, position: key.LogPos));
@@ -351,7 +347,9 @@ public class HashListMemTable : IMemTable {
 	}
 }
 
-public class ReverseComparer<T> : IComparer<T> where T : IComparable {
+public sealed class ReverseComparer<T> : IComparer<T> where T : IComparable<T> {
+	public static readonly ReverseComparer<T> Instance = new();
+
 	public int Compare(T x, T y) {
 		return -x.CompareTo(y);
 	}

--- a/src/KurrentDB.MicroBenchmarks/KurrentDB.MicroBenchmarks.csproj
+++ b/src/KurrentDB.MicroBenchmarks/KurrentDB.MicroBenchmarks.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<IsTestingPlatformApplication>false</IsTestingPlatformApplication>
+		<TestingPlatformCommandLineArguments></TestingPlatformCommandLineArguments>
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/KurrentDB.MicroBenchmarks/PTable/PTableBenchmarkData.cs
+++ b/src/KurrentDB.MicroBenchmarks/PTable/PTableBenchmarkData.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using KurrentDB.Core.Index;
+using KurrentDB.Core.Settings;
+
+namespace KurrentDB.MicroBenchmarks.PTable;
+
+public enum PTableLoad {
+	// A small pool of distinct streams queried repeatedly at random.
+	SmallSubset,
+
+	// Random access spread across (the majority of) all streams.
+	Majority,
+}
+
+public readonly record struct PTableQuery(ulong Stream, long EventNumber);
+
+// The streams a benchmark index is made of: a hash per stream and the number of events it holds
+// (event numbers 0, 1, 2, ... up to that count). Generated from a seeded RNG once per benchmark
+// setup and reused to build the index file and every workload that runs against it, so the queries
+// always reference entries that exist in the index and every run measures the same lookups.
+public sealed class PTableBenchmarkData {
+	// Number of events per stream, drawn uniformly from this (inclusive) range.
+	private const int MinEventsPerStream = 3;
+	private const int MaxEventsPerStream = 10;
+
+	// Distinct streams the SmallSubset load draws from.
+	private const int SmallSubsetStreams = 250;
+
+	private const int StreamsSeed = 1;
+	private const int WorkloadSeed = 2;
+
+	public const int InitialReaders = ESConsts.PTableInitialReaderCount;
+	public const int MaxReaders = 16;
+
+	public static readonly string WorkDir =
+		Path.Combine(Path.GetTempPath(), "KurrentDB.PTableBenchmarks");
+
+	static PTableBenchmarkData() => Directory.CreateDirectory(WorkDir);
+
+	private readonly ulong[] _hashes;
+	private readonly int[] _eventCounts;
+	private readonly int _entryCount;
+
+	private PTableBenchmarkData(ulong[] hashes, int[] eventCounts, int entryCount) {
+		_hashes = hashes;
+		_eventCounts = eventCounts;
+		_entryCount = entryCount;
+	}
+
+	public static PTableBenchmarkData Generate(int entryCount) {
+		var rng = new Random(StreamsSeed);
+		var hashes = new List<ulong>();
+		var eventCounts = new List<int>();
+		var entries = 0;
+		while (entries < entryCount) {
+			// Random hashes mean consecutive streams land at unrelated positions in the
+			// (hash-sorted) index, so picking a random stream picks a random position in it.
+			hashes.Add(unchecked((ulong)rng.NextInt64(long.MinValue, long.MaxValue)));
+			var events = rng.Next(MinEventsPerStream, MaxEventsPerStream + 1);
+			eventCounts.Add(events);
+			entries += events;
+		}
+
+		return new(hashes.ToArray(), eventCounts.ToArray(), entries);
+	}
+
+	public HashListMemTable BuildMemTable(byte version) {
+		var table = new HashListMemTable(version, maxSize: _entryCount);
+		long position = 0;
+		for (var s = 0; s < _hashes.Length; s++) {
+			for (long eventNumber = 0; eventNumber < _eventCounts[s]; eventNumber++)
+				table.Add(_hashes[s], eventNumber, position++);
+		}
+
+		return table;
+	}
+
+	// The path this data set's index is written to. Named after the data, so a benchmark that writes
+	// the file itself (rather than through CreateFile) still deletes it through DeleteFile.
+	public string FilePath(byte version) => Path.Combine(WorkDir, $"ptable_v{version}_{_entryCount}.idx");
+
+	// Builds the PTable file for the given version, overwriting any file left behind by a previous
+	// run, and returns its path. Call DeleteFile when done with it.
+	public string CreateFile(byte version) {
+		var path = FilePath(version);
+		var table = Core.Index.PTable.FromMemtable(
+			BuildMemTable(version), path, InitialReaders, MaxReaders, skipIndexVerify: true);
+		table.Dispose();
+		table.WaitForDisposal(TimeSpan.FromSeconds(120));
+		return path;
+	}
+
+	// Completely random point queries: each query independently picks a random stream and a random
+	// (existing) event number within it, so the queries land at random, non-sequential positions in
+	// the index.
+	public PTableQuery[] BuildRandomWorkload(PTableLoad load, int queryCount) {
+		var poolSize = PoolSize(load);
+		var rng = new Random(WorkloadSeed);
+		var workload = new PTableQuery[queryCount];
+		for (var i = 0; i < workload.Length; i++) {
+			var s = rng.Next(poolSize);
+			workload[i] = new PTableQuery(_hashes[s], rng.Next(_eventCounts[s]));
+		}
+
+		return workload;
+	}
+
+	// Sequential-within-a-stream queries: streams are visited in random order (so the index is
+	// still hit at random positions), but the queries for a given stream cover its events in order
+	// (0, 1, 2, ...). Consumers read this array forward as-is, or in reverse for a backward read.
+	public PTableQuery[] BuildSequentialWorkload(PTableLoad load, int queryCount) {
+		var poolSize = PoolSize(load);
+		var rng = new Random(WorkloadSeed);
+		var workload = new PTableQuery[queryCount];
+		var i = 0;
+		while (i < workload.Length) {
+			var s = rng.Next(poolSize);
+			for (long eventNumber = 0; eventNumber < _eventCounts[s] && i < workload.Length; eventNumber++)
+				workload[i++] = new PTableQuery(_hashes[s], eventNumber);
+		}
+
+		return workload;
+	}
+
+	// The number of streams a workload may draw from, depending on the load kind.
+	private int PoolSize(PTableLoad load) =>
+		load == PTableLoad.SmallSubset ? Math.Min(SmallSubsetStreams, _hashes.Length) : _hashes.Length;
+
+	// Deletes the index file and its bloom filter. Best effort: a file left behind is only wasted
+	// disk space, and the next run overwrites it anyway.
+	public void DeleteFile(byte version) {
+		var path = FilePath(version);
+		Delete(path);
+		Delete(Core.Index.PTable.GenBloomFilterFilename(path));
+
+		static void Delete(string path) {
+			try {
+				if (File.Exists(path)) {
+					File.SetAttributes(path, FileAttributes.Normal);
+					File.Delete(path);
+				}
+			} catch {
+				// ignored
+			}
+		}
+	}
+}

--- a/src/KurrentDB.MicroBenchmarks/PTable/PTableConstructionBenchmarks.cs
+++ b/src/KurrentDB.MicroBenchmarks/PTable/PTableConstructionBenchmarks.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using BenchmarkDotNet.Attributes;
+using KurrentDB.Core.Index;
+
+namespace KurrentDB.MicroBenchmarks.PTable;
+
+// Benchmarks writing a PTable to disk from an in-memory memtable. The memtable is built once in
+// the setup so only the dump (index entries + midpoints + bloom filter + MD5) is measured.
+[MemoryDiagnoser]
+public class PTableConstructionBenchmarks {
+	[Params(1_000_000, 16_000_000)]
+	public int IndexSize;
+
+	[Params(PTableVersions.IndexV2, PTableVersions.IndexV3, PTableVersions.IndexV4)]
+	public byte Version;
+
+	private PTableBenchmarkData _data;
+	private HashListMemTable _memTable;
+	private string _outputFile;
+
+	[GlobalSetup]
+	public void Setup() {
+		_data = PTableBenchmarkData.Generate(IndexSize);
+		_memTable = _data.BuildMemTable(Version);
+		_outputFile = _data.FilePath(Version);
+		_data.DeleteFile(Version);
+	}
+
+	[Benchmark]
+	public void FromMemtable() {
+		// FromMemtable creates the file with FileMode.Create, so reusing the same path just
+		// overwrites the previous invocation's output.
+		var table = Core.Index.PTable.FromMemtable(
+			_memTable,
+			_outputFile,
+			PTableBenchmarkData.InitialReaders,
+			PTableBenchmarkData.MaxReaders,
+			skipIndexVerify: true);
+		table.Dispose();
+		table.WaitForDisposal(TimeSpan.FromSeconds(120));
+	}
+
+	[GlobalCleanup]
+	public void Cleanup() => _data.DeleteFile(Version);
+}

--- a/src/KurrentDB.MicroBenchmarks/PTable/PTableQueryBenchmarksBase.cs
+++ b/src/KurrentDB.MicroBenchmarks/PTable/PTableQueryBenchmarksBase.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using KurrentDB.Core.Index;
+
+namespace KurrentDB.MicroBenchmarks.PTable;
+
+// Shared setup and threading harness for the PTable query benchmarks. Each concrete subclass is a
+// separate access pattern (so it can be run on its own) that supplies its workload and the
+// benchmark methods that consume it.
+//
+// All subclasses share the same dimensions: index size, thread count, and query load (a small
+// pool of hot keys vs. the majority of keys). The PTable file is built in the setup and deleted in
+// the cleanup.
+public abstract class PTableQueryBenchmarksBase {
+	protected const int QueriesPerInvocation = 100_000;
+
+	[Params(1_000_000, 16_000_000)]
+	public int IndexSize;
+
+	[Params(1, 4, 8)]
+	public int Threads;
+
+	[Params(PTableLoad.SmallSubset, PTableLoad.Majority)]
+	public PTableLoad Load;
+
+	[Params(PTableVersions.IndexV2, PTableVersions.IndexV3, PTableVersions.IndexV4)]
+	public byte Version;
+
+	protected Core.Index.PTable Table;
+	protected PTableQuery[] Workload;
+	private long[] _partialResults;
+	private PTableBenchmarkData _data;
+
+	[GlobalSetup]
+	public void Setup() {
+		_data = PTableBenchmarkData.Generate(IndexSize);
+		Table = Core.Index.PTable.FromFile(
+			_data.CreateFile(Version),
+			PTableBenchmarkData.InitialReaders,
+			PTableBenchmarkData.MaxReaders,
+			cacheDepth: 16,
+			skipIndexVerify: true);
+		Workload = BuildWorkload(_data);
+		_partialResults = new long[Threads];
+	}
+
+	protected abstract PTableQuery[] BuildWorkload(PTableBenchmarkData data);
+
+	// Spreads the workload across the configured number of threads (one contiguous slice each) and
+	// sums the per-thread accumulators. The range function is invoked once per thread, so it adds
+	// no per-query overhead.
+	protected long RunParallel(Func<int, int, long> queryRange) {
+		var threads = Threads;
+		if (threads == 1)
+			return queryRange(0, Workload.Length);
+
+		var chunk = Workload.Length / threads;
+		var tasks = new Task[threads];
+		for (var t = 0; t < threads; t++) {
+			var index = t;
+			var start = index * chunk;
+			var end = index == threads - 1 ? Workload.Length : start + chunk;
+			tasks[index] = Task.Run(() => _partialResults[index] = queryRange(start, end));
+		}
+
+		Task.WaitAll(tasks);
+
+		long sum = 0;
+		for (var t = 0; t < threads; t++)
+			sum += _partialResults[t];
+		return sum;
+	}
+
+	[GlobalCleanup]
+	public void Cleanup() {
+		Table?.Dispose();
+		Table?.WaitForDisposal(TimeSpan.FromSeconds(120));
+		_data.DeleteFile(Version);
+	}
+}

--- a/src/KurrentDB.MicroBenchmarks/PTable/PTableRandomQueryBenchmarks.cs
+++ b/src/KurrentDB.MicroBenchmarks/PTable/PTableRandomQueryBenchmarks.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using BenchmarkDotNet.Attributes;
+
+namespace KurrentDB.MicroBenchmarks.PTable;
+
+// Completely random point lookups: every query targets a random stream at a random, non-sequential
+// position in the index.
+//   - Latest        looks up each stream's newest event  (TryGetLatestEntry, uses the LRU cache)
+//   - SpecificEvent looks up a random existing event      (TryGetOneValue, binary chop, no LRU)
+[ShortRunJob]
+[MemoryDiagnoser]
+public class PTableRandomQueryBenchmarks : PTableQueryBenchmarksBase {
+	protected override PTableQuery[] BuildWorkload(PTableBenchmarkData data) =>
+		data.BuildRandomWorkload(Load, QueriesPerInvocation);
+
+	[Benchmark]
+	public long Latest() => RunParallel(LatestRange);
+
+	[Benchmark]
+	public long SpecificEvent() => RunParallel(SpecificEventRange);
+
+	// Accumulates the found positions so the lookups can't be optimized away.
+	private long LatestRange(int start, int end) {
+		long acc = 0;
+		var workload = Workload;
+		for (var i = start; i < end; i++) {
+			if (Table.TryGetLatestEntry(workload[i].Stream, out var entry))
+				acc += entry.Position;
+		}
+
+		return acc;
+	}
+
+	private long SpecificEventRange(int start, int end) {
+		long acc = 0;
+		var workload = Workload;
+		for (var i = start; i < end; i++) {
+			if (Table.TryGetOneValue(workload[i].Stream, workload[i].EventNumber, out var position))
+				acc += position;
+		}
+
+		return acc;
+	}
+}

--- a/src/KurrentDB.MicroBenchmarks/PTable/PTableReadBenchmarks.cs
+++ b/src/KurrentDB.MicroBenchmarks/PTable/PTableReadBenchmarks.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using BenchmarkDotNet.Attributes;
+using KurrentDB.Core.Index;
+
+namespace KurrentDB.MicroBenchmarks.PTable;
+
+// Benchmarks opening a PTable from disk. With index verification enabled the whole file is read
+// and its MD5 recomputed; with it disabled the midpoints are rebuilt without hashing (and, for V4,
+// loaded straight from the file's cached midpoints), so the two modes bracket the range of open
+// costs.
+[MemoryDiagnoser]
+public class PTableReadBenchmarks {
+	[Params(1_000_000, 16_000_000)]
+	public int IndexSize;
+
+	[Params(false, true)]
+	public bool SkipIndexVerify;
+
+	[Params(PTableVersions.IndexV2, PTableVersions.IndexV3, PTableVersions.IndexV4)]
+	public byte Version;
+
+	private PTableBenchmarkData _data;
+	private string _file;
+
+	[GlobalSetup]
+	public void Setup() {
+		_data = PTableBenchmarkData.Generate(IndexSize);
+		_file = _data.CreateFile(Version);
+	}
+
+	[GlobalCleanup]
+	public void Cleanup() => _data.DeleteFile(Version);
+
+	[Benchmark]
+	public long OpenFromFile() {
+		var table = Core.Index.PTable.FromFile(
+			_file,
+			PTableBenchmarkData.InitialReaders,
+			PTableBenchmarkData.MaxReaders,
+			cacheDepth: 16,
+			skipIndexVerify: SkipIndexVerify);
+		var count = table.Count;
+		table.Dispose();
+		table.WaitForDisposal(TimeSpan.FromSeconds(120));
+		return count;
+	}
+}

--- a/src/KurrentDB.MicroBenchmarks/PTable/PTableSequentialQueryBenchmarks.cs
+++ b/src/KurrentDB.MicroBenchmarks/PTable/PTableSequentialQueryBenchmarks.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using BenchmarkDotNet.Attributes;
+
+namespace KurrentDB.MicroBenchmarks.PTable;
+
+// Sequential-within-a-stream point lookups (TryGetOneValue). Streams are visited in random order,
+// but each visited stream's events are read in order, modelling reading a stream:
+//   - Forward  reads events 0, 1, 2, ...   (the workload as generated)
+//   - Backward reads events ..., 2, 1, 0   (the same workload consumed in reverse)
+[ShortRunJob]
+[MemoryDiagnoser]
+public class PTableSequentialQueryBenchmarks : PTableQueryBenchmarksBase {
+	protected override PTableQuery[] BuildWorkload(PTableBenchmarkData data) =>
+		data.BuildSequentialWorkload(Load, QueriesPerInvocation);
+
+	[Benchmark]
+	public long Forward() => RunParallel(ForwardRange);
+
+	[Benchmark]
+	public long Backward() => RunParallel(BackwardRange);
+
+	// Accumulates the found positions so the lookups can't be optimized away.
+	private long ForwardRange(int start, int end) {
+		long acc = 0;
+		var workload = Workload;
+		for (var i = start; i < end; i++) {
+			if (Table.TryGetOneValue(workload[i].Stream, workload[i].EventNumber, out var position))
+				acc += position;
+		}
+
+		return acc;
+	}
+
+	private long BackwardRange(int start, int end) {
+		long acc = 0;
+		var workload = Workload;
+		for (var i = end - 1; i >= start; i--) {
+			if (Table.TryGetOneValue(workload[i].Stream, workload[i].EventNumber, out var position))
+				acc += position;
+		}
+
+		return acc;
+	}
+}

--- a/src/KurrentDB.MicroBenchmarks/Program.cs
+++ b/src/KurrentDB.MicroBenchmarks/Program.cs
@@ -9,8 +9,12 @@ namespace KurrentDB.MicroBenchmarks;
 
 internal class Program {
 	static void Main(string[] args) {
-		var config = Debugger.IsAttached ? new DebugBuildConfig() { } : DefaultConfig.Instance;
-		BenchmarkRunner.Run<ProjectionSerializationBenchmarks>(config, args);
-//		BenchmarkRunner.Run<QueueBenchmarks>(config, args);
+		var config = Debugger.IsAttached ? new DebugBuildConfig() : DefaultConfig.Instance;
+
+		// Run without arguments for an interactive picker, or filter from the command line, e.g.:
+		//   dotnet run -c Release -- --filter *PTableQueryBenchmarks*
+		BenchmarkSwitcher
+			.FromAssembly(typeof(Program).Assembly)
+			.Run(args, config);
 	}
 }


### PR DESCRIPTION
- Added benchmarks for PTable covering construction, loading and querying it.
- Fixed unnecessary allocations in HashListMemTable (boxing + unnecessary Keys view creation)

Benchmark results for PTable construction (affected by the optimization) demonstrate that the memory traffic drops significantly.

Before:
```markdown
| Method       | IndexSize | Version | Mean       | Error    | StdDev  | Gen0        | Gen1     | Allocated  |
|------------- |---------- |-------- |-----------:|---------:|--------:|------------:|---------:|-----------:|
| FromMemtable | 1000000   | 2       |   112.4 ms |  1.50 ms | 1.17 ms |   8200.0000 | 200.0000 |   68.64 MB |                                                                                                                                                          
| FromMemtable | 1000000   | 3       |   118.5 ms |  1.62 ms | 1.52 ms |   8200.0000 | 200.0000 |   68.64 MB |
| FromMemtable | 1000000   | 4       |   120.2 ms |  2.33 ms | 2.94 ms |   8250.0000 | 250.0000 |   68.64 MB |
| FromMemtable | 16000000  | 2       | 2,845.1 ms | 11.08 ms | 9.25 ms | 150000.0000 |        - | 1234.68 MB |
| FromMemtable | 16000000  | 3       | 2,957.5 ms |  8.86 ms | 7.85 ms | 150000.0000 |        - | 1234.68 MB |
| FromMemtable | 16000000  | 4       | 2,981.1 ms | 10.28 ms | 9.61 ms | 150000.0000 |        - | 1234.68 MB |
``` 

After:
```markdown
| Method       | IndexSize | Version | Mean       | Error    | StdDev   | Allocated |
|------------- |---------- |-------- |-----------:|---------:|---------:|----------:|
| FromMemtable | 1000000   | 2       |   115.0 ms |  2.30 ms |  1.92 ms |   2.53 MB |                                                                                                                                                                                   
| FromMemtable | 1000000   | 3       |   119.7 ms |  1.40 ms |  1.24 ms |   2.53 MB |
| FromMemtable | 1000000   | 4       |   121.4 ms |  1.93 ms |  1.80 ms |   2.53 MB |
| FromMemtable | 16000000  | 2       | 2,863.6 ms | 12.67 ms | 11.85 ms |  37.76 MB |
| FromMemtable | 16000000  | 3       | 2,989.5 ms | 47.65 ms | 42.24 ms |  37.76 MB |
| FromMemtable | 16000000  | 4       | 2,894.3 ms | 12.92 ms | 10.79 ms |  37.76 MB |
```
